### PR TITLE
settings/chute: fix angle display, add gear ratio math and homed state

### DIFF
--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -800,9 +800,15 @@ def _live_chute_status() -> Dict[str, Any]:
         "stepper_position_degrees": None,
         "stepper_microsteps": None,
         "stepper_stopped": None,
+        "homed": None,
         "digital_inputs": [],
         "home_pin_channel": _pin_channel(getattr(chute, "home_pin", None)),
     }
+
+    try:
+        status["homed"] = bool(chute.homed)
+    except Exception:
+        pass
 
     try:
         status["raw_endstop_high"] = bool(chute.home_pin.value)

--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -74,6 +74,11 @@ class Chute:
         self.first_section_offset_deg = float(first_section_offset_deg)
         self.endstop_active_high = endstop_active_high
         self.operating_speed_microsteps_per_second = operating_speed_microsteps_per_second
+        self._homed: bool = False
+
+    @property
+    def homed(self) -> bool:
+        return self._homed
 
     @property
     def section_pitch_deg(self) -> float:
@@ -288,4 +293,5 @@ class Chute:
         if not self._backoffToFirstBin():
             return False
         self.logger.info("Chute: homed successfully")
+        self._homed = True
         return True

--- a/software/sorter/frontend/src/lib/components/settings/StepperSidebar.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/StepperSidebar.svelte
@@ -58,6 +58,9 @@
 	let currentPositionDegrees = $state<number | null>(null);
 	let stepperMicrosteps = $state<number | null>(null);
 	let stepperStopped = $state<boolean | null>(null);
+	let chuteOutputAngle = $state<number | null>(null);
+	let chuteStepperDegrees = $state<number | null>(null);
+	let chuteHomed = $state<boolean | null>(null);
 	let liveRequestInFlight = false;
 
 	// --- Stepper control (persisted per stepper) ---
@@ -235,6 +238,17 @@
 					? payload.stepper_direction_inverted
 					: stepperDirectionInverted;
 		}
+		// chute-specific fields
+		chuteOutputAngle =
+			typeof payload?.current_angle === 'number' && Number.isFinite(payload.current_angle)
+				? payload.current_angle
+				: null;
+		chuteStepperDegrees =
+			typeof payload?.stepper_position_degrees === 'number' &&
+			Number.isFinite(payload.stepper_position_degrees)
+				? payload.stepper_position_degrees
+				: null;
+		chuteHomed = typeof payload?.homed === 'boolean' ? payload.homed : null;
 	}
 
 	async function loadSettings() {
@@ -632,14 +646,31 @@
 					<span
 						>{stepperStopped === null ? '--' : stepperStopped ? 'Stopped' : 'Moving'}</span
 					>
-					<span>·</span>
-					<span>{formatNumber(currentPositionDegrees)}°</span>
-					<span>·</span>
-					<span>{stepperMicrosteps ?? '--'} µs</span>
+					{#if isChute}
+						<span>·</span>
+						<span>Chute {formatNumber(chuteOutputAngle)}°</span>
+						<span>·</span>
+						<span>Motor {formatNumber(chuteStepperDegrees)}°</span>
+						<span>·</span>
+						<span>{stepperMicrosteps ?? '--'} µs</span>
+					{:else}
+						<span>·</span>
+						<span>{formatNumber(currentPositionDegrees)}°</span>
+						<span>·</span>
+						<span>{stepperMicrosteps ?? '--'} µs</span>
+					{/if}
 				</div>
+				{#if isChute}
+					<div class="mt-1 text-xs text-text-muted">
+						Gear ratio {gearRatio.toFixed(2)}× ({chuteStepperDegrees !== null && chuteOutputAngle !== null ? `${formatNumber(chuteStepperDegrees, 1)}° ÷ ${gearRatio.toFixed(2)} = ${formatNumber(chuteOutputAngle, 1)}°` : 'motor ÷ ratio = chute'})
+					</div>
+					<div class="mt-0.5 text-xs {chuteHomed === true ? 'text-success dark:text-green-400' : chuteHomed === false ? 'text-warning' : 'text-text-muted'}">
+						{chuteHomed === true ? 'Homed' : chuteHomed === false ? 'Not homed' : 'Homed: --'}
+					</div>
+				{/if}
 				{#if hasEndstop && endstopTriggered !== null}
 					<div
-						class="mt-1 text-xs {endstopTriggered
+						class="mt-0.5 text-xs {endstopTriggered
 							? 'text-success dark:text-green-400'
 							: 'text-text-muted'}"
 					>


### PR DESCRIPTION
## Summary

- The chute live endpoint returns `current_angle` and `stepper_position_degrees`, but the frontend was reading `current_position_degrees` (the generic stepper field), so the header always showed `--`
- Adds `_homed` tracking to `Chute` class (set `True` after successful `home()`), exposed via `homed` property and in the live status endpoint
- Chute settings header now shows: chute output angle, raw motor angle, gear ratio equation (motor° ÷ 4.80 = chute°), and homed/not-homed state

## Test plan

- [ ] Navigate to `/settings/chute` — header should show live chute and motor angles instead of `--`
- [ ] Home the chute — status should flip from "Not homed" to "Homed"
- [ ] Move the chute and confirm gear ratio equation updates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)