### PR TITLE
Orange Pi bringup — chute stress test, servo setup fixes, debug tooling

### DIFF
--- a/software/sorter/backend/classification/brickognize.py
+++ b/software/sorter/backend/classification/brickognize.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Optional, cast
+import os
 import threading
 import io
 import requests
@@ -118,7 +119,12 @@ def _classifyImage(image: np.ndarray) -> BrickognizeResponse:
     return _classifyImages([image])
 
 
-def _classifyImages(images: list[np.ndarray]) -> BrickognizeResponse:
+def _classifyImages(
+    images: list[np.ndarray],
+    *,
+    dump_dir: Optional[str] = None,
+    dump_label: Optional[str] = None,
+) -> BrickognizeResponse:
     """Post multiple query_images in a single request.
 
     Brickognize uses all of them as evidence for one final prediction —
@@ -126,6 +132,8 @@ def _classifyImages(images: list[np.ndarray]) -> BrickognizeResponse:
     """
     if not images:
         raise ValueError("at least one image required")
+    if dump_dir:
+        os.makedirs(dump_dir, exist_ok=True)
     files: list[tuple[str, tuple[str, io.BytesIO, str]]] = []
     for i, image in enumerate(images):
         rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
@@ -133,6 +141,10 @@ def _classifyImages(images: list[np.ndarray]) -> BrickognizeResponse:
         img_bytes = io.BytesIO()
         img.save(img_bytes, format="JPEG")
         payload_bytes = img_bytes.getvalue()
+        if dump_dir:
+            label = dump_label or "img"
+            with open(os.path.join(dump_dir, f"{label}_{i:02d}.jpg"), "wb") as f:
+                f.write(payload_bytes)
         files.append(
             ("query_image", (f"image_{i}.jpg", io.BytesIO(payload_bytes), "image/jpeg"))
         )

--- a/software/sorter/backend/global_config.py
+++ b/software/sorter/backend/global_config.py
@@ -46,11 +46,13 @@ class GlobalConfig:
     disable_video_streams: list[str]  # "feeder", "classification_bottom", "classification_top"
     run_recorder: "RunRecorder"
     runtime_stats: "RuntimeStatsCollector"
+    brickognize_dump_images: bool
     def __init__(self):
         from runtime_stats import RuntimeStatsCollector
 
         self.debug_level = 0
         self.should_write_camera_feeds = False
+        self.brickognize_dump_images = False
         self.disable_chute = False
         # On the restart branch we explicitly simulate the distributor: the
         # Waveshare layer-servo bus isn't reliably available, but C1-C4 must
@@ -99,6 +101,7 @@ def mkGlobalConfig() -> GlobalConfig:
     gc.disable_chute = "chute" in args.disable or "chute" in env_disable
     gc.disable_servos = "servos" in args.disable or "servos" in env_disable
     gc.use_channel_bus = os.getenv("USE_CHANNEL_BUS", "0") == "1"
+    gc.brickognize_dump_images = os.getenv("BRICKOGNIZE_DUMP_IMAGES", "0") == "1"
     gc.region_provider = RegionProviderType.HANDDRAWN
 
     log_dir = os.path.join(os.path.dirname(__file__), "..", "..", "logs")

--- a/software/sorter/backend/local_state.py
+++ b/software/sorter/backend/local_state.py
@@ -15,7 +15,7 @@ from toml_config import loadTomlFile
 SOFTWARE_DIR = Path(__file__).resolve().parent
 
 _STATE_INIT_LOCK = threading.Lock()
-_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 4
 
 _STATE_KEY_MACHINE_ID = "machine_id"
 _STATE_KEY_STEPPER_POSITIONS = "stepper_positions"
@@ -427,6 +427,21 @@ def initialize_local_state() -> None:
                 "user_state TEXT NOT NULL DEFAULT 'auto', "
                 "updated_at REAL NOT NULL, "
                 "PRIMARY KEY(set_num, part_num, color_id)"
+                ")"
+            )
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS chute_stress_runs ("
+                "id TEXT PRIMARY KEY, "
+                "started_at REAL NOT NULL, "
+                "ended_at REAL, "
+                "mode TEXT NOT NULL, "
+                "target_max_deg REAL NOT NULL, "
+                "duration_target_s REAL NOT NULL, "
+                "speed_microsteps_per_sec INTEGER NOT NULL, "
+                "status TEXT NOT NULL, "
+                "total_distance_deg REAL NOT NULL DEFAULT 0, "
+                "total_time_s REAL NOT NULL DEFAULT 0, "
+                "error TEXT"
                 ")"
             )
             schema_version = _get_meta(conn, "schema_version")
@@ -1329,3 +1344,120 @@ def get_tailscale_hostname() -> str | None:
 
 def set_tailscale_hostname(hostname: str) -> None:
     _write_state(_STATE_KEY_TAILSCALE_HOSTNAME, hostname.strip())
