### PR TITLE
backend: per-stepper default acceleration applied on every move

### DIFF
--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -97,6 +97,14 @@ class StepperMotor:
         self._last_set_current: dict[str, int] | None = None
         self._gc = gc
         self.software_disabled = False
+        # Per-stepper default acceleration, set from StepperConfig at init. Every
+        # move re-asserts it (see _ensure_move_acceleration) so a move never runs
+        # on a stale acceleration left behind by a prior operation. None means
+        # "unmanaged" — leave whatever the firmware currently holds.
+        self._default_acceleration: int | None = None
+        # Last acceleration we sent to the firmware; lets _ensure_move_acceleration
+        # skip the UART write when the value is already correct.
+        self._applied_acceleration: int | None = None
 
     def _logical_to_physical_steps(self, value: int) -> int:
         return -value if self._direction_inverted else value
@@ -104,21 +112,26 @@ class StepperMotor:
     def _physical_to_logical_steps(self, value: int) -> int:
         return -value if self._direction_inverted else value
 
-    def move_degrees(self, degrees: float, *, force: bool = False) -> bool:
+    def move_degrees(self, degrees: float, *, acceleration: int | None = None, force: bool = False) -> bool:
         """
         Move the stepper by a given number of degrees (positive or negative).
         Uses steps_per_revolution to calculate the number of steps.
         """
         steps = self.microsteps_for_degrees(degrees)
-        return self.move_steps(steps, force=force)
+        return self.move_steps(steps, acceleration=acceleration, force=force)
 
-    def move_steps(self, steps: int, *, force: bool = False) -> bool:
-        """Move the stepper by a given number of microsteps (positive or negative)."""
+    def move_steps(self, steps: int, *, acceleration: int | None = None, force: bool = False) -> bool:
+        """Move the stepper by a given number of microsteps (positive or negative).
+
+        ``acceleration`` overrides the stepper's default for this move only; when
+        None the configured per-stepper default is (re-)asserted first.
+        """
         if steps == 0:
             return True
         if self.software_disabled and not force:
             self._gc.logger.debug(f"Stepper '{self._name}' ch{self._channel}: move_steps({steps}) suppressed (software_disabled)")
             return True
