### PR TITLE
settings: subsystem mode selectors + classification channel as default setup

### DIFF
--- a/software/sorter/backend/server/routers/setup.py
+++ b/software/sorter/backend/server/routers/setup.py
@@ -19,7 +19,11 @@ from machine_setup import (
 )
 from blob_manager import getMachineId, getMachineNickname
 from hardware.bus import MCUBus
-from irl.config import _requiredCanonicalStepperNames
+from irl.config import (
+    ClassificationChannelMode,
+    FeederMode,
+    _requiredCanonicalStepperNames,
+)
 from irl.parse_user_toml import (
     LOGICAL_STEPPER_BINDING_BASES,
     loadMachineSetupConfig,
@@ -62,6 +66,14 @@ class FeedingModePayload(BaseModel):
 
 class MachineSetupPayload(BaseModel):
     setup: Literal["standard_carousel", "classification_channel", "manual_carousel"]
+
+
+class ClassificationChannelModePayload(BaseModel):
+    mode: str
+
+
+class FeederSubsystemModePayload(BaseModel):
+    mode: str
 
 
 def _board_summary(board: Any) -> dict[str, Any]:
@@ -703,6 +715,62 @@ def set_machine_setup(payload: MachineSetupPayload) -> Dict[str, Any]:
         "options": get_machine_setup_options(),
         "requires_rehome": True,
     }
+
+
+@router.get("/api/classification-channel-mode")
+def get_classification_channel_mode() -> Dict[str, Any]:
+    _, config = _read_machine_params_config()
+    current = config.get("classification_channel", {}).get("mode", ClassificationChannelMode.SIMPLE_STATE_MACHINE_REV01.value)
+    return {
+        "mode": current,
+        "options": [m.value for m in ClassificationChannelMode],
+    }
+
+
+@router.post("/api/classification-channel-mode")
+def set_classification_channel_mode(payload: ClassificationChannelModePayload) -> Dict[str, Any]:
+    valid = {m.value for m in ClassificationChannelMode}
+    if payload.mode not in valid:
+        raise HTTPException(status_code=400, detail=f"Invalid mode {payload.mode!r}; valid: {sorted(valid)}")
+    params_path, config = _read_machine_params_config()
+    section = config.get("classification_channel", {})
+    if not isinstance(section, dict):
+        section = {}
+    section["mode"] = payload.mode
+    config["classification_channel"] = section
+    try:
+        _write_machine_params_config(params_path, config)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to write config: {exc}")
+    return {"ok": True, "mode": payload.mode}
+
+
+@router.get("/api/feeder-subsystem-mode")
+def get_feeder_subsystem_mode() -> Dict[str, Any]:
+    _, config = _read_machine_params_config()
+    current = config.get("feeder", {}).get("mode", FeederMode.GO_TO_ANGLE_REV01.value)
+    return {
+        "mode": current,
+        "options": [m.value for m in FeederMode],
+    }
+
+
+@router.post("/api/feeder-subsystem-mode")
+def set_feeder_subsystem_mode(payload: FeederSubsystemModePayload) -> Dict[str, Any]:
+    valid = {m.value for m in FeederMode}
+    if payload.mode not in valid:
+        raise HTTPException(status_code=400, detail=f"Invalid mode {payload.mode!r}; valid: {sorted(valid)}")
+    params_path, config = _read_machine_params_config()
+    section = config.get("feeder", {})
+    if not isinstance(section, dict):
+        section = {}
+    section["mode"] = payload.mode
+    config["feeder"] = section
+    try:
+        _write_machine_params_config(params_path, config)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to write config: {exc}")
+    return {"ok": True, "mode": payload.mode}
 
 
 @router.get("/api/setup-wizard/stepper-directions")

--- a/software/sorter/frontend/src/lib/components/settings/GeneralSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/GeneralSection.svelte
@@ -53,6 +53,16 @@
 	let machineSetupError = $state<string | null>(null);
 	let machineSetupStatus = $state('');
 
+	let classificationMode = $state('simple_state_machine_rev01');
+	let savingClassificationMode = $state(false);
+	let classificationModeError = $state<string | null>(null);
+	let classificationModeStatus = $state('');
+
+	let feederMode = $state('go_to_angle_rev01');
+	let savingFeederMode = $state(false);
+	let feederModeError = $state<string | null>(null);
+	let feederModeStatus = $state('');
+
 	function handleConnect() {
 		manager.connect(url);
 	}
@@ -109,6 +119,23 @@
 			: 'standard_carousel';
 	}
 
