### PR TITLE
sorteros: clone main + sync with Python 3.12 on firstboot

### DIFF
--- a/software/sorteros/build/config.toml
+++ b/software/sorteros/build/config.toml
@@ -9,7 +9,7 @@ sha256 = ""  # fill in when known
 
 [output]
 dir = "out"
-version = "3.4.5"
+version = "3.4.6"
 name = "sorteros-v{version}-{date}.img"
 
 [chroot]
@@ -36,7 +36,7 @@ extra_curl_installs = ["node22", "tailscale"]
 [branch]
 # Git branch to encode in /etc/sorteros/branch so the firstboot daemon
 # clones the right thing. Can be overridden with --branch on CLI.
-default = "sorteros-v3"
+default = "main"
 
 [firstboot]
 # Placeholder size for /etc/sorteros-config.toml (the file the browser

--- a/software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py
+++ b/software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py
@@ -338,7 +338,7 @@ def stage_uv_sync() -> None:
         raise RuntimeError("repo not cloned yet")
     if (backend / ".venv").exists():
         return
-    sh(["/usr/local/bin/uv", "sync", "--python", "3.13"], cwd=backend)
+    sh(["/usr/local/bin/uv", "sync", "--python", "3.12"], cwd=backend)
 
 
 def stage_pnpm_install() -> None:


### PR DESCRIPTION
The 3.4.5 image was unbootable for the backend/UI:

- firstboot cloned the stale \`sorteros-v3\` branch, which lacks the \`sorter-backend-dev\` / \`sorter-ui-dev\` systemd units, so \`install-services\` failed.
- firstboot ran \`uv sync --python 3.13\`, but the backend requires \`>=3.12,<3.13\`, so \`uv-sync\` failed.

This points firstboot at \`main\` and syncs with Python 3.12, and bumps the image version to 3.4.6.

Verified on a fresh machine by switching its repo to main + patching firstboot: \`uv-sync\` and \`install-services\` both pass and the backend reaches standby. Image \`sorteros-v3.4.6\` built and released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)