### PR TITLE
Reach the UI by IP or Tailscale name, and join Tailscale from settings

### DIFF
--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -28,8 +28,7 @@ from server.camera_discovery import shutdownCameraDiscovery
 from server.set_progress_sync import getSetProgressSyncWorker
 from server.waveshare_inventory import get_waveshare_inventory_manager
 from server.security import (
-    explicit_allowed_origins,
-    ui_allowed_origin_regex,
+    is_ui_origin_allowed,
     websocket_connection_allowed,
 )
 
@@ -66,10 +65,16 @@ app = FastAPI(title="Sorter API", version="0.0.1")
 #   SORTER_API_ALLOWED_ORIGINS comma-separated full origins override
 #                              (e.g. "https://sorter.lan,http://192.168.1.42:5173")
 #
+# Decide per-request, so the allowlist tracks this device's current IPs /
+# hostname / Tailscale name without a restart. is_ui_origin_allowed accepts only
+# this machine's own addresses (plus any SORTER_API_ALLOWED_ORIGINS override).
+class _DeviceCORSMiddleware(CORSMiddleware):
+    def is_allowed_origin(self, origin: str) -> bool:
+        return is_ui_origin_allowed(origin)
+
+
 app.add_middleware(
-    CORSMiddleware,
-    allow_origins=explicit_allowed_origins(),
-    allow_origin_regex=ui_allowed_origin_regex(),
+    _DeviceCORSMiddleware,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -27,7 +27,11 @@ from run_recorder import RECORDS_DIR
 from server.camera_discovery import shutdownCameraDiscovery
 from server.set_progress_sync import getSetProgressSyncWorker
 from server.waveshare_inventory import get_waveshare_inventory_manager
-from server.security import compute_allowed_ui_origins, websocket_connection_allowed
+from server.security import (
+    explicit_allowed_origins,
+    ui_allowed_origin_regex,
+    websocket_connection_allowed,
+)
 
 from server.shared_state import (
     active_connections,
@@ -64,7 +68,8 @@ app = FastAPI(title="Sorter API", version="0.0.1")
 #
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=compute_allowed_ui_origins(),
+    allow_origins=explicit_allowed_origins(),
+    allow_origin_regex=ui_allowed_origin_regex(),
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -536,7 +541,6 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     if not websocket_connection_allowed(
         websocket.headers.get("Origin"),
         client_host,
-        compute_allowed_ui_origins(),
     ):
         await websocket.close(
             code=status.WS_1008_POLICY_VIOLATION,

--- a/software/sorter/backend/server/routers/tailscale.py
+++ b/software/sorter/backend/server/routers/tailscale.py
@@ -1,6 +1,7 @@
 """Tailscale network management endpoints."""
 from __future__ import annotations
 
+import json
 import os
 import random
 import shutil
@@ -10,6 +11,8 @@ from typing import Any, Dict
 
 from fastapi import APIRouter
 from pydantic import BaseModel
+
+from server.security import refresh_device_identity
 
 router = APIRouter()
 
@@ -69,7 +72,7 @@ def _get_status() -> Dict[str, Any]:
 
     try:
         result = subprocess.run(
-            _cli("status", "--self"),
+            _cli("status", "--json"),
             capture_output=True,
             text=True,
             timeout=3.0,
@@ -82,14 +85,25 @@ def _get_status() -> Dict[str, Any]:
         err = (result.stderr or "").strip() or "Not connected"
         return {"installed": True, "connected": False, "error": err}
 
-    parts = result.stdout.strip().split()
-    ipv4 = parts[0] if parts else None
-    hostname = parts[1] if len(parts) > 1 else None
-    tailnet: str | None = None
-    if len(parts) >= 3:
-        fqdn_parts = parts[2].split(".")
-        if len(fqdn_parts) >= 3:
-            tailnet = ".".join(fqdn_parts[1:])
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {"installed": True, "connected": False, "error": str(exc)}
+
+    if data.get("BackendState") != "Running":
+        return {"installed": True, "connected": False, "error": data.get("BackendState") or "Not connected"}
+
+    self_node = data.get("Self") or {}
+    # DNSName is the authoritative name MagicDNS actually resolves (e.g.
+    # "sorter-green-arch-0ffbef.tailf1686d.ts.net."); the first label is the
+    # device name, the rest is the tailnet. HostName can differ from this when a
+    # requested name collided with an existing node.
+    dns_name = (self_node.get("DNSName") or "").rstrip(".")
+    labels = dns_name.split(".") if dns_name else []
+    hostname = labels[0] if labels else (self_node.get("HostName") or None)
+    tailnet = ".".join(labels[1:]) if len(labels) >= 3 else None
+    ips = self_node.get("TailscaleIPs") or []
+    ipv4 = next((ip for ip in ips if ":" not in ip), None)
 
     return {
         "installed": True,
@@ -141,6 +155,9 @@ def tailscale_up(payload: TailscaleUpPayload) -> Dict[str, Any]:
         err = (result.stderr or result.stdout or "unknown error").strip()
         return {"ok": False, "error": err, "status": _get_status()}
 
+    # The device name just changed; let the origin allowlist pick it up now so
+    # the UI reloaded at the new name isn't blocked during the refresh window.
+    refresh_device_identity()
     return {"ok": True, "status": _get_status()}
 
 
@@ -164,4 +181,5 @@ def tailscale_logout() -> Dict[str, Any]:
         err = (result.stderr or result.stdout or "unknown error").strip()
         return {"ok": False, "error": err, "status": _get_status()}
 
+    refresh_device_identity()
     return {"ok": True, "status": _get_status()}

--- a/software/sorter/backend/server/routers/tailscale.py
+++ b/software/sorter/backend/server/routers/tailscale.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import os
+import random
 import shutil
 import subprocess
+from pathlib import Path
 from typing import Any, Dict
 
 from fastapi import APIRouter
@@ -13,12 +15,52 @@ router = APIRouter()
 
 _TAILSCALE_SOCKET = os.getenv("TAILSCALE_SOCKET_PATH", "").strip()
 
+# Keep this naming scheme in sync with sorteros-firstboot.py's
+# _generate_machine_name() so UI-joined and firstboot-joined machines look alike.
+LEGO_COLORS = [
+    "aqua", "azure", "black", "blue", "bright-green", "bright-pink",
+    "brown", "coral", "dark-azure", "dark-blue", "dark-brown", "dark-gray",
+    "dark-green", "dark-orange", "dark-pink", "dark-purple", "dark-red",
+    "dark-tan", "dark-turquoise", "gray", "green", "lavender", "light-aqua",
+    "light-blue", "light-gray", "light-pink", "light-purple", "light-yellow",
+    "lime", "magenta", "medium-azure", "medium-blue", "medium-green",
+    "medium-lavender", "medium-nougat", "nougat", "olive", "orange", "pink",
+    "purple", "red", "reddish-brown", "sand-blue", "sand-green", "tan",
+    "teal", "warm-gold", "white", "yellow",
+]
+
+LEGO_PIECES = [
+    "arch", "axle", "beam", "bracket", "brick", "clip", "cone", "cylinder",
+    "dome", "gear", "hinge", "panel", "pin", "plate", "rail", "slope",
+    "stud", "technic", "tile", "turntable", "wedge",
+]
+
 
 def _cli(*args: str) -> list[str]:
     base = ["tailscale"]
     if _TAILSCALE_SOCKET:
         base += [f"--socket={_TAILSCALE_SOCKET}"]
     return base + list(args)
+
+
+def _mac_suffix() -> str:
+    net = Path("/sys/class/net")
+    if net.exists():
+        for iface in sorted(net.iterdir()):
+            if iface.name == "lo":
+                continue
+            addr_file = iface / "address"
+            if addr_file.exists():
+                mac = addr_file.read_text().strip().replace(":", "")
+                if mac and mac != "000000000000":
+                    return mac[-6:].lower()
+    return format(random.randint(0, 0xFFFFFF), "06x")
+
+
+def _generate_machine_name() -> str:
+    color = random.choice(LEGO_COLORS)
+    piece = random.choice(LEGO_PIECES)
+    return f"sorter-{color}-{piece}-{_mac_suffix()}"
 
 
 def _get_status() -> Dict[str, Any]:
@@ -76,9 +118,15 @@ def tailscale_up(payload: TailscaleUpPayload) -> Dict[str, Any]:
     if not shutil.which("tailscale"):
         return {"ok": False, "error": "Tailscale is not installed on this machine"}
 
+    # Keep an existing sorter-* device name so a re-join never renames the
+    # machine; replace a generic name (e.g. "orangepi") or generate one on first
+    # join, so every UI-joined machine lands as sorter-color-piece-mac.
+    existing = (_get_status().get("hostname") or "").strip()
+    hostname = existing if existing.startswith("sorter-") else _generate_machine_name()
+
     try:
         result = subprocess.run(
-            _cli("up", f"--authkey={auth_key}", "--ssh"),
+            _cli("up", f"--authkey={auth_key}", f"--hostname={hostname}", "--ssh"),
             capture_output=True,
             text=True,
             timeout=30.0,

--- a/software/sorter/backend/server/security.py
+++ b/software/sorter/backend/server/security.py
@@ -76,6 +76,11 @@ _LOCAL_HOST_PATTERNS: tuple[str, ...] = (
     r"\[::1\]",
     r"[A-Za-z0-9-]+\.local",
     r"[A-Za-z0-9-]+\.ts\.net",
+    # Bare single-label hostname (no dot) on the UI port: covers the Tailscale
+    # MagicDNS short name. Static so a UI-driven `tailscale up --hostname` rename
+    # is reachable immediately, without waiting for a backend restart to rebuild
+    # the cached regex with the new name.
+    r"[A-Za-z0-9-]+",
 )
 
 

--- a/software/sorter/backend/server/security.py
+++ b/software/sorter/backend/server/security.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import ipaddress
 import os
+import re
 import socket
 import subprocess
+from functools import lru_cache
 from urllib.parse import urlsplit
 
 
@@ -45,12 +47,76 @@ def is_loopback_client_address(host: str | None) -> bool:
 def websocket_connection_allowed(
     origin: str | None,
     client_host: str | None,
-    allowed_origins: list[str] | tuple[str, ...],
 ) -> bool:
     normalized = normalize_origin(origin)
     if normalized is None:
         return is_loopback_client_address(client_host)
-    return origin_allowed(normalized, allowed_origins)
+    return is_ui_origin_allowed(normalized)
+
+
+def _ui_port() -> str:
+    return os.getenv("SORTER_UI_PORT", "5173").strip() or "5173"
+
+
+# Hosts trusted as "the UI talking to its own backend over the LAN": loopback,
+# every RFC1918 private range, link-local, the Tailscale CGNAT range
+# (100.64/10), any mDNS *.local or Tailscale MagicDNS *.ts.net name, plus this
+# machine's own hostname / Tailscale name. Deliberately bounded to private/local
+# hosts — a public origin never matches. Combined with the UI port this lets the
+# operator reach the UI by IP, hostname, .local, or Tailscale without per-machine
+# origin config, and survives DHCP address changes without a restart.
+_LOCAL_HOST_PATTERNS: tuple[str, ...] = (
+    r"localhost",
+    r"127(?:\.\d{1,3}){3}",
+    r"10(?:\.\d{1,3}){3}",
+    r"192\.168(?:\.\d{1,3}){2}",
+    r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}",
+    r"169\.254(?:\.\d{1,3}){2}",
+    r"100\.(?:6[4-9]|[7-9]\d|1\d\d|2[0-4]\d|25[0-5])(?:\.\d{1,3}){2}",
+    r"\[::1\]",
+    r"[A-Za-z0-9-]+\.local",
+    r"[A-Za-z0-9-]+\.ts\.net",
+)
+
+
+@lru_cache(maxsize=1)
+def _local_origin_regex() -> re.Pattern[str]:
+    patterns: list[str] = list(_LOCAL_HOST_PATTERNS)
+    try:
+        hostname = socket.gethostname().strip().lower()
+    except Exception:
+        hostname = ""
+    if hostname:
+        patterns.append(re.escape(hostname))
+        if not hostname.endswith(".local"):
+            patterns.append(re.escape(f"{hostname}.local"))
+    tailscale_name = _tailscale_hostname()
+    if tailscale_name:
+        patterns.append(re.escape(tailscale_name.strip().lower()))
+    host_group = "|".join(patterns)
+    return re.compile(rf"^https?://(?:{host_group}):{re.escape(_ui_port())}$", re.IGNORECASE)
+
+
+def ui_allowed_origin_regex() -> str:
+    return _local_origin_regex().pattern
+
+
+def explicit_allowed_origins() -> list[str]:
+    override = os.getenv("SORTER_API_ALLOWED_ORIGINS")
+    if not override:
+        return []
+    return _dedupe_origins(
+        [origin for origin in (normalize_origin(item) for item in override.split(",")) if origin is not None]
+    )
+
+
+def is_ui_origin_allowed(origin: str | None) -> bool:
+    normalized = normalize_origin(origin)
+    if normalized is None:
+        return False
+    if normalized.lower() in {item.lower() for item in explicit_allowed_origins()}:
+        return True
+    return bool(_local_origin_regex().match(normalized))
 
 
 def compute_allowed_ui_origins() -> list[str]:

--- a/software/sorter/backend/server/security.py
+++ b/software/sorter/backend/server/security.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import ipaddress
+import json
 import os
-import re
 import socket
 import subprocess
-from functools import lru_cache
+import time
 from urllib.parse import urlsplit
+
+# How long a computed snapshot of this device's own addresses/names is reused
+# before we look them up again. Keeps a wifi/IP/Tailscale change visible within
+# a few seconds without spawning subprocesses on every request.
+_REFRESH_SECONDS = 15.0
 
 
 def normalize_origin(origin: str | None) -> str | None:
@@ -44,66 +49,8 @@ def is_loopback_client_address(host: str | None) -> bool:
         return False
 
 
-def websocket_connection_allowed(
-    origin: str | None,
-    client_host: str | None,
-) -> bool:
-    normalized = normalize_origin(origin)
-    if normalized is None:
-        return is_loopback_client_address(client_host)
-    return is_ui_origin_allowed(normalized)
-
-
 def _ui_port() -> str:
     return os.getenv("SORTER_UI_PORT", "5173").strip() or "5173"
-
-
-# Hosts trusted as "the UI talking to its own backend over the LAN": loopback,
-# every RFC1918 private range, link-local, the Tailscale CGNAT range
-# (100.64/10), any mDNS *.local or Tailscale MagicDNS *.ts.net name, plus this
-# machine's own hostname / Tailscale name. Deliberately bounded to private/local
-# hosts — a public origin never matches. Combined with the UI port this lets the
-# operator reach the UI by IP, hostname, .local, or Tailscale without per-machine
-# origin config, and survives DHCP address changes without a restart.
-_LOCAL_HOST_PATTERNS: tuple[str, ...] = (
-    r"localhost",
-    r"127(?:\.\d{1,3}){3}",
-    r"10(?:\.\d{1,3}){3}",
-    r"192\.168(?:\.\d{1,3}){2}",
-    r"172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}",
-    r"169\.254(?:\.\d{1,3}){2}",
-    r"100\.(?:6[4-9]|[7-9]\d|1\d\d|2[0-4]\d|25[0-5])(?:\.\d{1,3}){2}",
-    r"\[::1\]",
-    r"[A-Za-z0-9-]+\.local",
-    r"[A-Za-z0-9-]+\.ts\.net",
-    # Bare single-label hostname (no dot) on the UI port: covers the Tailscale
-    # MagicDNS short name. Static so a UI-driven `tailscale up --hostname` rename
-    # is reachable immediately, without waiting for a backend restart to rebuild
-    # the cached regex with the new name.
-    r"[A-Za-z0-9-]+",
-)
-
-
-@lru_cache(maxsize=1)
-def _local_origin_regex() -> re.Pattern[str]:
-    patterns: list[str] = list(_LOCAL_HOST_PATTERNS)
-    try:
-        hostname = socket.gethostname().strip().lower()
-    except Exception:
-        hostname = ""
-    if hostname:
-        patterns.append(re.escape(hostname))
-        if not hostname.endswith(".local"):
-            patterns.append(re.escape(f"{hostname}.local"))
-    tailscale_name = _tailscale_hostname()
-    if tailscale_name:
-        patterns.append(re.escape(tailscale_name.strip().lower()))
-    host_group = "|".join(patterns)
-    return re.compile(rf"^https?://(?:{host_group}):{re.escape(_ui_port())}$", re.IGNORECASE)
-
-
-def ui_allowed_origin_regex() -> str:
-    return _local_origin_regex().pattern
 
 
 def explicit_allowed_origins() -> list[str]:
@@ -115,67 +62,120 @@ def explicit_allowed_origins() -> list[str]:
     )
 
 
+def _local_ip_addresses() -> list[str]:
+    # `hostname -I` lists every current interface address (LAN, Tailscale, etc.),
+    # so it tracks wifi/DHCP changes without us hardcoding anything.
+    try:
+        result = subprocess.run(
+            ["hostname", "-I"], capture_output=True, text=True, timeout=2.0, check=False
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [token.lower() for token in result.stdout.split() if token]
+
+
+def _this_device_hosts() -> frozenset[str]:
+    # Every name/address that means "this machine's own UI talking to its own
+    # backend": loopback, the OS hostname (+ .local), the Tailscale name, and the
+    # device's current IPs. Deliberately scoped to this device only.
+    hosts: set[str] = {"localhost", "127.0.0.1", "::1"}
+    try:
+        hostname = socket.gethostname().strip().lower()
+    except Exception:
+        hostname = ""
+    if hostname:
+        hosts.add(hostname)
+        if not hostname.endswith(".local"):
+            hosts.add(f"{hostname}.local")
+    tailscale_name = _tailscale_hostname()
+    if tailscale_name:
+        hosts.add(tailscale_name.strip().lower())
+    hosts.update(_local_ip_addresses())
+    return frozenset(hosts)
+
+
+_hosts_snapshot: tuple[float, frozenset[str]] = (0.0, frozenset())
+
+
+def _allowed_hosts() -> frozenset[str]:
+    global _hosts_snapshot
+    now = time.monotonic()
+    cached_at, hosts = _hosts_snapshot
+    if hosts and now - cached_at < _REFRESH_SECONDS:
+        return hosts
+    hosts = _this_device_hosts()
+    _hosts_snapshot = (now, hosts)
+    return hosts
+
+
+def refresh_device_identity() -> None:
+    # Drop the cached snapshots so the next origin check re-reads this device's
+    # current IPs / hostname / Tailscale name. Call right after a join, logout,
+    # or rename so the new name is accepted immediately instead of after the
+    # refresh window.
+    global _hosts_snapshot, _tailscale_hostname_cache
+    _hosts_snapshot = (0.0, frozenset())
+    _tailscale_hostname_cache = (0.0, None)
+
+
 def is_ui_origin_allowed(origin: str | None) -> bool:
     normalized = normalize_origin(origin)
     if normalized is None:
         return False
     if normalized.lower() in {item.lower() for item in explicit_allowed_origins()}:
         return True
-    return bool(_local_origin_regex().match(normalized))
+    parsed = urlsplit(normalized.lower())
+    host = parsed.hostname or ""
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+    port_str = str(port) if port is not None else ("443" if parsed.scheme == "https" else "80")
+    if port_str != _ui_port():
+        return False
+    # Any mDNS .local name (e.g. sorter.local) resolves only on the local link,
+    # so it's treated as this device on the LAN.
+    if host.endswith(".local"):
+        return True
+    return host in _allowed_hosts()
+
+
+def websocket_connection_allowed(
+    origin: str | None,
+    client_host: str | None,
+) -> bool:
+    normalized = normalize_origin(origin)
+    if normalized is None:
+        return is_loopback_client_address(client_host)
+    return is_ui_origin_allowed(normalized)
 
 
 def compute_allowed_ui_origins() -> list[str]:
-    override = os.getenv("SORTER_API_ALLOWED_ORIGINS")
+    override = explicit_allowed_origins()
     if override:
-        return _dedupe_origins(
-            [
-                origin
-                for origin in (normalize_origin(item) for item in override.split(","))
-                if origin is not None
-            ]
-        )
-
-    bind_host = os.getenv("SORTER_API_HOST", "127.0.0.1").strip() or "127.0.0.1"
-    ui_port = os.getenv("SORTER_UI_PORT", "5173").strip() or "5173"
-    origins = [
-        f"http://localhost:{ui_port}",
-        f"http://127.0.0.1:{ui_port}",
-    ]
-
-    if bind_host not in ("127.0.0.1", "localhost", ""):
-        try:
-            hostname = socket.gethostname()
-        except Exception:
-            hostname = ""
-        if hostname:
-            origins.append(f"http://{hostname}:{ui_port}")
-            if not hostname.endswith(".local"):
-                origins.append(f"http://{hostname}.local:{ui_port}")
-        if bind_host != "0.0.0.0":
-            origins.append(f"http://{bind_host}:{ui_port}")
-
-    tailscale_name = _tailscale_hostname()
-    if tailscale_name:
-        origins.append(f"http://{tailscale_name}:{ui_port}")
-
-    return _dedupe_origins(origins)
+        return override
+    port = _ui_port()
+    return _dedupe_origins([f"http://{host}:{port}" for host in sorted(_this_device_hosts())])
 
 
-_tailscale_hostname_cache: tuple[bool, str | None] = (False, None)
+_tailscale_hostname_cache: tuple[float, str | None] = (0.0, None)
 
 
 def _tailscale_hostname() -> str | None:
     global _tailscale_hostname_cache
-    cached, value = _tailscale_hostname_cache
-    if cached:
+    now = time.monotonic()
+    cached_at, value = _tailscale_hostname_cache
+    if value is not None and now - cached_at < _REFRESH_SECONDS:
         return value
 
     from local_state import get_tailscale_hostname, set_tailscale_hostname
 
     resolved = _query_tailscale_hostname()
     if resolved:
-        # Persist to DB so future boots resolve the hostname even if Tailscale
-        # isn't up yet when this process starts.
+        # Persist so future boots resolve the name even if Tailscale isn't up yet
+        # when this process starts.
         try:
             set_tailscale_hostname(resolved)
         except Exception:
@@ -183,17 +183,17 @@ def _tailscale_hostname() -> str | None:
     else:
         resolved = get_tailscale_hostname()
 
-    _tailscale_hostname_cache = (True, resolved)
+    _tailscale_hostname_cache = (now, resolved)
     return resolved
 
 
 def _query_tailscale_hostname() -> str | None:
-    # tailscale status --self reads from the local daemon's in-memory state
-    # (loaded from disk at daemon startup), so it works without network access.
-    # First field is the IP, second is the bare hostname.
+    # `tailscale status --json` reads the local daemon's state (no network
+    # needed). Self.DNSName is the authoritative name MagicDNS resolves; its
+    # first label is the device name.
     try:
         result = subprocess.run(
-            ["tailscale", "status", "--self"],
+            ["tailscale", "status", "--json"],
             capture_output=True,
             text=True,
             timeout=2.0,
@@ -203,8 +203,14 @@ def _query_tailscale_hostname() -> str | None:
         return None
     if result.returncode != 0 or not result.stdout:
         return None
-    parts = result.stdout.strip().split()
-    return parts[1] if len(parts) >= 2 else None
+    try:
+        self_node = (json.loads(result.stdout).get("Self") or {})
+    except json.JSONDecodeError:
+        return None
+    dns_name = (self_node.get("DNSName") or "").rstrip(".")
+    if dns_name:
+        return dns_name.split(".")[0]
+    return self_node.get("HostName") or None
 
 
 def _dedupe_origins(origins: list[str]) -> list[str]:

--- a/software/sorter/backend/supervisor.py
+++ b/software/sorter/backend/supervisor.py
@@ -16,10 +16,9 @@ from urllib import request as urllib_request
 
 from dotenv import load_dotenv
 from server.security import (
-    compute_allowed_ui_origins,
     is_loopback_client_address,
+    is_ui_origin_allowed,
     normalize_origin,
-    origin_allowed,
 )
 
 
@@ -33,7 +32,6 @@ DEFAULT_HEALTH_INTERVAL_S = float(os.getenv("BACKEND_SUPERVISOR_HEALTH_INTERVAL_
 DEFAULT_HEALTH_TIMEOUT_S = float(os.getenv("BACKEND_SUPERVISOR_HEALTH_TIMEOUT_S", "1.5"))
 DEFAULT_RESTART_BACKOFF_S = float(os.getenv("BACKEND_SUPERVISOR_RESTART_BACKOFF_S", "0.2"))
 DEFAULT_STOP_TIMEOUT_S = float(os.getenv("BACKEND_SUPERVISOR_STOP_TIMEOUT_S", "5.0"))
-ALLOWED_UI_ORIGINS = tuple(compute_allowed_ui_origins())
 
 
 def _timestamp() -> float:
@@ -353,7 +351,7 @@ def _handler_factory(supervisor: BackendSupervisor):
                 return False, None
 
             origin = normalize_origin(self.headers.get("Origin"))
-            if origin is not None and not origin_allowed(origin, ALLOWED_UI_ORIGINS):
+            if origin is not None and not is_ui_origin_allowed(origin):
                 self._send_json(403, {"ok": False, "message": "Origin not allowed for supervisor control."})
                 return False, None
             if require_origin and origin is None:
@@ -372,7 +370,7 @@ def _handler_factory(supervisor: BackendSupervisor):
             self.send_response(status)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
-            if origin is not None and origin_allowed(origin, ALLOWED_UI_ORIGINS):
+            if origin is not None and is_ui_origin_allowed(origin):
                 self.send_header("Access-Control-Allow-Origin", origin)
                 self.send_header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
                 self.send_header("Access-Control-Allow-Headers", "Content-Type")

--- a/software/sorter/backend/tests/test_server_security.py
+++ b/software/sorter/backend/tests/test_server_security.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from server.security import (
     compute_allowed_ui_origins,
     is_loopback_client_address,
+    is_ui_origin_allowed,
     normalize_origin,
     origin_allowed,
     websocket_connection_allowed,
@@ -45,15 +46,33 @@ def test_compute_allowed_ui_origins_honors_override(monkeypatch) -> None:
 
 
 def test_websocket_connection_allows_approved_origin_from_remote_client() -> None:
-    allowed = ["http://localhost:5173", "http://sorter.local:5173"]
-    assert websocket_connection_allowed(
-        "http://sorter.local:5173/",
-        "192.168.1.42",
-        allowed,
-    ) is True
+    assert websocket_connection_allowed("http://sorter.local:5173/", "192.168.1.42") is True
 
 
 def test_websocket_connection_without_origin_requires_loopback_client() -> None:
-    allowed = ["http://localhost:5173"]
-    assert websocket_connection_allowed(None, "127.0.0.1", allowed) is True
-    assert websocket_connection_allowed(None, "192.168.1.42", allowed) is False
+    assert websocket_connection_allowed(None, "127.0.0.1") is True
+    assert websocket_connection_allowed(None, "192.168.1.42") is False
+
+
+def test_ui_origin_allows_local_and_private_hosts() -> None:
+    assert is_ui_origin_allowed("http://localhost:5173") is True
+    assert is_ui_origin_allowed("http://127.0.0.1:5173") is True
+    assert is_ui_origin_allowed("http://192.168.89.96:5173") is True
+    assert is_ui_origin_allowed("http://10.1.2.3:5173") is True
+    assert is_ui_origin_allowed("http://172.20.5.6:5173") is True
+    assert is_ui_origin_allowed("http://100.112.251.96:5173") is True  # Tailscale CGNAT
+    assert is_ui_origin_allowed("http://sorter.local:5173") is True
+    assert is_ui_origin_allowed("http://sorter-brown-axle.tail1234.ts.net:5173") is True
+
+
+def test_ui_origin_rejects_public_hosts_and_wrong_port() -> None:
+    assert is_ui_origin_allowed("http://8.8.8.8:5173") is False
+    assert is_ui_origin_allowed("https://evil.example:5173") is False
+    assert is_ui_origin_allowed("http://172.32.0.1:5173") is False  # just outside 172.16/12
+    assert is_ui_origin_allowed("http://192.168.1.5:9999") is False  # wrong port
+    assert is_ui_origin_allowed(None) is False
+
+
+def test_ui_origin_honors_explicit_override(monkeypatch) -> None:
+    monkeypatch.setenv("SORTER_API_ALLOWED_ORIGINS", "https://sorter.example.com")
+    assert is_ui_origin_allowed("https://sorter.example.com") is True

--- a/software/sorter/backend/tests/test_server_security.py
+++ b/software/sorter/backend/tests/test_server_security.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from server import security
 from server.security import (
     compute_allowed_ui_origins,
     is_loopback_client_address,
@@ -8,6 +9,15 @@ from server.security import (
     origin_allowed,
     websocket_connection_allowed,
 )
+
+
+def _set_device(monkeypatch, *, hostname="orangepi5", ips=(), tailscale=None) -> None:
+    # Pin what "this device" looks like and bypass the refresh cache so each test
+    # sees exactly the addresses it sets.
+    monkeypatch.setattr(security.socket, "gethostname", lambda: hostname)
+    monkeypatch.setattr(security, "_local_ip_addresses", lambda: [ip.lower() for ip in ips])
+    monkeypatch.setattr(security, "_tailscale_hostname", lambda: tailscale)
+    monkeypatch.setattr(security, "_hosts_snapshot", (0.0, frozenset()))
 
 
 def test_normalize_origin_rejects_invalid_values() -> None:
@@ -45,7 +55,16 @@ def test_compute_allowed_ui_origins_honors_override(monkeypatch) -> None:
     ]
 
 
-def test_websocket_connection_allows_approved_origin_from_remote_client() -> None:
+def test_compute_allowed_ui_origins_lists_this_devices_addresses(monkeypatch) -> None:
+    _set_device(monkeypatch, hostname="orangepi5", ips=["192.168.89.96", "100.107.232.19"])
+    origins = compute_allowed_ui_origins()
+    assert "http://orangepi5:5173" in origins
+    assert "http://192.168.89.96:5173" in origins
+    assert "http://100.107.232.19:5173" in origins
+
+
+def test_websocket_connection_allows_approved_origin_from_remote_client(monkeypatch) -> None:
+    _set_device(monkeypatch)
     assert websocket_connection_allowed("http://sorter.local:5173/", "192.168.1.42") is True
 
 
@@ -54,22 +73,29 @@ def test_websocket_connection_without_origin_requires_loopback_client() -> None:
     assert websocket_connection_allowed(None, "192.168.1.42") is False
 
 
-def test_ui_origin_allows_local_and_private_hosts() -> None:
+def test_ui_origin_allows_this_devices_own_addresses(monkeypatch) -> None:
+    _set_device(
+        monkeypatch,
+        hostname="orangepi5",
+        ips=["192.168.89.96"],
+        tailscale="sorter-red-brick-0ffbef",
+    )
     assert is_ui_origin_allowed("http://localhost:5173") is True
     assert is_ui_origin_allowed("http://127.0.0.1:5173") is True
-    assert is_ui_origin_allowed("http://192.168.89.96:5173") is True
-    assert is_ui_origin_allowed("http://10.1.2.3:5173") is True
-    assert is_ui_origin_allowed("http://172.20.5.6:5173") is True
-    assert is_ui_origin_allowed("http://100.112.251.96:5173") is True  # Tailscale CGNAT
-    assert is_ui_origin_allowed("http://sorter.local:5173") is True
-    assert is_ui_origin_allowed("http://sorter-brown-axle.tail1234.ts.net:5173") is True
+    assert is_ui_origin_allowed("http://192.168.89.96:5173") is True  # current LAN IP
+    assert is_ui_origin_allowed("http://orangepi5:5173") is True  # OS hostname
+    assert is_ui_origin_allowed("http://orangepi5.local:5173") is True
+    assert is_ui_origin_allowed("http://sorter-red-brick-0ffbef:5173") is True  # Tailscale name
+    assert is_ui_origin_allowed("http://sorter.local:5173") is True  # any mDNS .local
 
 
-def test_ui_origin_rejects_public_hosts_and_wrong_port() -> None:
+def test_ui_origin_rejects_other_hosts_and_wrong_port(monkeypatch) -> None:
+    _set_device(monkeypatch, hostname="orangepi5", ips=["192.168.89.96"])
     assert is_ui_origin_allowed("http://8.8.8.8:5173") is False
     assert is_ui_origin_allowed("https://evil.example:5173") is False
-    assert is_ui_origin_allowed("http://172.32.0.1:5173") is False  # just outside 172.16/12
-    assert is_ui_origin_allowed("http://192.168.1.5:9999") is False  # wrong port
+    assert is_ui_origin_allowed("http://10.1.2.3:5173") is False  # not one of our IPs
+    assert is_ui_origin_allowed("http://192.168.1.5:5173") is False  # different LAN IP
+    assert is_ui_origin_allowed("http://192.168.89.96:9999") is False  # wrong port
     assert is_ui_origin_allowed(None) is False
 
 

--- a/software/sorter/backend/tests/test_websocket_security.py
+++ b/software/sorter/backend/tests/test_websocket_security.py
@@ -11,7 +11,6 @@ from server.api import app
 
 def test_websocket_accepts_allowed_origin() -> None:
     with (
-        patch("server.api.compute_allowed_ui_origins", return_value=["http://localhost:5173"]),
         patch("server.api.getRecentKnownObjects", return_value=[]),
         TestClient(app) as client,
     ):
@@ -23,7 +22,6 @@ def test_websocket_accepts_allowed_origin() -> None:
 
 def test_websocket_rejects_disallowed_origin() -> None:
     with (
-        patch("server.api.compute_allowed_ui_origins", return_value=["http://localhost:5173"]),
         patch("server.api.getRecentKnownObjects", return_value=[]),
         TestClient(app) as client,
     ):


### PR DESCRIPTION
## Purpose

Make the Sorter UI **just work however you connect to it**, and make the **Tailscale auth-key flow in settings** actually usable end-to-end.

Two operator-facing goals:

1. **Load the UI by whatever address you have** — `localhost`, the machine's hostname, its current **LAN IP** (`http://192.168.x.y:5173`), `*.local`, or its **Tailscale name** — without hitting CORS errors or having to edit per-machine config.
2. **Paste a Tailscale auth key in settings and have it work** — the machine joins the tailnet **named** (e.g. `sorter-dark-red-plate-0ffbef`), and the UI keeps working at the new name immediately, with no restart and no manual steps.

## What was broken

- Loading the UI by LAN IP was blocked by CORS (the allowlist never included the machine's own IP).
- A first attempt fixed that with a broad range-matching regex (all RFC1918 / `*.local` / `*.ts.net` / the CGNAT range) — far broader than needed, and it captured the device name **once at startup**, so a Tailscale rename via the UI left the new name blocked until a backend restart.
- Joining Tailscale from the UI didn't set a device name, so machines landed in the tailnet under a generic/duplicate name.
- The Tailscale status the UI displayed was parsed positionally from `tailscale status --self`, which on the deployed version lists **all peers** — so it frequently showed the wrong name.
- Even after the rename was accepted, an identity cache meant the first requests after a join (theme, `/health`, the WebSocket) intermittently failed CORS for a few seconds.

## What this does

- **Device-scoped dynamic CORS** — replaces the broad regex with a simple allowlist of *this device's own* identities: `localhost`, OS hostname (+`.local`), its **current IP addresses** (via `hostname -I`, so it tracks wifi/DHCP changes), any `*.local`, and its Tailscale name. Decided **per request** (a `CORSMiddleware` subclass) instead of a regex frozen at startup.
- **Name on UI join** — `tailscale up` now passes `--hostname=sorter-color-piece-mac` (same scheme as firstboot), reusing an existing `sorter-*` name so a re-join doesn't spawn duplicates.
- **Immediate refresh on join/logout** — the identity cache is invalidated the moment the name changes, so the UI reloaded at the new name is reachable on the first request (no more intermittent theme/health/WS failures).
- **Robust name parsing** — reads `Self.DNSName` from `tailscale status --json` instead of splitting peer-list text.

## Testing

- `tests/test_server_security.py` updated for the device-scoped behavior; all green.
- Verified on a test Pi: UI loads and CORS passes via `localhost`, current LAN IP, and `sorter.local`; `8.8.8.8` denied; Tailscale join from the UI generates a fresh name and the UI keeps working at it without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)