### PR TITLE
settings: Tailscale network management + compact color picker

### DIFF
--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -126,6 +126,7 @@ from server.routers.hive_models import router as hive_models_router
 from server.routers.runtimes import router as runtimes_router
 from server.routers.chute_stress import router as chute_stress_router
 from server.routers.tuning import router as tuning_router
+from server.routers.tailscale import router as tailscale_router
 
 app.include_router(hardware_router)
 app.include_router(steppers_router)
@@ -139,6 +140,7 @@ app.include_router(hive_models_router)
 app.include_router(runtimes_router)
 app.include_router(chute_stress_router)
 app.include_router(tuning_router)
+app.include_router(tailscale_router)
 
 # ---------------------------------------------------------------------------
 # Lifecycle

--- a/software/sorter/backend/server/routers/tailscale.py
+++ b/software/sorter/backend/server/routers/tailscale.py
@@ -1,0 +1,96 @@
+"""Tailscale network management endpoints."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from typing import Any, Dict
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+_TAILSCALE_SOCKET = os.getenv("TAILSCALE_SOCKET_PATH", "").strip()
+
+
+def _cli(*args: str) -> list[str]:
+    base = ["tailscale"]
+    if _TAILSCALE_SOCKET:
+        base += [f"--socket={_TAILSCALE_SOCKET}"]
+    return base + list(args)
+
+
+def _get_status() -> Dict[str, Any]:
+    if not shutil.which("tailscale"):
+        return {"installed": False, "connected": False}
+
+    try:
+        result = subprocess.run(
+            _cli("status", "--self"),
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return {"installed": True, "connected": False, "error": str(exc)}
+
+    if result.returncode != 0 or not result.stdout.strip():
+        err = (result.stderr or "").strip() or "Not connected"
+        return {"installed": True, "connected": False, "error": err}
+
+    parts = result.stdout.strip().split()
+    ipv4 = parts[0] if parts else None
+    hostname = parts[1] if len(parts) > 1 else None
+    tailnet: str | None = None
+    if len(parts) >= 3:
+        fqdn_parts = parts[2].split(".")
+        if len(fqdn_parts) >= 3:
+            tailnet = ".".join(fqdn_parts[1:])
+
+    return {
+        "installed": True,
+        "connected": True,
+        "hostname": hostname,
+        "ipv4": ipv4,
+        "tailnet": tailnet,
+    }
+
+
+@router.get("/api/tailscale/status")
+def get_tailscale_status() -> Dict[str, Any]:
+    return _get_status()
+
+
+class TailscaleUpPayload(BaseModel):
+    auth_key: str
+
+
+@router.post("/api/tailscale/up")
+def tailscale_up(payload: TailscaleUpPayload) -> Dict[str, Any]:
+    auth_key = payload.auth_key.strip()
+    if not auth_key:
+        return {"ok": False, "error": "auth_key is required"}
+
+    if not shutil.which("tailscale"):
+        return {"ok": False, "error": "Tailscale is not installed on this machine"}
+
+    try:
+        result = subprocess.run(
+            _cli("up", f"--authkey={auth_key}", "--ssh"),
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "tailscale up timed out after 30 seconds", "status": _get_status()}
+    except (FileNotFoundError, OSError) as exc:
+        return {"ok": False, "error": str(exc)}
+
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "unknown error").strip()
+        return {"ok": False, "error": err, "status": _get_status()}
+
+    return {"ok": True, "status": _get_status()}

--- a/software/sorter/backend/server/routers/tailscale.py
+++ b/software/sorter/backend/server/routers/tailscale.py
@@ -94,3 +94,26 @@ def tailscale_up(payload: TailscaleUpPayload) -> Dict[str, Any]:
         return {"ok": False, "error": err, "status": _get_status()}
 
     return {"ok": True, "status": _get_status()}
+
+
+@router.post("/api/tailscale/logout")
+def tailscale_logout() -> Dict[str, Any]:
+    if not shutil.which("tailscale"):
+        return {"ok": False, "error": "Tailscale is not installed on this machine"}
+
+    try:
+        result = subprocess.run(
+            _cli("logout"),
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return {"ok": False, "error": str(exc)}
+
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "unknown error").strip()
+        return {"ok": False, "error": err, "status": _get_status()}
+
+    return {"ok": True, "status": _get_status()}

--- a/software/sorter/frontend/src/lib/components/LegoColorPicker.svelte
+++ b/software/sorter/frontend/src/lib/components/LegoColorPicker.svelte
@@ -10,22 +10,30 @@
 	import { Check } from 'lucide-svelte';
 
 	const selected = $derived(getCurrentThemeColorId());
+	let hovered = $state<string | null>(null);
 
 	function handlePick(colorId: string): void {
 		void setThemeColor(colorId);
 	}
+
+	const displayName = $derived(
+		LEGO_COLORS.find((c) => c.id === (hovered ?? selected))?.name ?? '—'
+	);
+	const isHovering = $derived(hovered !== null && hovered !== selected);
 </script>
 
-<div class="grid grid-cols-5 gap-1.5 sm:grid-cols-8 md:grid-cols-10">
+<div class="grid gap-1" style="grid-template-columns: repeat(auto-fill, minmax(1.5rem, 1fr));">
 	{#each LEGO_COLORS as color (color.id)}
 		{@const isActive = selected === color.id}
 		<button
 			type="button"
 			title={color.name}
 			onclick={() => handlePick(color.id)}
+			onmouseenter={() => (hovered = color.id)}
+			onmouseleave={() => (hovered = null)}
 			aria-pressed={isActive}
 			aria-label={color.name}
-			class="group relative flex aspect-square flex-col items-center justify-center text-center transition-transform hover:scale-105"
+			class="group relative flex h-6 w-full items-center justify-center transition-transform hover:scale-110"
 			style="background-color: {color.hex}; color: {color.contrast === 'white' ? '#ffffff' : '#000000'};"
 		>
 			{#if isActive}
@@ -40,5 +48,5 @@
 </div>
 
 <div class="mt-3 text-xs text-text-muted">
-	Picked: <span class="font-medium text-text">{LEGO_COLORS.find((c) => c.id === selected)?.name ?? '—'}</span>
+	{isHovering ? '' : 'Picked:'} <span class="font-medium text-text">{displayName}</span>
 </div>

--- a/software/sorter/frontend/src/lib/components/settings/TailscaleSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/TailscaleSection.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { machineHttpBaseUrlFromWsUrl, getBackendHttpBase } from '$lib/backend';
+	import { getMachineContext } from '$lib/machines/context';
+	import { Button, Input, Alert } from '$lib/components/primitives';
+	import { Wifi, WifiOff } from 'lucide-svelte';
+
+	const machine = getMachineContext();
+
+	type TailscaleStatus = {
+		installed: boolean;
+		connected: boolean;
+		hostname?: string;
+		ipv4?: string;
+		tailnet?: string;
+		error?: string;
+	};
+
+	let status = $state<TailscaleStatus | null>(null);
+	let loadError = $state<string | null>(null);
+	let authKeyDraft = $state('');
+	let applying = $state(false);
+	let applyError = $state<string | null>(null);
+	let applySuccess = $state(false);
+
+	function httpBase(): string {
+		return machineHttpBaseUrlFromWsUrl(machine.machine?.url) ?? getBackendHttpBase();
+	}
+
+	async function loadStatus() {
+		loadError = null;
+		try {
+			const res = await fetch(`${httpBase()}/api/tailscale/status`);
+			if (!res.ok) throw new Error(await res.text());
+			status = await res.json();
+		} catch (e: any) {
+			loadError = e.message ?? 'Failed to load Tailscale status';
+		}
+	}
+
+	async function applyAuthKey() {
+		const key = authKeyDraft.trim();
+		if (!key) return;
+		applying = true;
+		applyError = null;
+		applySuccess = false;
+		try {
+			const res = await fetch(`${httpBase()}/api/tailscale/up`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ auth_key: key })
+			});
+			if (!res.ok) throw new Error(await res.text());
+			const data = await res.json();
+			if (!data.ok) {
+				applyError = data.error ?? 'Failed to apply auth key';
+			} else {
+				applySuccess = true;
+				authKeyDraft = '';
+				if (data.status) status = data.status;
+			}
+		} catch (e: any) {
+			applyError = e.message ?? 'Failed to apply auth key';
+		} finally {
+			applying = false;
+		}
+	}
+
+	onMount(() => {
+		void loadStatus();
+	});
+</script>
+
+<div class="flex flex-col gap-4">
+	<!-- Status row -->
+	<div class="border border-border bg-surface px-3 py-3">
+		<div class="flex items-center gap-2">
+			{#if status?.connected}
+				<Wifi size={14} class="text-success" />
+				<span class="text-sm font-medium text-text">Connected</span>
+				<span class="ml-auto font-mono text-sm text-text-muted">{status.ipv4}</span>
+			{:else if status !== null}
+				<WifiOff size={14} class="text-text-muted" />
+				<span class="text-sm font-medium text-text">
+					{status.installed ? 'Not connected' : 'Tailscale not installed'}
+				</span>
+			{:else}
+				<span class="text-sm text-text-muted">Loading...</span>
+			{/if}
+		</div>
+		{#if status?.connected}
+			<div class="mt-2 flex flex-col gap-0.5">
+				<div class="text-sm text-text-muted">
+					Hostname: <span class="font-mono text-text">{status.hostname}</span>
+				</div>
+				{#if status.tailnet}
+					<div class="text-sm text-text-muted">
+						Tailnet: <span class="font-mono text-text">{status.tailnet}</span>
+					</div>
+				{/if}
+			</div>
+		{/if}
+		{#if status && !status.connected && status.error}
+			<div class="mt-1 text-sm text-text-muted">{status.error}</div>
+		{/if}
+	</div>
+
+	<!-- Auth key input -->
+	<div>
+		<div class="mb-2 text-sm font-medium text-text">Auth Key</div>
+		<div class="flex gap-2">
+			<Input
+				type="password"
+				placeholder="tskey-auth-..."
+				bind:value={authKeyDraft}
+				class="flex-1 font-mono"
+			/>
+			<Button
+				variant="primary"
+				size="sm"
+				disabled={!authKeyDraft.trim() || applying}
+				loading={applying}
+				onclick={() => void applyAuthKey()}
+			>
+				{applying ? 'Applying...' : 'Apply'}
+			</Button>
+		</div>
+		<div class="mt-1 text-sm text-text-muted">
+			Generate an auth key at <span class="font-mono">tailscale.com/admin/settings/keys</span>. The
+			machine will join (or switch to) that network immediately.
+		</div>
+	</div>
+
+	{#if applyError}
+		<Alert variant="danger">{applyError}</Alert>
+	{/if}
+	{#if applySuccess}
+		<Alert variant="success">Auth key applied — machine is now connected.</Alert>
+	{/if}
+	{#if loadError}
+		<Alert variant="warning">{loadError}</Alert>
+	{/if}
+</div>

--- a/software/sorter/frontend/src/lib/components/settings/TailscaleSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/TailscaleSection.svelte
@@ -22,6 +22,8 @@
 	let applying = $state(false);
 	let applyError = $state<string | null>(null);
 	let applySuccess = $state(false);
+	let revoking = $state(false);
+	let revokeError = $state<string | null>(null);
 
 	function httpBase(): string {
 		return machineHttpBaseUrlFromWsUrl(machine.machine?.url) ?? getBackendHttpBase();
@@ -66,6 +68,25 @@
 		}
 	}
 
+	async function revoke() {
+		revoking = true;
+		revokeError = null;
+		try {
+			const res = await fetch(`${httpBase()}/api/tailscale/logout`, { method: 'POST' });
+			if (!res.ok) throw new Error(await res.text());
+			const data = await res.json();
+			if (!data.ok) {
+				revokeError = data.error ?? 'Failed to disconnect';
+			} else {
+				if (data.status) status = data.status;
+			}
+		} catch (e: any) {
+			revokeError = e.message ?? 'Failed to disconnect';
+		} finally {
+			revoking = false;
+		}
+	}
+
 	onMount(() => {
 		void loadStatus();
 	});
@@ -89,21 +110,33 @@
 			{/if}
 		</div>
 		{#if status?.connected}
-			<div class="mt-2 flex flex-col gap-0.5">
-				<div class="text-sm text-text-muted">
-					Hostname: <span class="font-mono text-text">{status.hostname}</span>
-				</div>
-				{#if status.tailnet}
+			<div class="mt-2 flex items-end justify-between gap-4">
+				<div class="flex flex-col gap-0.5">
 					<div class="text-sm text-text-muted">
-						Tailnet: <span class="font-mono text-text">{status.tailnet}</span>
+						Hostname: <span class="font-mono text-text">{status.hostname}</span>
 					</div>
-				{/if}
+					{#if status.tailnet}
+						<div class="text-sm text-text-muted">
+							Tailnet: <span class="font-mono text-text">{status.tailnet}</span>
+						</div>
+					{/if}
+				</div>
+				<Button variant="danger" size="sm" loading={revoking} onclick={() => void revoke()}>
+					{revoking ? 'Disconnecting...' : 'Disconnect'}
+				</Button>
 			</div>
 		{/if}
 		{#if status && !status.connected && status.error}
 			<div class="mt-1 text-sm text-text-muted">{status.error}</div>
 		{/if}
 	</div>
+
+	<!-- Warning -->
+	<Alert variant="warning">
+		Entering an auth key gives the owner of that Tailscale network SSH access to this machine and
+		access to your local network. Only use a key you generated yourself or from someone you fully
+		trust.
+	</Alert>
 
 	<!-- Auth key input -->
 	<div>
@@ -136,6 +169,9 @@
 	{/if}
 	{#if applySuccess}
 		<Alert variant="success">Auth key applied — machine is now connected.</Alert>
+	{/if}
+	{#if revokeError}
+		<Alert variant="danger">{revokeError}</Alert>
 	{/if}
 	{#if loadError}
 		<Alert variant="warning">{loadError}</Alert>

--- a/software/sorter/frontend/src/routes/settings/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/+page.svelte
@@ -3,6 +3,7 @@ import GeneralSection from '$lib/components/settings/GeneralSection.svelte';
 import ApiKeysSection from '$lib/components/settings/ApiKeysSection.svelte';
 import DashboardSection from '$lib/components/settings/DashboardSection.svelte';
 import SampleStorageSection from '$lib/components/settings/SampleStorageSection.svelte';
+import TailscaleSection from '$lib/components/settings/TailscaleSection.svelte';
 import SectionCard from '$lib/components/settings/SectionCard.svelte';
 import LegoColorPicker from '$lib/components/LegoColorPicker.svelte';
 </script>
@@ -47,6 +48,13 @@ import LegoColorPicker from '$lib/components/LegoColorPicker.svelte';
 		description="Choose which panels appear on the main dashboard."
 	>
 		<DashboardSection />
+	</SectionCard>
+
+	<SectionCard
+		title="Tailscale"
+		description="View connection status and join or switch Tailscale networks."
+	>
+		<TailscaleSection />
 	</SectionCard>
 
 	<SectionCard


### PR DESCRIPTION
## Summary

- Adds a **Tailscale** section to `/settings` — shows connection status (hostname, IP, tailnet) and lets you apply an auth key to join or switch networks at runtime without reflashing
- `GET /api/tailscale/status` and `POST /api/tailscale/up` backend endpoints; respects optional `TAILSCALE_SOCKET_PATH` env var for non-standard installs, defaults match stock SorterOS
- Shrinks theme color swatches to auto-fill rows at a fixed 24px height; hover previews the color name before committing

## Test plan

- [ ] Open `/settings` on a connected machine — Tailscale card shows current hostname and IP
- [ ] Paste a valid auth key and click Apply — machine re-authenticates and card updates
- [ ] On a machine without Tailscale installed — card shows "not installed" gracefully
- [ ] Theme color picker — swatches fill the row compactly; hovering shows name; clicking applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)