+        self._ensure_move_acceleration(acceleration)
         physical_steps = self._logical_to_physical_steps(steps)
         self._gc.logger.info(
             f"Stepper '{self._name}' (hw='{self._hardware_name}') ch{self._channel}: "
@@ -135,11 +148,18 @@ class StepperMotor:
             self._gc.logger.error(f"Stepper '{self._name}' ch{self._channel}: move_steps({steps}) FAILED")
         return success
     
-    def move_at_speed(self, speed: int, *, force: bool = False) -> bool:
-        """Move the stepper at a given speed in microsteps per second."""
+    def move_at_speed(self, speed: int, *, acceleration: int | None = None, force: bool = False) -> bool:
+        """Move the stepper at a given speed in microsteps per second.
+
+        ``acceleration`` overrides the stepper's default for this move only; when
+        None the configured per-stepper default is (re-)asserted first. A stop
+        (speed 0) leaves acceleration untouched.
+        """
         if self.software_disabled and not force:
             self._gc.logger.debug(f"Stepper '{self._name}' ch{self._channel}: move_at_speed({speed}) suppressed (software_disabled)")
             return True
+        if speed != 0:
+            self._ensure_move_acceleration(acceleration)
         physical_speed = self._logical_to_physical_steps(speed)
         self._gc.logger.info(
             f"Stepper '{self._name}' (hw='{self._hardware_name}') ch{self._channel}: "
@@ -202,7 +222,27 @@ class StepperMotor:
         self._gc.logger.info(f"Stepper '{self._name}' ch{self._channel}: set_acceleration={acceleration} µsteps/s²")
         payload = struct.pack("<I", acceleration)  # 4 bytes, little-endian unsigned integer
         self._dev.send_command(InterfaceCommandCode.STEPPER_SET_ACCELERATION, self._channel, payload)
-    
+        self._applied_acceleration = int(acceleration)
+
+    def set_default_acceleration(self, acceleration: int) -> None:
+        """Store the per-stepper default acceleration (µsteps/s²) that every move
+        re-asserts. Set from StepperConfig at init; jitter manages its own."""
+        self._default_acceleration = int(acceleration)
+
+    @property
+    def default_acceleration(self) -> int | None:
+        return self._default_acceleration
+
+    def _ensure_move_acceleration(self, override: int | None) -> None:
+        """Assert the acceleration to use for an imminent move: the per-call
+        ``override`` if given, otherwise the stepper's default. Sends the command
+        only when the firmware is not already at that value, so the steady-state
+        sorting path adds no extra bus traffic."""
+        accel = override if override is not None else self._default_acceleration
+        if accel is None or accel == self._applied_acceleration:
+            return
+        self.set_acceleration(accel)
+
     @property
     def stopped(self) -> bool:
         """Check if the stepper is stopped."""

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -210,13 +210,29 @@ class CameraColorProfile:
         self.gamma_b = gamma_b
 
 
+# Matches the firmware's Stepper constructor default (`_accel(10000)` in
+# Stepper.cpp). The firmware keeps acceleration as mutable per-motor state that
+# is not reliably at this value at runtime, so the backend is authoritative: it
+# stores a per-stepper default here and re-applies it before every move (see
+# StepperMotor.move_*; jitter is the only exception, it manages its own).
+# Change this one value to retune the acceleration of every stepper at once.
+FIRMWARE_DEFAULT_ACCELERATION_MICROSTEPS_PER_SECOND_SQ = 10000
+
+
 class StepperConfig:
     default_steps_per_second: int
     microsteps: int
+    acceleration_microsteps_per_second_sq: int
 
-    def __init__(self, default_steps_per_second: int = 2000, microsteps: int = 8):
+    def __init__(
+        self,
+        default_steps_per_second: int = 2000,
+        microsteps: int = 8,
+        acceleration_microsteps_per_second_sq: int = FIRMWARE_DEFAULT_ACCELERATION_MICROSTEPS_PER_SECOND_SQ,
+    ):
         self.default_steps_per_second = default_steps_per_second
         self.microsteps = microsteps
+        self.acceleration_microsteps_per_second_sq = acceleration_microsteps_per_second_sq
 
 
 class RotorPulseConfig:
@@ -1305,8 +1321,6 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
     stepper_binding_overrides = loadStepperBindingOverrides(gc, machine_specific_params)
     stepper_current_overrides = machine_config.stepper_current_overrides
     stepper_direction_inverts = loadStepperDirectionInverts(gc, machine_specific_params)
-    servo_open_angle = machine_config.servo_open_angle
-    servo_closed_angle = machine_config.servo_closed_angle
     servo_channel_config = loadServoChannelConfig(gc, machine_specific_params)
     mcu_ports = MCUBus.enumerate_buses()
     required_stepper_names = _requiredCanonicalStepperNames(
@@ -1414,6 +1428,7 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
         if stepper_config is not None:
             microsteps = stepper_config.microsteps
             default_steps_per_second = stepper_config.default_steps_per_second
+            default_acceleration = stepper_config.acceleration_microsteps_per_second_sq
             _run_stepper_init_command_with_retry(
                 gc,
                 attr_base,
@@ -1426,8 +1441,17 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
                 f"speed limits min=16 max={default_steps_per_second}",
                 lambda: stepper.set_speed_limits(16, default_steps_per_second),
             )
+            # Record the default so every move re-asserts it, and apply it once
+            # now so the value is correct before the first move (e.g. homing).
+            stepper.set_default_acceleration(default_acceleration)
+            _run_stepper_init_command_with_retry(
+                gc,
+                attr_base,
+                f"acceleration={default_acceleration}",
+                lambda: stepper.set_acceleration(default_acceleration),
+            )
             gc.logger.info(
-                f"Stepper '{attr_base}' (physical '{physical_name}') config: microsteps={microsteps}, speed={default_steps_per_second}"
+                f"Stepper '{attr_base}' (physical '{physical_name}') config: microsteps={microsteps}, speed={default_steps_per_second}, acceleration={default_acceleration}"
             )
         else:
             gc.logger.warn(

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -743,11 +743,12 @@ def move_stepper_degrees(
     try:
         target.enable_force(True)
         if want_ramp:
-            target.set_acceleration(int(acceleration))
             target.set_speed_limits(min_speed=int(min_speed), max_speed=int(speed))
+            move_acceleration: int | None = int(acceleration)
         else:
             target.set_speed_limits(min_speed=16, max_speed=int(speed))
-        if not bool(target.move_degrees(degrees, force=True)):
+            move_acceleration = None
+        if not bool(target.move_degrees(degrees, acceleration=move_acceleration, force=True)):
             raise RuntimeError("move_degrees was not acknowledged")
     except Exception as e:
         lock.release()
@@ -1123,6 +1124,7 @@ def stallguard_sweep(
     try:
         target.write_driver_register(TMC_REG_TCOOLTHRS, tcoolthrs)
         target.enable_force(True)
+        # move_at_speed re-asserts the stepper's configured default acceleration.
         if not bool(target.move_at_speed(signed_speed, force=True)):
             raise RuntimeError("move_at_speed was not acknowledged")
 


### PR DESCRIPTION
## Problem

Steppers ran on the firmware's mutable per-motor acceleration (`_accel`), which was not reliably at its constructor default at runtime. A manual StallGuard sweep stalled the chute even though the same motor jogged fine at higher speed from the UI buttons. Confirmed on `sorter-dark-brown-axle`: explicitly setting the firmware default (10000) before the sweep's move made it move correctly — proving the default was not actually in effect.

## Change

Make the backend authoritative for stepper acceleration instead of relying on leftover firmware state:

- `StepperConfig` carries `acceleration_microsteps_per_second_sq`, defaulting to `FIRMWARE_DEFAULT_ACCELERATION_MICROSTEPS_PER_SECOND_SQ` (10000). Change that one constant to retune every stepper at once.
- Stored on each `StepperMotor` at init and applied once up front (so it's correct before the first move, e.g. homing).
- `move_steps` / `move_degrees` / `move_at_speed` re-assert it before every move, with an optional per-call `acceleration=` override. The send is idempotent — it only hits the bus when the value actually changed, so steady-state sorting adds no extra traffic.
- **Jitter is untouched** (it saves/restores its own), and a stop (speed 0) leaves acceleration alone.

### Effect on existing call sites
The scattered `set_acceleration(...)` calls in the classification-channel / C4 / exit-release / coordinator / detection paths are now overridden by the per-stepper default on the next move, so they all converge on the one configured default. Those lines are now dead-but-harmless; a follow-up can remove them.

## Testing
Diagnostic on the live machine confirmed the stall is fixed when the default is applied. Not yet run end-to-end through a full sort after this refactor — verify after loading.

## Note
Do not merge yet.