+	function classificationModeLabel(mode: string): string {
+		const labels: Record<string, string> = {
+			simple_state_machine_rev01: 'Simple State Machine',
+			classic_carousel: 'Classic Carousel',
+			dynamic: 'Dynamic'
+		};
+		return labels[mode] ?? mode;
+	}
+
+	function feederModeLabel(mode: string): string {
+		const labels: Record<string, string> = {
+			go_to_angle_rev01: 'Go to Angle',
+			drop_zone_reactive_rev01: 'Drop Zone Reactive'
+		};
+		return labels[mode] ?? mode;
+	}
+
 	async function loadMachineSetup() {
 		const machine = manager.selectedMachine;
 		const httpBase = machineHttpBase(machine);
@@ -129,6 +156,74 @@
 			machineSetupError = e.message ?? 'Failed to load machine setup';
 		} finally {
 			loadingMachineSetup = false;
+		}
+	}
+
+	async function loadSubsystemModes() {
+		const machine = manager.selectedMachine;
+		const httpBase = machineHttpBase(machine);
+		if (!machine || !httpBase) return;
+		try {
+			const [cRes, fRes] = await Promise.all([
+				fetch(`${httpBase}/api/classification-channel-mode`),
+				fetch(`${httpBase}/api/feeder-subsystem-mode`)
+			]);
+			if (cRes.ok) {
+				const d = await cRes.json();
+				classificationMode = d.mode;
+			}
+			if (fRes.ok) {
+				const d = await fRes.json();
+				feederMode = d.mode;
+			}
+		} catch {}
+	}
+
+	async function saveClassificationMode(mode: string) {
+		const machine = manager.selectedMachine;
+		const httpBase = machineHttpBase(machine);
+		if (!machine || !httpBase) return;
+		savingClassificationMode = true;
+		classificationModeError = null;
+		classificationModeStatus = '';
+		try {
+			const res = await fetch(`${httpBase}/api/classification-channel-mode`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ mode })
+			});
+			if (!res.ok) throw new Error(await res.text());
+			const data = await res.json();
+			classificationMode = data.mode;
+			classificationModeStatus = 'Saved. Restart the backend for changes to take effect.';
+		} catch (e: any) {
+			classificationModeError = e.message ?? 'Failed to save classification mode';
+		} finally {
+			savingClassificationMode = false;
+		}
+	}
+
+	async function saveFeederMode(mode: string) {
+		const machine = manager.selectedMachine;
+		const httpBase = machineHttpBase(machine);
+		if (!machine || !httpBase) return;
+		savingFeederMode = true;
+		feederModeError = null;
+		feederModeStatus = '';
+		try {
+			const res = await fetch(`${httpBase}/api/feeder-subsystem-mode`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ mode })
+			});
+			if (!res.ok) throw new Error(await res.text());
+			const data = await res.json();
+			feederMode = data.mode;
+			feederModeStatus = 'Saved. Restart the backend for changes to take effect.';
+		} catch (e: any) {
+			feederModeError = e.message ?? 'Failed to save feeder mode';
+		} finally {
+			savingFeederMode = false;
 		}
 	}
 
@@ -178,6 +273,7 @@
 			machineSetupStatus = '';
 			if (machineId) {
 				void loadMachineSetup();
+				void loadSubsystemModes();
 			}
 		}
 	});
@@ -332,6 +428,66 @@
 				{:else if loadingMachineSetup}
 					<div class="text-sm text-text-muted">Loading current machine setup...</div>
 				{/if}
