### PR TITLE
Remove ch3 per-detection dev-log from analyzeFeederChannels

### DIFF
--- a/software/sorter/backend/coordinator.py
+++ b/software/sorter/backend/coordinator.py
@@ -244,7 +244,7 @@ class Coordinator:
     def _channel_exit_state(self, channel: str) -> tuple[float, bool] | None:
         try:
             detections = self.vision.getFeederHeatmapDetections()
-            analysis = analyzeFeederChannels(self.gc, detections)
+            analysis = analyzeFeederChannels(detections)
         except Exception as exc:
             self.logger.warning(f"Coordinator: could not verify {channel} exit release: {exc}")
             return None

--- a/software/sorter/backend/subsystems/feeder/analysis.py
+++ b/software/sorter/backend/subsystems/feeder/analysis.py
@@ -1,10 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Dict, Tuple, TYPE_CHECKING
+from typing import Any, List, Dict, Tuple
 import numpy as np
-
-if TYPE_CHECKING:
-    from global_config import GlobalConfig
 
 from defs.consts import (
     CHANNEL_SECTION_DEG,
@@ -621,7 +618,6 @@ def _exitOverlapRatio(sections: set[int], exit_sections: set[int]) -> float:
 
 
 def analyzeFeederChannels(
-    gc: "GlobalConfig",
     detections: List[ChannelDetection],
     ignored_dropzone_detection_ids: set[tuple[int, int]] | None = None,
 ) -> FeederAnalysis:
@@ -637,24 +633,6 @@ def analyzeFeederChannels(
         )
 
         if det.channel_id == 3:
-            # DEV-LOG: remove before merge — per-detection dump used to diagnose
-            # empty exit_sections / dropzone_sections on ch3 tracks.
-            try:
-                _exit_sec = sorted(det.channel.exit_sections)
-                _drop_sec = sorted(det.channel.dropzone_sections)
-                x1, y1, x2, y2 = det.bbox
-                _bcx, _bcy = (x1 + x2) / 2.0, (y1 + y2) / 2.0
-                _exit_ov = _bboxExitOverlapRatio(det.bbox, det.channel)
-                _drop_ov = bboxSectionOverlapRatio(det.bbox, det.channel, det.channel.dropzone_sections)
-                gc.logger.info(
-                    f"[CH3-DET] gid={global_id} bbox=({x1},{y1},{x2},{y2}) center=({_bcx:.0f},{_bcy:.0f}) "
-                    f"bbox_sections={sorted(sections)} exit_sections={_exit_sec} dropzone_sections={_drop_sec} "
-                    f"exit_overlap={_exit_ov:.2f} drop_overlap={_drop_ov:.2f} "
-                    f"motion_confirmed={getattr(det, 'motion_confirmed', None)} "
-                    f"ch_center={det.channel.center} r1_angle={det.channel.radius1_angle_image:.1f}"
-                )
-            except Exception as _e:
-                gc.logger.warning(f"[CH3-DET] log failed: {_e}")
             drop_overlap = bboxSectionOverlapRatio(det.bbox, det.channel, det.channel.dropzone_sections)
             if drop_overlap > result.ch3_dropzone_overlap_max:
                 result.ch3_dropzone_overlap_max = drop_overlap

--- a/software/sorter/backend/subsystems/feeder/feeding.py
+++ b/software/sorter/backend/subsystems/feeder/feeding.py
@@ -804,7 +804,6 @@ class Feeding(BaseState):
 
             with prof.timer("feeder.analyze_state_ms"):
                 analysis = analyzeFeederChannels(
-                    self.gc,
                     detections,
                     ignored_dropzone_detection_ids=self._dropzone_incidents.ignored_detection_ids(),
                 )

--- a/software/sorter/backend/tests/test_dropzone_incidents.py
+++ b/software/sorter/backend/tests/test_dropzone_incidents.py
@@ -98,11 +98,10 @@ class DropzoneIncidentTests(unittest.TestCase):
         gc = SimpleNamespace()
         det = _detection()
 
-        blocked = analyzeFeederChannels(gc, [det])
+        blocked = analyzeFeederChannels([det])
         self.assertTrue(blocked.ch2_dropzone_occupied)
 
         ignored = analyzeFeederChannels(
-            gc,
             [det],
             ignored_dropzone_detection_ids={(2, 123)},
         )
@@ -113,7 +112,6 @@ class DropzoneIncidentTests(unittest.TestCase):
         gc = SimpleNamespace()
 
         unconfirmed = analyzeFeederChannels(
-            gc,
             [_exit_detection(motion_confirmed=False)],
         )
         self.assertEqual(0.0, unconfirmed.ch2_exit_overlap_max)
@@ -121,7 +119,6 @@ class DropzoneIncidentTests(unittest.TestCase):
         self.assertEqual(ChannelAction.PULSE_NORMAL, unconfirmed.ch2_action)
 
         confirmed = analyzeFeederChannels(
-            gc,
             [_exit_detection(motion_confirmed=True)],
         )
         self.assertGreater(confirmed.ch2_exit_overlap_max, 0.0)
@@ -158,7 +155,6 @@ class DropzoneIncidentTests(unittest.TestCase):
 
         manager.update([det], 8.2, rotating_channel_ids={2})
         analysis = analyzeFeederChannels(
-            gc,
             [det],
             ignored_dropzone_detection_ids=manager.ignored_detection_ids(),
         )


### PR DESCRIPTION
The [CH3-DET] block was a debug dump added to diagnose empty exit/dropzone sections — the comment said "remove before merge." With 4+ tracked objects at 50 Hz it was firing 200+ times/second, each formatting sorted() arrays of 80–130 section IDs. Removed the block and dropped the now-unused gc parameter from analyzeFeederChannels.