### PR TITLE
[spencer01] StallGuard stall detection + per-servo motion speeds + chute aiming

### DIFF
--- a/software/firmware/sorter_interface_firmware/Stepper.cpp
+++ b/software/firmware/sorter_interface_firmware/Stepper.cpp
@@ -269,6 +269,19 @@ void Stepper::stepgen_tick() {
  *  It updates the motion parameters (speed, acceleration, state transitions) of the stepper.
  */
 void Stepper::motion_update_tick() {
+    // StallGuard: the TMC2209 holds DIAG high while it reads a stall (SG_RESULT
+    // <= 2*SGTHRS above the TCOOLTHRS velocity floor). When armed, latch it and
+    // stop immediately — the backend poll then raises an operator incident.
+    // Skip while jittering: the unstick wiggle is *meant* to fight load, and a
+    // stall during it is expected, not a fault.
+    if (_stall_enabled.load() && _stall_pin >= 0 && _state.load() != STEPPER_STOPPED &&
+        !_jitter_active.load() && gpio_get(_stall_pin)) {
+        _stalled.store(true);
+        _state.store(STEPPER_STOPPED);
+        _current_speed.store(0);
+        _current_speed_frac.store(0);
+        return;
+    }
     switch (_state) {
         case STEPPER_STOPPED:
             // Chain the next jitter stroke if one is pending. A completed stroke

--- a/software/firmware/sorter_interface_firmware/Stepper.h
+++ b/software/firmware/sorter_interface_firmware/Stepper.h
@@ -64,6 +64,20 @@ public:
     void setPosition(int32_t position) { _absolute_position = position; }
     void home(int32_t home_speed, int home_pin, bool home_pin_polarity);
 
+    // StallGuard / DIAG. The TMC2209 drives its DIAG output high when SG_RESULT
+    // falls to/below 2*SGTHRS while running above the TCOOLTHRS velocity floor —
+    // i.e. the motor is stalling. setStallPin() records the wired GPIO (-1 if
+    // none); enableStallDetection() arms the motion-tick check; wasStalled()
+    // reports the latched event; clearStall() resets it. SGTHRS/TCOOLTHRS are
+    // configured by the backend over UART (write_driver_register), not here.
+    void setStallPin(int pin) { _stall_pin = pin; }
+    void enableStallDetection(bool enable) {
+        _stall_enabled.store(enable);
+        if (enable) _stalled.store(false);
+    }
+    bool wasStalled() { return _stalled.load(); }
+    void clearStall() { _stalled.store(false); }
+
 private:
     void beginJitterStroke();
 
@@ -101,6 +115,15 @@ private:
     std::atomic<int32_t> _jitter_amplitude; // microsteps per stroke
     std::atomic<int32_t> _jitter_strokes_remaining; // strokes still to perform (2 per cycle)
     std::atomic<int32_t> _jitter_dir; // direction of the next stroke (1 / -1)
+
+    // StallGuard state. _stall_pin is set once at init (core0) and only read by
+    // the core1 motion tick, so it needs no atomicity. _stall_enabled/_stalled
+    // are written from both cores (core0 commands, core1 detection) so they are
+    // atomic. _stalled latches until clearStall() so a transient stall is not
+    // lost between backend polls.
+    int _stall_pin = -1; // TMC2209 DIAG GPIO for this channel, -1 if not wired
+    std::atomic<bool> _stall_enabled{false}; // whether the motion tick checks DIAG
+    std::atomic<bool> _stalled{false}; // latched: DIAG fired while moving
 };
 
 #endif // STEPPER_H

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -69,6 +69,9 @@ void CMDH_stepper_drv_set_microsteps(const BusMessage *msg, BusMessage *resp);
 void CMDH_stepper_drv_set_current(const BusMessage *msg, BusMessage *resp);
 void CMDH_stepper_drv_read_register(const BusMessage *msg, BusMessage *resp);
 void CMDH_stepper_drv_write_register(const BusMessage *msg, BusMessage *resp);
+void CMDH_stepper_enable_stall_detection(const BusMessage *msg, BusMessage *resp);
+void CMDH_stepper_get_stall_status(const BusMessage *msg, BusMessage *resp);
+void CMDH_stepper_clear_stall(const BusMessage *msg, BusMessage *resp);
 bool VAL_stepper_channel(uint8_t channel);
 
 const struct CommandTable stepperCmdTable = {
@@ -84,6 +87,12 @@ const struct CommandTable stepperCmdTable = {
         {"HOME", "iB?", "", 6, VAL_stepper_channel, CMDH_stepper_home},
         {"JITTER", "iiii", "?", 16, VAL_stepper_channel, CMDH_stepper_jitter},
         {"IS_JITTERING", "", "B", 0, VAL_stepper_channel, CMDH_stepper_is_jittering},
+        // StallGuard. GET_STALL_STATUS ignores the channel and returns a bitmask
+        // of every channel on this board (bit i = stepper i latched-stalled), so
+        // the backend learns all stalls in one bus round-trip.
+        {"ENABLE_STALL_DETECTION", "?", "", 1, VAL_stepper_channel, CMDH_stepper_enable_stall_detection},
+        {"GET_STALL_STATUS", "", "B", 0, VAL_stepper_channel, CMDH_stepper_get_stall_status},
+        {"CLEAR_STALL", "", "", 0, VAL_stepper_channel, CMDH_stepper_clear_stall},
     }}};
 
 const struct CommandTable stepperDrvCmdTable = {
@@ -448,6 +457,18 @@ void initialize_hardware() {
         gpio_put(STEPPER_nEN_PINS[i], 1);
         stepper_hw_enabled[i] = false;
     }
+    // Initialize StallGuard DIAG inputs. TMC2209 drives DIAG high on stall, so
+    // pull down for a defined idle level. Channels with no DIAG wire (pin < 0)
+    // get _stall_pin = -1 and are simply never checked.
+    for (int i = 0; i < STEPPER_COUNT; i++) {
+        if (STEPPER_DIAG_PINS[i] >= 0) {
+            gpio_init(STEPPER_DIAG_PINS[i]);
+            gpio_set_dir(STEPPER_DIAG_PINS[i], GPIO_IN);
+            gpio_pull_down(STEPPER_DIAG_PINS[i]);
+        }
+        steppers[i].setStallPin(STEPPER_DIAG_PINS[i]);
+        steppers[i].enableStallDetection(false);
+    }
     // Initialize digital inputs
     for (int i = 0; i < DIGITAL_INPUT_COUNT; i++) {
         gpio_init(digital_input_pins[i]);
@@ -697,6 +718,33 @@ void CMDH_stepper_drv_write_register(const BusMessage *msg, BusMessage *resp) {
     uint32_t value;
     memcpy(&value, msg->payload + 1, sizeof(value));
     tmc_drivers[msg->channel].writeRegister(reg, value);
+    resp->payload_length = 0;
+}
+
+void CMDH_stepper_enable_stall_detection(const BusMessage *msg, BusMessage *resp) {
+    bool enable = msg->payload[0] != 0;
+    if (enable && STEPPER_DIAG_PINS[msg->channel] < 0) {
+        resp->command = msg->command | 0x80; // Set error bit
+        resp->payload_length =
+            snprintf((char *)resp->payload, MAX_PAYLOAD_SIZE, "No DIAG pin for channel %u", msg->channel);
+        return;
+    }
+    steppers[msg->channel].enableStallDetection(enable);
+    resp->payload_length = 0;
+}
+
+void CMDH_stepper_get_stall_status(const BusMessage *msg, BusMessage *resp) {
+    (void)msg; // Channel is ignored: we report every channel on this board at once.
+    uint8_t mask = 0;
+    for (int i = 0; i < STEPPER_COUNT; i++) {
+        if (steppers[i].wasStalled()) mask |= (uint8_t)(1u << i);
+    }
+    resp->payload[0] = mask;
+    resp->payload_length = 1;
+}
+
+void CMDH_stepper_clear_stall(const BusMessage *msg, BusMessage *resp) {
+    steppers[msg->channel].clearStall();
     resp->payload_length = 0;
 }
 

--- a/software/machine.example.toml
+++ b/software/machine.example.toml
@@ -5,8 +5,8 @@
 [servo]
 # For PCA9685 (default):
 # backend = "pca9685"
-open_angle = 10
-closed_angle = 83
+# PCA9685 open/closed angles are calibrated per-layer (see [layers] below), not
+# globally — there is no machine-wide default open/closed angle.
 
 # For Waveshare SC bus servos, uncomment below:
 # backend = "waveshare"
@@ -21,7 +21,9 @@ closed_angle = 83
 # invert = false
 
 # Each entry in sections is one layer's bin layout (bottom to top).
-# servo_open_angles / servo_closed_angles override the global [servo] defaults per layer index.
+# servo_open_angles / servo_closed_angles set the PCA9685 servo open/closed
+# angles per layer index. A layer is only "calibrated" (and driven on home)
+# when both its open and closed angle are set.
 [layers]
 sections = [
     [["medium", "medium"], ["medium", "medium"], ["medium", "medium"], ["medium", "medium"], ["medium", "medium"], ["medium", "medium"]],

--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -24,6 +24,9 @@ class InterfaceCommandCode(BaseCommandCode):
     STEPPER_HOME = 0x17
     STEPPER_JITTER = 0x18
     STEPPER_IS_JITTERING = 0x19
+    STEPPER_ENABLE_STALL_DETECTION = 0x1A
+    STEPPER_GET_STALL_STATUS = 0x1B  # channel ignored; returns a per-board stall bitmask
+    STEPPER_CLEAR_STALL = 0x1C
     # Stepper driver commands
     STEPPER_DRV_SET_ENABLED = 0x20
     STEPPER_DRV_SET_MICROSTEPS = 0x21
@@ -97,6 +100,12 @@ class StepperMotor:
         self._last_set_current: dict[str, int] | None = None
         self._gc = gc
         self.software_disabled = False
+        # StallGuard config, stamped from [stepper_stallguard.*] at init by
+        # applyStepperStallguard. The stall monitor reads these to decide which
+        # steppers to arm and at what threshold. sgthrs is None => unconfigured.
+        self.stallguard_sgthrs: int | None = None
+        self.stallguard_tcoolthrs: int = 0xFFFFF
+        self.stallguard_enabled: bool = False
         # Per-stepper default acceleration, set from StepperConfig at init. Every
         # move re-asserts it (see _ensure_move_acceleration) so a move never runs
         # on a stale acceleration left behind by a prior operation. None means
@@ -364,6 +373,13 @@ class StepperMotor:
         payload = struct.pack("<BI", address, value) # 1 byte for address, 4 bytes for value
         self._dev.send_command(InterfaceCommandCode.STEPPER_DRV_WRITE_REGISTER, self._channel, payload)
 
+    def enable_stall_detection(self, enable: bool) -> None:
+        payload = struct.pack("<?", enable)
+        self._dev.send_command(InterfaceCommandCode.STEPPER_ENABLE_STALL_DETECTION, self._channel, payload)
+
+    def clear_stall(self) -> None:
+        self._dev.send_command(InterfaceCommandCode.STEPPER_CLEAR_STALL, self._channel, b'')
+
     @property
     def steps_per_revolution(self):
         return self._steps_per_revolution
@@ -393,6 +409,10 @@ class StepperMotor:
     def total_steps_per_rev(self) -> int:
         """Get the total microsteps per revolution (considering microsteps)."""
         return self._steps_per_revolution * self._microsteps
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def set_name(self, name: str) -> None:
         """Set a human-readable name for this stepper."""
@@ -766,6 +786,13 @@ class SorterInterface(MCUDevice):
     @property
     def board_info(self) -> dict:
         return dict(self._board_info)
+
+    def get_stall_status(self) -> int:
+        """Return this board's stall bitmask: bit i set => stepper channel i is
+        latched-stalled. One bus round-trip covers every channel on the board.
+        Channel arg is ignored by the firmware, so we send 0."""
+        res = self.send_command(InterfaceCommandCode.STEPPER_GET_STALL_STATUS, 0, b"")
+        return res.payload[0] if res.payload else 0
 
     def get_observability_info(self, *, force_refresh: bool = False) -> dict:
         if self._observability_info is not None and not force_refresh:

--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -468,7 +468,11 @@ class ServoMotor:
         self._dev = device
         self._channel = channel
         self._name = f"servo_{channel}"
-        self._current_angle = 0
+        # What we think the servo's angle is. None means "unknown" — we have
+        # not commanded a move since boot, so we cannot claim to know where it
+        # is. Set on every move_to / move_to_and_release (so it tracks open,
+        # close, jog, and homing) and surfaced anywhere the servo is reported.
+        self._current_angle: int | None = None
         # No factory defaults: a PWM servo must be calibrated (its open and
         # closed angles locked in via the UI) before it is allowed to move.
         # None means "uncalibrated" — open()/close()/toggle() no-op until both
@@ -476,6 +480,13 @@ class ServoMotor:
         # angle that might be mechanically unsafe.
         self._open_angle: int | None = None
         self._closed_angle: int | None = None
+        # Configured motion speeds (°/s, None = firmware default). Speed is
+        # sticky firmware state, so callers apply the right one before a move:
+        # sorting uses open/close speed (apply_open_speed/apply_close_speed),
+        # homing and jog use the standard speed (apply_homing_speed).
+        self._open_speed: int | None = None
+        self._close_speed: int | None = None
+        self._homing_speed: int | None = None
         # Track enabled state locally; the firmware does not provide a GET for enabled.
         self._enabled = False
         self._gc = gc
@@ -611,6 +622,34 @@ class ServoMotor:
         payload = struct.pack("<HH", min_speed, max_speed) # 4 bytes, two little-endian unsigned integers
         self._dev.send_command(InterfaceCommandCode.SERVO_SET_SPEED_LIMITS, self._channel, payload)
 
+    def set_motion_speeds(
+        self,
+        open_speed: int | None,
+        close_speed: int | None,
+        homing_speed: int | None,
+    ) -> None:
+        """Store the configured open/close/homing speeds (°/s). These are not
+        pushed to the firmware here — a caller applies the relevant one with
+        apply_open_speed/apply_close_speed/apply_homing_speed before its move."""
+        self._open_speed = open_speed
+        self._close_speed = close_speed
+        self._homing_speed = homing_speed
+
+    def _apply_speed_deg_s(self, speed_deg_s: int | None) -> None:
+        if speed_deg_s is None:
+            return
+        # Floor of 10 (1°/s) matches _SERVO_SPEED_FLOOR_TENTHS in the router.
+        self.set_speed_limits(10, speed_deg_s * 10)
+
+    def apply_open_speed(self) -> None:
+        self._apply_speed_deg_s(self._open_speed)
+
+    def apply_close_speed(self) -> None:
+        self._apply_speed_deg_s(self._close_speed)
+
+    def apply_homing_speed(self) -> None:
+        self._apply_speed_deg_s(self._homing_speed)
+
     def set_acceleration(self, acceleration: int) -> None:
         """Set the acceleration for the servo in tenths of degrees per second squared."""
         self._gc.logger.info(f"Servo '{self._name}' ch{self._channel}: set_acceleration={acceleration} 0.1°/s²")
@@ -671,8 +710,9 @@ class ServoMotor:
         return self._open_angle is not None and self._closed_angle is not None
 
     @property
-    def angle(self) -> int:
-        """Get the current servo angle."""
+    def angle(self) -> int | None:
+        """What we think the current servo angle is, or None if unknown
+        (no move commanded since boot)."""
         return self._current_angle
 
     @property

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -1507,7 +1507,6 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
         irl_interface.servos = irl_interface.servo_controller.create_layer_servos(
             irl_interface.distribution_layout
         )
-        homing_speed = machine_config.servo_homing_speed
         for layer_index, servo in enumerate(irl_interface.servos):
             if not hasattr(servo, "set_preset_angles"):
                 continue
@@ -1515,8 +1514,15 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
             layer_closed = bin_layout.layers[layer_index].servo_closed_angle if layer_index < len(bin_layout.layers) else None
             if layer_open is not None and layer_closed is not None:
                 servo.set_preset_angles(layer_open, layer_closed)
-            if homing_speed is not None and hasattr(servo, "set_speed_limits"):
-                servo.set_speed_limits(10, homing_speed * 10)
+            if hasattr(servo, "set_motion_speeds"):
+                servo.set_motion_speeds(
+                    machine_config.servo_open_speed,
+                    machine_config.servo_close_speed,
+                    machine_config.servo_homing_speed,
+                )
+                # Start at the standard speed; sorting re-applies open/close
+                # speed per move and homing re-applies the standard speed.
+                servo.apply_homing_speed()
         restore_servo_states(irl_interface.servos, gc)
 
     irl_interface.machine_profile = build_machine_profile(

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -61,6 +61,7 @@ from .parse_user_toml import (
     loadCameraLayoutConfig,
     loadGpioLedsConfig,
     applyStepperCurrentOverride,
+    applyStepperStallguard,
 )
 from blob_manager import getBinCategories
 from local_state import get_servo_states, set_servo_states
@@ -1459,6 +1460,7 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
             )
 
         applyStepperCurrentOverride(stepper, canonical_name, stepper_current_overrides, gc)
+        applyStepperStallguard(stepper, canonical_name, machine_config.stepper_stallguard, gc)
         logical_name = logical_name_for_attr_base.get(attr_base)
         stepper.set_direction_inverted(
             stepper_direction_inverts.get(logical_name, False) if logical_name is not None else False

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -1507,16 +1507,16 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
         irl_interface.servos = irl_interface.servo_controller.create_layer_servos(
             irl_interface.distribution_layout
         )
+        homing_speed = machine_config.servo_homing_speed
         for layer_index, servo in enumerate(irl_interface.servos):
             if not hasattr(servo, "set_preset_angles"):
                 continue
             layer_open = bin_layout.layers[layer_index].servo_open_angle if layer_index < len(bin_layout.layers) else None
             layer_closed = bin_layout.layers[layer_index].servo_closed_angle if layer_index < len(bin_layout.layers) else None
-            # Servos only ever get angles that were explicitly locked in per
-            # layer via the UI. There is no global default to fall back on, so an
-            # uncalibrated layer stays None and will not move.
             if layer_open is not None and layer_closed is not None:
                 servo.set_preset_angles(layer_open, layer_closed)
+            if homing_speed is not None and hasattr(servo, "set_speed_limits"):
+                servo.set_speed_limits(10, homing_speed * 10)
         restore_servo_states(irl_interface.servos, gc)
 
     irl_interface.machine_profile = build_machine_profile(

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -157,6 +157,9 @@ class MachineConfig:
     servo_close_speed: int | None = None
     servo_homing_speed: int | None = None
     stepper_current_overrides: dict[str, tuple[int, int, int]] = field(default_factory=dict)
+    # canonical stepper name -> (sgthrs, tcoolthrs, enabled). From
+    # [stepper_stallguard.*]; consumed by applyStepperStallguard + the stall monitor.
+    stepper_stallguard: dict[str, tuple[int, int, bool]] = field(default_factory=dict)
 
 
 def loadMachineSpecificParams(gc: GlobalConfig) -> dict[str, object]:
@@ -277,6 +280,60 @@ def _parseStepperCurrentOverrides(
         )
 
     return overrides
+
+
+def _parseStepperStallguard(
+    gc: GlobalConfig,
+    raw: dict[str, object],
+) -> dict[str, tuple[int, int, bool]]:
+    table: object = raw.get("stepper_stallguard")
+    if table is None:
+        return {}
+
+    if not isinstance(table, dict):
+        gc.logger.warning("stepper_stallguard must be an object. Ignoring StallGuard config.")
+        return {}
+
+    configs: dict[str, tuple[int, int, bool]] = {}
+    for stepper_name, value in table.items():
+        if not isinstance(stepper_name, str):
+            gc.logger.warning(
+                f"Ignoring invalid stepper key in stallguard config: {stepper_name!r} (must be string)"
+            )
+            continue
+
+        if not isinstance(value, dict):
+            gc.logger.warning(
+                f"Ignoring stallguard config for '{stepper_name}': expected object with sgthrs/tcoolthrs/enabled."
+            )
+            continue
+
+        sgthrs = value.get("sgthrs", -1)  # -1 => missing; rejected by range check below
+        tcoolthrs = value.get("tcoolthrs", 0xFFFFF)
+        enabled = value.get("enabled", True)
+
+        fields_valid = (
+            type(sgthrs) is int
+            and type(tcoolthrs) is int
+            and isinstance(enabled, bool)
+            and 0 <= sgthrs <= 255
+            and 0 <= tcoolthrs <= 0xFFFFF
+        )
+
+        if not fields_valid:
+            gc.logger.warning(
+                f"Ignoring invalid stallguard config for '{stepper_name}': {value!r} "
+                f"(requires sgthrs:0-255, tcoolthrs:0-0xFFFFF, enabled:bool)."
+            )
+            continue
+
+        configs[normalizePhysicalStepperBindingName(stepper_name)] = (
+            int(sgthrs),
+            int(tcoolthrs),
+            bool(enabled),
+        )
+
+    return configs
 
 
 def loadStepperBindingOverrides(
@@ -423,6 +480,7 @@ def loadMachineConfig(
         gc.logger.warning("Ignoring invalid servo config: expected object.")
 
     config.stepper_current_overrides = _parseStepperCurrentOverrides(gc, raw)
+    config.stepper_stallguard = _parseStepperStallguard(gc, raw)
 
     return config
 
@@ -873,6 +931,64 @@ def applyStepperCurrentOverride(
     gc.logger.info(
         f"Stepper '{stepper_name}' current config applied from {source}: "
         f"IRUN={irun}, IHOLD={ihold}, IHOLD_DELAY={ihold_delay}"
+    )
+
+
+# TMC2209 StallGuard registers.
+_TMC_REG_TCOOLTHRS = 0x14
+_TMC_REG_SGTHRS = 0x40
+
+
+def applyStepperStallguard(
+    stepper: "StepperMotor",
+    stepper_name: str,
+    configs: dict[str, tuple[int, int, bool]],
+    gc: GlobalConfig,
+) -> None:
+    """Stamp [stepper_stallguard.*] onto the stepper and write SGTHRS/TCOOLTHRS.
+
+    This does NOT arm DIAG detection — the stall monitor does that on entering
+    RUNNING (and re-writes the registers then, so they survive sweeps/coolstep
+    toggles). Steppers with no entry, or enabled=false, are simply never armed.
+    """
+    config = configs.get(stepper_name)
+    if config is None:
+        return
+    sgthrs, tcoolthrs, enabled = config
+    stepper.stallguard_sgthrs = sgthrs
+    stepper.stallguard_tcoolthrs = tcoolthrs
+    stepper.stallguard_enabled = enabled
+
+    if not enabled:
+        gc.logger.info(
+            f"Stepper '{stepper_name}' StallGuard configured but disabled "
+            f"(sgthrs={sgthrs}); not arming."
+        )
+        return
+
+    for attempt in range(1, HARDWARE_INIT_COMMAND_ATTEMPTS + 1):
+        try:
+            stepper.write_driver_register(_TMC_REG_SGTHRS, sgthrs)
+            stepper.write_driver_register(_TMC_REG_TCOOLTHRS, tcoolthrs)
+            break
+        except (MCUBusError, OSError, DecodeError) as e:
+            if attempt == HARDWARE_INIT_COMMAND_ATTEMPTS:
+                gc.logger.warning(
+                    f"Failed to apply StallGuard config for '{stepper_name}' "
+                    f"(sgthrs={sgthrs}, tcoolthrs={tcoolthrs}) after "
+                    f"{HARDWARE_INIT_COMMAND_ATTEMPTS} attempts: {e}. Continuing."
+                )
+                return
+            gc.logger.warning(
+                f"Failed to apply StallGuard config for '{stepper_name}' on "
+                f"attempt {attempt}/{HARDWARE_INIT_COMMAND_ATTEMPTS}: {e}. "
+                f"Retrying in {HARDWARE_INIT_RETRY_DELAY_S:.2f}s..."
+            )
+            time.sleep(HARDWARE_INIT_RETRY_DELAY_S)
+
+    gc.logger.info(
+        f"Stepper '{stepper_name}' StallGuard config applied: "
+        f"sgthrs={sgthrs}, tcoolthrs={tcoolthrs:#x}, enabled={enabled}"
     )
 
 

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -155,6 +155,9 @@ def loadFeedingModeConfig(
 class MachineConfig:
     servo_open_angle: int | None = None
     servo_closed_angle: int | None = None
+    servo_open_speed: int | None = None
+    servo_close_speed: int | None = None
+    servo_homing_speed: int | None = None
     stepper_current_overrides: dict[str, tuple[int, int, int]] = field(default_factory=dict)
 
 
@@ -391,6 +394,13 @@ def _validateAngle(gc: GlobalConfig, name: str, value: object, default: int | No
     return default
 
 
+def _validateServoSpeed(gc: GlobalConfig, name: str, value: object, default: int | None) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 2000:
+        return value
+    gc.logger.warning(f"Invalid {name}={value!r}; expected int 1-2000 (°/s). Using {default}.")
+    return default
+
+
 def loadMachineConfig(
     gc: GlobalConfig,
     machine_specific_params: dict[str, object] | None = None,
@@ -413,6 +423,18 @@ def loadMachineConfig(
         if "closed_angle" in servo_params:
             config.servo_closed_angle = _validateAngle(
                 gc, "servo.closed_angle", servo_params.get("closed_angle"), None
+            )
+        if "open_speed" in servo_params:
+            config.servo_open_speed = _validateServoSpeed(
+                gc, "servo.open_speed", servo_params.get("open_speed"), None
+            )
+        if "close_speed" in servo_params:
+            config.servo_close_speed = _validateServoSpeed(
+                gc, "servo.close_speed", servo_params.get("close_speed"), None
+            )
+        if "homing_speed" in servo_params:
+            config.servo_homing_speed = _validateServoSpeed(
+                gc, "servo.homing_speed", servo_params.get("homing_speed"), None
             )
     elif servo_params is not None:
         gc.logger.warning("Ignoring invalid servo config: expected object.")

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -153,8 +153,6 @@ def loadFeedingModeConfig(
 
 @dataclass
 class MachineConfig:
-    servo_open_angle: int | None = None
-    servo_closed_angle: int | None = None
     servo_open_speed: int | None = None
     servo_close_speed: int | None = None
     servo_homing_speed: int | None = None
@@ -387,13 +385,6 @@ def loadStepperDirectionInverts(
     return overrides
 
 
-def _validateAngle(gc: GlobalConfig, name: str, value: object, default: int | None) -> int | None:
-    if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 180:
-        return value
-    gc.logger.warning(f"Invalid {name}={value!r}; expected int 0-180. Using {default}.")
-    return default
-
-
 def _validateServoSpeed(gc: GlobalConfig, name: str, value: object, default: int | None) -> int | None:
     if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 2000:
         return value
@@ -416,14 +407,6 @@ def loadMachineConfig(
 
     servo_params = raw.get("servo")
     if isinstance(servo_params, dict):
-        if "open_angle" in servo_params:
-            config.servo_open_angle = _validateAngle(
-                gc, "servo.open_angle", servo_params.get("open_angle"), None
-            )
-        if "closed_angle" in servo_params:
-            config.servo_closed_angle = _validateAngle(
-                gc, "servo.closed_angle", servo_params.get("closed_angle"), None
-            )
         if "open_speed" in servo_params:
             config.servo_open_speed = _validateServoSpeed(
                 gc, "servo.open_speed", servo_params.get("open_speed"), None

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -282,19 +282,31 @@ def _parseStepperCurrentOverrides(
     return overrides
 
 
+# Built-in StallGuard defaults so a fresh machine gets working stall detection on
+# the chute and carousel without any machine.toml [stepper_stallguard.*] block.
+# Keyed by canonical (physical) stepper name; (sgthrs, tcoolthrs, enabled). A
+# machine.toml entry for the same motor overrides its default; other motors get
+# nothing unless their TOML adds them. These were tuned on the rev04 bring-up.
+DEFAULT_STEPPER_STALLGUARD: dict[str, tuple[int, int, bool]] = {
+    "carousel": (148, 150, True),
+    "chute_stepper": (55, 150, True),
+}
+
+
 def _parseStepperStallguard(
     gc: GlobalConfig,
     raw: dict[str, object],
 ) -> dict[str, tuple[int, int, bool]]:
     table: object = raw.get("stepper_stallguard")
     if table is None:
-        return {}
+        return dict(DEFAULT_STEPPER_STALLGUARD)
 
     if not isinstance(table, dict):
         gc.logger.warning("stepper_stallguard must be an object. Ignoring StallGuard config.")
-        return {}
+        return dict(DEFAULT_STEPPER_STALLGUARD)
 
-    configs: dict[str, tuple[int, int, bool]] = {}
+    # Start from the built-in defaults; TOML entries below override per motor.
+    configs: dict[str, tuple[int, int, bool]] = dict(DEFAULT_STEPPER_STALLGUARD)
     for stepper_name, value in table.items():
         if not isinstance(stepper_name, str):
             gc.logger.warning(

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -945,11 +945,14 @@ def applyStepperStallguard(
     configs: dict[str, tuple[int, int, bool]],
     gc: GlobalConfig,
 ) -> None:
-    """Stamp [stepper_stallguard.*] onto the stepper and write SGTHRS/TCOOLTHRS.
+    """Stamp [stepper_stallguard.*] onto the stepper, write SGTHRS/TCOOLTHRS, and
+    turn DIAG detection ON.
 
-    This does NOT arm DIAG detection — the stall monitor does that on entering
-    RUNNING (and re-writes the registers then, so they survive sweeps/coolstep
-    toggles). Steppers with no entry, or enabled=false, are simply never armed.
+    Simple rule: if a stepper has an enabled entry, detection is on for every
+    move — there is no per-move or per-state arming. It's switched on once here at
+    hardware init and stays on. (Homing doesn't false-trip because it runs far
+    slower than cruise, below the TCOOLTHRS velocity floor where DIAG is inactive.)
+    Steppers with no entry, or enabled=false, are simply left off.
     """
     config = configs.get(stepper_name)
     if config is None:
@@ -986,8 +989,17 @@ def applyStepperStallguard(
             )
             time.sleep(HARDWARE_INIT_RETRY_DELAY_S)
 
+    try:
+        stepper.clear_stall()
+        stepper.enable_stall_detection(True)
+    except (MCUBusError, OSError, DecodeError) as e:
+        gc.logger.warning(
+            f"Wrote StallGuard regs for '{stepper_name}' but failed to arm DIAG "
+            f"detection: {e}. The stall monitor will retry on its next poll."
+        )
+
     gc.logger.info(
-        f"Stepper '{stepper_name}' StallGuard config applied: "
+        f"Stepper '{stepper_name}' StallGuard armed: "
         f"sgthrs={sgthrs}, tcoolthrs={tcoolthrs:#x}, enabled={enabled}"
     )
 

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -34,6 +34,7 @@ from server.shared_state import (
     setHardwareStartFn,
 )
 from sorter_controller import SorterController
+from stepper_stall_monitor import StepperStallMonitor
 from run_recorder import RunRecorder
 from message_queue.handler import handleServerToMainEvent
 from defs.events import HeartbeatEvent, HeartbeatData, MainThreadToServerCommand
@@ -620,6 +621,23 @@ def main() -> None:
     setHardwareStartFn(_home_hardware)
     setHardwareInitializeFn(_initialize_hardware)
     setHardwareResetFn(lambda: _cleanup_runtime_hardware("system reset"))
+
+    # StallGuard stall detection: a daemon thread polls the firmware DIAG latch
+    # while RUNNING and raises a blocking `stepper_stall` incident on a stall.
+    # Off the main loop so the UART reads never hitch operation.
+    if not _noPowerModeActive(gc):
+        stall_monitor = StepperStallMonitor(gc)
+
+        def _get_controller():
+            with controller_lock:
+                return controller
+
+        threading.Thread(
+            target=stall_monitor.run,
+            args=(_get_controller,),
+            daemon=True,
+            name="stall-monitor",
+        ).start()
 
     last_heartbeat = time.time()
     last_frame_record = time.time()

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -421,7 +421,20 @@ def main() -> None:
             gc.logger.info("Opening all layer servos...")
             for servo in irl.servos:
                 try:
-                    servo.open()
+                    if getattr(servo, "is_calibrated", True):
+                        servo.open()
+                    else:
+                        # An uncalibrated servo must never be driven or held. A prior
+                        # calibrator jog leaves the channel energized at a stale angle
+                        # (move_to never releases PWM) and that hold survives a backend
+                        # restart, so a plain open() no-op would leave the servo hunting
+                        # and twitching through homing. Disabling cuts PWM (duty=0) so it
+                        # goes slack and physically cannot move.
+                        servo.enabled = False
+                        gc.logger.info(
+                            f"Servo ch{getattr(servo, 'channel', '?')} uncalibrated — "
+                            "released (PWM off) instead of opening."
+                        )
                 except Exception as e:
                     gc.logger.warning(f"Failed to open servo: {e}. Continuing without initialization.")
             _checkServoBusHealth(gc, irl)

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -422,6 +422,8 @@ def main() -> None:
             for servo in irl.servos:
                 try:
                     if getattr(servo, "is_calibrated", True):
+                        if hasattr(servo, "apply_homing_speed"):
+                            servo.apply_homing_speed()
                         servo.open()
                     else:
                         # An uncalibrated servo must never be driven or held. A prior
@@ -605,6 +607,8 @@ def main() -> None:
             shared_state.setHardwareStatus(homing_step="Opening servos...")
             for servo in irl.servos:
                 try:
+                    if hasattr(servo, "apply_homing_speed"):
+                        servo.apply_homing_speed()
                     servo.open()
                 except Exception as e:
                     gc.logger.warning(f"Failed to open servo: {e}. Continuing without initialization.")

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -623,18 +623,14 @@ def main() -> None:
     setHardwareResetFn(lambda: _cleanup_runtime_hardware("system reset"))
 
     # StallGuard stall detection: a daemon thread polls the firmware DIAG latch
-    # while RUNNING and raises a blocking `stepper_stall` incident on a stall.
-    # Off the main loop so the UART reads never hitch operation.
+    # for every stepper that has an enabled threshold and raises a blocking
+    # `stepper_stall` incident on a stall. Detection is on for all moves (armed at
+    # hardware init), so this watcher needs no machine-state gating. Off the main
+    # loop so the UART reads never hitch operation.
     if not _noPowerModeActive(gc):
         stall_monitor = StepperStallMonitor(gc)
-
-        def _get_controller():
-            with controller_lock:
-                return controller
-
         threading.Thread(
             target=stall_monitor.run,
-            args=(_get_controller,),
             daemon=True,
             name="stall-monitor",
         ).start()

--- a/software/sorter/backend/piece_transport.py
+++ b/software/sorter/backend/piece_transport.py
@@ -193,6 +193,21 @@ class ClassificationChannelTransport(PieceTransport):
             piece_for_distribution_drop=self._exit_piece,
         )
 
+    def placePieceForDistribution(self, obj: KnownObject) -> None:
+        """Stage an externally-owned piece directly into the positioning slot.
+
+        The rev01 classification SM owns its own KnownObject and hands it off
+        only once, at discharge time, rather than registering it at intake.
+        This drops that piece into the wait (distribution-positioning) slot so
+        the distribution subsystem aims the chute for it; the subsequent
+        ``advanceTransport()`` (issued when the piece is flung into the chute)
+        promotes it to the drop slot. No-op in dynamic mode, which manages its
+        own slots via the zone manager.
+        """
+        if self._dynamic_mode:
+            return
+        self._wait_piece = obj
+
     def getPieceAtClassification(self) -> KnownObject | None:
         if self._dynamic_mode:
             if self._hood_piece_uuid is None:

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -230,6 +230,9 @@ class ServoHardwareSettingsPayload(BaseModel):
     backend: str = "pca9685"
     open_angle: Optional[int] = None
     closed_angle: Optional[int] = None
+    open_speed: Optional[int] = None
+    close_speed: Optional[int] = None
+    homing_speed: Optional[int] = None
     port: Optional[str] = None
     channels: List[ServoChannelConfigPayload] = []
 
@@ -496,6 +499,20 @@ def _live_servo_feedback_for_layer(layer_index: int, servo: Any | None = None) -
         return {**base, "error": str(e)}
 
 
+_SERVO_SPEED_FLOOR_TENTHS = 10  # 1°/s minimum floor sent to firmware
+
+
+def _apply_pca_servo_speed(servo: Any, speed_deg_per_sec: int | None) -> None:
+    if speed_deg_per_sec is None:
+        return
+    if not hasattr(servo, "set_speed_limits"):
+        return
+    try:
+        servo.set_speed_limits(_SERVO_SPEED_FLOOR_TENTHS, speed_deg_per_sec * 10)
+    except Exception:
+        pass
+
+
 def _servo_hardware_issues() -> List[Dict[str, Any]]:
     active_irl = _active_irl()
     if active_irl is None:
@@ -566,10 +583,32 @@ def _servo_settings_from_config(config: Dict[str, Any]) -> Dict[str, Any]:
             }
         )
 
+    _SPEED_RANGE = (1, 2000)
+    open_speed = servo.get("open_speed")
+    if not isinstance(open_speed, int) or isinstance(open_speed, bool) or open_speed <= 0:
+        open_speed = None
+    else:
+        open_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], open_speed))
+
+    close_speed = servo.get("close_speed")
+    if not isinstance(close_speed, int) or isinstance(close_speed, bool) or close_speed <= 0:
+        close_speed = None
+    else:
+        close_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], close_speed))
+
+    homing_speed = servo.get("homing_speed")
+    if not isinstance(homing_speed, int) or isinstance(homing_speed, bool) or homing_speed <= 0:
+        homing_speed = None
+    else:
+        homing_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], homing_speed))
+
     return {
         "backend": backend,
         "open_angle": (max(0, min(180, open_angle)) if open_angle is not None else None),
         "closed_angle": (max(0, min(180, closed_angle)) if closed_angle is not None else None),
+        "open_speed": open_speed,
+        "close_speed": close_speed,
+        "homing_speed": homing_speed,
         "port": port.strip() if isinstance(port, str) and port.strip() else None,
         "channels": channels,
         "layer_count": layer_count,
@@ -1011,6 +1050,10 @@ def save_servo_hardware_config(
     backend = payload.backend if payload.backend in {"pca9685", "waveshare"} else "pca9685"
     open_angle = max(0, min(180, int(payload.open_angle)))
     closed_angle = max(0, min(180, int(payload.closed_angle)))
+    _SPEED_RANGE = (1, 2000)
+    open_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], int(payload.open_speed))) if payload.open_speed is not None else None
+    close_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], int(payload.close_speed))) if payload.close_speed is not None else None
+    homing_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], int(payload.homing_speed))) if payload.homing_speed is not None else None
     port = payload.port.strip() if isinstance(payload.port, str) and payload.port.strip() else None
     layer_count = _distribution_layer_count()
     available_pca_channels = _pca_available_servo_channels()
@@ -1067,6 +1110,12 @@ def save_servo_hardware_config(
     if backend == "pca9685":
         servo_table["open_angle"] = open_angle
         servo_table["closed_angle"] = closed_angle
+        if open_speed is not None:
+            servo_table["open_speed"] = open_speed
+        if close_speed is not None:
+            servo_table["close_speed"] = close_speed
+        if homing_speed is not None:
+            servo_table["homing_speed"] = homing_speed
     if backend == "waveshare":
         if port is not None:
             servo_table["port"] = port
@@ -1107,6 +1156,7 @@ def save_servo_hardware_config(
                             servo.set_preset_angles(closed_angle, open_angle)
                         else:
                             servo.set_preset_angles(open_angle, closed_angle)
+                        _apply_pca_servo_speed(servo, homing_speed)
                 applied_live = True
         except Exception:
             applied_live = False
@@ -1129,6 +1179,54 @@ def save_servo_hardware_config(
     }
 
 
+class ServoSpeedSettingsPayload(BaseModel):
+    open_speed: Optional[int] = None
+    close_speed: Optional[int] = None
+    homing_speed: Optional[int] = None
+
+
+@router.post("/api/hardware-config/servo/speeds")
+def save_servo_speeds(payload: ServoSpeedSettingsPayload) -> Dict[str, Any]:
+    _SPEED_RANGE = (1, 2000)
+
+    def _clamp(v: int | None) -> int | None:
+        if v is None:
+            return None
+        return max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], int(v)))
+
+    open_speed = _clamp(payload.open_speed)
+    close_speed = _clamp(payload.close_speed)
+    homing_speed = _clamp(payload.homing_speed)
+
+    params_path, config = _read_machine_params_config()
+    servo = config.get("servo", {})
+    if not isinstance(servo, dict):
+        servo = {}
+
+    for key, val in [("open_speed", open_speed), ("close_speed", close_speed), ("homing_speed", homing_speed)]:
+        if val is not None:
+            servo[key] = val
+        else:
+            servo.pop(key, None)
+
+    config["servo"] = servo
+
+    try:
+        _write_machine_params_config(params_path, config)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to write config: {e}")
+
+    active_irl = _active_irl()
+    if active_irl is not None:
+        try:
+            for srv in getattr(active_irl, "servos", []):
+                _apply_pca_servo_speed(srv, homing_speed)
+        except Exception:
+            pass
+
+    return {"ok": True, "open_speed": open_speed, "close_speed": close_speed, "homing_speed": homing_speed}
+
+
 @router.post("/api/hardware-config/servo/layers/{layer_index}/toggle")
 def toggle_layer_servo(layer_index: int) -> Dict[str, Any]:
     _ensure_not_homing("toggle a servo")
@@ -1137,6 +1235,10 @@ def toggle_layer_servo(layer_index: int) -> Dict[str, Any]:
         raise HTTPException(status_code=500, detail="Selected servo does not support test toggling.")
 
     try:
+        _, _cfg = _read_machine_params_config()
+        _speeds = _servo_settings_from_config(_cfg)
+        currently_open = hasattr(servo, "isOpen") and servo.isOpen()
+        _apply_pca_servo_speed(servo, _speeds.get("close_speed") if currently_open else _speeds.get("open_speed"))
         servo.toggle()
         feedback = _live_servo_feedback_for_layer(layer_index, servo)
         is_open = bool(feedback.get("is_open")) if feedback.get("available") else False
@@ -1191,9 +1293,11 @@ def preview_layer_servo(
                 servo.set_preset_angles(open_angle, closed_angle)
 
         if desired_open:
+            _apply_pca_servo_speed(servo, servo_settings.get("open_speed"))
             if hasattr(servo, "open"):
                 servo.open()
         else:
+            _apply_pca_servo_speed(servo, servo_settings.get("close_speed"))
             if hasattr(servo, "close"):
                 servo.close()
         feedback = _live_servo_feedback_for_layer(layer_index, servo)
@@ -1250,6 +1354,9 @@ def nudge_layer_servo(layer_index: int, payload: ServoNudgePayload) -> Dict[str,
         raise HTTPException(status_code=500, detail="Servo does not support position-based movement.")
 
     try:
+        _, _cfg = _read_machine_params_config()
+        _apply_pca_servo_speed(servo, _servo_settings_from_config(_cfg).get("homing_speed"))
+
         current_pos = int(servo.position)
         # PCA ServoMotor.position returns tenths-of-degrees, move_to takes degrees 0-180
         # Waveshare BusServo.position returns raw 0-1023, move_to takes angle 0-180
@@ -1292,6 +1399,8 @@ def move_to_layer_servo(layer_index: int, payload: ServoLayerMovePayload) -> Dic
 
     angle = max(0, min(180, int(payload.angle)))
     try:
+        _, _cfg = _read_machine_params_config()
+        _apply_pca_servo_speed(servo, _servo_settings_from_config(_cfg).get("homing_speed"))
         servo.move_to(angle)
         feedback = _live_servo_feedback_for_layer(layer_index, servo)
     except Exception as e:

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -1865,7 +1865,7 @@ def calibrate_chute_find_endstop() -> Dict[str, Any]:
     if not homed:
         raise HTTPException(
             status_code=409,
-            detail="Chute homing stopped before the endstop triggered.",
+            detail="Chute homing stopped before the endstop triggered. It's possible that the switch is not making good contact with the chute. Try moving it closer to the chute.",
         )
 
     return {

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -762,6 +762,23 @@ def _storage_layer_settings_from_layout(layout: Any) -> Dict[str, Any]:
     }
 
 
+def _attach_live_servo_current_angles(layers: List[Dict[str, Any]]) -> None:
+    """Fill in each layer's ``servo_current_angle`` from the live servo's
+    internally-tracked angle (PCA path). None when there is no live hardware
+    or the servo has not been moved since boot."""
+    for layer in layers:
+        layer.setdefault("servo_current_angle", None)
+    active_irl = _active_irl()
+    if active_irl is None:
+        return
+    servos = list(getattr(active_irl, "servos", []))
+    for index, layer in enumerate(layers):
+        if index >= len(servos):
+            continue
+        angle = getattr(servos[index], "angle", None)
+        layer["servo_current_angle"] = angle if isinstance(angle, int) else None
+
+
 def _apply_live_storage_layer_enabled(layers: List[Dict[str, Any]]) -> bool:
     active_irl = _active_irl()
     if active_irl is None:
@@ -995,8 +1012,10 @@ def _stop_all_steppers() -> None:
 def get_hardware_config() -> Dict[str, Any]:
     _, config = _read_machine_params_config()
     layout = getBinLayout()
+    storage_layers = _storage_layer_settings_from_layout(layout)
+    _attach_live_servo_current_angles(storage_layers["layers"])
     return {
-        "storage_layers": _storage_layer_settings_from_layout(layout),
+        "storage_layers": storage_layers,
         "servo": _servo_settings_from_config(config),
         "chute": _chute_settings_from_config(config),
         "carousel": _carousel_settings_from_config(config),
@@ -1138,6 +1157,8 @@ def save_servo_hardware_config(
                     else:
                         # PCA open/closed angles are calibrated per-layer via the
                         # Servo Layer Calibrator, not here — only apply speed.
+                        if hasattr(servo, "set_motion_speeds"):
+                            servo.set_motion_speeds(open_speed, close_speed, homing_speed)
                         _apply_pca_servo_speed(servo, homing_speed)
                 applied_live = True
         except Exception:
@@ -1202,6 +1223,10 @@ def save_servo_speeds(payload: ServoSpeedSettingsPayload) -> Dict[str, Any]:
     if active_irl is not None:
         try:
             for srv in getattr(active_irl, "servos", []):
+                if hasattr(srv, "set_motion_speeds"):
+                    srv.set_motion_speeds(open_speed, close_speed, homing_speed)
+                # Leave the firmware at the standard speed between moves;
+                # sorting re-applies open/close speed per move.
                 _apply_pca_servo_speed(srv, homing_speed)
         except Exception:
             pass

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -228,8 +228,6 @@ class ServoChannelConfigPayload(BaseModel):
 
 class ServoHardwareSettingsPayload(BaseModel):
     backend: str = "pca9685"
-    open_angle: Optional[int] = None
-    closed_angle: Optional[int] = None
     open_speed: Optional[int] = None
     close_speed: Optional[int] = None
     homing_speed: Optional[int] = None
@@ -537,14 +535,6 @@ def _servo_settings_from_config(config: Dict[str, Any]) -> Dict[str, Any]:
     if backend not in {"pca9685", "waveshare"}:
         backend = "pca9685"
 
-    open_angle = servo.get("open_angle")
-    if not isinstance(open_angle, int) or isinstance(open_angle, bool):
-        open_angle = None
-
-    closed_angle = servo.get("closed_angle")
-    if not isinstance(closed_angle, int) or isinstance(closed_angle, bool):
-        closed_angle = None
-
     port = servo.get("port")
     if port is not None and not isinstance(port, str):
         port = None
@@ -604,8 +594,6 @@ def _servo_settings_from_config(config: Dict[str, Any]) -> Dict[str, Any]:
 
     return {
         "backend": backend,
-        "open_angle": (max(0, min(180, open_angle)) if open_angle is not None else None),
-        "closed_angle": (max(0, min(180, closed_angle)) if closed_angle is not None else None),
         "open_speed": open_speed,
         "close_speed": close_speed,
         "homing_speed": homing_speed,
@@ -1048,8 +1036,6 @@ def save_servo_hardware_config(
     payload: ServoHardwareSettingsPayload,
 ) -> Dict[str, Any]:
     backend = payload.backend if payload.backend in {"pca9685", "waveshare"} else "pca9685"
-    open_angle = max(0, min(180, int(payload.open_angle)))
-    closed_angle = max(0, min(180, int(payload.closed_angle)))
     _SPEED_RANGE = (1, 2000)
     open_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], int(payload.open_speed))) if payload.open_speed is not None else None
     close_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], int(payload.close_speed))) if payload.close_speed is not None else None
@@ -1108,8 +1094,6 @@ def save_servo_hardware_config(
 
     servo_table: Dict[str, Any] = {"backend": backend, "channels": channels}
     if backend == "pca9685":
-        servo_table["open_angle"] = open_angle
-        servo_table["closed_angle"] = closed_angle
         if open_speed is not None:
             servo_table["open_speed"] = open_speed
         if close_speed is not None:
@@ -1151,11 +1135,9 @@ def save_servo_hardware_config(
                     if backend == "waveshare":
                         if hasattr(servo, "set_invert"):
                             servo.set_invert(invert)
-                    elif hasattr(servo, "set_preset_angles"):
-                        if invert:
-                            servo.set_preset_angles(closed_angle, open_angle)
-                        else:
-                            servo.set_preset_angles(open_angle, closed_angle)
+                    else:
+                        # PCA open/closed angles are calibrated per-layer via the
+                        # Servo Layer Calibrator, not here — only apply speed.
                         _apply_pca_servo_speed(servo, homing_speed)
                 applied_live = True
         except Exception:
@@ -1277,20 +1259,27 @@ def preview_layer_servo(
     _, config = _read_machine_params_config()
     servo_settings = _servo_settings_from_config(config)
     backend = servo_settings["backend"]
-    open_angle = int(servo_settings["open_angle"])
-    closed_angle = int(servo_settings["closed_angle"])
     desired_open = bool(payload.is_open)
     invert = bool(payload.invert)
+
+    layout = getBinLayout()
+    layer = layout.layers[layer_index] if 0 <= layer_index < len(layout.layers) else None
+    layer_open = getattr(layer, "servo_open_angle", None)
+    layer_closed = getattr(layer, "servo_closed_angle", None)
 
     try:
         if backend == "waveshare":
             if hasattr(servo, "set_invert"):
                 servo.set_invert(invert)
-        elif hasattr(servo, "set_preset_angles"):
+        elif (
+            hasattr(servo, "set_preset_angles")
+            and isinstance(layer_open, int)
+            and isinstance(layer_closed, int)
+        ):
             if invert:
-                servo.set_preset_angles(closed_angle, open_angle)
+                servo.set_preset_angles(layer_closed, layer_open)
             else:
-                servo.set_preset_angles(open_angle, closed_angle)
+                servo.set_preset_angles(layer_open, layer_closed)
 
         if desired_open:
             _apply_pca_servo_speed(servo, servo_settings.get("open_speed"))

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -1060,10 +1060,14 @@ def save_servo_hardware_config(
     close_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], int(payload.close_speed))) if payload.close_speed is not None else None
     homing_speed = max(_SPEED_RANGE[0], min(_SPEED_RANGE[1], int(payload.homing_speed))) if payload.homing_speed is not None else None
     port = payload.port.strip() if isinstance(payload.port, str) and payload.port.strip() else None
-    layer_count = _distribution_layer_count()
     available_pca_channels = _pca_available_servo_channels()
     layout = getBinLayout()
     current_storage_layers = _storage_layer_settings_from_layout(layout)["layers"]
+    # Validate against the persisted layout we actually index into below, not the
+    # live distribution layout. After a layer add/remove the storage-layers save
+    # has already rewritten the config, but the running hardware still carries the
+    # old layer count until a restart — trusting it here rejected valid saves.
+    layer_count = len(current_storage_layers)
 
     if len(payload.channels) != layer_count:
         raise HTTPException(

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import os
+import random
 import threading
 import time
 from typing import Any, Dict, List, Optional
@@ -1063,6 +1064,178 @@ def _suggested_sgthrs(sg_min: int) -> int:
     return max(1, int(sg_min * 0.4) // 2)
 
 
+# ---------------------------------------------------------------------------
+# Sweep motion profiles
+#
+# A constant-speed spin is a poor stand-in for how a motor is actually loaded in
+# service: the chute aims to angles and reverses (a constant spin just rams its
+# endstop and reads SG_RESULT=0), and the rotors/carousel run in discrete pulses
+# with dwells and the odd unstick jitter — not a steady cruise. These profiles
+# reproduce that so the recorded SG_RESULT reflects real operating load.
+#
+# Each profile models its own timeline from estimated move durations and exposes
+# moving(now): the sampler only records load-bearing motion phases and ignores
+# idle dwells, so dwell zeros don't pollute the threshold. No extra UART status
+# reads — the sample loop is already bus-bound.
+# ---------------------------------------------------------------------------
+
+SWEEP_PROFILES = ("constant", "chute_random", "pulsed")
+
+# Defaults for the unstick jitter folded into the pulsed profile, matching the
+# feeder's real fall-recovery values (go_to_angle config).
+_PULSED_JITTER_AMPLITUDE_DEG = 6.0
+_PULSED_JITTER_CYCLES = 8
+_PULSED_JITTER_SPEED = 6500
+_PULSED_JITTER_ACCEL = 180000
+
+
+class _SweepMotion:
+    def start(self, now: float) -> None: ...
+    def tick(self, now: float) -> None: ...
+    def moving(self, now: float) -> bool:
+        return True
+
+
+class _ConstantMotion(_SweepMotion):
+    def __init__(self, target: Any, signed_speed: int) -> None:
+        self._target = target
+        self._signed_speed = signed_speed
+
+    def start(self, now: float) -> None:
+        if not bool(self._target.move_at_speed(self._signed_speed, force=True)):
+            raise RuntimeError("move_at_speed was not acknowledged")
+
+
+# The chute hits HARD STOPS at 0 and 360 deg of output travel (it can cross
+# neither). Stay well inside that with the same cap the stress test uses.
+CHUTE_SAFE_MAX_DEG = 345.0
+
+
+class _ChuteRandomMotion(_SweepMotion):
+    """Random go-to-angle with immediate turnaround on the real chute, like the
+    chute stress test. Operates on the homed Chute object in ABSOLUTE output
+    degrees clamped to [min_deg, max_deg] within [0, CHUTE_SAFE_MAX_DEG], so it
+    can never reach an endstop. Homes first if the chute lacks a reference —
+    without that, "0 deg" is wherever it powered on and the clamp is meaningless.
+    Targets are at least min_delta_deg apart so every move is a real excursion."""
+
+    def __init__(self, chute: Any, speed: int, min_delta_deg: float, min_deg: float, max_deg: float) -> None:
+        self._chute = chute
+        self._speed = speed
+        self._min_delta = max(1.0, min_delta_deg)
+        self._min = max(0.0, min(min_deg, CHUTE_SAFE_MAX_DEG))
+        self._max = max(self._min, min(max_deg, CHUTE_SAFE_MAX_DEG))
+        # Don't re-check stopped for a beat after issuing a move, so we don't read
+        # a stale "stopped" before the firmware has started the move.
+        self._next_check_at = 0.0
+
+    def _home_if_needed(self) -> None:
+        if bool(getattr(self._chute, "homed", False)):
+            return
+        from subsystems.distribution.chute import HOME_SPEED_MICROSTEPS_PER_SEC, HOME_TIMEOUT_MS
+
+        st = self._chute.stepper
+        st.enabled = True
+        st.home(
+            HOME_SPEED_MICROSTEPS_PER_SEC,
+            self._chute.home_pin,
+            home_pin_active_high=self._chute.endstop_active_high,
+        )
+        deadline = time.monotonic() + HOME_TIMEOUT_MS / 1000.0 + 5.0
+        while time.monotonic() < deadline:
+            try:
+                if st.stopped:
+                    break
+            except Exception:
+                break
+            time.sleep(0.02)
+
+    def _pick(self, current: float) -> float:
+        for _ in range(20):
+            cand = random.uniform(self._min, self._max)
+            if abs(cand - current) >= self._min_delta:
+                return cand
+        mid = (self._min + self._max) / 2.0
+        return self._max if current < mid else self._min
+
+    def _go(self, now: float) -> None:
+        current = float(self._chute.current_angle)
+        target_deg = self._pick(current)
+        self._chute.moveToAngle(target_deg)  # absolute, clamps to [0,360]
+        self._next_check_at = now + 0.05
+
+    def start(self, now: float) -> None:
+        self._chute.stepper.set_speed_limits(0, self._speed)
+        self._home_if_needed()
+        self._go(now)
+
+    def tick(self, now: float) -> None:
+        # Issue the next target only once the previous move has actually finished.
+        # Re-issuing on a guessed timer floods the chute with overlapping reversals
+        # it can't follow (it stalls in place); waiting for a real stop gives clean
+        # go-to-angle moves. Immediate turnaround on stop = the quick reversal.
+        if now < self._next_check_at:
+            return
+        try:
+            if self._chute.stepper.stopped:
+                self._go(now)
+        except Exception:
+            pass
+
+
+class _PulsedMotion(_SweepMotion):
+    """Discrete forward pulses with a dwell between (how the rotors and carousel
+    actually run), with an unstick jitter folded in every jitter_every pulses.
+    moving() is true only during the move/jitter phase, not the dwell."""
+
+    def __init__(
+        self,
+        target: Any,
+        speed: int,
+        pulse_deg: float,
+        dwell_ms: float,
+        jitter_every: int,
+        sign: int,
+    ) -> None:
+        self._target = target
+        self._speed = speed
+        self._pulse_deg = abs(pulse_deg) * (1 if sign >= 0 else -1)
+        self._dwell = max(0.0, dwell_ms) / 1000.0
+        self._jitter_every = max(0, jitter_every)
+        self._count = 0
+        self._phase_end = 0.0
+        self._dwell_end = 0.0
+
+    def _next(self, now: float) -> None:
+        self._count += 1
+        if self._jitter_every and self._count % self._jitter_every == 0:
+            self._target.jitter_degrees(
+                _PULSED_JITTER_AMPLITUDE_DEG,
+                _PULSED_JITTER_CYCLES,
+                _PULSED_JITTER_SPEED,
+                _PULSED_JITTER_ACCEL,
+                force=True,
+            )
+            # Rough upper bound on jitter duration; only gates sampling, not motion.
+            dur_ms = max(200, _PULSED_JITTER_CYCLES * 60)
+        else:
+            self._target.set_speed_limits(0, self._speed)
+            self._target.move_degrees(self._pulse_deg, force=True)
+            dur_ms = self._target.estimateMoveDegreesMs(abs(self._pulse_deg), max_speed=self._speed)
+        self._phase_end = now + max(dur_ms, 1) / 1000.0
+        self._dwell_end = self._phase_end + self._dwell
+
+    def start(self, now: float) -> None:
+        self._next(now)
+
+    def tick(self, now: float) -> None:
+        if now >= self._dwell_end:
+            self._next(now)
+
+    def moving(self, now: float) -> bool:
+        return now < self._phase_end
+
+
 @router.post("/stepper/stallguard-sweep", response_model=StallGuardSweepResponse)
 def stallguard_sweep(
     stepper: str,
@@ -1074,12 +1247,23 @@ def stallguard_sweep(
     tcoolthrs: int = DEFAULT_STALLGUARD_TCOOLTHRS,
     loaded: bool = False,
     label: Optional[str] = None,
+    profile: str = "constant",
+    chute_min_deg: float = 10.0,
+    chute_max_deg: float = 340.0,
+    min_delta_deg: float = 30.0,
+    pulse_deg: float = 30.0,
+    dwell_ms: float = 250.0,
+    jitter_every: int = 5,
 ) -> StallGuardSweepResponse:
     _ensure_manual_motion_allowed("run a StallGuard sweep")
     if speed <= 0:
         raise HTTPException(status_code=400, detail="speed must be > 0")
     if direction not in ("cw", "ccw"):
         raise HTTPException(status_code=400, detail="direction must be 'cw' or 'ccw'")
+    if profile not in SWEEP_PROFILES:
+        raise HTTPException(
+            status_code=400, detail=f"profile must be one of {', '.join(SWEEP_PROFILES)}"
+        )
     if duration_s <= 0 or duration_s > MAX_STALLGUARD_SWEEP_DURATION_S:
         raise HTTPException(
             status_code=400,
@@ -1095,8 +1279,30 @@ def stallguard_sweep(
         raise HTTPException(status_code=409, detail=f"Stepper '{stepper}' is busy")
 
     signed_speed = speed if direction == "cw" else -speed
+    sign = 1 if direction == "cw" else -1
     samples: List[StallGuardSample] = []
     telemetry_rows: List[Dict[str, Any]] = []
+
+    chute_restore_speed: Optional[int] = None
+    if profile == "chute_random":
+        # The chute has hard endstops, so its motion must run on the homed Chute
+        # object (absolute, clamped angles) — never a raw open-loop spin.
+        irl = shared_state.getActiveIRL()
+        chute = getattr(irl, "chute", None) if irl is not None else None
+        if chute is None:
+            lock.release()
+            raise HTTPException(
+                status_code=409,
+                detail="chute_random needs the initialized chute; initialize hardware first.",
+            )
+        chute_restore_speed = int(getattr(chute, "operating_speed_microsteps_per_second", speed))
+        motion: _SweepMotion = _ChuteRandomMotion(
+            chute, speed, min_delta_deg, chute_min_deg, chute_max_deg
+        )
+    elif profile == "pulsed":
+        motion = _PulsedMotion(target, speed, pulse_deg, dwell_ms, jitter_every, sign)
+    else:
+        motion = _ConstantMotion(target, signed_speed)
 
     # Static per-run context, captured once (these don't change mid-sweep).
     channel_ctx = getattr(target, "channel", None)
@@ -1125,24 +1331,40 @@ def stallguard_sweep(
             "acceleration": accel_ctx,
             "microsteps": microsteps_ctx,
             "stealthchop": stealth_ctx,
+            "profile": profile,
+            "chute_min_deg": chute_min_deg if profile == "chute_random" else None,
+            "chute_max_deg": chute_max_deg if profile == "chute_random" else None,
+            "min_delta_deg": min_delta_deg if profile == "chute_random" else None,
+            "pulse_deg": pulse_deg if profile == "pulsed" else None,
+            "dwell_ms": dwell_ms if profile == "pulsed" else None,
+            "jitter_every": jitter_every if profile == "pulsed" else None,
         },
     )
 
     try:
         target.write_driver_register(TMC_REG_TCOOLTHRS, tcoolthrs)
         target.enable_force(True)
-        # move_at_speed re-asserts the stepper's configured default acceleration.
-        if not bool(target.move_at_speed(signed_speed, force=True)):
-            raise RuntimeError("move_at_speed was not acknowledged")
+        motion.start(time.monotonic())
 
-        time.sleep(min(max(spin_up_s, 0.0), 2.0))
+        # A constant spin needs a moment to reach speed before SG_RESULT is valid;
+        # the pulsed/chute profiles are sampled per-move via moving(), so skip it.
+        if profile == "constant":
+            time.sleep(min(max(spin_up_s, 0.0), 2.0))
 
         wall_start = time.time()
         t_start = time.monotonic()
         while True:
-            t = time.monotonic() - t_start
+            now = time.monotonic()
+            t = now - t_start
             if t >= duration_s:
                 break
+            motion.tick(now)
+            if not motion.moving(now):
+                # Idle dwell between pulses — its SG_RESULT isn't load data.
+                remaining = sample_interval_s - (time.monotonic() - t_start - t)
+                if remaining > 0:
+                    time.sleep(remaining)
+                continue
             sg = _safe_read_register(target, TMC_REG_SG_RESULT)
             drv = _safe_read_register(target, TMC_REG_DRV_STATUS)
             tstep = _safe_read_register(target, TMC_REG_TSTEP)
@@ -1197,6 +1419,13 @@ def stallguard_sweep(
             target.write_driver_register(TMC_REG_TCOOLTHRS, 0)
         except Exception:
             pass
+        # chute_random retunes the chute stepper's speed limits; restore them to
+        # the chute's operating speed so normal aiming isn't left at sweep speed.
+        if chute_restore_speed is not None:
+            try:
+                target.set_speed_limits(16, chute_restore_speed)
+            except Exception:
+                pass
         try:
             lock.release()
         except RuntimeError:

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -272,6 +272,7 @@ TMC_REG_IHOLD_IRUN = 0x10
 TMC_REG_TSTEP = 0x12
 TMC_REG_TCOOLTHRS = 0x14
 TMC_REG_COOLCONF = 0x42
+TMC_REG_SGTHRS = 0x40
 TMC_REG_SG_RESULT = 0x41
 TMC_REG_MSCNT = 0x6A
 TMC_REG_MSCURACT = 0x6B
@@ -965,6 +966,10 @@ def get_tmc_settings(name: str) -> Dict[str, Any]:
     else:
         result["sg_result"] = None
 
+    # Persisted StallGuard stall-detection config (or defaults) so the driver
+    # settings UI can show/edit it alongside the other TMC settings.
+    result["stallguard"] = _stallguard_payload_from_persisted_config(name)
+
     return result
 
 
@@ -1514,6 +1519,36 @@ class StallGuardConfigResponse(BaseModel):
     enabled: bool
 
 
+# Defaults shown in the per-stepper driver settings when a motor has no saved
+# StallGuard config yet. Disabled by default; the numbers are just sane starting
+# points to tune from on the StallGuard page (cruise velocity floor ~150).
+DEFAULT_STALLGUARD_SGTHRS = 50
+DEFAULT_STALLGUARD_ENFORCE_TCOOLTHRS = 150
+
+
+def _stallguard_payload_from_persisted_config(name: str) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "sgthrs": DEFAULT_STALLGUARD_SGTHRS,
+        "tcoolthrs": DEFAULT_STALLGUARD_ENFORCE_TCOOLTHRS,
+        "enabled": False,
+    }
+    try:
+        _, config = _read_machine_params_config()
+    except Exception:
+        return result
+    toml_name = _STEPPER_API_TO_TOML_NAME.get(name, name)
+    section = config.get("stepper_stallguard", {})
+    entry = section.get(toml_name, {}) if isinstance(section, dict) else {}
+    if isinstance(entry, dict):
+        if isinstance(entry.get("sgthrs"), int):
+            result["sgthrs"] = entry["sgthrs"]
+        if isinstance(entry.get("tcoolthrs"), int):
+            result["tcoolthrs"] = entry["tcoolthrs"]
+        if isinstance(entry.get("enabled"), bool):
+            result["enabled"] = entry["enabled"]
+    return result
+
+
 def _persist_stepper_stallguard(api_name: str, sgthrs: int, tcoolthrs: int, enabled: bool) -> None:
     toml_name = _STEPPER_API_TO_TOML_NAME.get(api_name, api_name)
     params_path, config = _read_machine_params_config()
@@ -1533,9 +1568,26 @@ def _persist_stepper_stallguard(api_name: str, sgthrs: int, tcoolthrs: int, enab
 
 @router.post("/stepper/{stepper}/stallguard-config", response_model=StallGuardConfigResponse)
 def set_stallguard_config(stepper: str, body: StallGuardConfigBody) -> StallGuardConfigResponse:
-    _resolve_stepper(stepper)
+    target = _resolve_stepper(stepper)
     toml_name = _STEPPER_API_TO_TOML_NAME.get(stepper, stepper)
     _persist_stepper_stallguard(stepper, body.sgthrs, body.tcoolthrs, body.enabled)
+
+    # Apply live so the change takes effect on the very next move — no reinit
+    # needed. Stamp the attrs the stall monitor reads, write the driver registers,
+    # and turn detection on/off. When disabled, drop the velocity floor to 0 so
+    # DIAG can never fire. Best-effort: a UART hiccup here still leaves the config
+    # persisted, and hardware init will re-apply it.
+    try:
+        target.stallguard_sgthrs = body.sgthrs
+        target.stallguard_tcoolthrs = body.tcoolthrs
+        target.stallguard_enabled = body.enabled
+        target.write_driver_register(TMC_REG_SGTHRS, body.sgthrs)
+        target.write_driver_register(TMC_REG_TCOOLTHRS, body.tcoolthrs if body.enabled else 0)
+        target.clear_stall()
+        target.enable_stall_detection(bool(body.enabled))
+    except Exception:
+        pass
+
     return StallGuardConfigResponse(
         success=True,
         stepper=stepper,

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -270,7 +270,6 @@ TMC_REG_IOIN = 0x06
 TMC_REG_FACTORY_CONF = 0x07
 TMC_REG_IHOLD_IRUN = 0x10
 TMC_REG_TSTEP = 0x12
-TMC_REG_TPWMTHRS = 0x13
 TMC_REG_TCOOLTHRS = 0x14
 TMC_REG_COOLCONF = 0x42
 TMC_REG_SG_RESULT = 0x41
@@ -1246,7 +1245,7 @@ def stallguard_sweep(
     sample_interval_s: float = 0.02,
     spin_up_s: float = 0.3,
     tcoolthrs: int = DEFAULT_STALLGUARD_TCOOLTHRS,
-    tpwmthrs: int = 0,
+    cruise_tstep: int = 150,
     loaded: bool = False,
     label: Optional[str] = None,
     profile: str = "constant",
@@ -1266,8 +1265,8 @@ def stallguard_sweep(
         raise HTTPException(
             status_code=400, detail=f"profile must be one of {', '.join(SWEEP_PROFILES)}"
         )
-    if not (0 <= tpwmthrs <= 0xFFFFF):
-        raise HTTPException(status_code=400, detail="tpwmthrs must be in [0, 0xFFFFF]")
+    if cruise_tstep <= 0:
+        raise HTTPException(status_code=400, detail="cruise_tstep must be > 0")
     if duration_s <= 0 or duration_s > MAX_STALLGUARD_SWEEP_DURATION_S:
         raise HTTPException(
             status_code=400,
@@ -1330,7 +1329,7 @@ def stallguard_sweep(
             "duration_s": duration_s,
             "sample_interval_s": sample_interval_s,
             "tcoolthrs": tcoolthrs,
-            "tpwmthrs": tpwmthrs,
+            "cruise_tstep": cruise_tstep,
             "loaded": loaded,
             "irun": irun_ctx,
             "acceleration": accel_ctx,
@@ -1347,12 +1346,10 @@ def stallguard_sweep(
     )
 
     try:
+        # Measure with SG reported across the whole speed range; the cruise_tstep
+        # filter is applied at analysis time so we still see the transients in the
+        # chart but don't let them set the threshold.
         target.write_driver_register(TMC_REG_TCOOLTHRS, tcoolthrs)
-        # TPWMTHRS>0 makes the driver auto-switch StealthChop->SpreadCycle once it
-        # crosses this velocity (TSTEP < TPWMTHRS), so it stays quiet at low speed
-        # but measures load in SpreadCycle at cruise. Only meaningful while the
-        # driver is in StealthChop (which it is by default).
-        target.write_driver_register(TMC_REG_TPWMTHRS, tpwmthrs)
         target.enable_force(True)
         motion.start(time.monotonic())
 
@@ -1429,10 +1426,6 @@ def stallguard_sweep(
             target.write_driver_register(TMC_REG_TCOOLTHRS, 0)
         except Exception:
             pass
-        try:
-            target.write_driver_register(TMC_REG_TPWMTHRS, 0)  # back to pure StealthChop
-        except Exception:
-            pass
         # chute_random retunes the chute stepper's speed limits; restore them to
         # the chute's operating speed so normal aiming isn't left at sweep speed.
         if chute_restore_speed is not None:
@@ -1446,16 +1439,22 @@ def stallguard_sweep(
             pass
 
     valid = [s.sg_result for s in samples if s.sg_result >= 0]
+    # Threshold tuning only considers CRUISE samples (TSTEP <= cruise_tstep). At
+    # accel/decel/reversal the velocity is low and SG_RESULT dips even unloaded,
+    # which would drag the floor down and produce a uselessly low threshold. The
+    # chart still shows every sample; only the suggestion is cruise-filtered.
+    cruise = [s.sg_result for s in samples if s.sg_result >= 0 and 0 <= s.tstep <= cruise_tstep]
+    basis = cruise if cruise else valid
     stats: Optional[StallGuardSweepStats] = None
     sgthrs: Optional[int] = None
-    if valid:
-        sg_min = min(valid)
+    if basis:
+        sg_min = min(basis)
         sgthrs = _suggested_sgthrs(sg_min)
         stats = StallGuardSweepStats(
-            samples=len(valid),
+            samples=len(basis),
             sg_min=sg_min,
-            sg_max=max(valid),
-            sg_mean=round(sum(valid) / len(valid), 1),
+            sg_max=max(basis),
+            sg_mean=round(sum(basis) / len(basis), 1),
             suggested_sgthrs=sgthrs,
             suggested_trigger_level=sgthrs * 2,
         )

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -918,14 +918,45 @@ def stop_all_steppers() -> StepperStopAllResponse:
 
 @router.get("/api/stepper/{name}/tmc")
 def get_tmc_settings(name: str) -> Dict[str, Any]:
-    stepper = _resolve_stepper(name)
+    if name not in _STEPPER_API_TO_TOML_NAME:
+        raise HTTPException(status_code=400, detail=f"Unknown stepper '{name}'")
+
+    # Configured values (currents, StallGuard) live in machine.toml and don't need
+    # live hardware to read — so serve them even at standby, when there's no IRL
+    # yet. Only the register read-outs (microsteps, chopper mode, DRV_STATUS,
+    # SG_RESULT) require a live driver; those come back null until hardware is up.
+    try:
+        stepper = _resolve_stepper(name)
+    except HTTPException:
+        stepper = None
+
+    if stepper is None:
+        persisted_current = _current_payload_from_persisted_config(name)
+        return {
+            "hardware_ready": False,
+            "irun": persisted_current["irun"],
+            "ihold": persisted_current["ihold"],
+            "ihold_delay": persisted_current["ihold_delay"],
+            "stallguard": _stallguard_payload_from_persisted_config(name),
+            "capabilities": {
+                "tmc_uart_available": False,
+                "queryable_fields": list(TMC_QUERYABLE_FIELDS),
+            },
+            "registers": None,
+            "microsteps": None,
+            "stealthchop": None,
+            "coolstep": None,
+            "drv_status": None,
+            "sg_result": None,
+        }
+
     registers = _tmc_register_snapshot(stepper)
     gconf_raw = registers["gconf"]
     chopconf_raw = registers["chopconf"]
     coolconf_raw = registers["coolconf"]
     drv_status_raw = registers["drv_status"]
 
-    result: Dict[str, Any] = {}
+    result: Dict[str, Any] = {"hardware_ready": True}
     current_payload = _desired_stepper_current_payload(name, stepper)
     result["irun"] = current_payload["irun"]
     result["ihold"] = current_payload["ihold"]

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -1749,8 +1749,25 @@ def stallguard_suggestion(
         )
     elif dip is not None:
         detail = "Only loaded runs found — run an unloaded sweep to measure the normal floor."
+    elif unloaded_run is not None or loaded_run is not None:
+        # Runs exist and completed, but the cruise filter kept nothing from either
+        # — every sample was below cruise velocity (TSTEP > cruise_tstep). This is
+        # what the pulsed/jitter profiles produce: the motor never sustains cruise,
+        # so SG_RESULT is all accel/decel and there's no valid load reading to tune
+        # from. Don't tell the user to re-run sweeps they already ran.
+        have = " + ".join(
+            kind
+            for kind, run in (("unloaded", unloaded_run), ("loaded", loaded_run))
+            if run is not None
+        )
+        detail = (
+            f"Latest {have} run completed but produced 0 cruise samples "
+            f"(none reached TSTEP <= {ct}) — the profile never sustained cruise "
+            "velocity. StallGuard only reads load at constant cruise; use the "
+            "constant profile to calibrate SGTHRS."
+        )
     else:
-        detail = "No completed cruise samples for this motor yet — run an unloaded and a loaded sweep."
+        detail = "No completed runs for this motor yet — run an unloaded and a loaded sweep."
 
     return StallGuardSuggestionResponse(
         success=True,

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -1103,6 +1103,9 @@ def stallguard_sweep(
     microsteps_ctx = getattr(target, "_microsteps", None)
     last_current = getattr(target, "last_set_current", None)
     irun_ctx = last_current.get("irun") if isinstance(last_current, dict) else None
+    # Acceleration the sweep runs at: move_at_speed re-asserts the stepper's
+    # configured default acceleration, so that's the value in effect per sample.
+    accel_ctx = getattr(target, "default_acceleration", None)
     gconf = _safe_read_register(target, TMC_REG_GCONF)
     stealth_ctx = (not bool(gconf & (1 << 2))) if isinstance(gconf, int) else None
 
@@ -1118,6 +1121,10 @@ def stallguard_sweep(
             "sample_interval_s": sample_interval_s,
             "tcoolthrs": tcoolthrs,
             "loaded": loaded,
+            "irun": irun_ctx,
+            "acceleration": accel_ctx,
+            "microsteps": microsteps_ctx,
+            "stealthchop": stealth_ctx,
         },
     )
 
@@ -1161,6 +1168,7 @@ def stallguard_sweep(
                     "drv_status_raw": drv if isinstance(drv, int) else None,
                     "commanded_speed": signed_speed,
                     "irun": irun_ctx,
+                    "acceleration": accel_ctx,
                     "microsteps": microsteps_ctx,
                     "stealthchop": stealth_ctx,
                     "loaded": loaded,
@@ -1277,3 +1285,19 @@ def set_stallguard_config(stepper: str, body: StallGuardConfigBody) -> StallGuar
         tcoolthrs=body.tcoolthrs,
         enabled=body.enabled,
     )
+
+
+@router.post("/stall-incident/clear")
+def clear_stall_incident() -> Dict[str, Any]:
+    """Operator-acknowledge a stall. Clears the blocking incident; the stall
+    monitor resets the firmware latch and re-arms detection on its next poll."""
+    from stepper_stall_monitor import STEPPER_STALL_INCIDENT_KIND
+
+    gc = shared_state.gc_ref
+    runtime_stats = getattr(gc, "runtime_stats", None) if gc is not None else None
+    if runtime_stats is None or not hasattr(runtime_stats, "clearActiveIncident"):
+        raise HTTPException(status_code=503, detail="runtime stats unavailable")
+    active = runtime_stats.activeIncident() if hasattr(runtime_stats, "activeIncident") else None
+    runtime_stats.clearActiveIncident(kind=STEPPER_STALL_INCIDENT_KIND)
+    cleared = isinstance(active, dict) and active.get("kind") == STEPPER_STALL_INCIDENT_KIND
+    return {"ok": True, "cleared": cleared, "kind": STEPPER_STALL_INCIDENT_KIND}

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -1529,6 +1529,144 @@ def set_stallguard_config(stepper: str, body: StallGuardConfigBody) -> StallGuar
     )
 
 
+# ---------------------------------------------------------------------------
+# Threshold suggestion — pair-based, from the measured unloaded/loaded gap
+#
+# A single run can't set an accurate SGTHRS: an unloaded run only shows the floor
+# (the ceiling the trigger must stay under) and a loaded run only shows the stall
+# dip (the level the trigger must clear). The accurate trigger sits in the gap
+# between the two, so we take cruise samples from the LATEST run of BOTH kinds for
+# the motor and place the trigger at the geometric midpoint — equal ratio margin
+# above the stall dip and below the normal floor. SGTHRS = trigger / 2 because
+# DIAG fires at SG_RESULT <= 2*SGTHRS.
+#
+# Deliberately the *latest* run of each kind, not a pool of recent ones: pooling
+# sweeps in stale runs at other speeds or from a since-changed driver config
+# (e.g. the old SpreadCycle-hybrid runs whose floor collapsed to ~6), which drags
+# the pooled floor down and yields a uselessly low threshold. The freshest run is
+# the one tuned to the current config. Percentiles within that run still guard
+# against single-sample outliers.
+# ---------------------------------------------------------------------------
+
+_FLOOR_PERCENTILE = 0.05   # unloaded: worst-case normal cruise (low end of floor)
+_DIP_PERCENTILE = 0.10     # loaded: representative stall dip (low end)
+
+
+class StallGuardSuggestionResponse(BaseModel):
+    success: bool
+    stepper: str
+    cruise_tstep: int
+    unloaded_floor: Optional[int]
+    loaded_dip: Optional[int]
+    trigger_level: Optional[int]
+    suggested_sgthrs: Optional[int]
+    enough_data: bool
+    unloaded_runs: int
+    loaded_runs: int
+    detail: str
+
+
+def _percentile(sorted_vals: List[int], q: float) -> Optional[int]:
+    if not sorted_vals:
+        return None
+    idx = int(round(q * (len(sorted_vals) - 1)))
+    return sorted_vals[max(0, min(len(sorted_vals) - 1, idx))]
+
+
+def _cruise_sg(run: Optional[Dict[str, Any]], cruise_tstep: int) -> List[int]:
+    if run is None:
+        return []
+    out: List[int] = []
+    for s in stepper_telemetry.getRunSamples(run["id"]):
+        sg = s.get("sg_result")
+        ts = s.get("tstep")
+        if (
+            isinstance(sg, int)
+            and sg >= 0
+            and isinstance(ts, int)
+            and 0 <= ts <= cruise_tstep
+        ):
+            out.append(sg)
+    return sorted(out)
+
+
+@router.get(
+    "/stepper/{stepper}/stallguard-suggestion",
+    response_model=StallGuardSuggestionResponse,
+)
+def stallguard_suggestion(
+    stepper: str, cruise_tstep: Optional[int] = None
+) -> StallGuardSuggestionResponse:
+    """Pure DB analysis — no hardware. Takes cruise SG from the latest unloaded
+    (sweep) and latest loaded (stall_test) run for this motor and returns the
+    geometric-midpoint trigger between the normal floor and the stall dip."""
+    if stepper not in _STEPPER_API_TO_TOML_NAME:
+        raise HTTPException(status_code=400, detail=f"Unknown stepper '{stepper}'")
+
+    def _latest(source: str) -> Optional[Dict[str, Any]]:
+        rows = stepper_telemetry.listRuns(
+            stepper_name=stepper, source=source, limit=50
+        )
+        for r in rows:  # listRuns is newest-first
+            if r.get("status") == stepper_telemetry.RUN_STATUS_COMPLETED:
+                return r
+        return None
+
+    unloaded_run = _latest(stepper_telemetry.SOURCE_SWEEP)
+    loaded_run = _latest(stepper_telemetry.SOURCE_STALL_TEST)
+
+    if cruise_tstep is None:
+        latest_params = unloaded_run["params"] if unloaded_run else None
+        ct = int(latest_params.get("cruise_tstep", 150)) if isinstance(latest_params, dict) else 150
+    else:
+        ct = cruise_tstep
+    ct = max(1, ct)
+
+    floor = _percentile(_cruise_sg(unloaded_run, ct), _FLOOR_PERCENTILE)
+    dip = _percentile(_cruise_sg(loaded_run, ct), _DIP_PERCENTILE)
+
+    trigger: Optional[int] = None
+    sgthrs: Optional[int] = None
+    enough = False
+    if floor is not None and dip is not None:
+        # Geometric midpoint of the gap. Clamp dip to >=1 so a stall floor that
+        # reaches 0 doesn't collapse the geo-mean to 0.
+        trigger = int(round(math.sqrt(float(floor) * float(max(1, dip)))))
+        sgthrs = max(1, min(255, round(trigger / 2)))
+        enough = True
+        detail = (
+            f"Balanced trigger {trigger} = geo-mean(floor {floor}, dip {dip}) "
+            "from the latest unloaded + latest loaded run."
+        )
+    elif floor is not None:
+        # Provisional: no loaded stall test yet, so we can't see the dip. Fall
+        # back to a fraction of the floor and flag it as unvalidated.
+        trigger = int(round(floor * 0.4))
+        sgthrs = max(1, min(255, round(trigger / 2)))
+        detail = (
+            "No loaded stall test for this motor yet — provisional SGTHRS from the "
+            "unloaded floor only. Run a loaded (held/resisted) sweep to validate."
+        )
+    elif dip is not None:
+        detail = "Only loaded runs found — run an unloaded sweep to measure the normal floor."
+    else:
+        detail = "No completed cruise samples for this motor yet — run an unloaded and a loaded sweep."
+
+    return StallGuardSuggestionResponse(
+        success=True,
+        stepper=stepper,
+        cruise_tstep=ct,
+        unloaded_floor=floor,
+        loaded_dip=dip,
+        trigger_level=trigger,
+        suggested_sgthrs=sgthrs,
+        enough_data=enough,
+        unloaded_runs=1 if unloaded_run else 0,
+        loaded_runs=1 if loaded_run else 0,
+        detail=detail,
+    )
+
+
 @router.post("/stall-incident/clear")
 def clear_stall_incident() -> Dict[str, Any]:
     """Operator-acknowledge a stall. Clears the blocking incident; the stall

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -26,6 +26,7 @@ from irl.parse_user_toml import (
     DEFAULT_STEPPER_IHOLD,
     DEFAULT_STEPPER_IHOLD_DELAY,
     DEFAULT_STEPPER_IRUN,
+    DEFAULT_STEPPER_STALLGUARD,
 )
 from server import shared_state
 
@@ -1558,16 +1559,24 @@ DEFAULT_STALLGUARD_ENFORCE_TCOOLTHRS = 150
 
 
 def _stallguard_payload_from_persisted_config(name: str) -> Dict[str, Any]:
-    result: Dict[str, Any] = {
-        "sgthrs": DEFAULT_STALLGUARD_SGTHRS,
-        "tcoolthrs": DEFAULT_STALLGUARD_ENFORCE_TCOOLTHRS,
-        "enabled": False,
-    }
+    toml_name = _STEPPER_API_TO_TOML_NAME.get(name, name)
+    # Seed from the motor's built-in default (chute/carousel have tuned ones), so a
+    # fresh machine with no TOML entry still shows its real applied config rather
+    # than a generic placeholder. Motors with no built-in default fall back to the
+    # generic disabled placeholder.
+    builtin = DEFAULT_STEPPER_STALLGUARD.get(toml_name)
+    if builtin is not None:
+        result: Dict[str, Any] = {"sgthrs": builtin[0], "tcoolthrs": builtin[1], "enabled": builtin[2]}
+    else:
+        result = {
+            "sgthrs": DEFAULT_STALLGUARD_SGTHRS,
+            "tcoolthrs": DEFAULT_STALLGUARD_ENFORCE_TCOOLTHRS,
+            "enabled": False,
+        }
     try:
         _, config = _read_machine_params_config()
     except Exception:
         return result
-    toml_name = _STEPPER_API_TO_TOML_NAME.get(name, name)
     section = config.get("stepper_stallguard", {})
     entry = section.get(toml_name, {}) if isinstance(section, dict) else {}
     if isinstance(entry, dict):

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -1346,6 +1346,14 @@ def stallguard_sweep(
     )
 
     try:
+        # The sweep deliberately stalls the motor (loaded test) and opens the
+        # velocity floor wide — so turn live stall detection OFF for the duration,
+        # or an enabled motor would trip its own incident mid-sweep. This is the
+        # ONE place detection is suppressed; it's restored in the finally.
+        try:
+            target.enable_stall_detection(False)
+        except Exception:
+            pass
         # Measure with SG reported across the whole speed range; the cruise_tstep
         # filter is applied at analysis time so we still see the transients in the
         # chart but don't let them set the threshold.
@@ -1422,8 +1430,17 @@ def stallguard_sweep(
             _halt_stepper(target, force=True)
         except Exception:
             pass
+        # Restore the motor's resting state. If it has live stall detection
+        # configured, put its enforcement velocity floor back and re-enable
+        # detection (we turned it off above); otherwise just zero the floor so the
+        # sweep leaves nothing half-configured.
         try:
-            target.write_driver_register(TMC_REG_TCOOLTHRS, 0)
+            if getattr(target, "stallguard_enabled", False) and target.stallguard_sgthrs is not None:
+                target.write_driver_register(TMC_REG_TCOOLTHRS, target.stallguard_tcoolthrs)
+                target.clear_stall()
+                target.enable_stall_detection(True)
+            else:
+                target.write_driver_register(TMC_REG_TCOOLTHRS, 0)
         except Exception:
             pass
         # chute_random retunes the chute stepper's speed limits; restore them to

--- a/software/sorter/backend/server/routers/steppers.py
+++ b/software/sorter/backend/server/routers/steppers.py
@@ -270,6 +270,7 @@ TMC_REG_IOIN = 0x06
 TMC_REG_FACTORY_CONF = 0x07
 TMC_REG_IHOLD_IRUN = 0x10
 TMC_REG_TSTEP = 0x12
+TMC_REG_TPWMTHRS = 0x13
 TMC_REG_TCOOLTHRS = 0x14
 TMC_REG_COOLCONF = 0x42
 TMC_REG_SG_RESULT = 0x41
@@ -1245,6 +1246,7 @@ def stallguard_sweep(
     sample_interval_s: float = 0.02,
     spin_up_s: float = 0.3,
     tcoolthrs: int = DEFAULT_STALLGUARD_TCOOLTHRS,
+    tpwmthrs: int = 0,
     loaded: bool = False,
     label: Optional[str] = None,
     profile: str = "constant",
@@ -1264,6 +1266,8 @@ def stallguard_sweep(
         raise HTTPException(
             status_code=400, detail=f"profile must be one of {', '.join(SWEEP_PROFILES)}"
         )
+    if not (0 <= tpwmthrs <= 0xFFFFF):
+        raise HTTPException(status_code=400, detail="tpwmthrs must be in [0, 0xFFFFF]")
     if duration_s <= 0 or duration_s > MAX_STALLGUARD_SWEEP_DURATION_S:
         raise HTTPException(
             status_code=400,
@@ -1326,6 +1330,7 @@ def stallguard_sweep(
             "duration_s": duration_s,
             "sample_interval_s": sample_interval_s,
             "tcoolthrs": tcoolthrs,
+            "tpwmthrs": tpwmthrs,
             "loaded": loaded,
             "irun": irun_ctx,
             "acceleration": accel_ctx,
@@ -1343,6 +1348,11 @@ def stallguard_sweep(
 
     try:
         target.write_driver_register(TMC_REG_TCOOLTHRS, tcoolthrs)
+        # TPWMTHRS>0 makes the driver auto-switch StealthChop->SpreadCycle once it
+        # crosses this velocity (TSTEP < TPWMTHRS), so it stays quiet at low speed
+        # but measures load in SpreadCycle at cruise. Only meaningful while the
+        # driver is in StealthChop (which it is by default).
+        target.write_driver_register(TMC_REG_TPWMTHRS, tpwmthrs)
         target.enable_force(True)
         motion.start(time.monotonic())
 
@@ -1417,6 +1427,10 @@ def stallguard_sweep(
             pass
         try:
             target.write_driver_register(TMC_REG_TCOOLTHRS, 0)
+        except Exception:
+            pass
+        try:
+            target.write_driver_register(TMC_REG_TPWMTHRS, 0)  # back to pure StealthChop
         except Exception:
             pass
         # chute_random retunes the chute stepper's speed limits; restore them to

--- a/software/sorter/backend/stepper_stall_monitor.py
+++ b/software/sorter/backend/stepper_stall_monitor.py
@@ -1,0 +1,149 @@
+"""StallGuard stall detection -> operator incident.
+
+The TMC2209 raises its DIAG line when a configured motor stalls; the firmware
+latches that per channel. This monitor polls the latch over USB while the machine
+is RUNNING and, on a stall, publishes a blocking `stepper_stall` incident. The
+coordinator then halts all flow until the operator clears the jam and
+acknowledges — there is deliberately NO auto-recovery, because a real stall needs
+hands.
+
+Detection is armed ONLY while RUNNING. Homing drives motors into hard endstops,
+manual jogs and StallGuard sweeps push motors around at the operator's command —
+all of which would otherwise trip a stall. Gating on RUNNING keeps those quiet.
+"""
+
+import time
+
+from global_config import GlobalConfig
+from defs.sorter_controller import SorterLifecycle
+
+STEPPER_STALL_INCIDENT_KIND = "stepper_stall"
+
+# Poll cadence. Runs on its own daemon thread (not the main loop) so the UART
+# round-trips never hitch 30 Hz operation. Each cycle issues one GET_STALL_STATUS
+# per board, so cost scales with board count, not motor count.
+STALL_POLL_INTERVAL_S = 0.25
+
+_TMC_REG_TCOOLTHRS = 0x14
+_TMC_REG_SGTHRS = 0x40
+
+
+class StepperStallMonitor:
+    def __init__(self, gc: GlobalConfig):
+        self._gc = gc
+        self._armed = False
+        # True once we've raised an incident; reset after the operator clears it
+        # so we can re-arm the firmware latch and resume polling.
+        self._raised = False
+
+    def run(self, get_controller) -> None:
+        import server.shared_state as shared_state
+
+        while True:
+            try:
+                self.poll(get_controller(), shared_state.getActiveIRL())
+            except Exception as e:
+                self._gc.logger.warning(f"Stall monitor poll error: {e}")
+            time.sleep(STALL_POLL_INTERVAL_S)
+
+    def _armed_groups(self, irl) -> dict:
+        # board interface -> [StepperMotor] for every configured+enabled stepper.
+        groups: dict = {}
+        interfaces = getattr(irl, "interfaces", None) or {}
+        for iface in interfaces.values():
+            for stepper in getattr(iface, "steppers", ()):  # raw per-board steppers
+                if getattr(stepper, "stallguard_enabled", False) and stepper.stallguard_sgthrs is not None:
+                    groups.setdefault(iface, []).append(stepper)
+        return groups
+
+    def _arm(self, groups: dict) -> None:
+        # Re-write thresholds here (not just at init) so they survive sweeps and
+        # coolstep toggles that clobber SGTHRS/TCOOLTHRS between runs.
+        count = 0
+        for steppers in groups.values():
+            for stepper in steppers:
+                try:
+                    stepper.write_driver_register(_TMC_REG_SGTHRS, stepper.stallguard_sgthrs)
+                    stepper.write_driver_register(_TMC_REG_TCOOLTHRS, stepper.stallguard_tcoolthrs)
+                    stepper.clear_stall()
+                    stepper.enable_stall_detection(True)
+                    count += 1
+                except Exception as e:
+                    self._gc.logger.warning(f"StallGuard arm failed for '{stepper.name}': {e}")
+        self._armed = True
+        self._raised = False
+        self._gc.logger.info(f"StallGuard armed on {count} stepper(s).")
+
+    def _disarm(self, groups: dict) -> None:
+        for steppers in groups.values():
+            for stepper in steppers:
+                try:
+                    stepper.enable_stall_detection(False)
+                except Exception:
+                    pass
+        self._armed = False
+        self._raised = False
+
+    def poll(self, controller, irl) -> None:
+        running = controller is not None and getattr(controller, "state", None) == SorterLifecycle.RUNNING
+        groups = self._armed_groups(irl) if irl is not None else {}
+
+        if not running:
+            if self._armed:
+                self._disarm(groups)
+            return
+        if not groups:
+            return
+        if not self._armed:
+            self._arm(groups)
+            return
+
+        runtime_stats = self._gc.runtime_stats
+        active = runtime_stats.activeIncident()
+        if isinstance(active, dict) and active.get("kind") == STEPPER_STALL_INCIDENT_KIND:
+            return  # our incident is up; the machine is held, waiting for ack
+        if self._raised:
+            # Operator acknowledged (our incident is gone). Reset firmware latches
+            # and re-arm so the next stall is caught.
+            for steppers in groups.values():
+                for stepper in steppers:
+                    try:
+                        stepper.clear_stall()
+                        stepper.enable_stall_detection(True)
+                    except Exception:
+                        pass
+            self._raised = False
+            return
+        if isinstance(active, dict):
+            return  # a different incident holds the machine; don't poll over it
+
+        stalled: list[str] = []
+        for iface, steppers in groups.items():
+            try:
+                mask = iface.get_stall_status()
+            except Exception as e:
+                self._gc.logger.warning(
+                    f"StallGuard poll failed on board '{getattr(iface, 'name', '?')}': {e}"
+                )
+                continue
+            for stepper in steppers:
+                if mask & (1 << stepper.channel):
+                    stalled.append(stepper.name)
+        if stalled:
+            self._raise_incident(stalled)
+
+    def _raise_incident(self, names: list[str]) -> None:
+        self._gc.logger.error(f"Stepper stall detected on {names}; halting machine.")
+        self._gc.runtime_stats.setActiveIncident(
+            {
+                "kind": STEPPER_STALL_INCIDENT_KIND,
+                "channel": names[0],
+                "steppers": names,
+                "status": "needs_manual_fix",
+                "operator_message": (
+                    f"Motor stall detected on {', '.join(names)}. Clear the jam, "
+                    "then acknowledge to resume."
+                ),
+            }
+        )
+        self._raised = True

--- a/software/sorter/backend/stepper_stall_monitor.py
+++ b/software/sorter/backend/stepper_stall_monitor.py
@@ -1,21 +1,20 @@
 """StallGuard stall detection -> operator incident.
 
 The TMC2209 raises its DIAG line when a configured motor stalls; the firmware
-latches that per channel. This monitor polls the latch over USB while the machine
-is RUNNING and, on a stall, publishes a blocking `stepper_stall` incident. The
-coordinator then halts all flow until the operator clears the jam and
-acknowledges — there is deliberately NO auto-recovery, because a real stall needs
-hands.
+latches that per channel. Detection is turned ON for any stepper that has an
+enabled `[stepper_stallguard.*]` entry — switched on once at hardware init (see
+`applyStepperStallguard`) and left on. There is NO per-move or per-state arming:
+if a motor has a threshold, every move is protected, full stop.
 
-Detection is armed ONLY while RUNNING. Homing drives motors into hard endstops,
-manual jogs and StallGuard sweeps push motors around at the operator's command —
-all of which would otherwise trip a stall. Gating on RUNNING keeps those quiet.
+This monitor only watches. It polls the per-board latch over USB and, on a stall,
+publishes a blocking `stepper_stall` incident. The coordinator then halts all flow
+until the operator clears the jam and acknowledges — there is deliberately NO
+auto-recovery, because a real stall needs hands.
 """
 
 import time
 
 from global_config import GlobalConfig
-from defs.sorter_controller import SorterLifecycle
 
 STEPPER_STALL_INCIDENT_KIND = "stepper_stall"
 
@@ -24,29 +23,25 @@ STEPPER_STALL_INCIDENT_KIND = "stepper_stall"
 # per board, so cost scales with board count, not motor count.
 STALL_POLL_INTERVAL_S = 0.25
 
-_TMC_REG_TCOOLTHRS = 0x14
-_TMC_REG_SGTHRS = 0x40
-
 
 class StepperStallMonitor:
     def __init__(self, gc: GlobalConfig):
         self._gc = gc
-        self._armed = False
-        # True once we've raised an incident; reset after the operator clears it
-        # so we can re-arm the firmware latch and resume polling.
+        # True once we've raised an incident; reset (and the firmware latch
+        # cleared) after the operator acknowledges, so the next stall is caught.
         self._raised = False
 
-    def run(self, get_controller) -> None:
+    def run(self) -> None:
         import server.shared_state as shared_state
 
         while True:
             try:
-                self.poll(get_controller(), shared_state.getActiveIRL())
+                self.poll(shared_state.getActiveIRL())
             except Exception as e:
                 self._gc.logger.warning(f"Stall monitor poll error: {e}")
             time.sleep(STALL_POLL_INTERVAL_S)
 
-    def _armed_groups(self, irl) -> dict:
+    def _enabled_groups(self, irl) -> dict:
         # board interface -> [StepperMotor] for every configured+enabled stepper.
         groups: dict = {}
         interfaces = getattr(irl, "interfaces", None) or {}
@@ -56,46 +51,9 @@ class StepperStallMonitor:
                     groups.setdefault(iface, []).append(stepper)
         return groups
 
-    def _arm(self, groups: dict) -> None:
-        # Re-write thresholds here (not just at init) so they survive sweeps and
-        # coolstep toggles that clobber SGTHRS/TCOOLTHRS between runs.
-        count = 0
-        for steppers in groups.values():
-            for stepper in steppers:
-                try:
-                    stepper.write_driver_register(_TMC_REG_SGTHRS, stepper.stallguard_sgthrs)
-                    stepper.write_driver_register(_TMC_REG_TCOOLTHRS, stepper.stallguard_tcoolthrs)
-                    stepper.clear_stall()
-                    stepper.enable_stall_detection(True)
-                    count += 1
-                except Exception as e:
-                    self._gc.logger.warning(f"StallGuard arm failed for '{stepper.name}': {e}")
-        self._armed = True
-        self._raised = False
-        self._gc.logger.info(f"StallGuard armed on {count} stepper(s).")
-
-    def _disarm(self, groups: dict) -> None:
-        for steppers in groups.values():
-            for stepper in steppers:
-                try:
-                    stepper.enable_stall_detection(False)
-                except Exception:
-                    pass
-        self._armed = False
-        self._raised = False
-
-    def poll(self, controller, irl) -> None:
-        running = controller is not None and getattr(controller, "state", None) == SorterLifecycle.RUNNING
-        groups = self._armed_groups(irl) if irl is not None else {}
-
-        if not running:
-            if self._armed:
-                self._disarm(groups)
-            return
+    def poll(self, irl) -> None:
+        groups = self._enabled_groups(irl) if irl is not None else {}
         if not groups:
-            return
-        if not self._armed:
-            self._arm(groups)
             return
 
         runtime_stats = self._gc.runtime_stats
@@ -103,8 +61,8 @@ class StepperStallMonitor:
         if isinstance(active, dict) and active.get("kind") == STEPPER_STALL_INCIDENT_KIND:
             return  # our incident is up; the machine is held, waiting for ack
         if self._raised:
-            # Operator acknowledged (our incident is gone). Reset firmware latches
-            # and re-arm so the next stall is caught.
+            # Operator acknowledged (our incident is gone). Reset the firmware
+            # latches so the next stall is caught.
             for steppers in groups.values():
                 for stepper in steppers:
                     try:

--- a/software/sorter/backend/stepper_telemetry.py
+++ b/software/sorter/backend/stepper_telemetry.py
@@ -41,6 +41,12 @@ def _connect() -> sqlite3.Connection:
     return conn
 
 
+def _ensureColumn(conn: sqlite3.Connection, table: str, column: str, decl: str) -> None:
+    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    if column not in existing:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+
+
 @contextmanager
 def _connection() -> Iterator[sqlite3.Connection]:
     _ensureInitialized()
@@ -104,9 +110,13 @@ def _ensureInitialized() -> None:
                 "irun INTEGER, "
                 "microsteps INTEGER, "
                 "stealthchop INTEGER, "
-                "loaded INTEGER"
+                "loaded INTEGER, "
+                "acceleration INTEGER"
                 ")"
             )
+            # Migration: add columns introduced after the table first shipped, so
+            # DBs created by earlier versions gain them without a manual rebuild.
+            _ensureColumn(conn, "stepper_telemetry_samples", "acceleration", "INTEGER")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_stepper_telemetry_samples_run "
                 "ON stepper_telemetry_samples(run_id, recorded_at)"
@@ -171,6 +181,7 @@ def insertSamples(run_id: str, samples: Iterable[dict[str, Any]]) -> int:
             s.get("microsteps"),
             1 if s.get("stealthchop") else 0 if s.get("stealthchop") is not None else None,
             1 if s.get("loaded") else 0 if s.get("loaded") is not None else None,
+            s.get("acceleration"),
         )
         for s in samples
     ]
@@ -180,8 +191,8 @@ def insertSamples(run_id: str, samples: Iterable[dict[str, Any]]) -> int:
         conn.executemany(
             "INSERT INTO stepper_telemetry_samples "
             "(run_id, recorded_at, stepper_name, channel, sg_result, cs_actual, "
-            "tstep, drv_status_raw, commanded_speed, irun, microsteps, stealthchop, loaded) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "tstep, drv_status_raw, commanded_speed, irun, microsteps, stealthchop, loaded, acceleration) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             rows,
         )
         conn.commit()

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/__init__.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/__init__.py
@@ -4,6 +4,7 @@ from .classifying import Classifying
 from .context import SimpleStateMachineRev01Context
 from .discharging import Discharging
 from .idle import Idle
+from .positioning import Positioning
 from .rotating_and_capturing import RotatingAndCapturing
 from .verifying_discharge import VerifyingDischarge
 
@@ -25,6 +26,7 @@ def buildRev01StatesMap(
         ClassificationChannelState.IDLE: Idle(*args),
         ClassificationChannelState.REV01_ROTATING_AND_CAPTURING: RotatingAndCapturing(*args),
         ClassificationChannelState.REV01_CLASSIFYING: Classifying(*args),
+        ClassificationChannelState.REV01_POSITIONING: Positioning(*args),
         ClassificationChannelState.REV01_DISCHARGING: Discharging(*args),
         ClassificationChannelState.REV01_VERIFYING_DISCHARGE: VerifyingDischarge(*args),
     }
@@ -36,6 +38,7 @@ __all__ = [
     "Idle",
     "RotatingAndCapturing",
     "Classifying",
+    "Positioning",
     "Discharging",
     "VerifyingDischarge",
 ]

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/base.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/base.py
@@ -5,7 +5,6 @@ from typing import Optional
 import cv2
 import numpy as np
 
-from defs.known_object import PieceStage
 from global_config import GlobalConfig
 from irl.config import IRLConfig, IRLInterface
 from piece_transport import ClassificationChannelTransport
@@ -147,15 +146,6 @@ class Rev01BaseState(BaseState):
         ) % 360.0
         delta = (target_angle - piece_angle) % 360.0
         return max(2.0, min(delta, 270.0))
-
-    def stampDistributed(self) -> None:
-        obj = self.ctx.known_object
-        if obj is None:
-            return
-        obj.stage = PieceStage.distributed
-        obj.distributed_at = time.time()
-        obj.destination_bin = (0, 0, 0)
-        self.emitKnownObject()
 
     def bboxesOutsideExitZone(
         self, bboxes: list[tuple[int, int, int, int]]

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/classifying.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/classifying.py
@@ -49,7 +49,7 @@ class Classifying(Rev01BaseState):
                     f"{LOG_TAG} CLASSIFYING with zero captures — skipping Brickognize call"
                 )
                 self.ctx.classification_error = "no_captures"
-                return ClassificationChannelState.REV01_DISCHARGING
+                return ClassificationChannelState.REV01_POSITIONING
 
             total_bytes = sum(int(f.nbytes) for f in captures)
             self.logger.info(
@@ -88,7 +88,7 @@ class Classifying(Rev01BaseState):
                 result=result,
                 error=error,
             )
-            return ClassificationChannelState.REV01_DISCHARGING
+            return ClassificationChannelState.REV01_POSITIONING
 
         if now - self.ctx.classify_started_at > self.ctx.config.classify_timeout_s:
             self.logger.error(
@@ -101,7 +101,7 @@ class Classifying(Rev01BaseState):
                 result=None,
                 error="timeout",
             )
-            return ClassificationChannelState.REV01_DISCHARGING
+            return ClassificationChannelState.REV01_POSITIONING
         return None
 
     def _dumpBurstCaptureArtifacts(

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/discharging.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/discharging.py
@@ -42,6 +42,12 @@ class Discharging(Rev01BaseState):
 
         if self._stepper_done_at is None:
             self._stepper_done_at = time.monotonic()
+            # The piece has just been flung out of the C-channel into the chute,
+            # which distribution already aimed at the target bin during
+            # POSITIONING. Promote it from the positioning slot to the drop slot
+            # and drop the gate — distribution's Ready state is holding on the
+            # gate and advances to Sending (commit + record) when it goes False.
+            self._releaseToDistribution()
 
         pause_s = self.ctx.config.post_discharge_pause_ms / 1000.0
         if time.monotonic() - self._stepper_done_at < pause_s:
@@ -52,6 +58,17 @@ class Discharging(Rev01BaseState):
             f"{LOG_TAG} DISCHARGING -> VERIFYING_DISCHARGE (move complete after {elapsed:.2f}s)"
         )
         return ClassificationChannelState.REV01_VERIFYING_DISCHARGE
+
+    def _releaseToDistribution(self) -> None:
+        obj = self.ctx.known_object
+        # advanceTransport (non-dynamic) shifts wait -> exit, so the piece
+        # distribution positioned for now occupies the drop slot it reads from.
+        self.transport.advanceTransport()
+        self.shared.set_distribution_gate(False, reason="rev01_discharged")
+        if obj is not None:
+            self.logger.info(
+                f"{LOG_TAG} DISCHARGING: released piece {obj.uuid[:8]} to distribution"
+            )
 
     def _logDischargePlan(self, output_deg: float) -> None:
         perception_service = getattr(self.gc, "perception_service", None)

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/positioning.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/positioning.py
@@ -1,0 +1,84 @@
+import time
+from typing import Optional
+
+from defs.known_object import ClassificationStatus, PieceStage
+from subsystems.classification_channel.states import ClassificationChannelState
+
+from .base import Rev01BaseState
+from .constants import LOG_TAG
+
+
+class Positioning(Rev01BaseState):
+    """Hand the classified piece to distribution and wait for the chute to be
+    aimed at its target bin before discharging.
+
+    rev01 owns its own KnownObject; this is the single point where it is handed
+    to the transport so the distribution subsystem can look up the bin and aim
+    the chute. We block until distribution has both taken ownership of the piece
+    (``stage -> distributing``) AND signalled the chute is positioned
+    (``distribution_ready`` True), then release to DISCHARGING. Waiting on both
+    conditions is monotonic and avoids trusting a stale gate left True by a
+    previous cycle. No hard timeout — like the carousel path we hold the piece
+    in the channel through no-bin / servo incidents until distribution is ready.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._placed = False
+        self._entered_at = 0.0
+        self._last_wait_log_ms = 0.0
+
+    def step(self) -> Optional[ClassificationChannelState]:
+        self.setClassificationReady(False, "positioning")
+        obj = self.ctx.known_object
+        now = time.monotonic()
+
+        if obj is None:
+            self.logger.warning(
+                f"{LOG_TAG} POSITIONING: no known_object — skipping to DISCHARGING"
+            )
+            return ClassificationChannelState.REV01_DISCHARGING
+
+        if not self._placed:
+            self._entered_at = now
+            # Distribution only accepts a piece with a routable status. A piece
+            # whose classification never resolved (no captures / timeout /
+            # error) is still left pending/classifying — coerce it to
+            # ``unknown`` so it routes to MISC/discard rather than wedging the
+            # handoff (distribution's Idle gate ignores pending pieces).
+            if obj.part_id is None and obj.classification_status in (
+                ClassificationStatus.pending,
+                ClassificationStatus.classifying,
+            ):
+                obj.classification_status = ClassificationStatus.unknown
+            self.transport.placePieceForDistribution(obj)
+            self._placed = True
+            self.logger.info(
+                f"{LOG_TAG} POSITIONING: handed piece {obj.uuid[:8]} to distribution "
+                f"(status={obj.classification_status}, part_id={obj.part_id})"
+            )
+
+        distribution_ready = bool(self.shared.distribution_ready)
+        taken = obj.stage == PieceStage.distributing
+        if taken and distribution_ready:
+            waited_ms = (now - self._entered_at) * 1000.0
+            self.logger.info(
+                f"{LOG_TAG} POSITIONING -> DISCHARGING (chute aimed at "
+                f"bin={obj.destination_bin} after {waited_ms:.0f}ms)"
+            )
+            return ClassificationChannelState.REV01_DISCHARGING
+
+        waited_ms = (now - self._entered_at) * 1000.0
+        if waited_ms - self._last_wait_log_ms >= 1000.0:
+            self._last_wait_log_ms = waited_ms
+            self.logger.info(
+                f"{LOG_TAG} POSITIONING: waiting for distribution "
+                f"(taken={taken}, ready={distribution_ready}, {waited_ms:.0f}ms)"
+            )
+        return None
+
+    def cleanup(self) -> None:
+        super().cleanup()
+        self._placed = False
+        self._entered_at = 0.0
+        self._last_wait_log_ms = 0.0

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/rotating_and_capturing.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/rotating_and_capturing.py
@@ -105,10 +105,10 @@ class RotatingAndCapturing(Rev01BaseState):
         if now - self.ctx.rotating_started_at > self.ctx.config.rotate_timeout_s:
             self.logger.error(
                 f"{LOG_TAG} rotation timeout after {self.ctx.config.rotate_timeout_s}s "
-                f"(captures={len(self.ctx.captured_crops)}) — abort to DISCHARGING"
+                f"(captures={len(self.ctx.captured_crops)}) — abort to POSITIONING"
             )
             self.stopStepper()
-            return ClassificationChannelState.REV01_DISCHARGING
+            return ClassificationChannelState.REV01_POSITIONING
 
         primary_bbox_started = time.perf_counter()
         primary_bbox = self.cv.primaryBbox(bboxes)
@@ -228,10 +228,10 @@ class RotatingAndCapturing(Rev01BaseState):
         if now - self.ctx.rotating_started_at > self.ctx.config.rotate_timeout_s:
             self.logger.error(
                 f"{LOG_TAG} rotation timeout after {self.ctx.config.rotate_timeout_s}s "
-                f"(captures={len(self.ctx.captured_crops)}) — abort to DISCHARGING"
+                f"(captures={len(self.ctx.captured_crops)}) — abort to POSITIONING"
             )
             self.stopStepper()
-            return ClassificationChannelState.REV01_DISCHARGING
+            return ClassificationChannelState.REV01_POSITIONING
 
         primary_bbox_started = time.perf_counter()
         primary_bbox = self.cv.primaryBbox(bboxes)

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/verifying_discharge.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/verifying_discharge.py
@@ -40,7 +40,6 @@ class VerifyingDischarge(Rev01BaseState):
                     f"{LOG_TAG} VERIFYING_DISCHARGE -> IDLE (exit zone clear after "
                     f"{cfg.verify_discharge_wait_ms}ms settle)"
                 )
-                self.stampDistributed()
                 return ClassificationChannelState.IDLE
 
             # Stuck. Kick off the jitter sequence (may fail to build if the
@@ -51,7 +50,6 @@ class VerifyingDischarge(Rev01BaseState):
                     f"{LOG_TAG} VERIFYING_DISCHARGE: jitter sequence unavailable — "
                     f"giving up, returning to IDLE"
                 )
-                self.stampDistributed()
                 return ClassificationChannelState.IDLE
             self.logger.info(
                 f"{LOG_TAG} VERIFYING_DISCHARGE: piece still in exit zone — "
@@ -65,7 +63,6 @@ class VerifyingDischarge(Rev01BaseState):
             self.logger.info(
                 f"{LOG_TAG} VERIFYING_DISCHARGE -> IDLE (jitter cleared the piece)"
             )
-            self.stampDistributed()
             return ClassificationChannelState.IDLE
 
         if phase == JitterPhase.EXHAUSTED:
@@ -74,7 +71,6 @@ class VerifyingDischarge(Rev01BaseState):
                 f"{cfg.verify_discharge_max_jitter_attempts} jitter attempts — "
                 f"giving up, returning to IDLE"
             )
-            self.stampDistributed()
             return ClassificationChannelState.IDLE
 
         return None

--- a/software/sorter/backend/subsystems/classification_channel/states.py
+++ b/software/sorter/backend/subsystems/classification_channel/states.py
@@ -10,5 +10,6 @@ class ClassificationChannelState(str, Enum):
     # Rev01 simple-state-machine states
     REV01_ROTATING_AND_CAPTURING = "rev01_rotating_and_capturing"
     REV01_CLASSIFYING = "rev01_classifying"
+    REV01_POSITIONING = "rev01_positioning"
     REV01_DISCHARGING = "rev01_discharging"
     REV01_VERIFYING_DISCHARGE = "rev01_verifying_discharge"

--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -183,9 +183,16 @@ class Chute:
         )
         if unclamped:
             return angle
-        if angle < 0 or angle > CHUTE_MAX_ANGLE:
+        # The chute travels [0, CHUTE_MAX_ANGLE] and can never cross the home
+        # stop, so wrap the bin onto the circle: it is reachable iff its wrapped
+        # position lands inside the travel window. The arc (CHUTE_MAX_ANGLE, 360)
+        # just before home is the only dead wedge. Wrapping is what lets a
+        # section that home cut through still serve the bins sitting just
+        # clockwise of home — reached the long way round, never across the stop.
+        norm = angle % 360.0
+        if norm > CHUTE_MAX_ANGLE:
             return None
-        return angle
+        return norm
 
     def getAngleForBin(self, address: BinAddress) -> float | None:
         num_bins = self._binsInSection(address.layer_index, address.section_index)

--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -276,19 +276,36 @@ class Chute:
 
     def home(self) -> bool:
         self.logger.info("Chute: homing via sensor")
+        pos_before = self.current_angle
+        raw_before = self.raw_endstop_active
         self.stepper.home(
             HOME_SPEED_MICROSTEPS_PER_SEC,
             self.home_pin,
             home_pin_active_high=self.endstop_active_high,
         )
         start = time.monotonic()
+        polls = 0
         while not self.stepper.stopped:
+            polls += 1
             if (time.monotonic() - start) * 1000 > HOME_TIMEOUT_MS:
-                self.logger.error("Chute: homing timed out")
+                self.logger.error(
+                    f"Chute: homing timed out after {HOME_TIMEOUT_MS}ms "
+                    f"(polls={polls}, moved={self.current_angle - pos_before:.2f}°, "
+                    f"endstop raw={self.raw_endstop_active} triggered={self.endstop_triggered})"
+                )
                 return False
             time.sleep(0.01)
+        elapsed_ms = (time.monotonic() - start) * 1000
         if not self.endstop_triggered:
-            self.logger.warning("Chute: homing stopped before the endstop triggered")
+            self.logger.warning(
+                "Chute: homing stopped before the endstop triggered "
+                f"(elapsed={elapsed_ms:.0f}ms, polls={polls}, "
+                f"moved={self.current_angle - pos_before:.2f}° from {pos_before:.2f}°, "
+                f"endstop raw {raw_before}->{self.raw_endstop_active} "
+                f"(active_high={self.endstop_active_high}, triggered={self.endstop_triggered})). "
+                "polls<=1 / moved~0 means the firmware reported stopped before motion began (race); "
+                "large moved means it travelled without the switch ever firing."
+            )
             return False
         if not self._backoffToFirstBin():
             return False

--- a/software/sorter/backend/subsystems/distribution/positioning.py
+++ b/software/sorter/backend/subsystems/distribution/positioning.py
@@ -599,6 +599,8 @@ class Positioning(BaseState):
                 continue
             try:
                 if servo.isClosed():
+                    if hasattr(servo, "apply_open_speed"):
+                        servo.apply_open_speed()
                     servo.open()
             except Exception as exc:
                 self._markLayerUnavailable(
@@ -626,6 +628,8 @@ class Positioning(BaseState):
             if i == target_layer_index or not self._isLayerUsable(i):
                 continue
             try:
+                if hasattr(servo, "apply_open_speed"):
+                    servo.apply_open_speed()
                 servo.open()
             except Exception as exc:
                 self._markLayerUnavailable(
@@ -634,6 +638,8 @@ class Positioning(BaseState):
                 )
 
         try:
+            if hasattr(target_servo, "apply_close_speed"):
+                target_servo.apply_close_speed()
             target_servo.close()
         except Exception as exc:
             self._markLayerUnavailable(

--- a/software/sorter/frontend/src/lib/components/AppHeader.svelte
+++ b/software/sorter/frontend/src/lib/components/AppHeader.svelte
@@ -654,22 +654,15 @@
 		</div>
 	</Modal>
 
-	{#if restartingBackend}
-		<div
-			class="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
-		>
+	<Modal open={restartingBackend} title="Restarting backend..." dismissible={false}>
+		<div class="flex flex-col items-center gap-4 py-4">
 			<div
-				class="flex flex-col items-center gap-4 border border-border bg-surface px-10 py-8 shadow-lg"
-			>
-				<div
-					class="h-6 w-6 animate-spin border-2 border-primary border-t-transparent"
-					style="border-radius: 50%;"
-				></div>
-				<div class="text-sm font-medium text-text">Restarting backend...</div>
-				<div class="text-xs text-text-muted">Waiting for the service to come back online.</div>
-			</div>
+				class="h-6 w-6 animate-spin border-2 border-primary border-t-transparent"
+				style="border-radius: 50%;"
+			></div>
+			<div class="text-sm text-text-muted">Waiting for the service to come back online.</div>
 		</div>
-	{/if}
+	</Modal>
 
 	<Modal bind:open={homingDetailsOpen} title="Hardware Homing">
 		<div class="flex flex-col gap-4">

--- a/software/sorter/frontend/src/lib/components/Modal.svelte
+++ b/software/sorter/frontend/src/lib/components/Modal.svelte
@@ -7,12 +7,20 @@
 		open = $bindable(false),
 		title,
 		wide = false,
+		dismissible = true,
 		children
-	}: { open?: boolean; title?: string; wide?: boolean; children?: Snippet } = $props();
+	}: {
+		open?: boolean;
+		title?: string;
+		wide?: boolean;
+		dismissible?: boolean;
+		children?: Snippet;
+	} = $props();
 
 	const dispatch = createEventDispatcher<{ close: void }>();
 
 	function close() {
+		if (!dismissible) return;
 		open = false;
 		dispatch('close');
 	}

--- a/software/sorter/frontend/src/lib/components/servo/ServoLayerCalibrator.svelte
+++ b/software/sorter/frontend/src/lib/components/servo/ServoLayerCalibrator.svelte
@@ -14,6 +14,7 @@
 		Keyboard,
 		Cog
 	} from 'lucide-svelte';
+	import ServoSpeedSettings from './ServoSpeedSettings.svelte';
 	import { onMount } from 'svelte';
 	import { getBackendHttpBase, machineHttpBaseUrlFromWsUrl } from '$lib/backend';
 	import { getMachinesContext } from '$lib/machines/context';
@@ -55,6 +56,11 @@
 	let jogStep = $state(5);
 	let selectedIndex = $state<number | null>(null);
 
+	// Global servo speeds (°/s). null = not overridden (firmware default applies).
+	let openSpeed = $state<number | null>(null);
+	let closeSpeed = $state<number | null>(null);
+	let homingSpeed = $state<number | null>(null);
+
 	// Global angles are no longer used to drive PCA servos, but the /servo
 	// endpoint still round-trips them, so preserve whatever is stored.
 	let globalOpenAngle: number | null = null;
@@ -88,6 +94,9 @@
 			backend = servo.backend === 'waveshare' ? 'waveshare' : 'pca9685';
 			globalOpenAngle = typeof servo.open_angle === 'number' ? servo.open_angle : null;
 			globalClosedAngle = typeof servo.closed_angle === 'number' ? servo.closed_angle : null;
+			openSpeed = typeof servo.open_speed === 'number' ? servo.open_speed : null;
+			closeSpeed = typeof servo.close_speed === 'number' ? servo.close_speed : null;
+			homingSpeed = typeof servo.homing_speed === 'number' ? servo.homing_speed : null;
 			port = typeof servo.port === 'string' ? servo.port : null;
 			channelChoices = Array.isArray(servo.available_channel_ids)
 				? servo.available_channel_ids
@@ -253,6 +262,9 @@
 					backend: 'pca9685',
 					open_angle: globalOpenAngle,
 					closed_angle: globalClosedAngle,
+					open_speed: openSpeed,
+					close_speed: closeSpeed,
+					homing_speed: homingSpeed,
 					port,
 					channels
 				})
@@ -345,6 +357,15 @@
 			positions and lock in the angles — a layer must have both angles locked before it will move
 			during sorting.
 		</div>
+	{/if}
+
+	{#if backend === 'pca9685'}
+		<ServoSpeedSettings
+			bind:openSpeed
+			bind:closeSpeed
+			bind:homingSpeed
+			disabled={loading || saving}
+		/>
 	{/if}
 
 	{#if backend === 'waveshare'}

--- a/software/sorter/frontend/src/lib/components/servo/ServoLayerCalibrator.svelte
+++ b/software/sorter/frontend/src/lib/components/servo/ServoLayerCalibrator.svelte
@@ -34,6 +34,8 @@
 		closedAngle: number | null;
 		currentAngle: number | null;
 		busy: boolean;
+		lockStatus: 'idle' | 'saving' | 'saved' | 'error';
+		lockError: string;
 	};
 
 	let {
@@ -134,8 +136,11 @@
 							: '',
 					openAngle: typeof sl.servo_open_angle === 'number' ? sl.servo_open_angle : null,
 					closedAngle: typeof sl.servo_closed_angle === 'number' ? sl.servo_closed_angle : null,
-					currentAngle: null,
-					busy: false
+					currentAngle:
+						typeof sl.servo_current_angle === 'number' ? sl.servo_current_angle : null,
+					busy: false,
+					lockStatus: 'idle',
+					lockError: ''
 				});
 			}
 			layers = next;
@@ -188,13 +193,20 @@
 	}
 
 	async function lockAngle(layerIndex: number, which: 'open' | 'closed') {
+		// The /lock endpoint persists the angle to the backend immediately, so
+		// locking is the save — the per-layer indicator reflects that write.
+		setLayer(layerIndex, { lockStatus: 'saving', lockError: '' });
 		const result = await postLayerAction(layerIndex, 'lock', { which });
 		if (result) {
 			setLayer(layerIndex, {
 				openAngle: typeof result.open_angle === 'number' ? result.open_angle : null,
-				closedAngle: typeof result.closed_angle === 'number' ? result.closed_angle : null
+				closedAngle: typeof result.closed_angle === 'number' ? result.closed_angle : null,
+				lockStatus: 'saved',
+				lockError: ''
 			});
 			statusMsg = result.message ?? `Layer ${layerIndex + 1} ${which} angle locked.`;
+		} else {
+			setLayer(layerIndex, { lockStatus: 'error', lockError: errorMsg ?? 'Save failed' });
 		}
 	}
 
@@ -295,7 +307,9 @@
 				openAngle: null,
 				closedAngle: null,
 				currentAngle: null,
-				busy: false
+				busy: false,
+				lockStatus: 'idle',
+				lockError: ''
 			}
 		];
 	}
@@ -538,6 +552,13 @@
 						>
 							<Lock size={14} /> Lock closed
 						</Button>
+						{#if layer.lockStatus === 'saving'}
+							<span class="text-sm text-text-muted">Saving…</span>
+						{:else if layer.lockStatus === 'saved'}
+							<span class="text-sm text-success">Saved</span>
+						{:else if layer.lockStatus === 'error'}
+							<span class="text-sm text-danger" title={layer.lockError}>Failed</span>
+						{/if}
 					</div>
 
 					<div class="h-6 w-px bg-border"></div>

--- a/software/sorter/frontend/src/lib/components/servo/ServoLayerCalibrator.svelte
+++ b/software/sorter/frontend/src/lib/components/servo/ServoLayerCalibrator.svelte
@@ -58,6 +58,19 @@
 	let jogStep = $state(5);
 	let selectedIndex = $state<number | null>(null);
 
+	// Signature of everything the "Save servo layers" button persists (layer
+	// add/remove, channel, invert, bin count, max/bin, active). Captured at load
+	// and after each save; `dirty` flags the form whenever the two diverge. Open/
+	// closed angles and speeds persist through their own endpoints, so they're
+	// deliberately left out — they don't dirty this form.
+	let savedSignature = $state('');
+	function layerSignature(list: LayerDraft[]): string {
+		return JSON.stringify(
+			list.map((l) => [l.enabled, l.channel, l.invert, l.binCount, l.maxPiecesPerBin.trim()])
+		);
+	}
+	let dirty = $derived(layerSignature(layers) !== savedSignature);
+
 	// Global servo speeds (°/s). null = not overridden (firmware default applies).
 	let openSpeed = $state<number | null>(null);
 	let closeSpeed = $state<number | null>(null);
@@ -144,6 +157,7 @@
 				});
 			}
 			layers = next;
+			savedSignature = layerSignature(next);
 			if (selectedIndex !== null && selectedIndex >= layers.length) selectedIndex = null;
 		} catch (e: any) {
 			errorMsg = e.message ?? 'Failed to load servo layers';
@@ -292,6 +306,23 @@
 		}
 	}
 
+	function nextChannel(): string {
+		// Auto-assign the next channel after the highest one already used, so a
+		// fresh layer lands on an unused channel without manual picking. Falls back
+		// to the first available choice (or blank) when nothing is assigned yet.
+		const used = layers
+			.map((l) => (l.channel.trim().length > 0 ? Number(l.channel) : null))
+			.filter((n): n is number => n !== null && Number.isInteger(n));
+		if (used.length > 0) {
+			const candidate = Math.max(...used) + 1;
+			if (channelChoices.length === 0 || channelChoices.includes(candidate)) {
+				return String(candidate);
+			}
+		}
+		const firstFree = channelChoices.find((c) => !used.includes(c));
+		return firstFree !== undefined ? String(firstFree) : '';
+	}
+
 	function addLayer() {
 		const nextIndex = layers.length;
 		layers = [
@@ -300,7 +331,7 @@
 				layerIndex: nextIndex,
 				label: `Layer ${nextIndex + 1}`,
 				enabled: true,
-				channel: '',
+				channel: nextChannel(),
 				invert: false,
 				binCount: String(allowedCounts[0] ?? 12),
 				maxPiecesPerBin: '',
@@ -315,7 +346,6 @@
 	}
 
 	function removeLayer(layerIndex: number) {
-		if (!window.confirm(`Remove Layer ${layerIndex + 1}? Save to apply.`)) return;
 		layers = layers
 			.filter((l) => l.layerIndex !== layerIndex)
 			.map((l, i) => ({ ...l, layerIndex: i, label: `Layer ${i + 1}` }));
@@ -628,6 +658,11 @@
 			<Button variant="secondary" size="sm" onclick={loadSettings} disabled={loading || saving}>
 				<RotateCcw size={14} /> Reload
 			</Button>
+			{#if dirty}
+				<span class="inline-flex items-center gap-1 bg-warning/15 px-2 py-0.5 text-xs font-medium text-warning">
+					Unsaved changes — save to apply
+				</span>
+			{/if}
 		</div>
 	{/if}
 

--- a/software/sorter/frontend/src/lib/components/servo/ServoSpeedSettings.svelte
+++ b/software/sorter/frontend/src/lib/components/servo/ServoSpeedSettings.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import { Undo2 } from 'lucide-svelte';
+	import { getBackendHttpBase, machineHttpBaseUrlFromWsUrl } from '$lib/backend';
+	import { getMachinesContext } from '$lib/machines/context';
+
+	const FW_DEFAULT = 1500;
+
+	let {
+		openSpeed = $bindable<number | null>(null),
+		closeSpeed = $bindable<number | null>(null),
+		homingSpeed = $bindable<number | null>(null),
+		disabled = false,
+	}: {
+		openSpeed: number | null;
+		closeSpeed: number | null;
+		homingSpeed: number | null;
+		disabled?: boolean;
+	} = $props();
+
+	const manager = getMachinesContext();
+
+	type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+	let saveStatus = $state<SaveStatus>('idle');
+	let saveError = $state('');
+	let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function backendBase(): string {
+		return (
+			machineHttpBaseUrlFromWsUrl(
+				manager.selectedMachine?.status === 'connected' ? manager.selectedMachine.url : null
+			) ?? getBackendHttpBase()
+		);
+	}
+
+	function parseSpeed(raw: string): number | null {
+		const v = raw.trim();
+		if (v === '') return null;
+		const n = parseInt(v);
+		return isNaN(n) ? null : Math.max(1, Math.min(2000, n));
+	}
+
+	function scheduleAutoSave() {
+		if (saveTimer !== null) clearTimeout(saveTimer);
+		saveStatus = 'idle';
+		saveTimer = setTimeout(() => void autoSave(), 600);
+	}
+
+	async function autoSave() {
+		saveStatus = 'saving';
+		saveError = '';
+		try {
+			const res = await fetch(`${backendBase()}/api/hardware-config/servo/speeds`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					open_speed: openSpeed,
+					close_speed: closeSpeed,
+					homing_speed: homingSpeed,
+				}),
+			});
+			if (!res.ok) throw new Error(await res.text());
+			saveStatus = 'saved';
+		} catch (e: any) {
+			saveStatus = 'error';
+			saveError = e.message ?? 'Save failed';
+		}
+	}
+</script>
+
+<div class="border border-border">
+	<div class="flex items-center justify-between border-b border-border bg-surface px-3 py-2">
+		<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">Servo Speeds</span>
+		{#if saveStatus === 'saving'}
+			<span class="text-xs text-text-muted">Saving…</span>
+		{:else if saveStatus === 'saved'}
+			<span class="text-xs text-success">Saved</span>
+		{:else if saveStatus === 'error'}
+			<span class="text-xs text-danger" title={saveError}>Failed to save</span>
+		{/if}
+	</div>
+	<div class="flex flex-wrap items-center gap-x-6 gap-y-3 p-3">
+		{#each [
+			{ label: 'Open speed',     get: () => openSpeed,    set: (v: number | null) => { openSpeed = v;    scheduleAutoSave(); } },
+			{ label: 'Close speed',    get: () => closeSpeed,   set: (v: number | null) => { closeSpeed = v;   scheduleAutoSave(); } },
+			{ label: 'Standard speed', get: () => homingSpeed,  set: (v: number | null) => { homingSpeed = v;  scheduleAutoSave(); } },
+		] as entry}
+			<div class="flex flex-col gap-1">
+				<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">{entry.label}</span>
+				<div class="flex items-center gap-1.5">
+					<input
+						type="number" min="1" max="2000" step="1"
+						value={entry.get() ?? FW_DEFAULT}
+						oninput={(e) => entry.set(parseSpeed(e.currentTarget.value))}
+						{disabled}
+						class="setup-control w-24 px-2 py-1.5 text-text"
+					/>
+					<span class="text-sm text-text-muted">°/s</span>
+					{#if entry.get() !== null}
+						<button
+							onclick={() => entry.set(null)}
+							{disabled}
+							title="Reset to firmware default ({FW_DEFAULT} °/s)"
+							class="inline-flex items-center gap-1 border border-border bg-surface px-2 py-1.5 text-sm text-text-muted hover:bg-bg disabled:cursor-not-allowed disabled:opacity-50"
+						><Undo2 size={13} /> {FW_DEFAULT}</button>
+					{/if}
+				</div>
+			</div>
+		{/each}
+		<p class="w-full text-sm text-text-muted">
+			Applied to all layers. Standard speed is used at startup and for jog.
+		</p>
+	</div>
+</div>

--- a/software/sorter/frontend/src/lib/components/settings/ServoSettingsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/ServoSettingsSection.svelte
@@ -16,8 +16,6 @@
 	let errorMsg = $state<string | null>(null);
 	let statusMsg = $state('');
 	let backend = $state<ServoBackend>('pca9685');
-	let openAngle = $state(10);
-	let closedAngle = $state(83);
 	let port = $state('');
 	let layerCount = $state(0);
 	let channels = $state<ServoChannelDraft[]>([]);
@@ -50,8 +48,6 @@
 			const servo = payload?.servo ?? {};
 			layerCount = Number(servo.layer_count ?? 0);
 			backend = servo.backend === 'waveshare' ? 'waveshare' : 'pca9685';
-			openAngle = Number(servo.open_angle ?? 10);
-			closedAngle = Number(servo.closed_angle ?? 83);
 			port = typeof servo.port === 'string' ? servo.port : '';
 			channels = normalizedChannels(layerCount, Array.isArray(servo.channels) ? servo.channels : []);
 		} catch (e: any) {
@@ -82,8 +78,6 @@
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
 					backend,
-					open_angle: openAngle,
-					closed_angle: closedAngle,
 					port: backend === 'waveshare' ? port.trim() || null : null,
 					channels: parsedChannels
 				})
@@ -93,8 +87,6 @@
 			const servo = payload?.settings ?? {};
 			layerCount = Number(servo.layer_count ?? layerCount);
 			backend = servo.backend === 'waveshare' ? 'waveshare' : 'pca9685';
-			openAngle = Number(servo.open_angle ?? openAngle);
-			closedAngle = Number(servo.closed_angle ?? closedAngle);
 			port = typeof servo.port === 'string' ? servo.port : '';
 			channels = normalizedChannels(layerCount, Array.isArray(servo.channels) ? servo.channels : []);
 			statusMsg = payload?.message ?? 'Servo settings saved.';
@@ -144,30 +136,6 @@
 				<option value="pca9685">PCA9685</option>
 				<option value="waveshare">Waveshare SC</option>
 			</select>
-		</label>
-		<label class="text-xs text-text">
-			Open Angle
-			<input
-				type="number"
-				min="0"
-				max="180"
-				step="1"
-				bind:value={openAngle}
-				disabled={loading || saving}
-				class="mt-1 w-full border border-border bg-bg px-2 py-1.5 text-sm text-text"
-			/>
-		</label>
-		<label class="text-xs text-text">
-			Closed Angle
-			<input
-				type="number"
-				min="0"
-				max="180"
-				step="1"
-				bind:value={closedAngle}
-				disabled={loading || saving}
-				class="mt-1 w-full border border-border bg-bg px-2 py-1.5 text-sm text-text"
-			/>
 		</label>
 	</div>
 

--- a/software/sorter/frontend/src/lib/components/settings/StepperSidebar.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/StepperSidebar.svelte
@@ -112,6 +112,9 @@
 	let tmcMicrosteps = $state(8);
 	let tmcStealthchop = $state(true);
 	let tmcCoolstep = $state(false);
+	let sgEnabled = $state(false);
+	let sgThrs = $state(50);
+	let sgTcoolthrs = $state(150);
 	let tmcDrvStatus = $state<Record<string, any> | null>(null);
 	let tmcLoading = $state(false);
 	let tmcSaving = $state(false);
@@ -534,6 +537,11 @@
 			if (data.microsteps !== null) tmcMicrosteps = data.microsteps;
 			if (data.stealthchop !== null) tmcStealthchop = data.stealthchop;
 			if (data.coolstep !== null) tmcCoolstep = data.coolstep;
+			if (data.stallguard) {
+				sgEnabled = !!data.stallguard.enabled;
+				if (typeof data.stallguard.sgthrs === 'number') sgThrs = data.stallguard.sgthrs;
+				if (typeof data.stallguard.tcoolthrs === 'number') sgTcoolthrs = data.stallguard.tcoolthrs;
+			}
 			tmcDrvStatus = data.drv_status ?? null;
 			tmcLoaded = true;
 		} catch {
@@ -572,6 +580,23 @@
 			if (data.stealthchop !== null) tmcStealthchop = data.stealthchop;
 			if (data.coolstep !== null) tmcCoolstep = data.coolstep;
 			tmcDrvStatus = data.drv_status ?? null;
+
+			const sgRes = await fetch(
+				`${currentBackendBaseUrl()}/stepper/${stepperKey}/stallguard-config`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						sgthrs: sgThrs,
+						tcoolthrs: sgTcoolthrs,
+						enabled: sgEnabled
+					})
+				}
+			);
+			if (!sgRes.ok) {
+				errorMsg = await readErrorMessage(sgRes);
+				return;
+			}
 			statusMsg = 'Driver settings applied.';
 		} catch (e: any) {
 			errorMsg = e.message ?? 'Failed to save driver settings';
@@ -740,6 +765,9 @@
 			bind:tmcMicrosteps
 			bind:tmcStealthchop
 			bind:tmcCoolstep
+			bind:sgEnabled
+			bind:sgThrs
+			bind:sgTcoolthrs
 			bind:stepperDirectionInverted
 			{tmcDrvStatus}
 			onToggle={() => {

--- a/software/sorter/frontend/src/lib/components/settings/stepper/HoverEditNumber.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/stepper/HoverEditNumber.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	// Inline editable number: shows the value as plain text, but on hover/focus it
+	// reveals a bordered field you can click into and type directly — so the slider
+	// value isn't drag-only. Binds the same value as its companion slider.
+	let {
+		value = $bindable(),
+		min,
+		max
+	}: {
+		value: number;
+		min?: number;
+		max?: number;
+	} = $props();
+</script>
+
+<input
+	type="number"
+	bind:value
+	{min}
+	{max}
+	class="w-14 border border-transparent bg-transparent px-1 text-text tabular-nums transition-colors hover:border-border hover:bg-bg focus:border-primary focus:bg-bg focus:outline-none"
+/>

--- a/software/sorter/frontend/src/lib/components/settings/stepper/StepperDriverSettings.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/stepper/StepperDriverSettings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ChevronDown } from 'lucide-svelte';
 	import StepperDrvStatusGrid from './StepperDrvStatusGrid.svelte';
+	import HoverEditNumber from './HoverEditNumber.svelte';
 
 	let {
 		open = $bindable(),
@@ -60,12 +61,16 @@
 	{:else}
 		<div class="flex flex-col gap-3">
 			<label class="flex flex-col gap-1 text-xs text-text">
-				Run Current (IRUN): {tmcIrun}
+				<span class="flex items-center gap-1">
+					Run Current (IRUN): <HoverEditNumber bind:value={tmcIrun} min={0} max={31} />
+				</span>
 				<input type="range" min="0" max="31" bind:value={tmcIrun} class="w-full" />
 			</label>
 
 			<label class="flex flex-col gap-1 text-xs text-text">
-				Hold Current (IHOLD): {tmcIhold}
+				<span class="flex items-center gap-1">
+					Hold Current (IHOLD): <HoverEditNumber bind:value={tmcIhold} min={0} max={31} />
+				</span>
 				<input type="range" min="0" max="31" bind:value={tmcIhold} class="w-full" />
 			</label>
 
@@ -103,7 +108,9 @@
 				{#if sgEnabled}
 					<div class="mt-3 flex flex-col gap-3">
 						<label class="flex flex-col gap-1 text-xs text-text">
-							Threshold (SGTHRS): {sgThrs}
+							<span class="flex items-center gap-1">
+								Threshold (SGTHRS): <HoverEditNumber bind:value={sgThrs} min={0} max={255} />
+							</span>
 							<input type="range" min="0" max="255" bind:value={sgThrs} class="w-full" />
 						</label>
 						<label class="flex flex-col gap-1 text-xs text-text">

--- a/software/sorter/frontend/src/lib/components/settings/stepper/StepperDriverSettings.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/stepper/StepperDriverSettings.svelte
@@ -12,6 +12,9 @@
 		tmcMicrosteps = $bindable(),
 		tmcStealthchop = $bindable(),
 		tmcCoolstep = $bindable(),
+		sgEnabled = $bindable(),
+		sgThrs = $bindable(),
+		sgTcoolthrs = $bindable(),
 		stepperDirectionInverted = $bindable(),
 		tmcDrvStatus,
 		onToggle,
@@ -26,6 +29,9 @@
 		tmcMicrosteps: number;
 		tmcStealthchop: boolean;
 		tmcCoolstep: boolean;
+		sgEnabled: boolean;
+		sgThrs: number;
+		sgTcoolthrs: number;
 		stepperDirectionInverted: boolean;
 		tmcDrvStatus: Record<string, any> | null;
 		onToggle: () => void;
@@ -84,6 +90,37 @@
 				<input type="checkbox" bind:checked={tmcCoolstep} />
 				CoolStep
 			</label>
+
+			<div class="border border-border bg-bg px-3 py-3">
+				<label class="flex items-center gap-2 text-sm text-text">
+					<input type="checkbox" bind:checked={sgEnabled} />
+					StallGuard stall detection
+				</label>
+				<div class="mt-1 text-xs text-text-muted">
+					Halts the machine if this motor stalls — on every move while enabled. Tune the
+					threshold on the StallGuard page (Settings → Helpers).
+				</div>
+				{#if sgEnabled}
+					<div class="mt-3 flex flex-col gap-3">
+						<label class="flex flex-col gap-1 text-xs text-text">
+							Threshold (SGTHRS): {sgThrs}
+							<input type="range" min="0" max="255" bind:value={sgThrs} class="w-full" />
+						</label>
+						<label class="flex flex-col gap-1 text-xs text-text">
+							Velocity floor (TCOOLTHRS, TSTEP)
+							<input
+								type="number"
+								min="0"
+								bind:value={sgTcoolthrs}
+								class="border border-border bg-bg px-2 py-1.5 text-sm text-text"
+							/>
+						</label>
+						<div class="text-xs text-text-muted">
+							Trips when SG_RESULT ≤ {sgThrs * 2}, only at cruise (TSTEP ≤ {sgTcoolthrs}).
+						</div>
+					</div>
+				{/if}
+			</div>
 
 			<label class="flex items-center gap-2 text-sm text-text">
 				<input

--- a/software/sorter/frontend/src/lib/settings/stations.ts
+++ b/software/sorter/frontend/src/lib/settings/stations.ts
@@ -1,4 +1,4 @@
-import { Camera, Cloud, Cpu, Layers3, Settings, Shapes, Wrench } from 'lucide-svelte';
+import { Activity, Camera, Cloud, Cpu, Layers3, Settings, Shapes, Wrench } from 'lucide-svelte';
 import {
 	CLASSIFICATION_CHANNEL_STEPPER_GEAR_RATIO,
 	CLASSIFICATION_CHANNEL_STEPPER_LABEL
@@ -101,6 +101,12 @@ export const chuteAimingNavItem: SettingsNavItem = {
 	icon: Shapes
 };
 
+export const stallguardNavItem: SettingsNavItem = {
+	href: '/settings/stepper-stallguard',
+	label: 'StallGuard',
+	icon: Activity
+};
+
 export const stationPageConfigs: StationPageConfig[] = [
 	{
 		slug: 'c-channel-1',
@@ -195,8 +201,10 @@ const baseSettingsNavItems: SettingsNavEntry[] = [
 	{ type: 'heading', label: 'Hardware' },
 	...stationPageConfigs,
 	chuteNavItem,
+	storageLayersNavItem,
+	{ type: 'heading', label: 'Helpers' },
 	chuteAimingNavItem,
-	storageLayersNavItem
+	stallguardNavItem
 ];
 
 export function settingsNavItemsForSetup(setup: MachineSetupKey): SettingsNavEntry[] {

--- a/software/sorter/frontend/src/routes/+page.svelte
+++ b/software/sorter/frontend/src/routes/+page.svelte
@@ -183,6 +183,8 @@
 	let showSampleCapture = $state(false);
 	let exitIncidentActionPending = $state(false);
 	let exitIncidentActionError = $state<string | null>(null);
+	let stallIncidentActionPending = $state(false);
+	let stallIncidentActionError = $state<string | null>(null);
 	let exitReleaseOutputDeg = $state(EXIT_RELEASE_DEFAULTS.outputDeg);
 	let exitReleaseSpeed = $state(EXIT_RELEASE_DEFAULTS.speed);
 	let exitReleaseAcceleration = $state(EXIT_RELEASE_DEFAULTS.acceleration);
@@ -220,6 +222,7 @@
 	const startingSystem = $derived(hardwareState === 'homing' || startSystemPending);
 	const runtimeStats = $derived((machine.machine?.runtimeStats ?? {}) as Record<string, unknown>);
 	const exitIncident = $derived(normalizeExitIncident(runtimeStats.active_incident));
+	const stallIncident = $derived(stepperStallIncident(runtimeStats.active_incident));
 
 	async function startSystem() {
 		const baseUrl = currentBackendBaseUrl();
@@ -283,6 +286,41 @@
 		return active
 			? 'border-primary text-text'
 			: 'border-transparent text-text-muted hover:text-text';
+	}
+
+	function stepperStallIncident(value: unknown): Record<string, unknown> | null {
+		if (!value || typeof value !== 'object') return null;
+		const incident = value as Record<string, unknown>;
+		return incident.kind === 'stepper_stall' ? incident : null;
+	}
+
+	function stallIncidentSteppersLabel(incident: Record<string, unknown> | null): string {
+		const steppers = incident?.steppers;
+		if (Array.isArray(steppers) && steppers.length > 0) {
+			return steppers.filter((s) => typeof s === 'string').join(', ');
+		}
+		return incidentString(incident, 'channel', 'a motor');
+	}
+
+	async function acknowledgeStallIncident() {
+		if (stallIncidentActionPending) return;
+		stallIncidentActionPending = true;
+		stallIncidentActionError = null;
+		try {
+			const response = await fetch(`${currentBackendBaseUrl()}/stall-incident/clear`, {
+				method: 'POST'
+			});
+			const payload = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+			if (!response.ok || payload?.ok === false) {
+				throw new Error(
+					typeof payload?.detail === 'string' ? payload.detail : 'Could not clear stall'
+				);
+			}
+		} catch (e: any) {
+			stallIncidentActionError = e?.message ?? 'Could not clear stall';
+		} finally {
+			stallIncidentActionPending = false;
+		}
 	}
 
 	function normalizeExitIncident(value: unknown): Record<string, unknown> | null {
@@ -1468,6 +1506,51 @@
 							</div>
 							{#if exitIncidentActionError}
 								<div class="mt-2 text-xs text-danger">{exitIncidentActionError}</div>
+							{/if}
+						</div>
+					{/if}
+					{#if stallIncident}
+						<div class="shrink-0 border border-danger/50 bg-danger/10 px-4 py-3">
+							<div class="flex items-start justify-between gap-3">
+								<div class="flex min-w-0 items-start gap-2">
+									<AlertTriangle size={17} class="mt-0.5 shrink-0 text-danger" />
+									<div class="min-w-0">
+										<div class="flex flex-wrap items-center gap-2">
+											<div class="text-sm font-semibold text-text">Motor Stall</div>
+											<div class="bg-bg/70 px-1.5 py-0.5 text-[10px] text-text-muted">
+												{stallIncidentSteppersLabel(stallIncident)}
+											</div>
+											<div
+												class="bg-danger px-1.5 py-0.5 text-[10px] font-semibold text-white uppercase"
+											>
+												Halted
+											</div>
+										</div>
+										<div class="mt-1 text-xs text-text-muted">
+											A stepper stalled and the machine has stopped. Clear the jam, then
+											acknowledge to re-arm detection and resume.
+										</div>
+										{#if incidentString(stallIncident, 'operator_message')}
+											<div class="mt-2 bg-danger/10 px-2 py-1.5 text-xs text-danger">
+												{incidentString(stallIncident, 'operator_message')}
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+							<div class="mt-3 flex flex-wrap items-center gap-2">
+								<button
+									type="button"
+									onclick={acknowledgeStallIncident}
+									disabled={stallIncidentActionPending}
+									class="inline-flex min-h-10 items-center gap-1.5 bg-bg px-3 py-1.5 text-xs font-medium text-text shadow-[inset_0_0_0_1px_var(--color-border)] transition-transform hover:bg-surface active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50"
+								>
+									<Check size={13} />
+									Stall Cleared — Resume
+								</button>
+							</div>
+							{#if stallIncidentActionError}
+								<div class="mt-2 text-xs text-danger">{stallIncidentActionError}</div>
 							{/if}
 						</div>
 					{/if}

--- a/software/sorter/frontend/src/routes/settings/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/+page.svelte
@@ -70,16 +70,4 @@ import LegoColorPicker from '$lib/components/LegoColorPicker.svelte';
 	>
 		<SampleStorageSection />
 	</SectionCard>
-
-	<SectionCard
-		title="Stepper StallGuard Telemetry"
-		description="Record and graph TMC2209 motor load (SG_RESULT), run targeted sweeps, and tune stall thresholds."
-	>
-		<a
-			href="/settings/stepper-stallguard"
-			class="inline-flex items-center border border-primary bg-primary px-4 py-2 text-sm font-medium text-primary-contrast transition-colors hover:bg-primary-hover"
-		>
-			Open StallGuard Telemetry
-		</a>
-	</SectionCard>
 </div>

--- a/software/sorter/frontend/src/routes/settings/chute-aiming/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/chute-aiming/+page.svelte
@@ -2,7 +2,9 @@
 	import { getBackendHttpBase, machineHttpBaseUrlFromWsUrl } from '$lib/backend';
 	import { getMachinesContext } from '$lib/machines/context';
 	import { Alert, Button, Input } from '$lib/components/primitives';
-	import { onMount } from 'svelte';
+	import BinLayoutViz from './BinLayoutViz.svelte';
+	import ErrorBanner from './ErrorBanner.svelte';
+	import { binCenterAngle, reachInfo } from './geometry';
 
 	const manager = getMachinesContext();
 
@@ -23,6 +25,8 @@
 	let liveAvailable = $state(false);
 	let currentAngle = $state<number | null>(null);
 	let stepperStopped = $state<boolean | null>(null);
+	let liveEndstopTriggered = $state<boolean | null>(null);
+	let stepperPositionDeg = $state<number | null>(null);
 	let liveRequestInFlight = false;
 
 	// ---- Calibration measurement -------------------------------------------
@@ -81,12 +85,15 @@
 	}
 
 	function angleFor(section: number, bin: number, binsInSection: number): number {
-		const k = Math.max(1, binsInSection);
-		const slot = sectionWidthDeg / k;
-		return firstSectionOffsetDeg + section * (360 / Math.max(1, numSections)) + (bin + 0.5) * slot;
+		return binCenterAngle(
+			{ numSections, sectionWidthDeg, firstSectionOffsetDeg },
+			section,
+			bin,
+			binsInSection
+		);
 	}
 	function isReachable(angle: number): boolean {
-		return angle >= 0 && angle <= maxAngleDeg && angle <= 360;
+		return reachInfo(angle, maxAngleDeg).reachable;
 	}
 
 	async function loadSettings() {
@@ -128,6 +135,11 @@
 			currentAngle =
 				typeof p?.current_angle === 'number' && Number.isFinite(p.current_angle) ? p.current_angle : null;
 			stepperStopped = typeof p?.stepper_stopped === 'boolean' ? p.stepper_stopped : null;
+			liveEndstopTriggered = typeof p?.endstop_triggered === 'boolean' ? p.endstop_triggered : null;
+			stepperPositionDeg =
+				typeof p?.stepper_position_degrees === 'number' && Number.isFinite(p.stepper_position_degrees)
+					? p.stepper_position_degrees
+					: null;
 		} catch {
 			// keep last known
 		} finally {
@@ -287,8 +299,10 @@
 	}
 
 	// ---- Test aim ----------------------------------------------------------
-	let testBinsPerSection = $state(3);
-	let selected = $state<{ section: number; bin: number } | null>(null);
+	// One viz instance per layer size so all are visible at once, instead of a
+	// single circle you toggle between 1–5 bins.
+	const VIZ_SIZES = [1, 2, 3, 4, 5];
+	let selected = $state<{ section: number; bin: number; binCount: number } | null>(null);
 
 	async function testAimSelected() {
 		if (!selected) return;
@@ -302,7 +316,7 @@
 				section_index: selected.section,
 				bin_index: selected.bin
 			});
-			statusMsg = `Aiming at section ${selected.section + 1}, bin ${selected.bin + 1} (${fmt(p?.target_angle)}°).`;
+			statusMsg = `Aiming at ${selected.binCount}-bin section ${selected.section + 1}, bin ${selected.bin + 1} (${fmt(p?.target_angle)}°).`;
 			void loadLive();
 		} catch (e: any) {
 			errorMsg = e.message ?? 'Test aim failed';
@@ -335,29 +349,14 @@
 		}
 	});
 
-	onMount(() => {
-		const interval = setInterval(() => void loadLive(), 600);
+	// Poll live status; speed up while homing so you can watch the chute drive
+	// to 0° and back off to the first bin. Kept modest so it never floods.
+	$effect(() => {
+		const period = homingState ? 200 : 600;
+		const interval = setInterval(() => void loadLive(), period);
 		return () => clearInterval(interval);
 	});
 
-	// ---- SVG geometry for the test circle ----------------------------------
-	const CX = 130;
-	const CY = 130;
-	const R = 96;
-	function polar(angleDeg: number, radius = R) {
-		const rad = ((angleDeg - 90) * Math.PI) / 180;
-		return { x: CX + radius * Math.cos(rad), y: CY + radius * Math.sin(rad) };
-	}
-	const vizBins = $derived(
-		Array.from({ length: numSections }, (_, s) =>
-			Array.from({ length: testBinsPerSection }, (_, i) => {
-				const angle = angleFor(s, i, testBinsPerSection);
-				return { section: s, bin: i, angle, reachable: isReachable(angle), ...polar(angle) };
-			})
-		).flat()
-	);
-	const needle = $derived(currentAngle === null ? null : polar(currentAngle));
-	const homeMarker = $derived(polar(0, R + 10));
 </script>
 
 <svelte:window onkeydown={handleKey} />
@@ -406,7 +405,7 @@
 			<div class="flex flex-col gap-2 border-l border-border p-3">
 				<div class="text-sm font-medium text-text">Bins in this section</div>
 				<div class="grid grid-cols-3 gap-1">
-					{#each [1, 2, 3, 4, 5, 6] as n}
+					{#each [3, 4, 5, 6] as n}
 						<Button
 							variant={binsInTestSection === n ? 'primary' : 'secondary'}
 							size="sm"
@@ -417,7 +416,7 @@
 					{/each}
 				</div>
 				<p class="max-w-[13rem] text-sm text-text-muted">
-					How many bins evenly divide the section you're measuring.
+					How many bins are in the section you're measuring. More bins = more accurate; 3 or 5 is ideal.
 				</p>
 			</div>
 		{/if}
@@ -448,7 +447,7 @@
 	</div>
 
 	{#if errorMsg}
-		<Alert variant="danger">{errorMsg}</Alert>
+		<ErrorBanner message={errorMsg} />
 	{:else if statusMsg}
 		<Alert variant="info">{statusMsg}</Alert>
 	{/if}
@@ -474,11 +473,11 @@
 					<div class="text-sm font-medium text-text">{numSections}</div>
 				</div>
 				<div>
-					<div class="text-xs font-semibold uppercase tracking-wider text-text-muted">Section W</div>
+					<div class="text-xs font-semibold uppercase tracking-wider text-text-muted">Section width</div>
 					<div class="text-sm font-medium text-text">{fmt(sectionWidthDeg, 2)}°</div>
 				</div>
 				<div>
-					<div class="text-xs font-semibold uppercase tracking-wider text-text-muted">Offset θ₀</div>
+					<div class="text-xs font-semibold uppercase tracking-wider text-text-muted">Offset from home</div>
 					<div class="text-sm font-medium text-text">{fmt(firstSectionOffsetDeg, 2)}°</div>
 				</div>
 				<div>
@@ -529,9 +528,16 @@
 			{/if}
 		</div>
 
+		<p class="text-sm text-text-muted">
+			Calibration finds just two numbers: the <span class="font-medium text-text">width of a section</span>
+			(in degrees) and the <span class="font-medium text-text">offset of the first section from the zero
+			point</span> (home). From those, the machine works out where every bin sits and which ones each
+			layout can reach.
+		</p>
+
 		<Alert variant="warning">
-			Every step here moves the chute. It hits a hard stop at 0° and 360° and can never cross zero —
-			always home first.
+			Every step here moves the chute. It hits a hard stop at home and can never cross it, so it only has
+			~{fmt(maxAngleDeg, 0)}° of travel — always home first.
 		</Alert>
 
 		<!-- Step 1: Home -->
@@ -541,6 +547,22 @@
 				<div class="text-sm font-medium text-text">Home the chute</div>
 			</div>
 			<p class="text-sm text-text-muted">Establishes the 0° reference at the home switch.</p>
+			<div class="flex flex-wrap items-center gap-x-6 gap-y-1 border border-border bg-surface px-3 py-2">
+				<div class="flex items-baseline gap-2">
+					<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">Chute angle</span>
+					<span class="text-sm font-medium tabular-nums text-text">{fmt(currentAngle, 1)}°</span>
+				</div>
+				<div class="flex items-baseline gap-2">
+					<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">Motor angle</span>
+					<span class="text-sm font-medium tabular-nums text-text">{fmt(stepperPositionDeg, 1)}°</span>
+				</div>
+				<div class="flex items-baseline gap-2">
+					<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">Endstop</span>
+					<span class={`text-sm font-medium ${liveEndstopTriggered ? 'text-success' : 'text-text'}`}>
+						{liveEndstopTriggered === null ? '--' : liveEndstopTriggered ? 'triggered' : 'open'}
+					</span>
+				</div>
+			</div>
 			<div class="flex flex-wrap items-center gap-2">
 				<Button variant={homed ? 'secondary' : 'primary'} loading={homingState} onclick={homeChute}>
 					{homed ? 'Re-home' : 'Home chute'}
@@ -563,9 +585,16 @@
 				<div class="text-sm font-medium text-text">Aim at the FIRST bin of a section</div>
 			</div>
 			<p class="text-sm text-text-muted">
-				{#if step2Locked}Home the chute first.{:else}Jog until the chute points dead-center at the first bin, then capture.{/if}
+				{#if step2Locked}
+					Home the chute first.
+				{:else}
+					Pick any layer and a section you can see in full with <span class="font-medium text-text"
+						>more than 2 bins</span
+					> — 3 or 5 is best, more bins means more accuracy. Set its bin count below, then jog until the
+					chute is perfectly centered going into the first bin and capture.
+				{/if}
 			</p>
-			{@render jogPad(activeStep === 2, false)}
+			{@render jogPad(activeStep === 2, true)}
 			<div class="flex flex-wrap items-center gap-2">
 				<Button variant="primary" disabled={step2Locked || currentAngle === null} onclick={captureFirst}>
 					Capture first bin
@@ -585,9 +614,9 @@
 				<div class="text-sm font-medium text-text">Aim at the LAST bin of that same section</div>
 			</div>
 			<p class="text-sm text-text-muted">
-				{#if step3Locked}Capture the first bin first.{:else}Pick how many bins the section has, jog to its last bin, then capture.{/if}
+				{#if step3Locked}Capture the first bin first.{:else}Jog until the chute is perfectly centered going into the LAST bin of that same section, then capture.{/if}
 			</p>
-			{@render jogPad(activeStep === 3, true)}
+			{@render jogPad(activeStep === 3, false)}
 			<div class="flex flex-wrap items-center gap-3">
 				<Button variant="primary" disabled={step3Locked || currentAngle === null} onclick={captureLast}>
 					Capture last bin
@@ -610,8 +639,8 @@
 				{@const slot = (capturedLast! - capturedFirst!) / Math.max(1, binsInTestSection - 1)}
 				{@const w = slot * binsInTestSection}
 				<div class="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
-					<div><span class="text-text-muted">Section width W:</span> {fmt(w, 2)}°</div>
-					<div><span class="text-text-muted">Offset θ₀:</span> {fmt(capturedFirst! - 0.5 * slot, 2)}°</div>
+					<div><span class="text-text-muted">Section width:</span> {fmt(w, 2)}°</div>
+					<div><span class="text-text-muted">Offset from home:</span> {fmt(capturedFirst! - 0.5 * slot, 2)}°</div>
 					<div><span class="text-text-muted">Pillar:</span> {fmt(sectionPitchDeg - w, 2)}°</div>
 				</div>
 				<label class="flex max-w-sm flex-col gap-1 text-sm text-text">
@@ -663,70 +692,53 @@
 		{/if}
 	</section>
 
-	<!-- Verify -->
+	<!-- Verify — reachable bins per layer size -->
 	<section class="flex flex-col gap-3 border border-border bg-bg px-4 py-3">
-		<div class="text-sm font-semibold text-text">Verify aim</div>
-		<p class="text-sm text-text-muted">Pick a layout, click a bin, then test-aim to confirm reality matches.</p>
-		<div class="flex flex-wrap items-center gap-1">
-			<span class="mr-1 text-sm text-text-muted">Bins per section:</span>
-			{#each [1, 2, 3, 4, 5, 6] as preset}
-				<Button
-					variant={testBinsPerSection === preset ? 'primary' : 'secondary'}
-					size="sm"
-					onclick={() => { testBinsPerSection = preset; selected = null; }}
-				>
-					{preset}
-				</Button>
+		<div class="flex flex-wrap items-baseline justify-between gap-2">
+			<div class="text-sm font-semibold text-text">Reachable bins by layer size</div>
+			<div class="text-sm text-text-muted">
+				Chute travel 0–{fmt(maxAngleDeg, 0)}° · {fmt(360 - maxAngleDeg, 0)}° no-go wedge at home
+			</div>
+		</div>
+		<p class="text-sm text-text-muted">
+			Each layout shows where the chute points for that many bins per section. Bins crossed out in red
+			can't be reached: they fall in the deadzone wedge between max travel ({fmt(maxAngleDeg, 0)}°) and
+			home (0°) — which is what eats bins whenever home doesn't land on a pillar. Click any reachable
+			bin to test-aim at it.
+		</p>
+		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+			{#each VIZ_SIZES as size}
+				<BinLayoutViz
+					{numSections}
+					{sectionWidthDeg}
+					{firstSectionOffsetDeg}
+					{maxAngleDeg}
+					binCount={size}
+					liveAngleDeg={currentAngle}
+					{selected}
+					onSelect={(sel) => (selected = sel)}
+				/>
 			{/each}
 		</div>
-		<div class="flex flex-col items-start gap-4 sm:flex-row">
-			<svg viewBox="0 0 260 260" class="w-64 max-w-full" role="img" aria-label="Bin layout circle">
-				<circle cx={CX} cy={CY} r={R} class="fill-surface stroke-border" stroke-width="1" />
-				{#each Array.from({ length: numSections }, (_, s) => firstSectionOffsetDeg + s * sectionPitchDeg) as edge}
-					{@const p = polar(edge, R + 6)}
-					<line x1={CX} y1={CY} x2={p.x} y2={p.y} class="stroke-border" stroke-width="0.5" />
-				{/each}
-				<circle cx={homeMarker.x} cy={homeMarker.y} r="3" class="fill-primary" />
-				<text x={homeMarker.x} y={homeMarker.y - 6} text-anchor="middle" font-size="10" class="fill-text-muted">home 0°</text>
-				{#if needle}
-					<line x1={CX} y1={CY} x2={needle.x} y2={needle.y} class="stroke-primary" stroke-width="1.5" />
-				{/if}
-				{#each vizBins as b}
-					{@const isSel = selected?.section === b.section && selected?.bin === b.bin}
-					<circle
-						cx={b.x}
-						cy={b.y}
-						r={isSel ? 7 : 5}
-						class={`cursor-pointer ${!b.reachable ? 'fill-danger stroke-danger' : isSel ? 'fill-primary stroke-primary' : 'fill-bg stroke-text-muted'}`}
-						stroke-width="1"
-						role="button"
-						tabindex="0"
-						onclick={() => (selected = { section: b.section, bin: b.bin })}
-						onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') selected = { section: b.section, bin: b.bin }; }}
-					/>
-				{/each}
-				<circle cx={CX} cy={CY} r="2" class="fill-text-muted" />
-			</svg>
-			<div class="flex min-w-0 flex-1 flex-col gap-2">
-				{#if selected}
-					<div class="text-sm text-text">
-						Selected: section {selected.section + 1}, bin {selected.bin + 1}
-						<span class="text-text-muted">→ {fmt(angleFor(selected.section, selected.bin, testBinsPerSection), 2)}°</span>
-					</div>
-					<div>
-						<Button
-							variant="primary"
-							loading={busy}
-							disabled={!isReachable(angleFor(selected.section, selected.bin, testBinsPerSection))}
-							onclick={testAimSelected}
-						>
-							Test aim at this bin
-						</Button>
-					</div>
-				{:else}
-					<div class="text-sm text-text-muted">Click a bin in the circle to select it.</div>
-				{/if}
-			</div>
+		<div class="flex min-w-0 flex-col gap-2">
+			{#if selected}
+				<div class="text-sm text-text">
+					Selected: {selected.binCount}-bin layout, section {selected.section + 1}, bin {selected.bin + 1}
+					<span class="text-text-muted">→ {fmt(angleFor(selected.section, selected.bin, selected.binCount), 2)}°</span>
+				</div>
+				<div>
+					<Button
+						variant="primary"
+						loading={busy}
+						disabled={!isReachable(angleFor(selected.section, selected.bin, selected.binCount))}
+						onclick={testAimSelected}
+					>
+						Test aim at this bin
+					</Button>
+				</div>
+			{:else}
+				<div class="text-sm text-text-muted">Click a bin in any layout to select it, then test-aim.</div>
+			{/if}
 		</div>
 	</section>
 </div>

--- a/software/sorter/frontend/src/routes/settings/chute-aiming/BinLayoutViz.svelte
+++ b/software/sorter/frontend/src/routes/settings/chute-aiming/BinLayoutViz.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import { binCenterAngle, reachInfo, type ChuteGeometry } from './geometry';
+
+	type Selected = { section: number; bin: number; binCount: number };
+
+	let {
+		numSections,
+		sectionWidthDeg,
+		firstSectionOffsetDeg,
+		maxAngleDeg,
+		binCount,
+		liveAngleDeg = null,
+		selected = null,
+		onSelect
+	}: {
+		numSections: number;
+		sectionWidthDeg: number;
+		firstSectionOffsetDeg: number;
+		maxAngleDeg: number;
+		binCount: number;
+		liveAngleDeg?: number | null;
+		selected?: Selected | null;
+		onSelect?: (sel: Selected) => void;
+	} = $props();
+
+	const geo = $derived<ChuteGeometry>({ numSections, sectionWidthDeg, firstSectionOffsetDeg });
+	const sectionPitchDeg = $derived(360 / Math.max(1, numSections));
+
+	const CX = 110;
+	const CY = 110;
+	const R = 78;
+	function polar(angleDeg: number, radius = R) {
+		const rad = ((angleDeg - 90) * Math.PI) / 180;
+		return { x: CX + radius * Math.cos(rad), y: CY + radius * Math.sin(rad) };
+	}
+
+	function annularWedge(startDeg: number, endDeg: number, rInner: number, rOuter: number): string {
+		const a1 = polar(startDeg, rOuter);
+		const a2 = polar(endDeg, rOuter);
+		const b2 = polar(endDeg, rInner);
+		const b1 = polar(startDeg, rInner);
+		const large = endDeg - startDeg > 180 ? 1 : 0;
+		return `M ${a1.x} ${a1.y} A ${rOuter} ${rOuter} 0 ${large} 1 ${a2.x} ${a2.y} L ${b2.x} ${b2.y} A ${rInner} ${rInner} 0 ${large} 0 ${b1.x} ${b1.y} Z`;
+	}
+
+	const bins = $derived(
+		Array.from({ length: numSections }, (_, s) =>
+			Array.from({ length: binCount }, (_, i) => {
+				const angle = binCenterAngle(geo, s, i, binCount);
+				const r = reachInfo(angle, maxAngleDeg);
+				return { section: s, bin: i, angle, ...r, ...polar(r.norm) };
+			})
+		).flat()
+	);
+	const total = $derived(numSections * binCount);
+	const unreachableCount = $derived(bins.filter((b) => !b.reachable).length);
+
+	const deadzonePath = $derived(annularWedge(maxAngleDeg, 360, R - 16, R + 3));
+	const needle = $derived(liveAngleDeg === null ? null : polar(((liveAngleDeg % 360) + 360) % 360));
+	const maxTick = $derived(polar(maxAngleDeg, R + 8));
+	const homeLabel = $derived(polar(0, R + 9));
+	const homeRim = $derived(polar(0, R));
+
+	function pick(b: { section: number; bin: number; reachable: boolean }) {
+		if (!b.reachable) return;
+		onSelect?.({ section: b.section, bin: b.bin, binCount });
+	}
+</script>
+
+<div class="flex flex-col gap-1 border border-border bg-bg p-3">
+	<div class="flex items-baseline justify-between">
+		<div class="text-sm font-semibold text-text">{binCount} {binCount === 1 ? 'bin' : 'bins'}/section</div>
+		<div class={`text-sm ${unreachableCount === 0 ? 'text-success' : 'text-danger'}`}>
+			{#if unreachableCount === 0}
+				all {total} reachable
+			{:else}
+				{unreachableCount}/{total} unreachable
+			{/if}
+		</div>
+	</div>
+
+	<svg viewBox="0 0 220 220" class="w-full" role="img" aria-label={`${binCount}-bin layout`}>
+		<circle cx={CX} cy={CY} r={R} class="fill-surface stroke-border" stroke-width="1" />
+
+		<!-- The single mechanical deadzone: the wedge between max travel and home. -->
+		<path d={deadzonePath} class="fill-danger" opacity="0.12" />
+		<path
+			d={`M ${polar(maxAngleDeg, R + 3).x} ${polar(maxAngleDeg, R + 3).y} A ${R + 3} ${R + 3} 0 0 1 ${polar(360, R + 3).x} ${polar(360, R + 3).y}`}
+			class="stroke-danger"
+			fill="none"
+			stroke-width="1.5"
+		/>
+
+		<!-- Section boundary ticks. -->
+		{#each Array.from({ length: numSections }, (_, s) => firstSectionOffsetDeg + s * sectionPitchDeg) as edge}
+			{@const p = polar(edge, R + 5)}
+			{@const p0 = polar(edge, R - 4)}
+			<line x1={p0.x} y1={p0.y} x2={p.x} y2={p.y} class="stroke-border" stroke-width="0.75" />
+		{/each}
+
+		<!-- Home + max markers. -->
+		<line x1={CX} y1={CY} x2={homeRim.x} y2={homeRim.y} class="stroke-text-muted" stroke-width="0.5" stroke-dasharray="2 2" />
+		<circle cx={homeRim.x} cy={homeRim.y} r="2.5" class="fill-primary" />
+		<text x={homeLabel.x} y={homeLabel.y} text-anchor="middle" font-size="10" class="fill-text-muted">home 0°</text>
+		<text x={maxTick.x} y={maxTick.y} text-anchor="middle" font-size="10" class="fill-danger">max {maxAngleDeg.toFixed(0)}°</text>
+
+		{#if needle}
+			<line x1={CX} y1={CY} x2={needle.x} y2={needle.y} class="stroke-primary" stroke-width="1.5" />
+		{/if}
+
+		{#each bins as b}
+			{@const isSel = selected?.binCount === binCount && selected?.section === b.section && selected?.bin === b.bin}
+			<g>
+				<title>
+					Section {b.section + 1}, bin {b.bin + 1} → {b.angle.toFixed(1)}°{b.reachable
+						? ''
+						: ` — UNREACHABLE: ${b.reason}`}
+				</title>
+				<circle
+					cx={b.x}
+					cy={b.y}
+					r={isSel ? 6 : 4.5}
+					class={`${b.reachable ? 'cursor-pointer' : 'cursor-not-allowed'} ${
+						!b.reachable
+							? 'fill-surface stroke-danger'
+							: isSel
+								? 'fill-primary stroke-primary'
+								: 'fill-bg stroke-text-muted'
+					}`}
+					stroke-width="1"
+					role="button"
+					tabindex={b.reachable ? 0 : -1}
+					onclick={() => pick(b)}
+					onkeydown={(e) => {
+						if (e.key === 'Enter' || e.key === ' ') pick(b);
+					}}
+				/>
+				{#if !b.reachable}
+					<!-- Red X crossing out a bin the chute can't physically reach. -->
+					<line x1={b.x - 3.5} y1={b.y - 3.5} x2={b.x + 3.5} y2={b.y + 3.5} class="stroke-danger" stroke-width="1.25" />
+					<line x1={b.x - 3.5} y1={b.y + 3.5} x2={b.x + 3.5} y2={b.y - 3.5} class="stroke-danger" stroke-width="1.25" />
+				{/if}
+			</g>
+		{/each}
+
+		<circle cx={CX} cy={CY} r="2" class="fill-text-muted" />
+	</svg>
+
+	{#if unreachableCount > 0}
+		<p class="text-sm text-danger">
+			{unreachableCount}
+			{unreachableCount === 1 ? 'bin falls' : 'bins fall'} in the {maxAngleDeg.toFixed(0)}° no-go wedge by home.
+		</p>
+	{/if}
+</div>

--- a/software/sorter/frontend/src/routes/settings/chute-aiming/ErrorBanner.svelte
+++ b/software/sorter/frontend/src/routes/settings/chute-aiming/ErrorBanner.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { Alert } from '$lib/components/primitives';
+
+	let { message }: { message: string } = $props();
+
+	// Backend errors arrive as the raw response body — usually FastAPI's
+	// {"detail": "..."} JSON. Show just the detail when it's a plain string;
+	// otherwise (validation lists, non-JSON, etc.) fall back to the raw text.
+	function humanize(raw: string): string {
+		try {
+			const parsed = JSON.parse(raw);
+			if (parsed && typeof parsed.detail === 'string') return parsed.detail;
+		} catch {
+			// not JSON — show as-is
+		}
+		return raw;
+	}
+
+	const text = $derived(humanize(message));
+</script>
+
+<Alert variant="danger">{text}</Alert>

--- a/software/sorter/frontend/src/routes/settings/chute-aiming/geometry.ts
+++ b/software/sorter/frontend/src/routes/settings/chute-aiming/geometry.ts
@@ -1,0 +1,44 @@
+// Chute aiming geometry — mirrors backend chute.py's canonical formula:
+//   bin_center = θ0 + section·(360/N) + (i + 0.5)·(W / K)
+// Kept in one place so the calibration page and the per-size viz agree on
+// exactly where the chute points and which bins it can physically reach.
+
+export type ChuteGeometry = {
+	numSections: number;
+	sectionWidthDeg: number;
+	firstSectionOffsetDeg: number;
+};
+
+export function binCenterAngle(
+	geo: ChuteGeometry,
+	section: number,
+	bin: number,
+	binCount: number
+): number {
+	const k = Math.max(1, binCount);
+	const slot = geo.sectionWidthDeg / k;
+	return geo.firstSectionOffsetDeg + section * (360 / Math.max(1, geo.numSections)) + (bin + 0.5) * slot;
+}
+
+export function normDeg(angle: number): number {
+	return ((angle % 360) + 360) % 360;
+}
+
+// The chute travels [0, maxAngle]; the wedge (maxAngle, 360) straddling
+// home-zero is the single mechanical deadzone. A bin is reachable iff its
+// midpoint, wrapped onto the circle, lands inside the travel window. This is
+// what makes the model agnostic to whether home sits in a pillar or in the
+// middle of a section — the deadzone simply eats whichever bins fall in it.
+export function reachInfo(
+	angle: number,
+	maxAngleDeg: number
+): { reachable: boolean; norm: number; reason: string | null } {
+	const norm = normDeg(angle);
+	if (norm <= maxAngleDeg) return { reachable: true, norm, reason: null };
+	const into = norm - maxAngleDeg;
+	return {
+		reachable: false,
+		norm,
+		reason: `${into.toFixed(1)}° into the no-go wedge — the chute would have to pass ${maxAngleDeg.toFixed(0)}° to reach it, but it hits the home stop first`
+	};
+}

--- a/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
@@ -49,10 +49,17 @@
 	let swDuration = $state(4);
 	let swLoaded = $state(false);
 	let swLabel = $state('');
+	let swEnterToRun = $state(false);
 	let running = $state(false);
 	let savingThreshold = $state(false);
 
 	const base = () => getBackendHttpBase();
+
+	function onKeydown(ev: KeyboardEvent) {
+		if (!swEnterToRun || ev.key !== 'Enter' || running) return;
+		ev.preventDefault();
+		runSweep();
+	}
 
 	function fmtTime(epoch: number | null): string {
 		if (!epoch) return '—';
@@ -104,14 +111,7 @@
 	}
 
 	async function runSweep() {
-		const verb = swLoaded ? 'spin (and you will hand-load)' : 'spin';
-		if (
-			!confirm(
-				`This will ${verb} "${swStepper}" for ${swDuration}s at ${swSpeed} µsteps/s. ` +
-					`Make sure the area is clear. Continue?`
-			)
-		)
-			return;
+		if (running) return;
 		running = true;
 		error = null;
 		notice = null;
@@ -203,6 +203,8 @@
 		loadSummary();
 	});
 </script>
+
+<svelte:window onkeydown={onKeydown} />
 
 <div class="flex flex-col gap-6 p-6">
 	<div>
@@ -300,6 +302,10 @@
 				Loaded (stall test)
 			</label>
 			<Button variant="primary" onclick={runSweep} loading={running}>Run sweep</Button>
+			<label class="flex items-center gap-2 text-sm text-text">
+				<input type="checkbox" bind:checked={swEnterToRun} class="accent-primary" />
+				Enter to run
+			</label>
 		</div>
 	</SectionCard>
 
@@ -349,11 +355,15 @@
 		<div class="lg:col-span-2">
 			<SectionCard title="Load curve" description="SG_RESULT over time. Lower = more load; a stall drops it toward 0.">
 				{#if selectedRun}
-					<div class="mb-3 flex flex-wrap items-center gap-4 text-sm">
+					<div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
 						<span class="text-text-muted">Motor:</span>
 						<span class="font-mono text-text">{selectedRun.stepper_name}</span>
 						<span class="text-text-muted">Speed:</span>
 						<span class="text-text">{selectedRun.params?.speed ?? '—'} µsteps/s</span>
+						<span class="text-text-muted">Dir:</span>
+						<span class="text-text">{selectedRun.params?.direction ?? '—'}</span>
+						<span class="text-text-muted">Duration:</span>
+						<span class="text-text">{selectedRun.params?.duration_s ?? '—'} s</span>
 						{#if selectedRun.sg_mean != null}
 							<span class="text-text-muted">Mean SG:</span>
 							<span class="text-text">{Math.round(selectedRun.sg_mean)}</span>
@@ -363,6 +373,24 @@
 							<span class="text-text">{selectedRun.suggested_sgthrs}</span>
 							<span class="text-text-muted">(trigger ≤ {triggerLevel})</span>
 						{/if}
+					</div>
+					<div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+						<span class="text-text-muted">IRUN:</span>
+						<span class="text-text">{selectedRun.params?.irun ?? '—'}</span>
+						<span class="text-text-muted">Accel:</span>
+						<span class="text-text">{selectedRun.params?.acceleration ?? '—'} µsteps/s²</span>
+						<span class="text-text-muted">Microsteps:</span>
+						<span class="text-text">{selectedRun.params?.microsteps ?? '—'}</span>
+						<span class="text-text-muted">Chopper:</span>
+						<span class="text-text">
+							{selectedRun.params?.stealthchop == null
+								? '—'
+								: selectedRun.params.stealthchop
+									? 'StealthChop'
+									: 'SpreadCycle'}
+						</span>
+						<span class="text-text-muted">Loaded:</span>
+						<span class="text-text">{selectedRun.params?.loaded ? 'yes' : 'no'}</span>
 					</div>
 					<div class="mb-3 flex items-center gap-4 text-sm">
 						<label class="flex items-center gap-2 text-text">

--- a/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
@@ -43,6 +43,7 @@
 	let showTstep = $state(false);
 
 	// Sweep form
+	type Profile = 'constant' | 'chute_random' | 'pulsed';
 	let swStepper = $state('carousel');
 	let swSpeed = $state(1500);
 	let swDirection = $state<'cw' | 'ccw'>('cw');
@@ -50,10 +51,28 @@
 	let swLoaded = $state(false);
 	let swLabel = $state('');
 	let swEnterToRun = $state(false);
+	// Motion profile. Constant spin only suits a free-running motor; the chute
+	// aims to angles (random go-to + turnaround) and the rotors/carousel pulse
+	// with the odd jitter — those mirror real load. Default by motor.
+	let swProfile = $state<Profile>('pulsed');
+	let swChuteMinDeg = $state(10);
+	let swChuteMaxDeg = $state(340);
+	let swMinDeltaDeg = $state(30);
+	let swPulseDeg = $state(30);
+	let swDwellMs = $state(250);
+	let swJitterEvery = $state(5);
 	let running = $state(false);
 	let savingThreshold = $state(false);
 
 	const base = () => getBackendHttpBase();
+
+	function defaultProfileFor(stepper: string): Profile {
+		return stepper === 'chute' ? 'chute_random' : 'pulsed';
+	}
+
+	function onStepperChange() {
+		swProfile = defaultProfileFor(swStepper);
+	}
 
 	function onKeydown(ev: KeyboardEvent) {
 		if (!swEnterToRun || ev.key !== 'Enter' || running) return;
@@ -122,7 +141,17 @@
 				direction: swDirection,
 				duration_s: String(swDuration),
 				loaded: String(swLoaded),
+				profile: swProfile,
 			});
+			if (swProfile === 'chute_random') {
+				qs.set('chute_min_deg', String(swChuteMinDeg));
+				qs.set('chute_max_deg', String(swChuteMaxDeg));
+				qs.set('min_delta_deg', String(swMinDeltaDeg));
+			} else if (swProfile === 'pulsed') {
+				qs.set('pulse_deg', String(swPulseDeg));
+				qs.set('dwell_ms', String(swDwellMs));
+				qs.set('jitter_every', String(swJitterEvery));
+			}
 			if (swLabel.trim()) qs.set('label', swLabel.trim());
 			const res = await fetch(`${base()}/stepper/stallguard-sweep?${qs}`, { method: 'POST' });
 			if (!res.ok) {
@@ -258,7 +287,7 @@
 
 	<SectionCard
 		title="Run a targeted sweep"
-		description="Spins one motor at constant speed and records its load curve. Use the loaded option for a deliberate stall test — hold/resist the motor by hand while it runs."
+		description="Drives one motor with a representative motion profile and records its load curve. Use the loaded option for a deliberate stall test — hold/resist the motor by hand while it runs."
 	>
 		<Alert variant="warning">
 			This moves a real motor. Keep the area clear and your hand near the stop control.
@@ -270,12 +299,21 @@
 				<select
 					id="sw-stepper"
 					bind:value={swStepper}
+					onchange={onStepperChange}
 					class="setup-control"
 					style="min-width: 10rem;"
 				>
 					{#each STEPPERS as s}
 						<option value={s}>{s}</option>
 					{/each}
+				</select>
+			</div>
+			<div class="flex flex-col gap-1">
+				<label class="text-sm text-text" for="sw-profile">Motion profile</label>
+				<select id="sw-profile" bind:value={swProfile} class="setup-control" style="min-width: 11rem;">
+					<option value="constant">constant spin</option>
+					<option value="chute_random">chute: random go-to-angle</option>
+					<option value="pulsed">pulsed + jitter</option>
 				</select>
 			</div>
 			<label class="flex w-40 flex-col gap-1 text-sm text-text">
@@ -307,6 +345,48 @@
 				Enter to run
 			</label>
 		</div>
+
+		{#if swProfile === 'chute_random'}
+			<div class="mt-4 flex flex-wrap items-end gap-4">
+				<label class="flex w-40 flex-col gap-1 text-sm text-text">
+					Min angle (output °)
+					<Input type="number" bind:value={swChuteMinDeg} />
+				</label>
+				<label class="flex w-40 flex-col gap-1 text-sm text-text">
+					Max angle (output °)
+					<Input type="number" bind:value={swChuteMaxDeg} />
+				</label>
+				<label class="flex w-40 flex-col gap-1 text-sm text-text">
+					Min angle delta (°)
+					<Input type="number" bind:value={swMinDeltaDeg} />
+				</label>
+				<div class="max-w-md text-sm text-text-muted">
+					Random go-to-angle within [min, max] output degrees (auto-clamped to the chute's safe
+					travel, max 345°), with an immediate turnaround on each arrival. Homes the chute first if
+					needed, so it operates on absolute angles and can never reach an endstop.
+				</div>
+			</div>
+		{:else if swProfile === 'pulsed'}
+			<div class="mt-4 flex flex-wrap items-end gap-4">
+				<label class="flex w-40 flex-col gap-1 text-sm text-text">
+					Pulse size (motor °)
+					<Input type="number" bind:value={swPulseDeg} />
+				</label>
+				<label class="flex w-32 flex-col gap-1 text-sm text-text">
+					Dwell (ms)
+					<Input type="number" bind:value={swDwellMs} />
+				</label>
+				<label class="flex w-40 flex-col gap-1 text-sm text-text">
+					Jitter every N pulses
+					<Input type="number" bind:value={swJitterEvery} />
+				</label>
+				<div class="max-w-md text-sm text-text-muted">
+					Discrete pulses with a dwell between (how the rotors and carousel actually run), with an
+					unstick jitter every N pulses. Only the moving phases are sampled. Set jitter to 0 to
+					disable it.
+				</div>
+			</div>
+		{/if}
 	</SectionCard>
 
 	<div class="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
@@ -5,7 +5,6 @@
 	import StallGuardChart from '$lib/components/StallGuardChart.svelte';
 
 	const STEPPERS = ['carousel', 'chute', 'c_channel_1', 'c_channel_2', 'c_channel_3'];
-	const DEFAULT_TCOOLTHRS = 1048575; // 0xFFFFF — StallGuard active across the speed range
 
 	type Run = {
 		id: string;
@@ -61,13 +60,12 @@
 	let swPulseDeg = $state(30);
 	let swDwellMs = $state(250);
 	let swJitterEvery = $state(5);
-	// StallGuard register thresholds (TSTEP units; lower TSTEP = faster). Default
-	// = report SG at every speed, pure StealthChop. The "hybrid" preset floors SG
-	// to cruise and switches to SpreadCycle there for a cleaner load signal while
-	// staying quiet at low speed.
-	let swTcoolthrs = $state(1048575);
-	let swTpwmthrs = $state(0);
-	let swHybrid = $state(false);
+	// Only motion at/above cruise (TSTEP <= this; lower TSTEP = faster) counts for
+	// the threshold — accel/decel/reversal transients dip SG even unloaded and
+	// would drag the floor down. This is also saved as the enforcement velocity
+	// floor (TCOOLTHRS) so DIAG only acts at cruise. The chute cruises at TSTEP
+	// ~75-150; transients are >200.
+	let swCruiseTstep = $state(150);
 	let running = $state(false);
 	let savingThreshold = $state(false);
 
@@ -79,18 +77,6 @@
 
 	function onStepperChange() {
 		swProfile = defaultProfileFor(swStepper);
-	}
-
-	function onHybridToggle() {
-		// Chute cruises at TSTEP ~75–150, transients are >200, so ~200 floors SG to
-		// cruise and puts SpreadCycle there. Tune the raw fields after if needed.
-		if (swHybrid) {
-			swTcoolthrs = 200;
-			swTpwmthrs = 200;
-		} else {
-			swTcoolthrs = 1048575;
-			swTpwmthrs = 0;
-		}
 	}
 
 	function onKeydown(ev: KeyboardEvent) {
@@ -161,8 +147,7 @@
 				duration_s: String(swDuration),
 				loaded: String(swLoaded),
 				profile: swProfile,
-				tcoolthrs: String(swTcoolthrs),
-				tpwmthrs: String(swTpwmthrs),
+				cruise_tstep: String(swCruiseTstep),
 			});
 			if (swProfile === 'chute_random') {
 				qs.set('chute_min_deg', String(swChuteMinDeg));
@@ -207,7 +192,9 @@
 					headers: { 'Content-Type': 'application/json' },
 					body: JSON.stringify({
 						sgthrs: selectedRun.suggested_sgthrs,
-						tcoolthrs: DEFAULT_TCOOLTHRS,
+						// Save the cruise floor as the enforcement TCOOLTHRS so DIAG only
+						// acts at cruise (matching where the threshold was tuned).
+						tcoolthrs: selectedRun.params?.cruise_tstep ?? swCruiseTstep,
 						enabled: true,
 					}),
 				}
@@ -410,27 +397,15 @@
 		{/if}
 
 		<div class="mt-4 flex flex-wrap items-end gap-4 border-t border-border/40 pt-4">
-			<label class="flex items-center gap-2 text-sm text-text">
-				<input
-					type="checkbox"
-					bind:checked={swHybrid}
-					onchange={onHybridToggle}
-					class="accent-primary"
-				/>
-				SpreadCycle at cruise (hybrid)
-			</label>
 			<label class="flex w-44 flex-col gap-1 text-sm text-text">
-				TCOOLTHRS (SG velocity floor)
-				<Input type="number" bind:value={swTcoolthrs} />
+				Cruise TSTEP (threshold)
+				<Input type="number" bind:value={swCruiseTstep} />
 			</label>
-			<label class="flex w-48 flex-col gap-1 text-sm text-text">
-				TPWMTHRS (SpreadCycle above)
-				<Input type="number" bind:value={swTpwmthrs} />
-			</label>
-			<div class="max-w-md text-sm text-text-muted">
-				TSTEP units (lower = faster). Default reports SG at every speed in StealthChop (quiet but
-				noisy). The hybrid preset (≈200/200) floors StallGuard to cruise and switches to SpreadCycle
-				there — cleaner separation, still quiet at low speed. Set TPWMTHRS=0 for pure StealthChop.
+			<div class="max-w-lg text-sm text-text-muted">
+				Only motion at cruise (TSTEP ≤ this; lower = faster) sets the threshold — the accel/decel and
+				reversal transients dip SG even unloaded and would drag the floor down. Stays in StealthChop
+				(the TMC2209's StallGuard works there, not SpreadCycle). The chute cruises at TSTEP ~75–150;
+				saved as the enforcement velocity floor so DIAG only acts at cruise.
 			</div>
 		</div>
 	</SectionCard>
@@ -517,10 +492,8 @@
 						</span>
 						<span class="text-text-muted">Loaded:</span>
 						<span class="text-text">{selectedRun.params?.loaded ? 'yes' : 'no'}</span>
-						<span class="text-text-muted">TCOOLTHRS:</span>
-						<span class="text-text">{selectedRun.params?.tcoolthrs ?? '—'}</span>
-						<span class="text-text-muted">TPWMTHRS:</span>
-						<span class="text-text">{selectedRun.params?.tpwmthrs ?? '—'}</span>
+						<span class="text-text-muted">Cruise TSTEP:</span>
+						<span class="text-text">{selectedRun.params?.cruise_tstep ?? '—'}</span>
 					</div>
 					<div class="mb-3 flex items-center gap-4 text-sm">
 						<label class="flex items-center gap-2 text-text">

--- a/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
@@ -61,6 +61,13 @@
 	let swPulseDeg = $state(30);
 	let swDwellMs = $state(250);
 	let swJitterEvery = $state(5);
+	// StallGuard register thresholds (TSTEP units; lower TSTEP = faster). Default
+	// = report SG at every speed, pure StealthChop. The "hybrid" preset floors SG
+	// to cruise and switches to SpreadCycle there for a cleaner load signal while
+	// staying quiet at low speed.
+	let swTcoolthrs = $state(1048575);
+	let swTpwmthrs = $state(0);
+	let swHybrid = $state(false);
 	let running = $state(false);
 	let savingThreshold = $state(false);
 
@@ -72,6 +79,18 @@
 
 	function onStepperChange() {
 		swProfile = defaultProfileFor(swStepper);
+	}
+
+	function onHybridToggle() {
+		// Chute cruises at TSTEP ~75–150, transients are >200, so ~200 floors SG to
+		// cruise and puts SpreadCycle there. Tune the raw fields after if needed.
+		if (swHybrid) {
+			swTcoolthrs = 200;
+			swTpwmthrs = 200;
+		} else {
+			swTcoolthrs = 1048575;
+			swTpwmthrs = 0;
+		}
 	}
 
 	function onKeydown(ev: KeyboardEvent) {
@@ -142,6 +161,8 @@
 				duration_s: String(swDuration),
 				loaded: String(swLoaded),
 				profile: swProfile,
+				tcoolthrs: String(swTcoolthrs),
+				tpwmthrs: String(swTpwmthrs),
 			});
 			if (swProfile === 'chute_random') {
 				qs.set('chute_min_deg', String(swChuteMinDeg));
@@ -387,6 +408,31 @@
 				</div>
 			</div>
 		{/if}
+
+		<div class="mt-4 flex flex-wrap items-end gap-4 border-t border-border/40 pt-4">
+			<label class="flex items-center gap-2 text-sm text-text">
+				<input
+					type="checkbox"
+					bind:checked={swHybrid}
+					onchange={onHybridToggle}
+					class="accent-primary"
+				/>
+				SpreadCycle at cruise (hybrid)
+			</label>
+			<label class="flex w-44 flex-col gap-1 text-sm text-text">
+				TCOOLTHRS (SG velocity floor)
+				<Input type="number" bind:value={swTcoolthrs} />
+			</label>
+			<label class="flex w-48 flex-col gap-1 text-sm text-text">
+				TPWMTHRS (SpreadCycle above)
+				<Input type="number" bind:value={swTpwmthrs} />
+			</label>
+			<div class="max-w-md text-sm text-text-muted">
+				TSTEP units (lower = faster). Default reports SG at every speed in StealthChop (quiet but
+				noisy). The hybrid preset (≈200/200) floors StallGuard to cruise and switches to SpreadCycle
+				there — cleaner separation, still quiet at low speed. Set TPWMTHRS=0 for pure StealthChop.
+			</div>
+		</div>
 	</SectionCard>
 
 	<div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
@@ -471,6 +517,10 @@
 						</span>
 						<span class="text-text-muted">Loaded:</span>
 						<span class="text-text">{selectedRun.params?.loaded ? 'yes' : 'no'}</span>
+						<span class="text-text-muted">TCOOLTHRS:</span>
+						<span class="text-text">{selectedRun.params?.tcoolthrs ?? '—'}</span>
+						<span class="text-text-muted">TPWMTHRS:</span>
+						<span class="text-text">{selectedRun.params?.tpwmthrs ?? '—'}</span>
 					</div>
 					<div class="mb-3 flex items-center gap-4 text-sm">
 						<label class="flex items-center gap-2 text-text">

--- a/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/stepper-stallguard/+page.svelte
@@ -69,6 +69,23 @@
 	let running = $state(false);
 	let savingThreshold = $state(false);
 
+	// Pair-based threshold suggestion for the selected motor — pooled from the
+	// motor's recent unloaded floor + loaded stall dip (server-computed), placed
+	// at the geometric midpoint of the gap. This, not any single run, drives Save.
+	type Suggestion = {
+		stepper: string;
+		cruise_tstep: number;
+		unloaded_floor: number | null;
+		loaded_dip: number | null;
+		trigger_level: number | null;
+		suggested_sgthrs: number | null;
+		enough_data: boolean;
+		unloaded_runs: number;
+		loaded_runs: number;
+		detail: string;
+	};
+	let suggestion = $state<Suggestion | null>(null);
+
 	const base = () => getBackendHttpBase();
 
 	function defaultProfileFor(stepper: string): Profile {
@@ -110,11 +127,23 @@
 		}
 	}
 
+	async function loadSuggestion(motor: string) {
+		suggestion = null;
+		try {
+			const res = await fetch(`${base()}/stepper/${motor}/stallguard-suggestion`);
+			if (!res.ok) return;
+			suggestion = await res.json();
+		} catch {
+			suggestion = null;
+		}
+	}
+
 	async function selectRun(run: Run) {
 		selectedRun = run;
 		loadingSamples = true;
 		points = [];
 		error = null;
+		if (run.stepper_name) loadSuggestion(run.stepper_name);
 		try {
 			const res = await fetch(`${base()}/api/stepper-telemetry/runs/${run.id}/samples`);
 			if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -172,6 +201,7 @@
 			await loadSummary();
 			const fresh = runs.find((r) => r.id === data.run_id);
 			if (fresh) await selectRun(fresh);
+			else await loadSuggestion(swStepper);
 		} catch (e: any) {
 			error = e.message ?? 'Sweep failed';
 		} finally {
@@ -180,25 +210,23 @@
 	}
 
 	async function saveThreshold() {
-		if (!selectedRun?.stepper_name || selectedRun.suggested_sgthrs == null) return;
+		const motor = suggestion?.stepper;
+		if (!motor || suggestion?.suggested_sgthrs == null) return;
 		savingThreshold = true;
 		error = null;
 		notice = null;
 		try {
-			const res = await fetch(
-				`${base()}/stepper/${selectedRun.stepper_name}/stallguard-config`,
-				{
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({
-						sgthrs: selectedRun.suggested_sgthrs,
-						// Save the cruise floor as the enforcement TCOOLTHRS so DIAG only
-						// acts at cruise (matching where the threshold was tuned).
-						tcoolthrs: selectedRun.params?.cruise_tstep ?? swCruiseTstep,
-						enabled: true,
-					}),
-				}
-			);
+			const res = await fetch(`${base()}/stepper/${motor}/stallguard-config`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					sgthrs: suggestion.suggested_sgthrs,
+					// The cruise velocity floor is the enforcement TCOOLTHRS so DIAG only
+					// acts at cruise (matching where the threshold was tuned).
+					tcoolthrs: suggestion.cruise_tstep,
+					enabled: true,
+				}),
+			});
 			if (!res.ok) {
 				const body = await res.json().catch(() => ({}));
 				throw new Error(body.detail ?? `HTTP ${res.status}`);
@@ -231,8 +259,15 @@
 		}
 	}
 
+	// Trigger line on the chart prefers the pair-based suggestion (the level we'd
+	// actually save); falls back to the selected run's own suggestion if there's
+	// not yet a loaded run to pair with.
 	const triggerLevel = $derived(
-		selectedRun?.suggested_sgthrs != null ? selectedRun.suggested_sgthrs * 2 : null
+		suggestion?.trigger_level != null
+			? suggestion.trigger_level
+			: selectedRun?.suggested_sgthrs != null
+				? selectedRun.suggested_sgthrs * 2
+				: null
 	);
 
 	$effect(() => {
@@ -516,11 +551,40 @@
 						/>
 					{/if}
 
-					{#if selectedRun.suggested_sgthrs != null && selectedRun.stepper_name}
-						<div class="mt-4">
-							<Button variant="secondary" onclick={saveThreshold} loading={savingThreshold}>
-								Save SGTHRS={selectedRun.suggested_sgthrs} to machine.toml
-							</Button>
+					{#if suggestion}
+						<div class="mt-4 border border-border bg-bg px-4 py-4">
+							<div class="text-base font-semibold text-text">
+								Threshold suggestion for {suggestion.stepper}
+							</div>
+							<div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+								<span class="text-text-muted">Unloaded floor:</span>
+								<span class="text-text">{suggestion.unloaded_floor ?? '—'}</span>
+								<span class="text-text-muted">Loaded dip:</span>
+								<span class="text-text">{suggestion.loaded_dip ?? '—'}</span>
+								<span class="text-text-muted">→ Trigger ≤:</span>
+								<span class="text-text">{suggestion.trigger_level ?? '—'}</span>
+								<span class="text-text-muted">Cruise TSTEP:</span>
+								<span class="text-text">{suggestion.cruise_tstep}</span>
+							</div>
+							<div class="mt-1 text-sm text-text-muted">
+								Geometric midpoint of the measured gap, from the latest unloaded + loaded test for this
+								motor.
+							</div>
+							{#if !suggestion.enough_data}
+								<Alert variant="warning">{suggestion.detail}</Alert>
+							{/if}
+							{#if suggestion.suggested_sgthrs != null}
+								<div class="mt-3">
+									<Button
+										variant={suggestion.enough_data ? 'secondary' : 'ghost'}
+										onclick={saveThreshold}
+										loading={savingThreshold}
+									>
+										Save{suggestion.enough_data ? '' : ' provisional'} SGTHRS={suggestion.suggested_sgthrs}
+										to machine.toml
+									</Button>
+								</div>
+							{/if}
 						</div>
 					{/if}
 				{:else}


### PR DESCRIPTION
This branch (`servo-speed-and-homing-release-wip`) bundles several areas of work. The headline addition is end-to-end TMC2209 **StallGuard stall detection**; it also carries the per-servo motion-speed work, the chute-aiming rework, and a few smaller fixes. The base (`01` — per-stepper default acceleration) already merged to `main` via #159, so this targets `main` directly.

---

## StallGuard stall detection (new)

Detect a motor stall/jam in hardware, halt the machine, and require an operator acknowledge — with per-motor thresholds tuned from real load data.

### Detection → halt → acknowledge
- **Firmware** (`Stepper.{h,cpp}`, `sorter_interface_firmware.cpp`): a DIAG latch in the core1 motion tick stops the motor instantly on a stall (skipped while jittering). Three new STEPPER commands — enable-detection (per channel), get-stall-status (**per-board bitmask**, one bus round-trip), clear-stall. DIAG pins init as pulled-down inputs; all build variants compile clean.
- **Backend** (`hardware/sorter_interface.py`): command wrappers, `SorterInterface.get_stall_status()`, per-stepper `stallguard_*` attrs.
- **Monitor** (`stepper_stall_monitor.py`): a daemon thread polls the firmware latch and raises a blocking `stepper_stall` incident; the coordinator halts all flow (no auto-recovery). The dashboard shows a "Motor Stall" banner with an acknowledge button that resets the firmware latch and re-arms.

### Always-on model
If a stepper has an enabled `[stepper_stallguard.*]` entry, detection is **on for every move** — switched on once at hardware init (`applyStepperStallguard`) and left on. No RUNNING gate, no per-move arming. Homing doesn't false-trip because it runs slower than cruise, below the `TCOOLTHRS` velocity floor where DIAG is inactive. The StallGuard sweep is the single exception: it deliberately stalls the motor, so it turns detection off for its run and restores it afterward.

### Tuning workflow (Settings → Helpers → StallGuard)
- **Representative sweep motion**: `chute_random` (random go-to-angle + immediate turnaround on the homed chute object, in absolute degrees clamped to safe travel so it can never reach an endstop) and `pulsed` (discrete pulses + dwell + unstick jitter — how the rotors/carousel actually run), instead of a constant spin that just rams an endstop and reads SG_RESULT=0.
- **StealthChop, cruise-only tuning**: TMC2209 StallGuard4 works in StealthChop (not SpreadCycle — that's the older TMC2130). The sweep measures across the whole speed range for the chart but computes the threshold from **cruise samples only** (TSTEP ≤ floor), so accel/decel/reversal dips don't drag it down. `cruise_tstep` is saved as the enforcement `TCOOLTHRS`.
- **Pair-based threshold suggestion**: takes the latest unloaded run (the normal floor) + latest loaded run (the stall dip) and places the trigger at the **geometric midpoint** of the gap — equal ratio margin from both. `SGTHRS = trigger / 2` (DIAG fires at `SG_RESULT ≤ 2 × SGTHRS`). Telemetry records irun/accel/microsteps/chopper per run.

### Config UI
- StallGuard is editable in **each stepper's Driver Settings** (enable toggle + SGTHRS slider + TCOOLTHRS field). Apply writes it live to the driver **and** persists to `machine.toml`, so it takes effect on the next move with no reinit.
- Driver settings now load their persisted config (currents + StallGuard) **even at standby** — the TMC GET no longer 503s when there's no live hardware; only register read-outs come back null.
- The slider values (IRUN / IHOLD / SGTHRS) are click/hover-to-edit number fields, not drag-only.
- New "Helpers" settings section holds Chute Aiming + StallGuard.

**Status:** detection → incident → halt → ack is wired and flashed; the chute is tuned (SGTHRS 55, from floor 356 / dip 34). A live RUNNING hand-stall and the physical DIAG wire are still to be verified on hardware.

---

## Per-servo motion speeds
Servo speed is sticky firmware state, so callers apply the right one before each move: sorting uses the configured open/close speed, homing/jog use the standard speed.
- `ServoMotor` gains `set_motion_speeds()` + `apply_open/close/homing_speed()`.
- Config init, the home path in `main.py`, and the servo save endpoints store and apply these.
- `positioning.py` applies open/close speed per move during sorting.

### Current-angle tracking
- `_current_angle` is now `int | None` — `None` means "unknown, no move commanded since boot" rather than falsely claiming 0°.
- Surfaced via the hardware config payload (`_attach_live_servo_current_angles`) and shown as the live current angle in the Servo Layer Calibrator.

### Lock-save UI
- Per-layer Saving/Saved/Failed indicator on the calibrator lock buttons, since locking is the persist; plus save-after-add/remove fixes, a dirty indicator, and auto channel assignment.

---

## Chute aiming
- Reachability model, per-bin-size visualization, calibration rework, and a live home-angle readout.

## Smaller
- `classification_channel`: wire rev01 into distribution.
- `modal`: route the restarting-backend overlay through the shared Modal.
- Diagnostic logs for chute homing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