+
+				<div class="mt-4 flex flex-col gap-4">
+					<div>
+						<div class="mb-1.5 text-xs font-medium text-text">Classification Channel Mode</div>
+						<div class="flex flex-wrap gap-2">
+							{#each ['simple_state_machine_rev01', 'classic_carousel', 'dynamic'] as mode}
+								<button
+									onclick={() => saveClassificationMode(mode)}
+									disabled={savingClassificationMode}
+									class={`flex items-center gap-1.5 border px-3 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+										classificationMode === mode
+											? 'border-primary bg-primary/10 text-text'
+											: 'border-border bg-bg text-text hover:bg-surface'
+									}`}
+								>
+									{classificationModeLabel(mode)}
+									{#if mode === 'simple_state_machine_rev01'}
+										<span class="border border-primary/40 bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-primary">
+											default
+										</span>
+									{/if}
+								</button>
+							{/each}
+						</div>
+						{#if classificationModeError}
+							<div class="mt-1 text-xs text-danger">{classificationModeError}</div>
+						{:else if classificationModeStatus}
+							<div class="mt-1 text-xs text-text-muted">{classificationModeStatus}</div>
+						{/if}
+					</div>
+
+					<div>
+						<div class="mb-1.5 text-xs font-medium text-text">Feeder Mode</div>
+						<div class="flex flex-wrap gap-2">
+							{#each ['go_to_angle_rev01', 'drop_zone_reactive_rev01'] as mode}
+								<button
+									onclick={() => saveFeederMode(mode)}
+									disabled={savingFeederMode}
+									class={`flex items-center gap-1.5 border px-3 py-1.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+										feederMode === mode
+											? 'border-primary bg-primary/10 text-text'
+											: 'border-border bg-bg text-text hover:bg-surface'
+									}`}
+								>
+									{feederModeLabel(mode)}
+									{#if mode === 'go_to_angle_rev01'}
+										<span class="border border-primary/40 bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-[0.14em] text-primary">
+											default
+										</span>
+									{/if}
+								</button>
+							{/each}
+						</div>
+						{#if feederModeError}
+							<div class="mt-1 text-xs text-danger">{feederModeError}</div>
+						{:else if feederModeStatus}
+							<div class="mt-1 text-xs text-text-muted">{feederModeStatus}</div>
+						{/if}
+					</div>
+				</div>
 			</div>
 		{:else}
 			<div class="text-sm text-text-muted">

--- a/software/sorter/frontend/src/lib/components/settings/GeneralSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/GeneralSection.svelte
@@ -11,24 +11,22 @@
 		title: string;
 		description: string;
 		detail: string;
-		experimental?: boolean;
 	};
 
 	const MACHINE_SETUP_CARDS: MachineSetupCard[] = [
-		{
-			key: 'standard_carousel',
-			title: 'Standard Setup',
-			description: 'FIDA + Carousel + Classification Chamber',
-			detail:
-				'Uses the current automatic path with C-channel feeding, carousel handoff, and chamber classification.'
-		},
 		{
 			key: 'classification_channel',
 			title: 'Classification Channel',
 			description: 'C-Channels + Classification Channel',
 			detail:
-				'Replaces the carousel/chamber pair with a dedicated classification C-channel on the former carousel motor port.',
-			experimental: true
+				'Replaces the carousel/chamber pair with a dedicated classification C-channel on the former carousel motor port.'
+		},
+		{
+			key: 'standard_carousel',
+			title: 'Carousel Setup',
+			description: 'FIDA + Carousel + Classification Chamber',
+			detail:
+				'Uses the current automatic path with C-channel feeding, carousel handoff, and chamber classification.'
 		},
 		{
 			key: 'manual_carousel',
@@ -47,7 +45,7 @@
 	let nameSaving = $state(false);
 	let nameError = $state<string | null>(null);
 	let nameStatus = $state('');
-	let machineSetup = $state<MachineSetup>('standard_carousel');
+	let machineSetup = $state<MachineSetup>('classification_channel');
 	let loadingMachineSetup = $state(false);
 	let savingMachineSetup = $state(false);
 	let machineSetupError = $state<string | null>(null);
@@ -114,9 +112,9 @@
 	}
 
 	function normalizeMachineSetup(value: unknown): MachineSetup {
-		return value === 'classification_channel' || value === 'manual_carousel'
+		return value === 'standard_carousel' || value === 'manual_carousel'
 			? value
-			: 'standard_carousel';
+			: 'classification_channel';
 	}
 
 	function classificationModeLabel(mode: string): string {
@@ -402,24 +400,13 @@
 									: 'border-border bg-bg text-text hover:bg-surface'
 							}`}
 						>
-							<div class="flex w-full items-start justify-between gap-3">
-								<div class="text-sm font-medium">{card.title}</div>
-								{#if card.experimental}
-									<span class="border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.16em] text-amber-700 dark:text-amber-300">
-										Experimental
-									</span>
-								{/if}
-							</div>
+							<div class="text-sm font-medium">{card.title}</div>
 							<div class="text-xs font-medium text-text">{card.description}</div>
 							<div class="text-xs text-text-muted">
 								{card.detail}
 							</div>
 						</button>
 					{/each}
-				</div>
-				<div class="text-xs text-text-muted">
-					Changing the machine setup persists to the machine TOML and takes effect after `Reset` and
-					`Re-Home`.
 				</div>
 				{#if machineSetupError}
 					<div class="text-sm text-danger dark:text-red-400">{machineSetupError}</div>
@@ -486,6 +473,11 @@
 						{:else if feederModeStatus}
 							<div class="mt-1 text-xs text-text-muted">{feederModeStatus}</div>
 						{/if}
+					</div>
+
+					<div class="text-xs text-text-muted">
+						Changing the machine setup persists to the machine TOML and takes effect after Reset and
+						Re-Home.
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Adds Classification Channel Mode and Feeder Mode selectors to the Machine Setup section in Settings, backed by new `GET/POST /api/classification-channel-mode` and `GET/POST /api/feeder-subsystem-mode` endpoints that persist to machine.toml
- Moves Classification Channel first in the machine setup list and makes it the UI default; removes the Experimental badge
- Renames "Standard Setup" → "Carousel Setup"
- Moves the "persists to TOML" note below the subsystem mode selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)