### PR TITLE
hive: resilient, resumable catalog sync with admin dashboard

### DIFF
--- a/software/hive/backend/app/routers/profiles.py
+++ b/software/hive/backend/app/routers/profiles.py
@@ -86,7 +86,7 @@ def _build_ai_usage_payload(proposal_result: AiProposalResult) -> dict[str, obje
 
 @router.get("/profile-catalog/status")
 def get_profile_catalog_status(
-    _current_user: User = Depends(require_role("reviewer", "admin")),
+    _current_user: User = Depends(require_role("admin")),
 ):
     return get_profile_catalog_service().status()
 
@@ -94,7 +94,7 @@ def get_profile_catalog_status(
 @router.post("/profile-catalog/sync/{sync_type}")
 def start_profile_catalog_sync(
     sync_type: str,
-    _current_user: User = Depends(require_role("reviewer", "admin")),
+    _current_user: User = Depends(require_role("admin")),
     _csrf: None = Depends(verify_csrf),
 ):
     if sync_type not in CATALOG_SYNC_TYPES:
@@ -111,7 +111,7 @@ def start_profile_catalog_sync(
 
 @router.post("/profile-catalog/stop")
 def stop_profile_catalog_sync(
-    _current_user: User = Depends(require_role("reviewer", "admin")),
+    _current_user: User = Depends(require_role("admin")),
     _csrf: None = Depends(verify_csrf),
 ):
     get_profile_catalog_service().stop_sync()

--- a/software/hive/backend/app/services/profile_catalog.py
+++ b/software/hive/backend/app/services/profile_catalog.py
@@ -53,6 +53,9 @@ class ProfileCatalogService:
         self._conn = profile_db.initDb(self._config.db_path)
         self._parts_data = profile_db.PartsData()
         profile_db.reloadPartsData(self._conn, self._parts_data)
+        # A sync row still marked 'running' means a prior process died mid-sync;
+        # flag it 'interrupted' so the UI offers a resume instead of a dead bar.
+        profile_db.markRunningSyncsInterrupted(self._conn)
         self._sync = profile_parts_cache.SyncManager()
         self._auto_sync_state_lock = Lock()
         self._auto_sync_stop_event = Event()
@@ -81,7 +84,43 @@ class ProfileCatalogService:
             status["auto_sync_last_checked_at"] = self._auto_sync_last_checked_at
             status["auto_sync_last_started_at"] = self._auto_sync_last_started_at
         status["last_synced_at"] = self.get_last_synced_at_map()
+        status["types"] = self._build_types_status(status.get("sync_type"))
         return status
+
+    def _build_types_status(self, running_type: str | None) -> dict[str, dict[str, Any]]:
+        persisted = profile_db.getAllCatalogSyncStates(self._conn)
+        cached_counts = {
+            "categories": len(self._parts_data.categories),
+            "colors": len(self._parts_data.colors),
+            "parts": len(self._parts_data.parts),
+        }
+        types: dict[str, dict[str, Any]] = {}
+        for sync_type in PROFILE_CATALOG_SYNC_TYPES:
+            state = dict(
+                persisted.get(sync_type)
+                or {
+                    "sync_type": sync_type,
+                    "status": "idle",
+                    "progress_current": None,
+                    "progress_total": None,
+                    "pages_fetched": 0,
+                    "last_message": None,
+                    "error": None,
+                    "started_at": None,
+                    "updated_at": None,
+                    "completed_at": None,
+                }
+            )
+            # The live thread is the source of truth for "is this one running now";
+            # persisted status can lag a tick behind a fresh start/stop.
+            if running_type == sync_type:
+                state["status"] = "running"
+            elif state["status"] == "running":
+                state["status"] = "interrupted"
+            state["cached_count"] = cached_counts.get(sync_type)
+            state["last_synced_at"] = self.get_last_synced_at(sync_type)
+            types[sync_type] = state
+        return types
 
     def start_sync(self, sync_type: str) -> bool:
         with self._lock:

--- a/software/hive/backend/app/services/profile_engine/db.py
+++ b/software/hive/backend/app/services/profile_engine/db.py
@@ -471,6 +471,66 @@ def getMeta(conn, key):
     return row[0] if row else None
 
 
+# --- catalog sync state (durable, survives restart) ---
+
+CATALOG_SYNC_STATE_COLUMNS = (
+    "status", "progress_current", "progress_total", "pages_fetched",
+    "last_message", "error", "started_at", "updated_at", "completed_at",
+)
+_CATALOG_SYNC_STATE_SELECT = (
+    "SELECT sync_type, status, progress_current, progress_total, pages_fetched, "
+    "last_message, error, started_at, updated_at, completed_at FROM catalog_sync_state"
+)
+
+
+def _rowToCatalogSyncState(row):
+    return {
+        "sync_type": row[0],
+        "status": row[1],
+        "progress_current": row[2],
+        "progress_total": row[3],
+        "pages_fetched": row[4],
+        "last_message": row[5],
+        "error": row[6],
+        "started_at": row[7],
+        "updated_at": row[8],
+        "completed_at": row[9],
+    }
+
+
+def upsertCatalogSyncState(conn, sync_type, **fields):
+    conn.execute("INSERT OR IGNORE INTO catalog_sync_state (sync_type) VALUES (?)", (sync_type,))
+    cols = [c for c in CATALOG_SYNC_STATE_COLUMNS if c in fields]
+    if cols:
+        assignments = ", ".join(f"{c}=?" for c in cols)
+        params = [fields[c] for c in cols] + [sync_type]
+        conn.execute(f"UPDATE catalog_sync_state SET {assignments} WHERE sync_type=?", params)
+    conn.commit()
+
+
+def getCatalogSyncState(conn, sync_type):
+    row = conn.execute(
+        f"{_CATALOG_SYNC_STATE_SELECT} WHERE sync_type=?", (sync_type,)
+    ).fetchone()
+    return _rowToCatalogSyncState(row) if row else None
+
+
+def getAllCatalogSyncStates(conn):
+    rows = conn.execute(_CATALOG_SYNC_STATE_SELECT).fetchall()
+    return {row[0]: _rowToCatalogSyncState(row) for row in rows}
+
+
+def markRunningSyncsInterrupted(conn):
+    # A row left in 'running' means the process died mid-sync; surface that so the
+    # UI can offer a resume rather than showing a stuck-forever "running".
+    conn.execute(
+        "UPDATE catalog_sync_state SET status='interrupted', "
+        "last_message='Interrupted by server restart — start again to resume' "
+        "WHERE status='running'"
+    )
+    conn.commit()
+
+
 # --- brickstore db import ---
 
 def importBrickstoreDb(conn, brickstore_db_path):

--- a/software/hive/backend/app/services/profile_engine/migrations/007_catalog_sync_state.sql
+++ b/software/hive/backend/app/services/profile_engine/migrations/007_catalog_sync_state.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS catalog_sync_state (
+    sync_type TEXT PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'idle',
+    progress_current INTEGER,
+    progress_total INTEGER,
+    pages_fetched INTEGER NOT NULL DEFAULT 0,
+    last_message TEXT,
+    error TEXT,
+    started_at TEXT,
+    updated_at TEXT,
+    completed_at TEXT
+)

--- a/software/hive/backend/app/services/profile_engine/parts_cache.py
+++ b/software/hive/backend/app/services/profile_engine/parts_cache.py
@@ -1,16 +1,76 @@
 import os
 import threading
 import time
+from datetime import datetime, timezone
+
 import requests
 
 from .db import (
     upsertCategories, upsertColors, upsertParts, setMeta,
-    reloadPartsData, importBrickstoreDb, syncBricklinkPrices, PartsData,
+    upsertCatalogSyncState, reloadPartsData, importBrickstoreDb,
+    syncBricklinkPrices, PartsData,
 )
 
 REBRICKABLE_BASE_URL = "https://rebrickable.com/api/v3/lego"
 REBRICKABLE_PAGE_SIZE = 1000
 THROTTLE_SECONDS = 1.1
+REQUEST_TIMEOUT_SECONDS = 30
+# Transient HTTP statuses worth retrying rather than aborting a long sync.
+RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+RETRY_BACKOFF_SCHEDULE = (2, 5, 15, 30, 60)
+MAX_REQUEST_RETRIES = len(RETRY_BACKOFF_SCHEDULE)
+
+
+def _nowIso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _interruptibleSleep(seconds: float, should_stop=None) -> None:
+    slept = 0.0
+    while slept < seconds:
+        if should_stop and should_stop():
+            return
+        chunk = min(1.0, seconds - slept)
+        time.sleep(chunk)
+        slept += chunk
+
+
+def _requestJson(url, params, throttle_fn, should_stop=None, on_retry=None):
+    # Retries transient failures (rate limits, 5xx, network blips) with backoff so
+    # a single hiccup doesn't kill a multi-minute paginated sync. The throttle keeps
+    # us under Rebrickable's steady-state rate; this handles the spikes.
+    attempt = 0
+    while True:
+        throttle_fn()
+        resp = None
+        retryable = True
+        error: Exception | None = None
+        try:
+            resp = requests.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+        except requests.RequestException as exc:
+            error = exc
+        else:
+            if resp.ok:
+                return resp.json()
+            retryable = resp.status_code in RETRYABLE_STATUSES
+            error = requests.HTTPError(
+                f"{resp.status_code} {resp.reason} for url: {resp.url}", response=resp
+            )
+
+        if not retryable or attempt >= MAX_REQUEST_RETRIES:
+            raise error
+
+        delay = RETRY_BACKOFF_SCHEDULE[min(attempt, len(RETRY_BACKOFF_SCHEDULE) - 1)]
+        if resp is not None:
+            retry_after = resp.headers.get("Retry-After")
+            if retry_after and retry_after.isdigit():
+                delay = max(delay, int(retry_after))
+        attempt += 1
+        if on_retry:
+            on_retry(f"Transient error ({error}); retry {attempt}/{MAX_REQUEST_RETRIES} in {delay}s")
+        _interruptibleSleep(delay, should_stop)
+        if should_stop and should_stop():
+            raise error
 
 
 class SyncManager:
@@ -70,6 +130,7 @@ class SyncManager:
             self.sync_type = "parts"
             self.error = None
             self.last_message = "Starting parts sync..."
+            self._markRunning(conn, "parts")
         t = threading.Thread(target=self._syncPartsLoop, args=(gc, conn, parts_data, on_complete, on_error), daemon=True)
         t.start()
         return True
@@ -86,6 +147,7 @@ class SyncManager:
             self.sync_type = "categories"
             self.error = None
             self.last_message = "Syncing categories..."
+            self._markRunning(conn, "categories")
         t = threading.Thread(target=self._syncCategoriesOnce, args=(gc, conn, parts_data, on_complete, on_error), daemon=True)
         t.start()
         return True
@@ -102,6 +164,7 @@ class SyncManager:
             self.sync_type = "colors"
             self.error = None
             self.last_message = "Syncing colors..."
+            self._markRunning(conn, "colors")
         t = threading.Thread(target=self._syncColorsOnce, args=(gc, conn, parts_data, on_complete, on_error), daemon=True)
         t.start()
         return True
@@ -118,6 +181,7 @@ class SyncManager:
             self.sync_type = "brickstore"
             self.error = None
             self.last_message = "Importing BrickStore DB..."
+            self._markRunning(conn, "brickstore")
         t = threading.Thread(target=self._importBrickstoreOnce, args=(gc, conn, parts_data, on_complete, on_error), daemon=True)
         t.start()
         return True
@@ -137,6 +201,7 @@ class SyncManager:
             self.sync_type = "prices"
             self.error = None
             self.last_message = "Starting BrickLink price sync..."
+            self._markRunning(conn, "prices")
         t = threading.Thread(target=self._syncPricesLoop, args=(gc, conn, parts_data, on_complete, on_error), daemon=True)
         t.start()
         return True
@@ -148,6 +213,32 @@ class SyncManager:
             callback(*args)
         except Exception as exc:
             print(f"[sync] callback failed: {exc}")
+
+    def _persist(self, conn, sync_type, **fields) -> None:
+        fields.setdefault("updated_at", _nowIso())
+        try:
+            upsertCatalogSyncState(conn, sync_type, **fields)
+        except Exception as exc:
+            print(f"[sync] failed to persist {sync_type} state: {exc}")
+
+    def _note(self, conn, sync_type, message) -> None:
+        with self._lock:
+            self.last_message = message
+        self._persist(conn, sync_type, last_message=message)
+
+    def _markRunning(self, conn, sync_type) -> None:
+        self._persist(
+            conn,
+            sync_type,
+            status="running",
+            started_at=_nowIso(),
+            pages_fetched=self.pages_fetched,
+            progress_current=self.progress_current,
+            progress_total=self.progress_total,
+            last_message=self.last_message,
+            error=None,
+            completed_at=None,
+        )
 
     def _throttle(self):
         elapsed = time.time() - self._last_request_time
@@ -163,17 +254,32 @@ class SyncManager:
                 with self._lock:
                     if self.stop_requested:
                         self.last_message = f"Stopped after {self.pages_fetched} pages"
+                        self._persist(conn, "parts", status="stopped", last_message=self.last_message)
                         break
-                result = _syncPartsPage(gc, conn, parts_data, self._throttle)
+                result = _syncPartsPage(
+                    gc, conn, parts_data, self._throttle,
+                    should_stop=self._shouldStop,
+                    on_retry=lambda msg: self._note(conn, "parts", msg),
+                )
                 with self._lock:
                     self.pages_fetched += 1
                     pct = round((result["cached"] / result["total"]) * 100) if result["total"] else 0
                     self.progress_current = result["cached"]
                     self.progress_total = result["total"]
                     self.last_message = f'{result["cached"]} / {result["total"]} parts ({pct}%)'
+                    self._persist(
+                        conn, "parts", status="running", error=None,
+                        progress_current=result["cached"], progress_total=result["total"],
+                        pages_fetched=self.pages_fetched, last_message=self.last_message,
+                    )
                 if result["done"]:
                     with self._lock:
                         self.last_message = f'Sync complete! {result["cached"]} parts'
+                        self._persist(
+                            conn, "parts", status="completed", completed_at=_nowIso(),
+                            progress_current=result["cached"], progress_total=result["total"],
+                            last_message=self.last_message, error=None,
+                        )
                     reloadPartsData(conn, parts_data)
                     self._invoke_callback(on_complete)
                     break
@@ -181,6 +287,7 @@ class SyncManager:
             with self._lock:
                 self.error = str(e)
                 self.last_message = f"Error: {e}"
+                self._persist(conn, "parts", status="error", error=str(e), last_message=self.last_message)
             self._invoke_callback(on_error, e)
         finally:
             with self._lock:
@@ -190,15 +297,25 @@ class SyncManager:
 
     def _syncCategoriesOnce(self, gc, conn, parts_data, on_complete=None, on_error=None) -> None:
         try:
-            count = _syncCategories(gc, conn, self._throttle)
+            count = _syncCategories(
+                gc, conn, self._throttle,
+                should_stop=self._shouldStop,
+                on_retry=lambda msg: self._note(conn, "categories", msg),
+            )
             reloadPartsData(conn, parts_data)
             with self._lock:
                 self.last_message = f"Synced {count} categories"
+                self._persist(
+                    conn, "categories", status="completed", completed_at=_nowIso(),
+                    progress_current=count, progress_total=count,
+                    last_message=self.last_message, error=None,
+                )
             self._invoke_callback(on_complete)
         except Exception as e:
             with self._lock:
                 self.error = str(e)
                 self.last_message = f"Error: {e}"
+                self._persist(conn, "categories", status="error", error=str(e), last_message=self.last_message)
             self._invoke_callback(on_error, e)
         finally:
             with self._lock:
@@ -207,15 +324,25 @@ class SyncManager:
 
     def _syncColorsOnce(self, gc, conn, parts_data, on_complete=None, on_error=None) -> None:
         try:
-            count = _syncColors(gc, conn, self._throttle)
+            count = _syncColors(
+                gc, conn, self._throttle,
+                should_stop=self._shouldStop,
+                on_retry=lambda msg: self._note(conn, "colors", msg),
+            )
             reloadPartsData(conn, parts_data)
             with self._lock:
                 self.last_message = f"Synced {count} colors"
+                self._persist(
+                    conn, "colors", status="completed", completed_at=_nowIso(),
+                    progress_current=count, progress_total=count,
+                    last_message=self.last_message, error=None,
+                )
             self._invoke_callback(on_complete)
         except Exception as e:
             with self._lock:
                 self.error = str(e)
                 self.last_message = f"Error: {e}"
+                self._persist(conn, "colors", status="error", error=str(e), last_message=self.last_message)
             self._invoke_callback(on_error, e)
         finally:
             with self._lock:
@@ -233,11 +360,16 @@ class SyncManager:
                     f"Imported {result['categories']} categories, "
                     f"{result['items']} items ({result['skipped']} skipped)"
                 )
+                self._persist(
+                    conn, "brickstore", status="completed", completed_at=_nowIso(),
+                    last_message=self.last_message, error=None,
+                )
             self._invoke_callback(on_complete)
         except Exception as e:
             with self._lock:
                 self.error = str(e)
                 self.last_message = f"Error: {e}"
+                self._persist(conn, "brickstore", status="error", error=str(e), last_message=self.last_message)
             self._invoke_callback(on_error, e)
         finally:
             with self._lock:
@@ -260,10 +392,19 @@ class SyncManager:
                         f"Stopped price sync: {result['updated']} / {result['total']} updated "
                         f"({result['batches']} batches)"
                     )
+                    self._persist(
+                        conn, "prices", status="stopped", last_message=self.last_message,
+                        progress_current=result["updated"], progress_total=result["total"],
+                    )
                 else:
                     self.last_message = (
                         f"Price sync complete: {result['updated']} / {result['total']} updated "
                         f"({result['batches']} batches)"
+                    )
+                    self._persist(
+                        conn, "prices", status="completed", completed_at=_nowIso(),
+                        last_message=self.last_message, error=None,
+                        progress_current=result["updated"], progress_total=result["total"],
                     )
             if not result["stopped"]:
                 self._invoke_callback(on_complete)
@@ -271,6 +412,7 @@ class SyncManager:
             with self._lock:
                 self.error = str(e)
                 self.last_message = f"Error: {e}"
+                self._persist(conn, "prices", status="error", error=str(e), last_message=self.last_message)
             self._invoke_callback(on_error, e)
         finally:
             with self._lock:
@@ -289,12 +431,12 @@ class SyncManager:
             self.last_message = message
 
 
-def _syncCategories(gc, conn, throttle_fn):
-    throttle_fn()
+def _syncCategories(gc, conn, throttle_fn, should_stop=None, on_retry=None):
     url = f"{REBRICKABLE_BASE_URL}/part_categories/"
-    resp = requests.get(url, params={"key": gc.rebrickable_api_key, "page_size": 1000})
-    resp.raise_for_status()
-    data = resp.json()
+    data = _requestJson(
+        url, {"key": gc.rebrickable_api_key, "page_size": 1000},
+        throttle_fn, should_stop=should_stop, on_retry=on_retry,
+    )
     cat_list = []
     for cat_data in data.get("results", []):
         cat_list.append({
@@ -306,12 +448,12 @@ def _syncCategories(gc, conn, throttle_fn):
     return len(cat_list)
 
 
-def _syncColors(gc, conn, throttle_fn):
-    throttle_fn()
+def _syncColors(gc, conn, throttle_fn, should_stop=None, on_retry=None):
     url = f"{REBRICKABLE_BASE_URL}/colors/"
-    resp = requests.get(url, params={"key": gc.rebrickable_api_key, "page_size": 1000})
-    resp.raise_for_status()
-    data = resp.json()
+    data = _requestJson(
+        url, {"key": gc.rebrickable_api_key, "page_size": 1000},
+        throttle_fn, should_stop=should_stop, on_retry=on_retry,
+    )
     color_list = []
     for color_data in data.get("results", []):
         color_list.append(color_data)
@@ -319,18 +461,24 @@ def _syncColors(gc, conn, throttle_fn):
     return len(color_list)
 
 
-def _syncPartsPage(gc, conn, parts_data, throttle_fn):
-    throttle_fn()
-    page_num = (len(parts_data.parts) // REBRICKABLE_PAGE_SIZE) + 1
+def _syncPartsPage(gc, conn, parts_data, throttle_fn, should_stop=None, on_retry=None):
+    # Page must advance off the persisted DB count, not parts_data.parts: the
+    # in-memory cache is only refreshed by reloadPartsData() after the whole
+    # sync finishes, so deriving the page from it pins page_num at 1 and
+    # re-fetches page 1 forever (which Rebrickable eventually 429s).
+    cached_before = conn.execute("SELECT COUNT(*) FROM parts").fetchone()[0]
+    page_num = (cached_before // REBRICKABLE_PAGE_SIZE) + 1
     url = f"{REBRICKABLE_BASE_URL}/parts/"
-    resp = requests.get(url, params={
-        "key": gc.rebrickable_api_key,
-        "page_size": REBRICKABLE_PAGE_SIZE,
-        "inc_part_details": 1,
-        "page": page_num,
-    })
-    resp.raise_for_status()
-    data = resp.json()
+    data = _requestJson(
+        url,
+        {
+            "key": gc.rebrickable_api_key,
+            "page_size": REBRICKABLE_PAGE_SIZE,
+            "inc_part_details": 1,
+            "page": page_num,
+        },
+        throttle_fn, should_stop=should_stop, on_retry=on_retry,
+    )
     total = data["count"]
     parts_list = []
     for part_data in data.get("results", []):

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -407,6 +407,31 @@ export interface SortingProfileAiMessage {
 	created_at: string;
 }
 
+export type CatalogSyncType = 'categories' | 'colors' | 'parts' | 'brickstore' | 'prices';
+
+export type CatalogSyncStatus =
+	| 'idle'
+	| 'running'
+	| 'completed'
+	| 'error'
+	| 'interrupted'
+	| 'stopped';
+
+export interface CatalogSyncTypeState {
+	sync_type: string;
+	status: CatalogSyncStatus;
+	progress_current: number | null;
+	progress_total: number | null;
+	pages_fetched: number;
+	last_message: string | null;
+	error: string | null;
+	started_at: string | null;
+	updated_at: string | null;
+	completed_at: string | null;
+	cached_count: number | null;
+	last_synced_at: string | null;
+}
+
 export interface ProfileCatalogStatus {
 	running: boolean;
 	last_message: string;
@@ -427,6 +452,7 @@ export interface ProfileCatalogStatus {
 	auto_sync_last_checked_at: string | null;
 	auto_sync_last_started_at: string | null;
 	last_synced_at: Record<string, string | null>;
+	types: Record<string, CatalogSyncTypeState>;
 }
 
 export interface ProfileCatalogSearchResult {
@@ -745,7 +771,7 @@ export const api = {
 	getProfileCatalogStatus() {
 		return request<ProfileCatalogStatus>('GET', '/api/profile-catalog/status');
 	},
-	startProfileCatalogSync(syncType: 'categories' | 'colors' | 'parts' | 'brickstore' | 'prices') {
+	startProfileCatalogSync(syncType: CatalogSyncType) {
 		return request<{ started: boolean }>('POST', `/api/profile-catalog/sync/${syncType}`);
 	},
 	stopProfileCatalogSync() {

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -161,6 +161,16 @@
 										</svg>
 										Teacher Jobs
 									</a>
+									<a
+										href="/settings/catalog-sync"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										onclick={() => { dropdownOpen = false; }}
+									>
+										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+										</svg>
+										Catalog Sync
+									</a>
 								{/if}
 
 								<div class="border-t border-[var(--color-border)] my-1"></div>

--- a/software/hive/frontend/src/routes/settings/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/+page.svelte
@@ -520,6 +520,21 @@
 		</div>
 
 		{#if auth.user.role === 'admin'}
+			<!-- Catalog sync dashboard (admin-only dedicated page) -->
+			<div class="border border-border bg-white p-6">
+				<h2 class="mb-2 font-semibold text-text">Catalog Sync</h2>
+				<p class="mb-4 text-sm text-text-muted">
+					Sync the Rebrickable parts / categories / colors catalog and BrickLink prices, with
+					live progress and resume-after-restart.
+				</p>
+				<a
+					href="/settings/catalog-sync"
+					class="inline-flex items-center gap-2 border border-border bg-bg px-4 py-2 text-sm font-medium text-text hover:bg-surface"
+				>
+					Open Catalog Sync →
+				</a>
+			</div>
+
 			<!-- Perceptron native API key (teacher-only, admin scope) -->
 			<div class="border border-border bg-white p-6">
 				<h2 class="mb-4 font-semibold text-text">Perceptron Teacher</h2>

--- a/software/hive/frontend/src/routes/settings/catalog-sync/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/catalog-sync/+page.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { auth } from '$lib/auth.svelte';
+	import {
+		api,
+		type ProfileCatalogStatus,
+		type CatalogSyncType,
+		type CatalogSyncStatus,
+		type CatalogSyncTypeState
+	} from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import Badge from '$lib/components/Badge.svelte';
+	import { Button, Alert } from '$lib/components/primitives';
+
+	const REFRESH_MS = 2000;
+
+	const TYPE_ORDER: CatalogSyncType[] = ['parts', 'categories', 'colors', 'prices', 'brickstore'];
+	const TYPE_LABELS: Record<CatalogSyncType, string> = {
+		parts: 'Parts',
+		categories: 'Categories',
+		colors: 'Colors',
+		prices: 'BrickLink Prices',
+		brickstore: 'BrickStore Import'
+	};
+	const TYPE_BLURBS: Record<CatalogSyncType, string> = {
+		parts: 'Full part catalog from Rebrickable (largest sync — paginated, resumable).',
+		categories: 'Rebrickable part categories.',
+		colors: 'Rebrickable color list.',
+		prices: 'BrickLink affiliate price guide (requires BL_AFFILIATE_API_KEY).',
+		brickstore: 'Import from a local BrickStore database file.'
+	};
+
+	let status = $state<ProfileCatalogStatus | null>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let actionError = $state<string | null>(null);
+	let busy = $state<CatalogSyncType | 'stop' | null>(null);
+	let timer: ReturnType<typeof setInterval> | null = null;
+
+	$effect(() => {
+		if (!auth.isAdmin) {
+			goto('/');
+			return;
+		}
+		void load();
+		timer = setInterval(load, REFRESH_MS);
+		return () => {
+			if (timer) clearInterval(timer);
+		};
+	});
+
+	onDestroy(() => {
+		if (timer) clearInterval(timer);
+	});
+
+	function errText(e: unknown): string {
+		return e && typeof e === 'object' && 'error' in e
+			? String((e as { error: unknown }).error)
+			: 'Request failed';
+	}
+
+	async function load() {
+		try {
+			status = await api.getProfileCatalogStatus();
+			error = null;
+		} catch (e: unknown) {
+			error = errText(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function startSync(type: CatalogSyncType) {
+		actionError = null;
+		busy = type;
+		try {
+			await api.startProfileCatalogSync(type);
+			await load();
+		} catch (e: unknown) {
+			actionError = errText(e);
+		} finally {
+			busy = null;
+		}
+	}
+
+	async function stopSync() {
+		actionError = null;
+		busy = 'stop';
+		try {
+			await api.stopProfileCatalogSync();
+			await load();
+		} catch (e: unknown) {
+			actionError = errText(e);
+		} finally {
+			busy = null;
+		}
+	}
+
+	function badgeVariant(s: CatalogSyncStatus): 'success' | 'warning' | 'danger' | 'info' | 'neutral' {
+		if (s === 'running') return 'info';
+		if (s === 'completed') return 'success';
+		if (s === 'error') return 'danger';
+		if (s === 'interrupted') return 'warning';
+		return 'neutral';
+	}
+
+	function actionLabel(s: CatalogSyncStatus): string {
+		if (s === 'interrupted' || s === 'stopped' || s === 'error') return 'Resume';
+		if (s === 'completed') return 'Re-sync';
+		return 'Sync';
+	}
+
+	function pct(state: CatalogSyncTypeState): number | null {
+		if (!state.progress_total || state.progress_total <= 0) return null;
+		const current = state.progress_current ?? 0;
+		return Math.min(100, Math.round((current / state.progress_total) * 100));
+	}
+
+	function fmtTime(iso: string | null): string {
+		if (!iso) return 'never';
+		const d = new Date(iso);
+		if (Number.isNaN(d.getTime())) return iso;
+		return d.toLocaleString();
+	}
+
+	let anyRunning = $derived(status?.running ?? false);
+	let orderedTypes = $derived(
+		status ? TYPE_ORDER.filter((t) => status!.types[t]).map((t) => [t, status!.types[t]] as const) : []
+	);
+</script>
+
+<svelte:head><title>Catalog Sync · Hive</title></svelte:head>
+
+<div class="mx-auto max-w-3xl px-4 py-8">
+	<div class="mb-6 flex items-center justify-between">
+		<div>
+			<a href="/settings" class="text-sm text-text-muted hover:text-text">← Settings</a>
+			<h1 class="mt-1 text-2xl font-bold text-text">Catalog Sync</h1>
+			<p class="text-sm text-text-muted">
+				Manage the Rebrickable / BrickLink catalog. Syncs resume where they left off — if the
+				server restarts mid-sync, just start the same one again.
+			</p>
+		</div>
+	</div>
+
+	{#if error}
+		<div class="mb-4"><Alert variant="danger">{error}</Alert></div>
+	{/if}
+	{#if actionError}
+		<div class="mb-4"><Alert variant="danger">{actionError}</Alert></div>
+	{/if}
+
+	{#if loading && !status}
+		<Spinner />
+	{:else if status}
+		<div class="mb-6 border border-border bg-bg p-4 text-sm text-text-muted">
+			<div class="flex flex-wrap gap-x-6 gap-y-1">
+				<span>
+					Auto-sync:
+					<span class="font-medium text-text">{status.auto_sync_enabled ? 'on' : 'off'}</span>
+				</span>
+				<span>
+					Currently running:
+					<span class="font-medium text-text">{status.sync_type ?? 'nothing'}</span>
+				</span>
+				<span>Last checked: {fmtTime(status.auto_sync_last_checked_at)}</span>
+			</div>
+		</div>
+
+		<div class="space-y-4">
+			{#each orderedTypes as [type, state] (type)}
+				{@const percent = pct(state)}
+				<div class="border border-border bg-surface p-5">
+					<div class="flex items-start justify-between gap-3">
+						<div>
+							<div class="flex items-center gap-2">
+								<h2 class="font-semibold text-text">{TYPE_LABELS[type]}</h2>
+								<Badge text={state.status} variant={badgeVariant(state.status)} />
+							</div>
+							<p class="mt-1 text-xs text-text-muted">{TYPE_BLURBS[type]}</p>
+						</div>
+						<div class="flex shrink-0 gap-2">
+							{#if state.status === 'running'}
+								<Button
+									variant="danger"
+									size="sm"
+									loading={busy === 'stop'}
+									disabled={busy !== null}
+									onclick={stopSync}
+								>
+									Stop
+								</Button>
+							{:else}
+								<Button
+									variant="primary"
+									size="sm"
+									loading={busy === type}
+									disabled={anyRunning || busy !== null}
+									onclick={() => startSync(type)}
+								>
+									{actionLabel(state.status)}
+								</Button>
+							{/if}
+						</div>
+					</div>
+
+					{#if percent !== null}
+						<div class="mt-4">
+							<div class="mb-1 flex justify-between text-xs text-text-muted">
+								<span>{state.progress_current ?? 0} / {state.progress_total}</span>
+								<span>{percent}%</span>
+							</div>
+							<div class="h-2 bg-bg">
+								<div
+									class="h-full bg-primary transition-[width] duration-300"
+									style="width: {percent}%"
+								></div>
+							</div>
+						</div>
+					{/if}
+
+					{#if state.last_message}
+						<p class="mt-3 text-sm text-text">{state.last_message}</p>
+					{/if}
+
+					{#if state.error && state.status !== 'running'}
+						<div class="mt-3"><Alert variant="danger">{state.error}</Alert></div>
+					{/if}
+
+					<div class="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-xs text-text-muted">
+						{#if state.cached_count !== null}
+							<span>Cached: <span class="font-medium text-text">{state.cached_count}</span></span>
+						{/if}
+						<span>Last completed: {fmtTime(state.last_synced_at)}</span>
+						{#if state.pages_fetched > 0}
+							<span>Pages this run: {state.pages_fetched}</span>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary

Makes the Hive Rebrickable/BrickLink catalog sync **survive server restarts**, **resume where it left off**, and **report live progress**, plus adds a dedicated **admin-only** page to drive it.

This also fixes the root cause of the parts-sync 429s we hit: the parts loop derived the page number from the in-memory cache (only refreshed at the *end* of a sync), so it re-fetched **page 1 forever** and Rebrickable rate-limited the repeated heavy request. Page advancement now comes from the persisted DB row count, which is also what makes resume work.

## Backend
- **New migration `007_catalog_sync_state`** — durable per-type sync state (status / progress / pages / message / error / timestamps).
- **`parts_cache.py`** — persists state on start, each page, and completion/error/stop; adds `_requestJson` with **retry + exponential backoff** (429/5xx/network, honors `Retry-After`, interruptible) so a transient failure no longer aborts a multi-minute sync.
- **`profile_catalog.py`** — on startup, any sync left `running` (process died mid-sync) is flagged `interrupted`; `status()` now returns a per-type `types` map (status, progress, cached count, last-synced, error).
- **`profiles.py`** — `/profile-catalog/status`, `/sync/{type}`, `/stop` are now **admin-only** (`require_role("admin")`). Catalog search/colors routes are untouched (the profile editor uses them for all roles).

## Frontend
- **New `/settings/catalog-sync` page** — admin-gated, polls status every 2s, per-type progress bars + **Sync / Resume / Re-sync / Stop** controls (one sync at a time; others disable while one runs).
- **`api.ts`** — `CatalogSyncType` / `CatalogSyncStatus` / `CatalogSyncTypeState` types and `types` on `ProfileCatalogStatus`.
- Links from the admin dropdown and the settings page.

## Validation
- Backend: all changed files byte-compile; migration + state helpers + interrupt-on-restart unit-tested against a temp SQLite DB.
- Frontend: `pnpm check` → 0 errors; `pnpm build` → success (Node 22; note the repo's frontend tooling requires Node ≥20.19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)