### PR TITLE
flash.py: handle RPI-RP2 block device not yet mounted on Linux

### DIFF
--- a/software/firmware/sorter_interface_firmware/flash.py
+++ b/software/firmware/sorter_interface_firmware/flash.py
@@ -19,6 +19,7 @@ PICO_VID = 0x2E8A
 PICO_PID = 0x000A
 CMD_INIT = 0x00
 CMD_REBOOT_BOOTLOADER = 0x02
+CMD_GET_VERSION = 0x04
 
 
 def _cobs_encode(message: bytes) -> bytearray:
@@ -168,6 +169,9 @@ def main() -> None:
     # Check if board is already in bootloader mode before scanning serial ports
     if _find_rpi_rp2():
         print(f"RPI-RP2 already mounted in bootloader mode — flashing directly.")
+        target_port = None
+    elif platform.system() != "Darwin" and _find_rpi_rp2_blockdev():
+        print(f"RPI-RP2 block device found (not yet mounted) — flashing directly.")
         target_port = None
     else:
         print("Scanning for Pico boards...")


### PR DESCRIPTION
## Summary
- Fixes a case where `flash.py` bails with "No Pico boards found over USB" on Linux when the Pico is already in bootloader mode but the RPI-RP2 volume hasn't been auto-mounted yet (block device exists at e.g. `/dev/sda1` but no mount point)
- Adds a `_find_rpi_rp2_blockdev()` check before falling through to serial port scanning

## Test plan
- [ ] Reproduce: reboot Pico to bootloader, run `flash.py` before OS auto-mounts — previously failed, now flashes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)