### PR TITLE
Use full git clone in SorterOS firstboot

### DIFF
--- a/software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py
+++ b/software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py
@@ -276,8 +276,8 @@ def stage_clone_repo() -> None:
         return
     branch_file = Path("/etc/sorteros/branch")
     branch = branch_file.read_text().strip() if branch_file.exists() else "main"
-    sh(["git", "clone", "--branch", branch, "--depth", "1",
-        "https://github.com/basicallysource/sorter-v2", str(REPO_DIR)])
+    sh(["git", "clone", "https://github.com/basicallysource/sorter-v2", str(REPO_DIR)])
+    sh(["git", "-C", str(REPO_DIR), "checkout", branch])
     sh(["git", "config", "--global", "--add", "safe.directory", str(REPO_DIR)])
 
 


### PR DESCRIPTION
## Summary
- change SorterOS firstboot repo setup from a shallow branch clone to a normal full clone
- checkout the configured branch after cloning so /etc/sorteros/branch still controls the initial ref
- leave the resulting checkout as a regular git repository that can switch branches normally

## Testing
- /opt/homebrew/opt/python@3.11/libexec/bin/python -m py_compile software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py