+
+
+# ---------------------------------------------------------------------------
+# Chute stress test runs
+# ---------------------------------------------------------------------------
+
+
+def _chuteStressRowToDict(row: sqlite3.Row | None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    return {
+        "id": row["id"],
+        "started_at": row["started_at"],
+        "ended_at": row["ended_at"],
+        "mode": row["mode"],
+        "target_max_deg": row["target_max_deg"],
+        "duration_target_s": row["duration_target_s"],
+        "speed_microsteps_per_sec": row["speed_microsteps_per_sec"],
+        "status": row["status"],
+        "total_distance_deg": row["total_distance_deg"],
+        "total_time_s": row["total_time_s"],
+        "error": row["error"],
+    }
+
+
+def recordChuteStressRunStart(
+    *,
+    run_id: str,
+    started_at: float,
+    mode: str,
+    target_max_deg: float,
+    duration_target_s: float,
+    speed_microsteps_per_sec: int,
+) -> None:
+    initialize_local_state()
+    with _connection() as conn:
+        conn.execute(
+            "INSERT INTO chute_stress_runs("
+            "id, started_at, mode, target_max_deg, duration_target_s, "
+            "speed_microsteps_per_sec, status, total_distance_deg, total_time_s"
+            ") VALUES(?, ?, ?, ?, ?, ?, 'running', 0, 0)",
+            (
+                run_id,
+                started_at,
+                mode,
+                float(target_max_deg),
+                float(duration_target_s),
+                int(speed_microsteps_per_sec),
+            ),
+        )
+        conn.commit()
+
+
+def updateChuteStressRunProgress(
+    *,
+    run_id: str,
+    total_distance_deg: float,
+    total_time_s: float,
+) -> None:
+    initialize_local_state()
+    with _connection() as conn:
+        conn.execute(
+            "UPDATE chute_stress_runs SET total_distance_deg = ?, total_time_s = ? "
+            "WHERE id = ?",
+            (float(total_distance_deg), float(total_time_s), run_id),
+        )
+        conn.commit()
+
+
+def finalizeChuteStressRun(
+    *,
+    run_id: str,
+    ended_at: float,
+    status: str,
+    total_distance_deg: float,
+    total_time_s: float,
+    error: str | None,
+) -> None:
+    initialize_local_state()
+    with _connection() as conn:
+        conn.execute(
+            "UPDATE chute_stress_runs SET ended_at = ?, status = ?, "
+            "total_distance_deg = ?, total_time_s = ?, error = ? WHERE id = ?",
+            (
+                float(ended_at),
+                status,
+                float(total_distance_deg),
+                float(total_time_s),
+                error,
+                run_id,
+            ),
+        )
+        conn.commit()
+
+
+def listChuteStressRuns(limit: int = 100) -> list[dict[str, Any]]:
+    initialize_local_state()
+    with _connection() as conn:
+        rows = conn.execute(
+            "SELECT id, started_at, ended_at, mode, target_max_deg, duration_target_s, "
+            "speed_microsteps_per_sec, status, total_distance_deg, total_time_s, error "
+            "FROM chute_stress_runs ORDER BY started_at DESC LIMIT ?",
+            (int(limit),),
+        ).fetchall()
+    return [d for d in (_chuteStressRowToDict(r) for r in rows) if d is not None]
+
+
+def getChuteStressRun(run_id: str) -> dict[str, Any] | None:
+    initialize_local_state()
+    with _connection() as conn:
+        row = conn.execute(
+            "SELECT id, started_at, ended_at, mode, target_max_deg, duration_target_s, "
+            "speed_microsteps_per_sec, status, total_distance_deg, total_time_s, error "
+            "FROM chute_stress_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+    return _chuteStressRowToDict(row)

--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -101,6 +101,7 @@ from server.routers.setup import router as setup_router
 from server.routers.logs import router as logs_router
 from server.routers.hive_models import router as hive_models_router
 from server.routers.runtimes import router as runtimes_router
+from server.routers.chute_stress import router as chute_stress_router
 
 app.include_router(hardware_router)
 app.include_router(steppers_router)
@@ -112,6 +113,7 @@ app.include_router(setup_router)
 app.include_router(logs_router)
 app.include_router(hive_models_router)
 app.include_router(runtimes_router)
+app.include_router(chute_stress_router)
 
 # ---------------------------------------------------------------------------
 # Lifecycle

--- a/software/sorter/backend/server/routers/chute_stress.py
+++ b/software/sorter/backend/server/routers/chute_stress.py
@@ -1,0 +1,163 @@
+"""Router for the chute stress-test mode."""
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from local_state import getChuteStressRun, listChuteStressRuns
+from server import shared_state
+from subsystems.distribution.chute_stress import (
+    CHUTE_MAX_ANGLE_LIMIT_DEG,
+    ChuteStressTestRunner,
+    StressTestParams,
+    getActiveChuteStressRunner,
+    getChuteStressRunner,
+)
+
+router = APIRouter()
+
+
+class StartStressTestRequest(BaseModel):
+    mode: str = Field(..., description="'sweep' or 'random'")
+    target_max_deg: float = Field(..., gt=0, le=CHUTE_MAX_ANGLE_LIMIT_DEG)
+    duration_s: float = Field(..., gt=0)
+    speed_microsteps_per_sec: int = Field(..., gt=0)
+    invert_direction: bool = False
+
+
+class StressTestStateResponse(BaseModel):
+    active: bool
+    run: Optional[dict[str, Any]] = None
+
+
+class StressTestRunsResponse(BaseModel):
+    runs: List[dict[str, Any]]
+
+
+def _resolveChute() -> Any:
+    irl = shared_state.getActiveIRL()
+    if irl is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Hardware not initialized. Start or home the system first.",
+        )
+    chute = getattr(irl, "chute", None)
+    if chute is None:
+        raise HTTPException(status_code=500, detail="Chute hardware unavailable")
+    return chute
+
+
+def _hardwareWorkerAlive() -> bool:
+    worker = shared_state.hardware_worker_thread
+    return bool(worker is not None and worker.is_alive())
+
+
+def _ensureManualMotionAllowed() -> None:
+    state = shared_state.hardware_state
+    if _hardwareWorkerAlive() or state in {"homing", "initializing"}:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot run chute stress test while hardware is {state}.",
+        )
+
+
+def _activeRunner() -> ChuteStressTestRunner:
+    runner = getActiveChuteStressRunner()
+    if runner is None:
+        raise HTTPException(status_code=409, detail="No chute stress test is running.")
+    return runner
+
+
+@router.post("/api/chute/stress-test/start", response_model=StressTestStateResponse)
+def startStressTest(payload: StartStressTestRequest) -> StressTestStateResponse:
+    _ensureManualMotionAllowed()
+    chute = _resolveChute()
+    gc = chute.gc
+
+    runner = getChuteStressRunner(gc, chute)
+    try:
+        params = StressTestParams(
+            mode=payload.mode,  # type: ignore[arg-type]
+            target_max_deg=float(payload.target_max_deg),
+            duration_s=float(payload.duration_s),
+            speed_microsteps_per_sec=int(payload.speed_microsteps_per_sec),
+            invert_direction=bool(payload.invert_direction),
+        )
+        state = runner.start(params)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+
+    return StressTestStateResponse(active=True, run=state.toDict())
+
+
+@router.post("/api/chute/stress-test/pause", response_model=StressTestStateResponse)
+def pauseStressTest() -> StressTestStateResponse:
+    runner = _activeRunner()
+    try:
+        runner.pause()
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    state = runner.getState()
+    return StressTestStateResponse(
+        active=runner.isActive(),
+        run=state.toDict() if state is not None else None,
+    )
+
+
+@router.post("/api/chute/stress-test/resume", response_model=StressTestStateResponse)
+def resumeStressTest() -> StressTestStateResponse:
+    runner = _activeRunner()
+    try:
+        runner.resume()
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    state = runner.getState()
+    return StressTestStateResponse(
+        active=runner.isActive(),
+        run=state.toDict() if state is not None else None,
+    )
+
+
+@router.post("/api/chute/stress-test/stop", response_model=StressTestStateResponse)
+def stopStressTest() -> StressTestStateResponse:
+    runner = _activeRunner()
+    try:
+        runner.stop()
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    state = runner.getState()
+    return StressTestStateResponse(
+        active=runner.isActive(),
+        run=state.toDict() if state is not None else None,
+    )
+
+
+@router.get("/api/chute/stress-test/status", response_model=StressTestStateResponse)
+def getStressTestStatus() -> StressTestStateResponse:
+    runner = getActiveChuteStressRunner()
+    if runner is None:
+        return StressTestStateResponse(active=False, run=None)
+    state = runner.getState()
+    return StressTestStateResponse(
+        active=runner.isActive(),
+        run=state.toDict() if state is not None else None,
+    )
+
+
+@router.get("/api/chute/stress-test/runs", response_model=StressTestRunsResponse)
+def listStressTestRuns(limit: int = 100) -> StressTestRunsResponse:
+    if limit <= 0 or limit > 1000:
+        raise HTTPException(status_code=400, detail="limit must be in (0, 1000]")
+    return StressTestRunsResponse(runs=listChuteStressRuns(limit=limit))
+
+
+@router.get("/api/chute/stress-test/runs/{run_id}")
+def getStressTestRun(run_id: str) -> dict[str, Any]:
+    run = getChuteStressRun(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+    return run

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -642,6 +642,7 @@ def _live_chute_status() -> Dict[str, Any]:
         "endstop_triggered": None,
         "raw_endstop_high": None,
         "endstop_active_high": getattr(chute, "endstop_active_high", True),
+        "stepper_direction_inverted": bool(getattr(stepper, "direction_inverted", True)),
         "current_angle": None,
         "stepper_position_degrees": None,
         "stepper_microsteps": None,

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -523,7 +523,7 @@ def move_stepper_degrees(
             target.set_acceleration(int(acceleration))
             target.set_speed_limits(min_speed=int(min_speed), max_speed=int(speed))
         else:
-            target.set_speed_limits(min_speed=int(speed), max_speed=int(speed))
+            target.set_speed_limits(min_speed=16, max_speed=int(speed))
         if not bool(target.move_degrees(degrees)):
             raise RuntimeError("move_degrees was not acknowledged")
     except Exception as e:

--- a/software/sorter/backend/server/routers/system.py
+++ b/software/sorter/backend/server/routers/system.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import os
 import signal
 import threading
-from typing import Callable, Dict, Any
+from typing import Callable, Dict, Any, Optional
 
 from fastapi import APIRouter
+from pydantic import BaseModel
 
 import server.shared_state as shared_state
 from subsystems.sample_collection_speed import (
@@ -588,3 +589,31 @@ def force_teacher_capture(payload: Dict[str, Any]) -> Dict[str, Any]:
         return {"ok": False, "reason": "vision_not_initialized"}
     queued = bool(vm.forceQueueAuxiliaryTeacherCapture(role))
     return {"ok": True, "role": role, "queued": queued}
+
+
+class ClientErrorPayload(BaseModel):
+    message: Optional[str] = None
+    source: Optional[str] = None
+    lineno: Optional[int] = None
+    colno: Optional[int] = None
+    stack: Optional[str] = None
+    type: Optional[str] = None
+
+
+@router.post("/api/system/client-error")
+def report_client_error(payload: ClientErrorPayload) -> Dict[str, Any]:
+    logger = getattr(shared_state.gc_ref, "logger", None)
+    msg = payload.message or "(no message)"
+    location = ""
+    if payload.source:
+        location = f" @ {payload.source}"
+        if payload.lineno is not None:
+            location += f":{payload.lineno}"
+    stack = f"\n{payload.stack}" if payload.stack else ""
+    full = f"[browser] {payload.type or 'error'}: {msg}{location}{stack}"
+    if logger is not None:
+        logger.error(full)
+    else:
+        import logging
+        logging.getLogger(__name__).error(full)
+    return {"ok": True}

--- a/software/sorter/backend/subsystems/classification_channel/recognition.py
+++ b/software/sorter/backend/subsystems/classification_channel/recognition.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import math
+import os
 import threading
 import time
 from typing import Optional
@@ -270,7 +271,7 @@ class ClassificationChannelRecognizer:
                     best_view,
                     part_name,
                     part_category,
-                ) = self._classifyTrackedCrops(images)
+                ) = self._classifyTrackedCrops(images, piece_uuid=piece_uuid)
                 api_call_succeeded = True
             except Exception as exc:
                 logger.error(
@@ -401,9 +402,22 @@ class ClassificationChannelRecognizer:
                 best_crop = crop
         return best_crop
 
+    def _brickognizeDumpDir(self, piece_uuid: Optional[str]) -> Optional[str]:
+        if not getattr(self.gc, "brickognize_dump_images", False):
+            return None
+        if not piece_uuid:
+            return None
+        base = os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "..", "logs", "brickognize"
+        )
+        run_id = getattr(self.gc, "run_id", "unknown_run")
+        return os.path.abspath(os.path.join(base, str(run_id), str(piece_uuid)))
+
     def _classifyTrackedCrops(
         self,
         images: list[CropEntry],
+        *,
+        piece_uuid: Optional[str] = None,
     ) -> tuple[
         Optional[str],
         str,
@@ -426,7 +440,12 @@ class ClassificationChannelRecognizer:
         selected_images = [
             self._padCropForBrickognize(image) for image, _role, _ts in selected
         ]
-        primary_result = _classifyImages(selected_images)
+        dump_dir = self._brickognizeDumpDir(piece_uuid)
+        primary_result = _classifyImages(
+            selected_images,
+            dump_dir=dump_dir,
+            dump_label="primary",
+        )
         candidate = self._candidateFromResult(
             primary_result,
             source_view="tracked_multi",
@@ -435,8 +454,12 @@ class ClassificationChannelRecognizer:
             return candidate
 
         best_single = candidate
-        for crop in selected_images[:SINGLE_CROP_FALLBACK_COUNT]:
-            single_result = _classifyImages([crop])
+        for fallback_idx, crop in enumerate(selected_images[:SINGLE_CROP_FALLBACK_COUNT]):
+            single_result = _classifyImages(
+                [crop],
+                dump_dir=dump_dir,
+                dump_label=f"fallback_{fallback_idx:02d}",
+            )
             single_candidate = self._candidateFromResult(
                 single_result,
                 source_view="tracked_single",

--- a/software/sorter/backend/subsystems/distribution/chute_stress.py
+++ b/software/sorter/backend/subsystems/distribution/chute_stress.py
@@ -1,0 +1,349 @@
+"""Chute stress-test loop runner.
+
+Drives the chute back and forth between angles for endurance / wear testing.
+Runs in a background thread; exposes start/pause/resume/stop and live progress.
+"""
+from __future__ import annotations
+
+import random
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from global_config import GlobalConfig
+from local_state import (
+    finalizeChuteStressRun,
+    recordChuteStressRunStart,
+    updateChuteStressRunProgress,
+)
+from subsystems.distribution.chute import GEAR_RATIO, Chute
+
+StressMode = Literal["sweep", "random"]
+RunStatus = Literal["running", "paused", "stopping", "completed", "stopped", "failed"]
+
+CHUTE_MAX_ANGLE_LIMIT_DEG = 345.0
+LEG_TIMEOUT_BUFFER_S = 5.0
+POLL_INTERVAL_S = 0.02
+MIN_RANDOM_DELTA_DEG = 5.0
+
+
+@dataclass
+class StressTestParams:
+    mode: StressMode
+    target_max_deg: float
+    duration_s: float
+    speed_microsteps_per_sec: int
+    invert_direction: bool = False
+
+
+@dataclass
+class StressTestState:
+    run_id: str
+    params: StressTestParams
+    started_at: float
+    status: RunStatus = "running"
+    total_distance_deg: float = 0.0
+    elapsed_s: float = 0.0
+    ended_at: float | None = None
+    error: str | None = None
+    last_target_deg: float | None = None
+
+    def toDict(self) -> dict[str, Any]:
+        return {
+            "id": self.run_id,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "mode": self.params.mode,
+            "target_max_deg": self.params.target_max_deg,
+            "duration_target_s": self.params.duration_s,
+            "speed_microsteps_per_sec": self.params.speed_microsteps_per_sec,
+            "invert_direction": self.params.invert_direction,
+            "status": self.status,
+            "total_distance_deg": self.total_distance_deg,
+            "total_time_s": self.elapsed_s,
+            "last_target_deg": self.last_target_deg,
+            "error": self.error,
+        }
+
+
+def _snapshot(state: StressTestState) -> StressTestState:
+    return StressTestState(
+        run_id=state.run_id,
+        params=state.params,
+        started_at=state.started_at,
+        status=state.status,
+        total_distance_deg=state.total_distance_deg,
+        elapsed_s=state.elapsed_s,
+        ended_at=state.ended_at,
+        error=state.error,
+        last_target_deg=state.last_target_deg,
+    )
+
+
+class ChuteStressTestRunner:
+    def __init__(self, gc: GlobalConfig, chute: Chute) -> None:
+        self.gc = gc
+        self.logger = gc.logger
+        self.chute = chute
+        self._lock = threading.RLock()
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._pause_event = threading.Event()
+        self._pause_event.set()
+        self._state: StressTestState | None = None
+
+    def isActive(self) -> bool:
+        with self._lock:
+            t = self._thread
+            return bool(t is not None and t.is_alive())
+
+    def getState(self) -> StressTestState | None:
+        with self._lock:
+            return _snapshot(self._state) if self._state is not None else None
+
+    def start(self, params: StressTestParams) -> StressTestState:
+        with self._lock:
+            if self.isActive():
+                raise RuntimeError("A chute stress test is already running")
+            if params.target_max_deg <= 0 or params.target_max_deg > CHUTE_MAX_ANGLE_LIMIT_DEG:
+                raise ValueError(
+                    f"target_max_deg must be in (0, {CHUTE_MAX_ANGLE_LIMIT_DEG}]"
+                )
+            if params.duration_s <= 0:
+                raise ValueError("duration_s must be > 0")
+            if params.speed_microsteps_per_sec <= 0:
+                raise ValueError("speed_microsteps_per_sec must be > 0")
+            if params.mode not in ("sweep", "random"):
+                raise ValueError("mode must be 'sweep' or 'random'")
+
+            now = time.time()
+            run_id = str(uuid.uuid4())
+            recordChuteStressRunStart(
+                run_id=run_id,
+                started_at=now,
+                mode=params.mode,
+                target_max_deg=params.target_max_deg,
+                duration_target_s=params.duration_s,
+                speed_microsteps_per_sec=params.speed_microsteps_per_sec,
+            )
+            self._state = StressTestState(
+                run_id=run_id,
+                params=params,
+                started_at=now,
+            )
+            self._stop_event.clear()
+            self._pause_event.set()
+            self._thread = threading.Thread(
+                target=self._run, name="ChuteStressTest", daemon=True
+            )
+            self._thread.start()
+            return _snapshot(self._state)
+
+    def pause(self) -> None:
+        with self._lock:
+            if not self.isActive() or self._state is None:
+                raise RuntimeError("No chute stress test is running")
+            if self._state.status in ("paused", "stopping"):
+                return
+            self._pause_event.clear()
+            self._state.status = "paused"
+        self.logger.info("Chute stress: pause requested (will hold after current leg)")
+
+    def resume(self) -> None:
+        with self._lock:
+            if not self.isActive() or self._state is None:
+                raise RuntimeError("No chute stress test is running")
+            if self._state.status != "paused":
+                return
+            self._state.status = "running"
+            self._pause_event.set()
+        self.logger.info("Chute stress: resumed")
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._state is None:
+                raise RuntimeError("No chute stress test is running")
+            self._stop_event.set()
+            self._pause_event.set()
+            if self._state.status not in ("completed", "stopped", "failed"):
+                self._state.status = "stopping"
+        self.logger.info("Chute stress: stop requested")
+
+    def _pickNextTarget(self, current_deg: float) -> float:
+        assert self._state is not None
+        params = self._state.params
+        max_deg = params.target_max_deg
+        min_deg = float(self.chute.first_bin_center or 0.0)
+        if params.mode == "sweep":
+            last = self._state.last_target_deg
+            if last is None or last < max_deg / 2.0:
+                return max_deg
+            return min_deg
+        for _ in range(10):
+            candidate = random.uniform(min_deg, max_deg)
+            if abs(candidate - current_deg) >= MIN_RANDOM_DELTA_DEG:
+                return candidate
+        return max_deg if current_deg < max_deg / 2.0 else min_deg
+
+    def _halt(self) -> None:
+        stepper = self.chute.stepper
+        halt = getattr(stepper, "halt", None)
+        try:
+            if callable(halt):
+                halt(disable_driver=False)
+            else:
+                stepper.move_at_speed(0)
+        except Exception as e:
+            self.logger.warning(f"Chute stress: halt failed: {e}")
+
+    def _moveTo(self, target_deg: float) -> float:
+        assert self._state is not None
+        stepper = self.chute.stepper
+        current_deg = self.chute.current_angle
+        target_deg = max(0.0, min(CHUTE_MAX_ANGLE_LIMIT_DEG, target_deg))
+        delta_output = target_deg - current_deg
+        if abs(delta_output) < 0.01:
+            return 0.0
+        delta_motor = delta_output * GEAR_RATIO * (-1 if self._state.params.invert_direction else 1)
+
+        try:
+            est_ms = stepper.estimateMoveDegreesMs(
+                delta_motor,
+                max_speed=self._state.params.speed_microsteps_per_sec,
+            )
+        except Exception:
+            est_ms = 5000
+        timeout_s = (est_ms / 1000.0) + LEG_TIMEOUT_BUFFER_S
+
+        stepper.enabled = True
+        if not bool(stepper.move_degrees(delta_motor)):
+            raise RuntimeError("Stepper did not accept move_degrees")
+
+        leg_start = time.monotonic()
+        while True:
+            if self._stop_event.is_set():
+                self._halt()
+                break
+            try:
+                if stepper.stopped:
+                    break
+            except Exception:
+                self._halt()
+                break
+            if (time.monotonic() - leg_start) > timeout_s:
+                self.logger.warning(
+                    f"Chute stress: leg to {target_deg:.1f}° exceeded {timeout_s:.1f}s timeout"
+                )
+                self._halt()
+                break
+            time.sleep(POLL_INTERVAL_S)
+
+        # Use actual final position to record true distance traveled
+        try:
+            final_deg = self.chute.current_angle
+            return abs(final_deg - current_deg)
+        except Exception:
+            return abs(delta_output)
+
+    def _run(self) -> None:
+        assert self._state is not None
+        params = self._state.params
+        stepper = self.chute.stepper
+        prev_operating_speed = int(self.chute.operating_speed_microsteps_per_second)
+
+        try:
+            stepper.set_speed_limits(
+                min_speed=int(params.speed_microsteps_per_sec),
+                max_speed=int(params.speed_microsteps_per_sec),
+            )
+            self.chute.setOperatingSpeed(int(params.speed_microsteps_per_sec))
+
+            start_monotonic = time.monotonic()
+            last_persist = 0.0
+            while True:
+                if self._stop_event.is_set():
+                    break
+                self._pause_event.wait()
+                if self._stop_event.is_set():
+                    break
+
+                elapsed = time.monotonic() - start_monotonic
+                if elapsed >= params.duration_s:
+                    break
+
+                target = self._pickNextTarget(self.chute.current_angle)
+                with self._lock:
+                    self._state.last_target_deg = target
+
+                distance = self._moveTo(target)
+                with self._lock:
+                    self._state.total_distance_deg += distance
+                    self._state.elapsed_s = time.monotonic() - start_monotonic
+
+                now = time.monotonic()
+                if now - last_persist >= 1.0:
+                    last_persist = now
+                    updateChuteStressRunProgress(
+                        run_id=self._state.run_id,
+                        total_distance_deg=self._state.total_distance_deg,
+                        total_time_s=self._state.elapsed_s,
+                    )
+
+            final_status: RunStatus = (
+                "stopped" if self._stop_event.is_set() else "completed"
+            )
+            with self._lock:
+                self._state.status = final_status
+                self._state.ended_at = time.time()
+        except Exception as exc:
+            self.logger.error(f"Chute stress test failed: {exc}", exc_info=True)
+            self._halt()
+            with self._lock:
+                if self._state is not None:
+                    self._state.status = "failed"
+                    self._state.error = str(exc)
+                    self._state.ended_at = time.time()
+        finally:
+            try:
+                stepper.set_speed_limits(
+                    min_speed=int(prev_operating_speed),
+                    max_speed=int(prev_operating_speed),
+                )
+                self.chute.setOperatingSpeed(int(prev_operating_speed))
+            except Exception as e:
+                self.logger.warning(
+                    f"Chute stress: failed to restore operating speed: {e}"
+                )
+            if self._state is not None:
+                finalizeChuteStressRun(
+                    run_id=self._state.run_id,
+                    ended_at=self._state.ended_at or time.time(),
+                    status=self._state.status,
+                    total_distance_deg=self._state.total_distance_deg,
+                    total_time_s=self._state.elapsed_s,
+                    error=self._state.error,
+                )
+
+
+_runner_lock = threading.Lock()
+_runner: ChuteStressTestRunner | None = None
+
+
+def getChuteStressRunner(gc: GlobalConfig, chute: Chute) -> ChuteStressTestRunner:
+    """Get or create the singleton stress-test runner bound to the given chute."""
+    global _runner
+    with _runner_lock:
+        if _runner is None or _runner.chute is not chute:
+            if _runner is not None and _runner.isActive():
+                raise RuntimeError(
+                    "A chute stress test is running against a different chute instance"
+                )
+            _runner = ChuteStressTestRunner(gc, chute)
+        return _runner
+
+
+def getActiveChuteStressRunner() -> ChuteStressTestRunner | None:
+    with _runner_lock:
+        return _runner

--- a/software/sorter/backend/subsystems/distribution/chute_stress.py
+++ b/software/sorter/backend/subsystems/distribution/chute_stress.py
@@ -18,7 +18,7 @@ from local_state import (
     recordChuteStressRunStart,
     updateChuteStressRunProgress,
 )
-from subsystems.distribution.chute import GEAR_RATIO, Chute
+from subsystems.distribution.chute import GEAR_RATIO, HOME_SPEED_MICROSTEPS_PER_SEC, HOME_TIMEOUT_MS, Chute
 
 StressMode = Literal["sweep", "random"]
 RunStatus = Literal["running", "paused", "stopping", "completed", "stopped", "failed"]
@@ -27,6 +27,7 @@ CHUTE_MAX_ANGLE_LIMIT_DEG = 345.0
 LEG_TIMEOUT_BUFFER_S = 5.0
 POLL_INTERVAL_S = 0.02
 MIN_RANDOM_DELTA_DEG = 5.0
+MIN_RANDOM_ANGLE_DEG = 5.0
 
 
 @dataclass
@@ -171,21 +172,58 @@ class ChuteStressTestRunner:
                 self._state.status = "stopping"
         self.logger.info("Chute stress: stop requested")
 
-    def _pickNextTarget(self, current_deg: float) -> float:
+    def _pickNextTarget(self, current_deg: float) -> float | None:
+        # Returns None to signal that sweep should home rather than move to a position.
         assert self._state is not None
         params = self._state.params
         max_deg = params.target_max_deg
-        min_deg = float(self.chute.first_bin_center or 0.0)
         if params.mode == "sweep":
             last = self._state.last_target_deg
             if last is None or last < max_deg / 2.0:
                 return max_deg
-            return min_deg
+            return None  # home leg
+        min_deg = max(MIN_RANDOM_ANGLE_DEG, float(self.chute.first_bin_center or 0.0))
         for _ in range(10):
             candidate = random.uniform(min_deg, max_deg)
             if abs(candidate - current_deg) >= MIN_RANDOM_DELTA_DEG:
                 return candidate
         return max_deg if current_deg < max_deg / 2.0 else min_deg
+
+    def _homeToZero(self) -> float:
+        assert self._state is not None
+        stepper = self.chute.stepper
+        current_deg = self.chute.current_angle
+        timeout_s = (HOME_TIMEOUT_MS / 1000.0) + LEG_TIMEOUT_BUFFER_S
+
+        stepper.enabled = True
+        stepper.home(
+            HOME_SPEED_MICROSTEPS_PER_SEC,
+            self.chute.home_pin,
+            home_pin_active_high=self.chute.endstop_active_high,
+        )
+
+        leg_start = time.monotonic()
+        while True:
+            if self._stop_event.is_set():
+                self._halt()
+                break
+            try:
+                if stepper.stopped:
+                    break
+            except Exception:
+                self._halt()
+                break
+            if (time.monotonic() - leg_start) > timeout_s:
+                self.logger.warning("Chute stress: home leg timed out")
+                self._halt()
+                break
+            time.sleep(POLL_INTERVAL_S)
+
+        try:
+            final_deg = self.chute.current_angle
+            return abs(final_deg - current_deg)
+        except Exception:
+            return abs(current_deg)
 
     def _halt(self) -> None:
         stepper = self.chute.stepper
@@ -255,7 +293,7 @@ class ChuteStressTestRunner:
 
         try:
             stepper.set_speed_limits(
-                min_speed=int(params.speed_microsteps_per_sec),
+                min_speed=16,
                 max_speed=int(params.speed_microsteps_per_sec),
             )
             self.chute.setOperatingSpeed(int(params.speed_microsteps_per_sec))
@@ -275,9 +313,12 @@ class ChuteStressTestRunner:
 
                 target = self._pickNextTarget(self.chute.current_angle)
                 with self._lock:
-                    self._state.last_target_deg = target
+                    self._state.last_target_deg = target if target is not None else 0.0
 
-                distance = self._moveTo(target)
+                if target is None:
+                    distance = self._homeToZero()
+                else:
+                    distance = self._moveTo(target)
                 with self._lock:
                     self._state.total_distance_deg += distance
                     self._state.elapsed_s = time.monotonic() - start_monotonic
@@ -308,7 +349,7 @@ class ChuteStressTestRunner:
         finally:
             try:
                 stepper.set_speed_limits(
-                    min_speed=int(prev_operating_speed),
+                    min_speed=16,
                     max_speed=int(prev_operating_speed),
                 )
                 self.chute.setOperatingSpeed(int(prev_operating_speed))

--- a/software/sorter/backend/tests/test_camera_device_controls.py
+++ b/software/sorter/backend/tests/test_camera_device_controls.py
@@ -10,6 +10,8 @@ from vision.camera import (
     _bool_from_capture_value,
     _capture_failure_backoff_s,
     _is_macos_camera_index_available,
+    _try_v4l2ctl_describe,
+    _try_v4l2ctl_get_number,
     probe_camera_device_controls,
 )
 
@@ -257,6 +259,34 @@ class CameraDeviceControlsTests(unittest.TestCase):
             self.assertTrue(_bool_from_capture_value("auto_exposure", 3.0))
             self.assertFalse(_bool_from_capture_value("auto_exposure", 0.25))
             self.assertTrue(_bool_from_capture_value("auto_exposure", 0.75))
+
+    def test_linux_v4l2_numeric_readback(self) -> None:
+        completed = SimpleNamespace(returncode=0, stdout="exposure_time_absolute: 200\n")
+        with patch("vision.camera.subprocess.run", return_value=completed):
+            self.assertEqual(200.0, _try_v4l2ctl_get_number(4, "exposure"))
+
+    def test_linux_v4l2_describe_parses_numeric_ranges(self) -> None:
+        stdout = """
+User Controls
+
+                     brightness 0x00980900 (int)    : min=-64 max=64 step=1 default=0 value=0
+      white_balance_temperature 0x0098091a (int)    : min=2800 max=6500 step=10 default=4600 value=2800 flags=inactive
+
+Camera Controls
+
+                  auto_exposure 0x009a0901 (menu)   : min=0 max=3 default=3 value=3 (Aperture Priority Mode)
+         exposure_time_absolute 0x009a0902 (int)    : min=0 max=10000 step=1 default=166 value=200 flags=inactive
+"""
+        completed = SimpleNamespace(returncode=0, stdout=stdout)
+        with patch("vision.camera.subprocess.run", return_value=completed):
+            described = _try_v4l2ctl_describe(4)
+
+        self.assertEqual(-64.0, described["brightness"]["min"])
+        self.assertEqual(64.0, described["brightness"]["max"])
+        self.assertEqual(1.0, described["brightness"]["step"])
+        self.assertEqual(200.0, described["exposure"]["value"])
+        self.assertTrue(bool(described["exposure"]["inactive"]))
+        self.assertTrue(bool(described["white_balance_temperature"]["inactive"]))
 
 
 if __name__ == "__main__":

--- a/software/sorter/backend/vision/camera.py
+++ b/software/sorter/backend/vision/camera.py
@@ -278,6 +278,17 @@ _LINUX_V4L2CTL_CONTROL_MAP: dict[str, tuple[str, Any]] = {
     "auto_exposure": ("auto_exposure", lambda v: "3" if bool(v) else "1"),
     "auto_white_balance": ("white_balance_automatic", lambda v: "1" if bool(v) else "0"),
     "autofocus": ("focus_automatic_continuous", lambda v: "1" if bool(v) else "0"),
+    "brightness": ("brightness", lambda v: str(int(round(float(v))))),
+    "contrast": ("contrast", lambda v: str(int(round(float(v))))),
+    "saturation": ("saturation", lambda v: str(int(round(float(v))))),
+    "sharpness": ("sharpness", lambda v: str(int(round(float(v))))),
+    "gamma": ("gamma", lambda v: str(int(round(float(v))))),
+    "gain": ("gain", lambda v: str(int(round(float(v))))),
+    "exposure": ("exposure_time_absolute", lambda v: str(int(round(float(v))))),
+    "white_balance_temperature": ("white_balance_temperature", lambda v: str(int(round(float(v))))),
+    "focus": ("focus_absolute", lambda v: str(int(round(float(v))))),
+    "power_line_frequency": ("power_line_frequency", lambda v: str(int(round(float(v))))),
+    "backlight_compensation": ("backlight_compensation", lambda v: str(int(round(float(v))))),
 }
 
 
@@ -300,7 +311,7 @@ def _try_v4l2ctl_set(source: int, key: str, value: bool | float) -> bool:
 # OpenCV's V4L2 backend lies about menu controls (auto_exposure especially) on
 # some drivers — cap.get returns 0.0/0.25 even when the kernel has the control
 # in mode 3. v4l2-ctl is the authoritative source. Returns None if unavailable.
-def _try_v4l2ctl_get_bool(source: int, key: str) -> bool | None:
+def _try_v4l2ctl_get_raw(source: int, key: str) -> str | None:
     entry = _LINUX_V4L2CTL_CONTROL_MAP.get(key)
     if entry is None:
         return None
@@ -319,12 +330,73 @@ def _try_v4l2ctl_get_bool(source: int, key: str) -> bool | None:
         raw = raw.strip()
         if not raw:
             return None
-        n = int(raw.split()[0])
-        if key == "auto_exposure":
-            return n == 3
-        return n != 0
+        return raw.split()[0]
     except Exception:
         return None
+
+
+def _try_v4l2ctl_get_bool(source: int, key: str) -> bool | None:
+    raw = _try_v4l2ctl_get_raw(source, key)
+    if raw is None:
+        return None
+    try:
+        n = int(raw)
+    except Exception:
+        return None
+    if key == "auto_exposure":
+        return n == 3
+    return n != 0
+
+
+def _try_v4l2ctl_get_number(source: int, key: str) -> float | None:
+    raw = _try_v4l2ctl_get_raw(source, key)
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except Exception:
+        return None
+
+
+def _try_v4l2ctl_describe(source: int) -> dict[str, dict[str, float | bool]]:
+    by_ctrl_name: dict[str, str] = {}
+    for key, (ctrl_name, _) in _LINUX_V4L2CTL_CONTROL_MAP.items():
+        by_ctrl_name[ctrl_name] = key
+    try:
+        result = subprocess.run(
+            ["v4l2-ctl", "-d", f"/dev/video{source}", "-L"],
+            capture_output=True,
+            timeout=3,
+            text=True,
+        )
+        if result.returncode != 0:
+            return {}
+    except Exception:
+        return {}
+
+    described: dict[str, dict[str, float | bool]] = {}
+    for line in result.stdout.splitlines():
+        raw_line = line.rstrip()
+        if not raw_line or raw_line.lstrip() == raw_line or "0x" not in raw_line:
+            continue
+        ctrl_name = raw_line.split()[0]
+        key = by_ctrl_name.get(ctrl_name)
+        if key is None:
+            continue
+        details: dict[str, float | bool] = {}
+        for token in raw_line.split():
+            if "=" not in token:
+                continue
+            token_key, token_value = token.split("=", 1)
+            if token_key in {"min", "max", "step", "default", "value"}:
+                try:
+                    details[token_key] = float(token_value)
+                except Exception:
+                    continue
+            elif token_key == "flags":
+                details["inactive"] = "inactive" in token_value
+        described[key] = details
+    return described
 
 
 def _read_capture_value(
@@ -337,14 +409,18 @@ def _read_capture_value(
     if prop is None:
         return None
     if (
-        spec["kind"] == "boolean"
-        and platform.system() == "Linux"
+        platform.system() == "Linux"
         and isinstance(source, int)
         and spec["key"] in _LINUX_V4L2CTL_CONTROL_MAP
     ):
-        v = _try_v4l2ctl_get_bool(source, spec["key"])
-        if v is not None:
-            return v
+        if spec["kind"] == "boolean":
+            v = _try_v4l2ctl_get_bool(source, spec["key"])
+            if v is not None:
+                return v
+        else:
+            v = _try_v4l2ctl_get_number(source, spec["key"])
+            if v is not None:
+                return v
     raw = cap.get(prop)
     if raw is None or (isinstance(raw, float) and (np.isnan(raw) or np.isinf(raw))):
         return None
@@ -485,6 +561,11 @@ def describe_camera_device_controls(
         return macos_controls
 
     controls: list[dict[str, Any]] = []
+    linux_described = (
+        _try_v4l2ctl_describe(source)
+        if platform.system() == "Linux" and isinstance(source, int)
+        else {}
+    )
     for spec in _usb_camera_control_specs():
         # Do NOT cap.set() here as a "support test" — on UVC cameras, writing
         # CAP_PROP_EXPOSURE silently flips auto_exposure to Manual mode, so a
@@ -506,6 +587,14 @@ def describe_camera_device_controls(
             min_value = spec.get("min")
             max_value = spec.get("max")
             step_value = spec.get("step", 1.0)
+            linux_spec = linux_described.get(spec["key"])
+            if linux_spec:
+                if isinstance(linux_spec.get("min"), (int, float)):
+                    min_value = float(linux_spec["min"])
+                if isinstance(linux_spec.get("max"), (int, float)):
+                    max_value = float(linux_spec["max"])
+                if isinstance(linux_spec.get("step"), (int, float)):
+                    step_value = float(linux_spec["step"])
             if isinstance(current, (int, float)) and not isinstance(current, bool):
                 if isinstance(min_value, (int, float)):
                     min_value = min(min_value, float(current))

--- a/software/sorter/frontend/src/lib/components/settings/StepperSidebar.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/StepperSidebar.svelte
@@ -16,6 +16,7 @@
 	import StepperDriverSettings from './stepper/StepperDriverSettings.svelte';
 	import StepperEndstopSettings from './stepper/StepperEndstopSettings.svelte';
 	import StepperChuteOperation from './stepper/StepperChuteOperation.svelte';
+	import StepperChuteStressTest from './stepper/StepperChuteStressTest.svelte';
 
 	let {
 		stepperKey,
@@ -693,6 +694,10 @@
 				onCancel={cancelHoming}
 				onCalibrate={calibrate}
 			/>
+		{/if}
+
+		{#if isChute}
+			<StepperChuteStressTest operatingSpeed={chuteOperatingSpeed} />
 		{/if}
 
 		<StepperDriverSettings

--- a/software/sorter/frontend/src/lib/components/settings/stepper/StepperChuteStressTest.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/stepper/StepperChuteStressTest.svelte
@@ -1,0 +1,520 @@
+<script lang="ts">
+	import { getBackendHttpBase, machineHttpBaseUrlFromWsUrl } from '$lib/backend';
+	import { getMachinesContext } from '$lib/machines/context';
+	import { ChevronDown, Play, Pause, Square } from 'lucide-svelte';
+	import { onDestroy, onMount } from 'svelte';
+
+	type StressMode = 'sweep' | 'random';
+	type RunStatus =
+		| 'running'
+		| 'paused'
+		| 'stopping'
+		| 'completed'
+		| 'stopped'
+		| 'failed';
+
+	type RunRecord = {
+		id: string;
+		started_at: number;
+		ended_at: number | null;
+		mode: StressMode;
+		target_max_deg: number;
+		duration_target_s: number;
+		speed_microsteps_per_sec: number;
+		status: RunStatus;
+		total_distance_deg: number;
+		total_time_s: number;
+		error: string | null;
+		last_target_deg?: number | null;
+	};
+
+	const CHUTE_STRESS_MAX_ANGLE = 345;
+
+	let {
+		operatingSpeed
+	}: {
+		operatingSpeed: number;
+	} = $props();
+
+	const manager = getMachinesContext();
+
+	let open = $state(false);
+	let mode = $state<StressMode>('sweep');
+	let targetMaxDeg = $state(300);
+	let durationSec = $state(60);
+	let useMaxSpeed = $state(true);
+	let speedOverride = $state(operatingSpeed);
+	let invertDirection = $state(false);
+
+	let errorMsg = $state<string | null>(null);
+	let statusMsg = $state('');
+	let activeRun = $state<RunRecord | null>(null);
+	let active = $state(false);
+	let busy = $state(false);
+
+	let runs = $state<RunRecord[]>([]);
+	let selectedRunId = $state<string | null>(null);
+	let pollHandle: ReturnType<typeof setInterval> | null = null;
+
+	const effectiveSpeed = $derived(
+		useMaxSpeed ? Math.max(1, Math.floor(operatingSpeed)) : Math.max(1, Math.floor(speedOverride))
+	);
+
+	$effect(() => {
+		if (useMaxSpeed) speedOverride = operatingSpeed;
+	});
+
+	function backendBase(): string {
+		return (
+			machineHttpBaseUrlFromWsUrl(
+				manager.selectedMachine?.status === 'connected' ? manager.selectedMachine.url : null
+			) ?? getBackendHttpBase()
+		);
+	}
+
+	async function readError(res: Response): Promise<string> {
+		try {
+			const data = await res.json();
+			if (typeof data?.detail === 'string') return data.detail;
+		} catch {
+			/* fall through */
+		}
+		try {
+			return await res.text();
+		} catch {
+			return `Request failed with status ${res.status}`;
+		}
+	}
+
+	async function loadStatus() {
+		try {
+			const res = await fetch(`${backendBase()}/api/chute/stress-test/status`);
+			if (!res.ok) return;
+			const data = await res.json();
+			active = Boolean(data?.active);
+			activeRun = data?.run ?? null;
+		} catch {
+			// silent
+		}
+	}
+
+	async function loadRuns() {
+		try {
+			const res = await fetch(`${backendBase()}/api/chute/stress-test/runs?limit=50`);
+			if (!res.ok) return;
+			const data = await res.json();
+			if (Array.isArray(data?.runs)) runs = data.runs;
+		} catch {
+			// silent
+		}
+	}
+
+	async function postAction(path: string, body?: unknown): Promise<boolean> {
+		busy = true;
+		errorMsg = null;
+		statusMsg = '';
+		try {
+			const res = await fetch(`${backendBase()}${path}`, {
+				method: 'POST',
+				headers: body ? { 'Content-Type': 'application/json' } : undefined,
+				body: body ? JSON.stringify(body) : undefined
+			});
+			if (!res.ok) {
+				errorMsg = await readError(res);
+				return false;
+			}
+			const data = await res.json();
+			active = Boolean(data?.active);
+			activeRun = data?.run ?? null;
+			return true;
+		} catch (e: any) {
+			errorMsg = e?.message ?? 'Request failed';
+			return false;
+		} finally {
+			busy = false;
+		}
+	}
+
+	async function startRun() {
+		if (targetMaxDeg <= 0 || targetMaxDeg > CHUTE_STRESS_MAX_ANGLE) {
+			errorMsg = `Target angle must be in (0, ${CHUTE_STRESS_MAX_ANGLE}]`;
+			return;
+		}
+		if (durationSec <= 0) {
+			errorMsg = 'Duration must be > 0 seconds';
+			return;
+		}
+		const ok = await postAction('/api/chute/stress-test/start', {
+			mode,
+			target_max_deg: targetMaxDeg,
+			duration_s: durationSec,
+			speed_microsteps_per_sec: effectiveSpeed,
+			invert_direction: invertDirection
+		});
+		if (ok) {
+			statusMsg = 'Stress test started.';
+			await loadRuns();
+		}
+	}
+
+	async function pauseRun() {
+		const ok = await postAction('/api/chute/stress-test/pause');
+		if (ok) statusMsg = 'Pause requested (finishing current leg).';
+	}
+
+	async function resumeRun() {
+		const ok = await postAction('/api/chute/stress-test/resume');
+		if (ok) statusMsg = 'Resumed.';
+	}
+
+	async function stopRun() {
+		const ok = await postAction('/api/chute/stress-test/stop');
+		if (ok) {
+			statusMsg = 'Stop requested.';
+			await loadRuns();
+		}
+	}
+
+	function formatDuration(seconds: number): string {
+		if (!Number.isFinite(seconds) || seconds < 0) return '--';
+		const total = Math.floor(seconds);
+		const h = Math.floor(total / 3600);
+		const m = Math.floor((total % 3600) / 60);
+		const s = total % 60;
+		if (h > 0) return `${h}h ${m}m ${s}s`;
+		if (m > 0) return `${m}m ${s}s`;
+		return `${s}s`;
+	}
+
+	function formatTimestamp(epoch_s: number | null | undefined): string {
+		if (!epoch_s || !Number.isFinite(epoch_s)) return '--';
+		try {
+			return new Date(epoch_s * 1000).toLocaleString();
+		} catch {
+			return '--';
+		}
+	}
+
+	function statusLabel(status: RunStatus): string {
+		switch (status) {
+			case 'running':
+				return 'Running';
+			case 'paused':
+				return 'Paused';
+			case 'stopping':
+				return 'Stopping';
+			case 'completed':
+				return 'Completed';
+			case 'stopped':
+				return 'Stopped';
+			case 'failed':
+				return 'Failed';
+			default:
+				return status;
+		}
+	}
+
+	function statusColor(status: RunStatus): string {
+		if (status === 'running') return 'text-primary';
+		if (status === 'paused' || status === 'stopping') return 'text-warning';
+		if (status === 'completed') return 'text-success dark:text-green-400';
+		if (status === 'failed') return 'text-danger dark:text-red-400';
+		return 'text-text-muted';
+	}
+
+	function toggleOpen() {
+		open = !open;
+		if (open) {
+			void loadStatus();
+			void loadRuns();
+		}
+	}
+
+	function startPolling() {
+		if (pollHandle !== null) return;
+		pollHandle = setInterval(() => {
+			void loadStatus();
+		}, 500);
+	}
+
+	function stopPolling() {
+		if (pollHandle !== null) {
+			clearInterval(pollHandle);
+			pollHandle = null;
+		}
+	}
+
+	$effect(() => {
+		if (open && active) {
+			startPolling();
+		} else if (!active) {
+			stopPolling();
+		}
+	});
+
+	$effect(() => {
+		// When the active run transitions away from running/paused, refresh the runs list
+		const status = activeRun?.status;
+		if (status === 'completed' || status === 'stopped' || status === 'failed') {
+			void loadRuns();
+		}
+	});
+
+	onMount(() => {
+		void loadStatus();
+	});
+
+	onDestroy(stopPolling);
+
+	const selectedRun = $derived(
+		selectedRunId ? runs.find((r) => r.id === selectedRunId) ?? null : null
+	);
+</script>
+
+<div class="border-t border-border pt-4"></div>
+
+<div class="flex flex-col gap-2">
+	<button
+		onclick={toggleOpen}
+		class="flex w-full items-center justify-between text-left"
+	>
+		<div class="flex flex-col gap-0.5">
+			<div class="text-sm font-medium text-text">Stress Test</div>
+			<div class="text-xs text-text-muted">
+				Bounce the chute back and forth at speed to exercise mechanics and stepper.
+			</div>
+		</div>
+		<ChevronDown
+			size={16}
+			class="text-text-muted transition-transform {open ? 'rotate-180' : ''}"
+		/>
+	</button>
+
+	{#if active && activeRun}
+		<div class="border border-border bg-surface px-3 py-2 text-sm">
+			<div class="flex items-center justify-between">
+				<span class="font-medium {statusColor(activeRun.status)}">
+					{statusLabel(activeRun.status)}
+				</span>
+				<span class="text-text-muted">{activeRun.mode}</span>
+			</div>
+			<div class="mt-1 grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs text-text-muted">
+				<span>Elapsed</span>
+				<span class="text-right text-text">
+					{formatDuration(activeRun.total_time_s)} / {formatDuration(
+						activeRun.duration_target_s
+					)}
+				</span>
+				<span>Distance</span>
+				<span class="text-right text-text">
+					{activeRun.total_distance_deg.toFixed(1)}°
+				</span>
+				<span>Last target</span>
+				<span class="text-right text-text">
+					{activeRun.last_target_deg !== null && activeRun.last_target_deg !== undefined
+						? `${activeRun.last_target_deg.toFixed(1)}°`
+						: '--'}
+				</span>
+				<span>Speed</span>
+				<span class="text-right text-text">
+					{activeRun.speed_microsteps_per_sec} µsteps/s
+				</span>
+			</div>
+		</div>
+	{/if}
+</div>
+
+{#if open}
+	<div class="flex flex-col gap-3">
+		<label class="text-xs text-text">
+			Mode
+			<select
+				bind:value={mode}
+				disabled={active || busy}
+				class="mt-1 block w-full border border-border bg-bg px-2 py-1.5 text-sm text-text disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				<option value="sweep">Sweep (home ↔ target)</option>
+				<option value="random">Random within [0°, target]</option>
+			</select>
+		</label>
+
+		<label class="text-xs text-text">
+			Target Max Angle (°) — max {CHUTE_STRESS_MAX_ANGLE}
+			<input
+				type="number"
+				min="1"
+				max={CHUTE_STRESS_MAX_ANGLE}
+				step="1"
+				bind:value={targetMaxDeg}
+				disabled={active || busy}
+				class="mt-1 block w-full border border-border bg-bg px-2 py-1.5 text-sm text-text disabled:cursor-not-allowed disabled:opacity-50"
+			/>
+		</label>
+
+		<label class="text-xs text-text">
+			Duration (seconds)
+			<input
+				type="number"
+				min="1"
+				step="1"
+				bind:value={durationSec}
+				disabled={active || busy}
+				class="mt-1 block w-full border border-border bg-bg px-2 py-1.5 text-sm text-text disabled:cursor-not-allowed disabled:opacity-50"
+			/>
+		</label>
+
+		<label class="flex items-center gap-2 text-xs text-text">
+			<input
+				type="checkbox"
+				bind:checked={useMaxSpeed}
+				disabled={active || busy}
+				class="h-3.5 w-3.5"
+			/>
+			Use operating speed ({operatingSpeed} µsteps/s)
+		</label>
+
+		<label class="flex items-center gap-2 text-xs text-text">
+			<input
+				type="checkbox"
+				bind:checked={invertDirection}
+				disabled={active || busy}
+				class="h-3.5 w-3.5"
+			/>
+			Invert direction
+		</label>
+
+		{#if !useMaxSpeed}
+			<label class="text-xs text-text">
+				Speed Override (µsteps/s)
+				<input
+					type="number"
+					min="1"
+					step="100"
+					bind:value={speedOverride}
+					disabled={active || busy}
+					class="mt-1 block w-full border border-border bg-bg px-2 py-1.5 text-sm text-text disabled:cursor-not-allowed disabled:opacity-50"
+				/>
+			</label>
+		{/if}
+
+		<div class="flex flex-col gap-2">
+			{#if !active}
+				<button
+					onclick={startRun}
+					disabled={busy}
+					class="inline-flex cursor-pointer items-center justify-center gap-1.5 border border-border bg-bg px-3 py-2 text-sm text-text transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
+				>
+					<Play size={14} />
+					{busy ? 'Starting...' : 'Start Stress Test'}
+				</button>
+			{:else}
+				{#if activeRun?.status === 'paused'}
+					<button
+						onclick={resumeRun}
+						disabled={busy}
+						class="inline-flex cursor-pointer items-center justify-center gap-1.5 border border-border bg-bg px-3 py-2 text-sm text-text transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						<Play size={14} />
+						{busy ? 'Resuming...' : 'Resume'}
+					</button>
+				{:else}
+					<button
+						onclick={pauseRun}
+						disabled={busy || activeRun?.status === 'stopping'}
+						class="inline-flex cursor-pointer items-center justify-center gap-1.5 border border-border bg-bg px-3 py-2 text-sm text-text transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						<Pause size={14} />
+						{busy ? 'Pausing...' : 'Pause'}
+					</button>
+				{/if}
+				<button
+					onclick={stopRun}
+					disabled={busy}
+					class="inline-flex cursor-pointer items-center justify-center gap-1.5 border border-danger bg-danger/20 px-3 py-2 text-sm text-danger transition-colors hover:bg-danger/30 disabled:cursor-not-allowed disabled:opacity-50"
+				>
+					<Square size={14} />
+					{busy ? 'Stopping...' : 'Stop'}
+				</button>
+			{/if}
+		</div>
+
+		{#if errorMsg}
+			<div class="text-sm text-danger dark:text-red-400">{errorMsg}</div>
+		{:else if statusMsg}
+			<div class="text-sm text-text-muted">{statusMsg}</div>
+		{/if}
+
+		<div class="flex flex-col gap-2 border-t border-border pt-3">
+			<div class="flex items-center justify-between">
+				<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+					Past Runs
+				</div>
+				<button
+					onclick={() => void loadRuns()}
+					class="cursor-pointer text-xs text-text-muted underline hover:text-text"
+				>
+					Refresh
+				</button>
+			</div>
+
+			{#if runs.length === 0}
+				<div class="text-sm text-text-muted">No stress runs recorded yet.</div>
+			{:else}
+				<div class="flex max-h-48 flex-col overflow-y-auto border border-border">
+					{#each runs as run (run.id)}
+						<button
+							onclick={() => (selectedRunId = selectedRunId === run.id ? null : run.id)}
+							class="flex items-center justify-between gap-2 border-b border-border px-2 py-1.5 text-left text-sm last:border-b-0 hover:bg-surface
+							{selectedRunId === run.id ? 'bg-surface' : ''}"
+						>
+							<span class="min-w-0 truncate text-text">
+								{formatTimestamp(run.started_at)}
+							</span>
+							<span class="shrink-0 text-xs {statusColor(run.status)}">
+								{statusLabel(run.status)}
+							</span>
+						</button>
+					{/each}
+				</div>
+			{/if}
+
+			{#if selectedRun}
+				<div class="border border-border bg-surface px-3 py-2 text-sm">
+					<div class="grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs text-text-muted">
+						<span>Started</span>
+						<span class="text-right text-text">{formatTimestamp(selectedRun.started_at)}</span>
+						<span>Ended</span>
+						<span class="text-right text-text">{formatTimestamp(selectedRun.ended_at)}</span>
+						<span>Mode</span>
+						<span class="text-right text-text">{selectedRun.mode}</span>
+						<span>Target max</span>
+						<span class="text-right text-text">{selectedRun.target_max_deg.toFixed(1)}°</span>
+						<span>Duration target</span>
+						<span class="text-right text-text">
+							{formatDuration(selectedRun.duration_target_s)}
+						</span>
+						<span>Time elapsed</span>
+						<span class="text-right text-text">{formatDuration(selectedRun.total_time_s)}</span>
+						<span>Distance</span>
+						<span class="text-right text-text">
+							{selectedRun.total_distance_deg.toFixed(1)}°
+						</span>
+						<span>Speed</span>
+						<span class="text-right text-text">
+							{selectedRun.speed_microsteps_per_sec} µsteps/s
+						</span>
+						<span>Status</span>
+						<span class="text-right {statusColor(selectedRun.status)}">
+							{statusLabel(selectedRun.status)}
+						</span>
+					</div>
+					{#if selectedRun.error}
+						<div class="mt-2 text-xs text-danger dark:text-red-400">
+							{selectedRun.error}
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/software/sorter/frontend/src/lib/components/setup/SetupHomingSection.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/SetupHomingSection.svelte
@@ -27,6 +27,7 @@
 		raw_endstop_high: boolean | null;
 		endstop_active_high: boolean | null;
 		endstop_error?: string;
+		stepper_direction_inverted: boolean | null;
 		current_angle: number | null;
 		stepper_position_degrees: number | null;
 		stepper_microsteps: number | null;
@@ -82,6 +83,7 @@
 		endstop_triggered: null,
 		raw_endstop_high: null,
 		endstop_active_high: null,
+		stepper_direction_inverted: null,
 		current_angle: null,
 		stepper_position_degrees: null,
 		stepper_microsteps: null,
@@ -250,6 +252,30 @@
 	async function flipChutePolarity() {
 		chuteEndstopActiveHigh = !chuteEndstopActiveHigh;
 		await saveChuteSettings();
+	}
+
+	async function flipChuteDirection() {
+		chuteSaving = true;
+		chuteError = null;
+		chuteStatus = '';
+		const current = chuteLive.stepper_direction_inverted ?? false;
+		try {
+			const res = await fetch(
+				`${currentBackendBaseUrl()}/api/setup-wizard/stepper-directions/chute`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ inverted: !current })
+				}
+			);
+			if (!res.ok) throw new Error(await res.text());
+			chuteStatus = `Chute direction set to ${!current ? 'inverted' : 'normal'}.`;
+			await loadChuteSettings();
+		} catch (e: any) {
+			chuteError = e.message ?? 'Failed to flip chute direction';
+		} finally {
+			chuteSaving = false;
+		}
 	}
 
 	async function cancelCarousel() {
@@ -642,21 +668,40 @@
 				</label>
 			</div>
 
-			<div class="mt-3">
-				<button
-					onclick={flipChutePolarity}
-					disabled={chuteSaving}
-					class="setup-button-secondary inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-text transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-				>
-					{chuteSaving
-						? 'Flipping…'
-						: 'Trigger state looks inverted? Flip polarity'}
-				</button>
-				<div class="mt-1 text-sm text-text-muted">
-					Currently treating the input as
-					<span class="font-medium text-text"
-						>{chuteEndstopActiveHigh ? 'active-high' : 'active-low'}</span
-					>.
+			<div class="mt-3 flex flex-col gap-2">
+				<div>
+					<button
+						onclick={flipChutePolarity}
+						disabled={chuteSaving}
+						class="setup-button-secondary inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-text transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+					>
+						{chuteSaving ? 'Saving…' : 'Trigger state looks inverted? Flip polarity'}
+					</button>
+					<div class="mt-1 text-sm text-text-muted">
+						Currently treating the input as
+						<span class="font-medium text-text"
+							>{chuteEndstopActiveHigh ? 'active-high' : 'active-low'}</span
+						>.
+					</div>
+				</div>
+				<div>
+					<button
+						onclick={flipChuteDirection}
+						disabled={chuteSaving}
+						class="setup-button-secondary inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-text transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+					>
+						{chuteSaving ? 'Saving…' : 'Chute moves the wrong way? Flip direction'}
+					</button>
+					<div class="mt-1 text-sm text-text-muted">
+						Stepper direction is currently
+						<span class="font-medium text-text">
+							{chuteLive.stepper_direction_inverted === null
+								? '--'
+								: chuteLive.stepper_direction_inverted
+									? 'inverted'
+									: 'normal'}
+						</span>.
+					</div>
 				</div>
 			</div>
 

--- a/software/sorter/frontend/src/lib/components/setup/SetupServoOnboardingSection.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/SetupServoOnboardingSection.svelte
@@ -86,6 +86,9 @@
 	let openAngleByLayer = $state<Record<number, string>>({});
 	let closedAngleByLayer = $state<Record<number, string>>({});
 
+	// estimated angle after nudge, per layer (1-based) for PCA where no feedback exists
+	let estimatedAngleByLayer = $state<Record<number, number>>({});
+
 	// per-servo UI state
 	let busyByServoId = $state<Record<number, string>>({}); // 'calibrating' | 'moving' | 'promoting'
 	let lastMoveByServoId = $state<Record<number, 'open' | 'close' | 'center'>>({});
@@ -409,6 +412,10 @@
 				const text = await res.text();
 				throw new Error(text);
 			}
+			const data = await res.json();
+			if (typeof data.new_angle === 'number') {
+				estimatedAngleByLayer = { ...estimatedAngleByLayer, [layerIdx]: Math.round(data.new_angle) };
+			}
 		} catch (e: any) {
 			errorMsg = e.message ?? `Failed to nudge layer ${layerIdx} servo`;
 		}
@@ -430,6 +437,10 @@
 			if (!res.ok) {
 				const text = await res.text();
 				throw new Error(text);
+			}
+			const data = await res.json();
+			if (typeof data.raw_position === 'number' && data.limits) {
+				busServos = busServos.map(s => s.id === servoId ? { ...s, position: data.raw_position } : s);
 			}
 		} catch (e: any) {
 			errorMsg = e.message ?? `Failed to nudge servo ${servoId}`;
@@ -658,9 +669,22 @@
 	</div>
 
 	{#if !settingsLoaded}
-		<div class="setup-panel px-4 py-6 text-center text-sm text-text-muted">
-			Loading servo configuration…
-		</div>
+		{#if errorMsg}
+			<div class="setup-panel border border-danger bg-primary-light px-4 py-4 text-sm text-[#7A0A0B]">
+				<div class="font-medium">Failed to load servo configuration</div>
+				<div class="mt-1">{errorMsg}</div>
+				<button
+					onclick={() => void loadSettings()}
+					class="mt-3 border border-danger px-3 py-1.5 text-sm font-medium text-[#7A0A0B] transition-colors hover:bg-danger/10"
+				>
+					Retry
+				</button>
+			</div>
+		{:else}
+			<div class="setup-panel px-4 py-6 text-center text-sm text-text-muted">
+				Loading servo configuration…
+			</div>
+		{/if}
 	{:else}
 	<div class="setup-panel p-4">
 		<div class="text-sm font-semibold text-text">Servo backend</div>
@@ -736,6 +760,7 @@
 			bind:closedAngleByLayer
 			bind:nudgeDegrees
 			{selectedLayerIdx}
+			{estimatedAngleByLayer}
 			onSetInvert={setInvertForLayer}
 			onNudgeLayer={(layerIdx, degrees) => void nudgeLayer(layerIdx, degrees)}
 			onSelectLayer={(layerIdx) => {

--- a/software/sorter/frontend/src/lib/components/setup/servo/PcaChannelMapping.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/servo/PcaChannelMapping.svelte
@@ -12,6 +12,7 @@
 		closedAngleByLayer = $bindable(),
 		nudgeDegrees = $bindable(),
 		selectedLayerIdx,
+		estimatedAngleByLayer,
 		onSetInvert,
 		onNudgeLayer,
 		onSelectLayer
@@ -26,6 +27,7 @@
 		closedAngleByLayer: Record<number, string>;
 		nudgeDegrees: number;
 		selectedLayerIdx: number | null;
+		estimatedAngleByLayer: Record<number, number>;
 		onSetInvert: (layerIdx: number, value: boolean) => void;
 		onNudgeLayer: (layerIdx: number, degrees: number) => void;
 		onSelectLayer: (layerIdx: number) => void;
@@ -178,6 +180,9 @@
 								>
 									{selectedLayerIdx === layerIdx ? '← → active' : 'keys'}
 								</button>
+								{#if estimatedAngleByLayer[layerIdx] !== undefined}
+									<span class="ml-1 text-sm font-medium text-text">{estimatedAngleByLayer[layerIdx]}°</span>
+								{/if}
 							</div>
 						</td>
 					</tr>

--- a/software/sorter/frontend/src/lib/components/setup/servo/ServoInventoryCard.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/servo/ServoInventoryCard.svelte
@@ -71,6 +71,16 @@
 	const layer = $derived(setup.layer);
 	const inverted = $derived(setup.inverted);
 	const isFactory = $derived(setup.isFactory);
+
+	const estimatedAngleDeg = $derived.by(() => {
+		const pos = servo.position;
+		const min = servo.min_limit;
+		const max = servo.max_limit;
+		if (pos == null || min == null || max == null) return null;
+		const range = max - min;
+		if (range < 20) return null;
+		return Math.round((pos - min) * 180 / range);
+	});
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -260,6 +270,9 @@
 					<span class="text-xs text-info">Selected — use ←/→ arrow keys</span>
 				{:else}
 					<span class="text-xs text-text-muted">Click card to use arrow keys</span>
+				{/if}
+				{#if estimatedAngleDeg !== null}
+					<span class="ml-2 text-sm font-medium text-text">{estimatedAngleDeg}°</span>
 				{/if}
 			</div>
 		{/if}

--- a/software/sorter/frontend/src/routes/+layout.svelte
+++ b/software/sorter/frontend/src/routes/+layout.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import './layout.css';
 	import MachinesProvider from '$lib/components/MachinesProvider.svelte';
 	import MachineProvider from '$lib/components/MachineProvider.svelte';
@@ -28,6 +28,15 @@
 		}
 	});
 
+	function reportClientError(payload: Record<string, unknown>) {
+		const base = `${window.location.protocol}//${window.location.hostname}:8000`;
+		fetch(`${base}/api/system/client-error`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(payload)
+		}).catch(() => {});
+	}
+
 	onMount(() => {
 		try {
 			const stored = window.localStorage.getItem('settings');
@@ -40,6 +49,26 @@
 			console.error(e);
 		}
 		void loadThemeColor();
+
+		window.addEventListener('error', (e) => {
+			reportClientError({
+				type: 'uncaught',
+				message: e.message,
+				source: e.filename,
+				lineno: e.lineno,
+				colno: e.colno,
+				stack: e.error?.stack
+			});
+		});
+
+		window.addEventListener('unhandledrejection', (e) => {
+			const reason = e.reason;
+			reportClientError({
+				type: 'unhandledrejection',
+				message: reason instanceof Error ? reason.message : String(reason),
+				stack: reason instanceof Error ? reason.stack : undefined
+			});
+		});
 	});
 </script>
 


### PR DESCRIPTION
## Summary

- **Chute stress test** — new backend subsystem and frontend panel in the stepper sidebar for running timed sweep/random stress cycles on the chute stepper. Persisted to SQLite (`chute_stress_runs` table, schema v4). Supports configurable speed, duration, max angle, and direction inversion. Sweep returns to `first_bin_center` instead of 0° to avoid jamming against the home stop.
- **Servo setup UX** — estimated angle now updates inline after each nudge; loading failures show an error panel with a retry button instead of silently staying on "Loading servo configuration…" forever.
- **Browser error reporter** — uncaught frontend errors and unhandled promise rejections POST to `/api/system/client-error` and appear in journalctl, so agent/developer visibility doesn't require browser devtools.
- **Brickognize debug dump** — gated by `BRICKOGNIZE_DUMP_IMAGES=1`; writes the exact JPEG payload POSTed to Brickognize under `software/logs/brickognize/<run_id>/<piece_uuid>/` for comparing what the API receives vs. what the tracked-page UI shows.
- **V4L2 camera controls fix** — manual camera controls (exposure, gain, etc.) now work correctly on Linux/V4L2.
