### PR TITLE
Bump SorterOS to v3.4.5

### DIFF
--- a/software/sorteros/build-dashboard/README.md
+++ b/software/sorteros/build-dashboard/README.md
@@ -37,7 +37,7 @@ colima start --arch aarch64 --cpu 4 --memory 8 --disk 60 \
 # Start a build
 curl -X POST http://localhost:7373/build \
   -H 'Content-Type: application/json' \
-  -d '{"version": "3.4.4", "branch": "sorteros-v3"}'
+  -d '{"version": "3.4.5", "branch": "sorteros-v3"}'
 
 # Poll status
 curl http://localhost:7373/build/status

--- a/software/sorteros/build/config.toml
+++ b/software/sorteros/build/config.toml
@@ -9,7 +9,7 @@ sha256 = ""  # fill in when known
 
 [output]
 dir = "out"
-version = "3.4.4"
+version = "3.4.5"
 name = "sorteros-v{version}-{date}.img"
 
 [chroot]


### PR DESCRIPTION
## Summary
- bump the SorterOS build version to 3.4.5
- update the build-dashboard README example payload to match

## Testing
- /opt/homebrew/opt/python@3.11/libexec/bin/python software/sorteros/build/test_marker_roundtrip.py
- local SorterOS image build in progress for v3.4.5