### PR TITLE
General updates: 6-bin layers, local sorting profiles, chute-aiming fix

### DIFF
--- a/software/.gitignore
+++ b/software/.gitignore
@@ -106,6 +106,8 @@ sorter/backend/every_part_bl_api_res.json
 sorter/backend/machine_params.toml
 sorter/backend/stepper_current_overrides.json
 sorter/backend/sorting_profile.json
+sorter/backend/active_sorting_profile.json
+sorter/backend/sorting_profiles/
 sorter/backend/servo_states.json
 sorter/backend/local_state.sqlite
 sorter/backend/local_state.sqlite-shm

--- a/software/install.sh
+++ b/software/install.sh
@@ -131,7 +131,6 @@ else
 export DEBUG_LEVEL=2
 
 export MACHINE_SPECIFIC_PARAMS_PATH="$SOFTWARE_DIR/machine.example.toml"
-export SORTING_PROFILE_PATH="$SOFTWARE_DIR/sorter/backend/sorting_profile.json"
 
 EOF
     ok ".env written"

--- a/software/sorter/backend/global_config.py
+++ b/software/sorter/backend/global_config.py
@@ -35,6 +35,7 @@ class GlobalConfig:
     debug_level: int
     timeouts: Timeouts
     sorting_profile_path: str
+    local_profiles_dir: str
     should_write_camera_feeds: bool
     machine_id: str
     run_id: str
@@ -103,7 +104,15 @@ def mkGlobalConfig() -> GlobalConfig:
     gc = GlobalConfig()
     gc.debug_level = int(os.getenv("DEBUG_LEVEL", "0"))
     gc.timeouts = mkTimeouts()
-    gc.sorting_profile_path = os.environ["SORTING_PROFILE_PATH"]
+    # Local sorting profiles live next to local_state.sqlite in the backend
+    # dir: durable across git resets (gitignored) and on the same persistent
+    # filesystem the rest of the machine state already trusts. The active
+    # artifact is a single file the runtime reads once into memory on reload;
+    # the library dir holds every saved/uploaded profile to choose from.
+    backend_dir = Path(__file__).resolve().parent
+    gc.sorting_profile_path = str(backend_dir / "active_sorting_profile.json")
+    gc.local_profiles_dir = str(backend_dir / "sorting_profiles")
+    os.makedirs(gc.local_profiles_dir, exist_ok=True)
     gc.machine_id = getMachineId()
     gc.run_id = str(uuid.uuid4())
     # Allow env-var fallback so the launching supervisor can flip these

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -341,7 +341,7 @@ class StorageLayerSettingsPayload(BaseModel):
 # Constants
 # ---------------------------------------------------------------------------
 
-ALLOWED_STORAGE_LAYER_BIN_COUNTS = [12, 18, 30]
+ALLOWED_STORAGE_LAYER_BIN_COUNTS = [6, 12, 18, 30]
 DEFAULT_STORAGE_LAYER_SECTION_COUNT = 6
 DEFAULT_CAROUSEL_ENDSTOP_ACTIVE_HIGH = False
 CAROUSEL_CALIBRATE_TIMEOUT_MS = 60000

--- a/software/sorter/backend/server/routers/sorting_profiles.py
+++ b/software/sorter/backend/server/routers/sorting_profiles.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -146,13 +147,115 @@ def _atomic_write_json(path: str, data: dict[str, Any]) -> None:
         raise
 
 
+# ─── Local (on-disk) sorting profiles ──────────────────────────────────────
+# A properly-named library of saved profiles sitting next to local_state.sqlite.
+# Each is a standard artifact JSON (same shape Hive emits). Writes are atomic
+# (temp + fsync + rename) and reads open-and-close — nothing is held open, so a
+# crash or OS hiccup can't leave a half-written or locked profile behind.
+
+
+def _local_profiles_dir() -> Path:
+    if shared_state.gc_ref is not None and getattr(shared_state.gc_ref, "local_profiles_dir", None):
+        directory = Path(shared_state.gc_ref.local_profiles_dir)
+    else:
+        directory = Path(__file__).resolve().parents[2] / "sorting_profiles"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _safe_local_path(filename: str) -> Path:
+    name = os.path.basename((filename or "").strip())
+    if not name or name.startswith(".") or not name.endswith(".json"):
+        raise HTTPException(status_code=400, detail="Invalid profile filename.")
+    directory = _local_profiles_dir()
+    resolved = (directory / name).resolve()
+    if resolved.parent != directory.resolve():
+        raise HTTPException(status_code=400, detail="Invalid profile filename.")
+    return resolved
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", (value or "").lower()).strip("-")
+    return slug or "profile"
+
+
+def _unique_local_path(base: str) -> Path:
+    directory = _local_profiles_dir()
+    stem = _slugify(base)
+    candidate = directory / f"{stem}.json"
+    counter = 2
+    while candidate.exists():
+        candidate = directory / f"{stem}-{counter}.json"
+        counter += 1
+    return candidate
+
+
+def _local_profile_entry(
+    path: Path, active_hash: str | None, active_filename: str | None
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "filename": path.name,
+        "id": path.stem,
+        "name": None,
+        "description": None,
+        "profile_type": None,
+        "rule_count": None,
+        "category_count": None,
+        "part_count": None,
+        "artifact_hash": None,
+        "updated_at": None,
+        "is_active": False,
+        "error": None,
+    }
+    try:
+        with open(path, "r") as handle:
+            data = json.load(handle)
+    except Exception as exc:
+        entry["error"] = str(exc)
+        return entry
+    if not isinstance(data, dict):
+        entry["error"] = "profile file is not a JSON object"
+        return entry
+    artifact_hash = data.get("artifact_hash")
+    entry.update(
+        {
+            "name": data.get("name") or path.stem,
+            "description": data.get("description"),
+            "profile_type": data.get("profile_type"),
+            "rule_count": len(data.get("rules", []) or []),
+            "category_count": len(data.get("categories", {}) or {}),
+            "part_count": len(data.get("part_to_category", {}) or {}),
+            "artifact_hash": artifact_hash,
+        }
+    )
+    try:
+        entry["updated_at"] = datetime.fromtimestamp(
+            path.stat().st_mtime, tz=timezone.utc
+        ).isoformat()
+    except OSError:
+        pass
+    if active_filename and path.name == active_filename:
+        entry["is_active"] = True
+    elif artifact_hash and active_hash and artifact_hash == active_hash:
+        entry["is_active"] = True
+    return entry
+
+
+def _list_local_profiles() -> list[dict[str, Any]]:
+    sync_state = getSortingProfileSyncState() or {}
+    active_filename = (
+        sync_state.get("local_filename") if sync_state.get("source") == "local" else None
+    )
+    active_hash = sync_state.get("artifact_hash")
+    return [
+        _local_profile_entry(path, active_hash, active_filename)
+        for path in sorted(_local_profiles_dir().glob("*.json"))
+    ]
+
+
 def _current_local_profile_status() -> dict[str, Any]:
     sync_state = getSortingProfileSyncState() or {}
-    path = (
-        shared_state.gc_ref.sorting_profile_path
-        if shared_state.gc_ref is not None
-        else os.environ.get("SORTING_PROFILE_PATH")
-    )
+    path = shared_state.gc_ref.sorting_profile_path if shared_state.gc_ref is not None else None
     metadata: dict[str, Any] = {}
     if path and os.path.exists(path):
         try:
@@ -228,6 +331,7 @@ def get_sorting_profile_library() -> dict[str, Any]:
         target_payloads.append(payload)
     return {
         "targets": target_payloads,
+        "local_profiles": _list_local_profiles(),
         **_current_local_profile_status(),
     }
 
@@ -316,6 +420,8 @@ def apply_sorting_profile(payload: ApplySortingProfilePayload) -> dict[str, Any]
         preassigned_count = _preassign_bins_from_rules(artifact)
 
     sync_state = {
+        "source": "hive",
+        "local_filename": None,
         "target_id": payload.target_id,
         "target_name": target.get("name") or target.get("url"),
         "target_url": base_url,
@@ -373,3 +479,124 @@ def apply_sorting_profile(payload: ApplySortingProfilePayload) -> dict[str, Any]
         "activation_error": activation_error,
         **status,
     }
+
+
+class ApplyLocalSortingProfilePayload(BaseModel):
+    filename: str
+    reset_bin_categories: bool = False
+    preassign_mode: str | None = None
+
+
+class UploadLocalSortingProfilePayload(BaseModel):
+    artifact: dict[str, Any]
+    name: str | None = None
+
+
+def _load_local_artifact(path: Path) -> dict[str, Any]:
+    try:
+        with open(path, "r") as handle:
+            artifact = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"Profile file is corrupt: {exc}")
+    if not isinstance(artifact, dict) or "part_to_category" not in artifact:
+        raise HTTPException(
+            status_code=400,
+            detail="Profile is not a valid sorting profile (missing part_to_category).",
+        )
+    return artifact
+
+
+@router.post("/api/sorting-profiles/local/apply")
+def apply_local_sorting_profile(payload: ApplyLocalSortingProfilePayload) -> dict[str, Any]:
+    if shared_state.gc_ref is None:
+        raise HTTPException(status_code=500, detail="Global config not initialized.")
+
+    path = _safe_local_path(payload.filename)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Local profile not found.")
+    artifact = _load_local_artifact(path)
+
+    mode = payload.preassign_mode
+    if mode is None and payload.reset_bin_categories:
+        mode = "empty"
+    reset_result: dict[str, Any] | None = None
+    if mode in ("empty", "rules"):
+        reset_result = clear_bin_category_assignments(scope="all")
+
+    _atomic_write_json(shared_state.gc_ref.sorting_profile_path, artifact)
+    reloaded = _reload_runtime_profile()
+
+    preassigned_count = 0
+    if mode == "rules":
+        preassigned_count = _preassign_bins_from_rules(artifact)
+
+    name = str(artifact.get("name") or path.stem)
+    now = datetime.now(timezone.utc).isoformat()
+    sync_state = {
+        "source": "local",
+        "local_filename": path.name,
+        "target_id": None,
+        "target_name": "Local",
+        "target_url": None,
+        "profile_id": None,
+        "profile_name": name,
+        "version_id": None,
+        "version_number": None,
+        "version_label": None,
+        "artifact_hash": str(artifact.get("artifact_hash") or "") or None,
+        "applied_at": now,
+        "activated_at": now,
+        "last_error": None,
+    }
+    setSortingProfileSyncState(sync_state)
+    start_new_sorting_session(reason="profile_activated")
+    try:
+        from server.set_progress_sync import getSetProgressSyncWorker
+
+        getSetProgressSyncWorker().notify()
+    except Exception:
+        pass
+
+    status = _current_local_profile_status()
+    shared_state.publishSortingProfileStatus(status)
+    return {
+        "ok": True,
+        "reloaded": reloaded,
+        "bin_categories_reset": bool(reset_result),
+        "bin_categories_reset_message": reset_result.get("message") if isinstance(reset_result, dict) else None,
+        "preassigned_count": preassigned_count,
+        "local_profiles": _list_local_profiles(),
+        **status,
+    }
+
+
+@router.post("/api/sorting-profiles/local/upload")
+def upload_local_sorting_profile(payload: UploadLocalSortingProfilePayload) -> dict[str, Any]:
+    artifact = payload.artifact
+    if not isinstance(artifact, dict) or "part_to_category" not in artifact:
+        raise HTTPException(
+            status_code=400,
+            detail="Uploaded JSON is not a valid sorting profile (missing part_to_category).",
+        )
+    name = (payload.name or "").strip()
+    if name:
+        artifact = {**artifact, "name": name}
+    base = name or str(artifact.get("name") or artifact.get("id") or "profile")
+    dest = _unique_local_path(base)
+    _atomic_write_json(str(dest), artifact)
+    return {
+        "ok": True,
+        "profile": _local_profile_entry(dest, None, None),
+        "local_profiles": _list_local_profiles(),
+    }
+
+
+@router.delete("/api/sorting-profiles/local/{filename}")
+def delete_local_sorting_profile(filename: str) -> dict[str, Any]:
+    path = _safe_local_path(filename)
+    if path.exists():
+        try:
+            path.unlink()
+        except OSError as exc:
+            raise HTTPException(status_code=500, detail=f"Could not delete profile: {exc}")
+    return {"ok": True, "local_profiles": _list_local_profiles()}

--- a/software/sorter/frontend/src/lib/components/SortingProfileDropdown.svelte
+++ b/software/sorter/frontend/src/lib/components/SortingProfileDropdown.svelte
@@ -13,6 +13,8 @@
 	import Modal from '$lib/components/Modal.svelte';
 
 	type SortingProfileSyncState = {
+		source?: 'hive' | 'local' | null;
+		local_filename?: string | null;
 		target_id?: string | null;
 		target_name?: string | null;
 		profile_id?: string | null;
@@ -63,8 +65,17 @@
 		profiles: SortingProfileSummary[];
 	};
 
+	type LocalProfileEntry = {
+		filename: string;
+		name?: string | null;
+		rule_count?: number | null;
+		is_active: boolean;
+		error?: string | null;
+	};
+
 	type SortingProfileLibraryResponse = {
 		targets: HiveTargetLibrary[];
+		local_profiles?: LocalProfileEntry[];
 	};
 
 	type QuickSwitchProfileEntry = {
@@ -293,6 +304,55 @@
 		}
 	}
 
+	const local_profiles = $derived<LocalProfileEntry[]>(profile_library?.local_profiles ?? []);
+
+	let pending_local_profile = $state<LocalProfileEntry | null>(null);
+	let local_modal_open = $state(false);
+
+	function requestApplyLocalProfile(profile: LocalProfileEntry) {
+		pending_local_profile = profile;
+		local_modal_open = true;
+		action_error = null;
+		action_message = null;
+	}
+
+	function cancelApplyLocalProfile() {
+		local_modal_open = false;
+	}
+
+	async function confirmApplyLocalProfile(mode: 'empty' | 'rules') {
+		const profile = pending_local_profile;
+		if (profile === null) return;
+		local_modal_open = false;
+		applying_key = `local::${profile.filename}`;
+		action_error = null;
+		action_message = null;
+		try {
+			const res = await fetch(`${currentBackendBaseUrl()}/api/sorting-profiles/local/apply`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ filename: profile.filename, preassign_mode: mode })
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => null);
+				throw new Error(body?.detail ?? `HTTP ${res.status}`);
+			}
+			const payload = await res.json().catch(() => null);
+			await sortingProfileStore.reload(currentBackendBaseUrl()).catch(() => null);
+			await loadQuickProfileLibrary();
+			const label = profile.name || profile.filename;
+			const preassigned = payload?.preassigned_count as number | undefined;
+			action_message =
+				mode === 'rules' && preassigned
+					? `Switched to ${label}, pre-assigned ${preassigned} bin${preassigned === 1 ? '' : 's'}.`
+					: `Switched to ${label}.`;
+		} catch (e: unknown) {
+			action_error = e instanceof Error ? e.message : 'Failed to switch sorting profile';
+		} finally {
+			applying_key = null;
+		}
+	}
+
 	let pending_switch_entry = $state<QuickSwitchProfileEntry | null>(null);
 
 	function requestApplyRecentProfile(entry: QuickSwitchProfileEntry) {
@@ -353,7 +413,12 @@
 	const current_profile_name = $derived(status?.sync_state?.profile_name ?? status?.local_profile?.name ?? 'No profile');
 	const current_profile_version = $derived(status?.sync_state?.version_number ?? null);
 	const current_profile_version_label = $derived(status?.sync_state?.version_label ?? null);
-	const current_profile_target = $derived(status?.sync_state?.target_name ?? 'Local');
+	const current_profile_target = $derived.by(() => {
+		const ss = status?.sync_state;
+		if (ss?.source === 'local') return `local:${ss.local_filename ?? ss.profile_name ?? 'profile'}`;
+		if (ss?.target_name) return `hive:${ss.target_name}`;
+		return ss?.target_name ?? 'Local';
+	});
 	const current_profile_updated = $derived(
 		formatRelativeTime(status?.sync_state?.applied_at ?? status?.local_profile?.updated_at)
 	);
@@ -482,6 +547,8 @@
 									</span>
 								</div>
 								<div class="mt-0.5 flex flex-wrap items-center gap-x-1.5 text-xs text-text-muted">
+									<span class="min-w-0 truncate font-mono">hive:{entry.target_name}</span>
+									<span aria-hidden="true">·</span>
 									{#if entry.rule_count != null}
 										<span>{entry.rule_count} rules</span>
 										<span aria-hidden="true">·</span>
@@ -499,9 +566,83 @@
 					</div>
 				{/if}
 			</div>
+
+			<!-- Local section — profiles saved on this machine. -->
+			<div class="border-t border-border bg-bg px-3 py-1.5">
+				<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">Local</span>
+			</div>
+			<div>
+				{#if local_profiles.length === 0}
+					<div class="px-3 py-2 text-xs text-text-muted">No local profiles.</div>
+				{:else}
+					<div class="divide-y divide-border">
+						{#each local_profiles as profile}
+							<button
+								type="button"
+								onclick={() => requestApplyLocalProfile(profile)}
+								disabled={applying_key === `local::${profile.filename}` || Boolean(profile.error)}
+								class="block w-full px-3 py-2 text-left transition-colors hover:bg-bg disabled:cursor-not-allowed disabled:opacity-60"
+							>
+								<div class="flex items-center justify-between gap-2">
+									<span class="min-w-0 truncate text-sm font-medium text-text">{profile.name || profile.filename}</span>
+									<span class="shrink-0 font-mono text-xs text-text-muted">
+										{#if applying_key === `local::${profile.filename}`}
+											switching…
+										{:else if profile.is_active}
+											active
+										{/if}
+									</span>
+								</div>
+								<div class="mt-0.5 flex flex-wrap items-center gap-x-1.5 text-xs text-text-muted">
+									<span class="min-w-0 truncate font-mono">local:{profile.filename}</span>
+									{#if profile.rule_count != null}
+										<span aria-hidden="true">·</span>
+										<span>{profile.rule_count} rules</span>
+									{/if}
+								</div>
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
 		</div>
 	{/if}
 </div>
+
+<Modal bind:open={local_modal_open} title="Switch sorting profile">
+	{#if pending_local_profile !== null}
+		{@const profile = pending_local_profile}
+		<div class="flex flex-col gap-4">
+			<p class="text-sm text-text">
+				Switch to <span class="font-semibold">{profile.name || profile.filename}</span>?
+			</p>
+			<p class="text-sm text-text-muted">Choose how bins should be initialized for the new profile.</p>
+			<div class="flex flex-wrap items-center justify-end gap-2 border-t border-border pt-3">
+				<button
+					type="button"
+					onclick={cancelApplyLocalProfile}
+					class="border border-border bg-surface px-3 py-1.5 text-sm text-text hover:bg-bg"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={() => void confirmApplyLocalProfile('empty')}
+					class="border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-bg"
+				>
+					Reset bins
+				</button>
+				<button
+					type="button"
+					onclick={() => void confirmApplyLocalProfile('rules')}
+					class="border border-primary bg-primary/10 px-3 py-1.5 text-sm font-medium text-primary hover:bg-primary/20"
+				>
+					Pre-assign from rules
+				</button>
+			</div>
+		</div>
+	{/if}
+</Modal>
 
 <Modal open={pending_switch_entry !== null} title="Switch sorting profile">
 	{#if pending_switch_entry !== null}

--- a/software/sorter/frontend/src/lib/components/profiles/ProfileCard.svelte
+++ b/software/sorter/frontend/src/lib/components/profiles/ProfileCard.svelte
@@ -219,18 +219,12 @@
 				{/if}
 			</div>
 			<div class="text-center">
-				{#if targetWebUrl(props.target)}
-					<a
+				<span class="font-mono text-text-muted">hive:</span>{#if targetWebUrl(props.target)}<a
 						href={targetWebUrl(props.target) ?? undefined}
 						target="_blank"
 						rel="noreferrer"
 						class="transition-colors hover:text-text hover:underline"
-					>
-						{sourceLabel(props.target)}
-					</a>
-				{:else}
-					{sourceLabel(props.target)}
-				{/if}
+					>{sourceLabel(props.target)}</a>{:else}{sourceLabel(props.target)}{/if}
 			</div>
 			<div class="text-right">
 				{#if displayVersion(props.profile)?.created_at}

--- a/software/sorter/frontend/src/lib/components/servo/ServoLayerCalibrator.svelte
+++ b/software/sorter/frontend/src/lib/components/servo/ServoLayerCalibrator.svelte
@@ -54,7 +54,7 @@
 	let backend = $state<ServoBackend>('pca9685');
 	let layers = $state<LayerDraft[]>([]);
 	let channelChoices = $state<number[]>([]);
-	let allowedCounts = $state<number[]>([12, 18, 30]);
+	let allowedCounts = $state<number[]>([6, 12, 18, 30]);
 	let jogStep = $state(5);
 	let selectedIndex = $state<number | null>(null);
 
@@ -122,7 +122,7 @@
 			const storage = payload?.storage_layers ?? {};
 			allowedCounts = Array.isArray(storage.allowed_bin_counts)
 				? storage.allowed_bin_counts.filter((v: unknown): v is number => typeof v === 'number')
-				: [12, 18, 30];
+				: [6, 12, 18, 30];
 
 			const servoChannels: Array<{ id: number | null; invert: boolean }> = Array.isArray(
 				servo.channels

--- a/software/sorter/frontend/src/lib/components/settings/StorageLayerSettingsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/StorageLayerSettingsSection.svelte
@@ -72,7 +72,7 @@
 	let saving = $state(false);
 	let errorMsg = $state<string | null>(null);
 	let statusMsg = $state('');
-	let allowedCounts = $state<number[]>([12, 18, 30]);
+	let allowedCounts = $state<number[]>([6, 12, 18, 30]);
 	let availableServoIds = $state<number[]>([]);
 	let servoIssues = $state<HardwareIssue[]>([]);
 	let backend = $state<ServoBackend>('pca9685');
@@ -229,7 +229,7 @@ function applySettings(payload: any) {
 
 		allowedCounts = Array.isArray(storage?.allowed_bin_counts)
 			? storage.allowed_bin_counts.filter((value: unknown): value is number => typeof value === 'number')
-			: [12, 18, 30];
+			: [6, 12, 18, 30];
 
 		backend = servo.backend === 'waveshare' ? 'waveshare' : 'pca9685';
 		openAngle = Number(servo.open_angle ?? 10);

--- a/software/sorter/frontend/src/lib/sorting-profiles/api.ts
+++ b/software/sorter/frontend/src/lib/sorting-profiles/api.ts
@@ -60,6 +60,46 @@ export async function applyProfile(
 	return unwrap<ApplyProfileResponse>(res);
 }
 
+export async function applyLocalProfile(
+	baseUrl: string,
+	filename: string,
+	mode: 'empty' | 'rules'
+): Promise<ApplyProfileResponse> {
+	const res = await fetch(`${baseUrl}/api/sorting-profiles/local/apply`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ filename, preassign_mode: mode })
+	});
+	return unwrap<ApplyProfileResponse>(res);
+}
+
+export async function uploadLocalProfile(
+	baseUrl: string,
+	artifact: unknown,
+	name?: string | null
+): Promise<void> {
+	const res = await fetch(`${baseUrl}/api/sorting-profiles/local/upload`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ artifact, name: name ?? null })
+	});
+	if (!res.ok) {
+		const body = (await res.json().catch(() => null)) as JsonError | null;
+		throw new Error(body?.detail ?? `HTTP ${res.status}`);
+	}
+}
+
+export async function deleteLocalProfile(baseUrl: string, filename: string): Promise<void> {
+	const res = await fetch(
+		`${baseUrl}/api/sorting-profiles/local/${encodeURIComponent(filename)}`,
+		{ method: 'DELETE' }
+	);
+	if (!res.ok) {
+		const body = (await res.json().catch(() => null)) as JsonError | null;
+		throw new Error(body?.detail ?? `HTTP ${res.status}`);
+	}
+}
+
 export async function reloadRuntimeProfile(baseUrl: string): Promise<void> {
 	const res = await fetch(`${baseUrl}/api/sorting-profiles/reload`, { method: 'POST' });
 	if (!res.ok) {

--- a/software/sorter/frontend/src/lib/sorting-profiles/types.ts
+++ b/software/sorter/frontend/src/lib/sorting-profiles/types.ts
@@ -108,6 +108,8 @@ export type SortingProfileDetail = SortingProfileSummary & {
 };
 
 export type SortingProfileSyncState = {
+	source?: 'hive' | 'local' | null;
+	local_filename?: string | null;
 	target_id?: string | null;
 	target_name?: string | null;
 	target_url?: string | null;
@@ -156,8 +158,24 @@ export type HiveTargetLibrary = {
 	error: string | null;
 };
 
+export type LocalSortingProfile = {
+	filename: string;
+	id: string;
+	name: string | null;
+	description: string | null;
+	profile_type?: string | null;
+	rule_count: number | null;
+	category_count: number | null;
+	part_count?: number | null;
+	artifact_hash: string | null;
+	updated_at: string | null;
+	is_active: boolean;
+	error?: string | null;
+};
+
 export type SortingProfileLibraryResponse = {
 	targets: HiveTargetLibrary[];
+	local_profiles: LocalSortingProfile[];
 	sync_state: SortingProfileSyncState | null;
 	local_profile: LocalProfileStatus;
 };

--- a/software/sorter/frontend/src/routes/profiles/+page.svelte
+++ b/software/sorter/frontend/src/routes/profiles/+page.svelte
@@ -9,22 +9,27 @@
 	import StatusBanner from '$lib/components/StatusBanner.svelte';
 	import { getMachinesContext } from '$lib/machines/context';
 	import {
+		applyLocalProfile,
 		applyProfile,
+		deleteLocalProfile,
 		fetchLibrary,
 		fetchProfileDetail,
 		reloadRuntimeProfile as callReloadRuntime,
+		uploadLocalProfile,
 		visibleVersions
 	} from '$lib/sorting-profiles/api';
 	import { sortingProfileStore } from '$lib/stores/sortingProfile.svelte';
 	import type {
 		HiveTargetLibrary,
+		LocalSortingProfile,
 		PendingProfileApply,
 		SortingProfileCardEntry,
 		SortingProfileDetail,
 		SortingProfileLibraryResponse,
 		SortingProfileSummary
 	} from '$lib/sorting-profiles/types';
-	import { RotateCw } from 'lucide-svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import { RotateCw, Trash2, Upload } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	const manager = getMachinesContext();
@@ -54,6 +59,14 @@
 	let applyConfirmOpen = $state(false);
 	let pendingApply = $state<PendingProfileApply | null>(null);
 	let openVersionMenuKey = $state<string | null>(null);
+	let fileInput = $state<HTMLInputElement | null>(null);
+	let uploading = $state(false);
+	let pendingLocal = $state<LocalSortingProfile | null>(null);
+	let localApplyOpen = $state(false);
+	let localApplyingFilename = $state<string | null>(null);
+	let deletingFilename = $state<string | null>(null);
+	let pendingDelete = $state<LocalSortingProfile | null>(null);
+	let localDeleteOpen = $state(false);
 
 	function baseUrl(): string {
 		return (
@@ -219,6 +232,90 @@
 		} finally {
 			pendingApply = null;
 			applyingKey = null;
+		}
+	}
+
+	function localProfiles(): LocalSortingProfile[] {
+		return library?.local_profiles ?? [];
+	}
+
+	async function handleUploadFile(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		const file = input.files?.[0];
+		input.value = '';
+		if (!file) return;
+		uploading = true;
+		error = null;
+		success = null;
+		warning = null;
+		try {
+			const text = await file.text();
+			let artifact: unknown;
+			try {
+				artifact = JSON.parse(text);
+			} catch {
+				throw new Error('That file is not valid JSON.');
+			}
+			const fallbackName = file.name.replace(/\.json$/i, '');
+			const artifactName =
+				artifact && typeof artifact === 'object' && 'name' in artifact
+					? (artifact as { name?: string }).name
+					: null;
+			await uploadLocalProfile(baseUrl(), artifact, artifactName || fallbackName);
+			await loadLibrary();
+			success = `Uploaded ${artifactName || fallbackName}.`;
+		} catch (e: unknown) {
+			error = e instanceof Error ? e.message : 'Failed to upload sorting profile';
+		} finally {
+			uploading = false;
+		}
+	}
+
+	function requestApplyLocal(profile: LocalSortingProfile) {
+		pendingLocal = profile;
+		localApplyOpen = true;
+	}
+
+	async function confirmApplyLocal(mode: 'empty' | 'rules') {
+		const profile = pendingLocal;
+		if (!profile) return;
+		localApplyOpen = false;
+		localApplyingFilename = profile.filename;
+		error = null;
+		success = null;
+		warning = null;
+		try {
+			const payload = await applyLocalProfile(baseUrl(), profile.filename, mode);
+			const label = profile.name || profile.filename;
+			const preassigned = payload?.preassigned_count as number | undefined;
+			if (mode === 'rules' && preassigned) {
+				success = `Using ${label}. Pre-assigned ${preassigned} bin${preassigned === 1 ? '' : 's'}.`;
+			} else {
+				success = `Using ${label} on this machine. Bin assignments were reset.`;
+			}
+			await sortingProfileStore.reload(baseUrl());
+			await loadLibrary();
+		} catch (e: unknown) {
+			error = e instanceof Error ? e.message : 'Failed to apply local sorting profile';
+		} finally {
+			localApplyingFilename = null;
+		}
+	}
+
+	async function confirmDeleteLocal() {
+		const profile = pendingDelete;
+		if (!profile) return;
+		localDeleteOpen = false;
+		deletingFilename = profile.filename;
+		error = null;
+		try {
+			await deleteLocalProfile(baseUrl(), profile.filename);
+			await loadLibrary();
+			success = `Deleted ${profile.name || profile.filename}.`;
+		} catch (e: unknown) {
+			error = e instanceof Error ? e.message : 'Failed to delete local sorting profile';
+		} finally {
+			deletingFilename = null;
 		}
 	}
 
@@ -516,6 +613,107 @@
 		<StatusBanner message={warning ?? ''} variant="warning" />
 		<StatusBanner message={error ?? ''} variant="error" />
 
+		<input
+			bind:this={fileInput}
+			type="file"
+			accept="application/json,.json"
+			class="hidden"
+			onchange={handleUploadFile}
+		/>
+
+		{#if library}
+			<div class="mb-6">
+				<div class="mb-3 flex items-center justify-between gap-3">
+					<h3 class="text-sm font-semibold uppercase tracking-wider text-text-muted">
+						Local profiles
+					</h3>
+					<button
+						type="button"
+						onclick={() => fileInput?.click()}
+						disabled={uploading}
+						class="flex items-center gap-2 border border-border bg-surface px-3 py-1.5 text-sm text-text transition-colors hover:bg-bg disabled:opacity-50"
+					>
+						<Upload size={14} />
+						{uploading ? 'Uploading…' : 'Upload JSON'}
+					</button>
+				</div>
+
+				{#if localProfiles().length === 0}
+					<div class="border border-border bg-surface px-4 py-6 text-center text-sm text-text-muted">
+						No local profiles saved yet. Upload a profile JSON to keep it on this machine.
+					</div>
+				{:else}
+					<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+						{#each localProfiles() as profile}
+							<div
+								class="setup-card-shell flex h-full flex-col overflow-hidden border transition-colors {profile.is_active
+									? 'border-success ring-1 ring-success/20'
+									: 'border-border hover:border-text-muted'}"
+							>
+								<div class="setup-card-header px-3 py-2 text-sm">
+									<div class="flex items-start justify-between gap-3">
+										<div class="min-w-0 flex-1">
+											<div class="truncate text-sm font-semibold text-text">
+												{profile.name || profile.filename}
+											</div>
+											<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+												<span class="font-mono">local:{profile.filename}</span>
+												{#if profile.is_active}
+													<span
+														class="border border-success/30 bg-success/10 px-1.5 py-0.5 font-medium uppercase tracking-wide text-success"
+														>Active</span
+													>
+												{/if}
+											</div>
+										</div>
+										<div class="flex shrink-0 items-center gap-2">
+											<button
+												type="button"
+												onclick={() => requestApplyLocal(profile)}
+												disabled={localApplyingFilename === profile.filename || Boolean(profile.error)}
+												class="border border-border bg-white px-3 py-2 text-sm text-text transition-colors hover:bg-bg disabled:opacity-50"
+											>
+												{localApplyingFilename === profile.filename ? 'Activating…' : 'activate'}
+											</button>
+											<button
+												type="button"
+												onclick={() => {
+													pendingDelete = profile;
+													localDeleteOpen = true;
+												}}
+												disabled={deletingFilename === profile.filename}
+												title="Delete local profile"
+												class="border border-border bg-white p-2 text-text-muted transition-colors hover:bg-bg hover:text-danger disabled:opacity-50"
+											>
+												<Trash2 size={16} />
+											</button>
+										</div>
+									</div>
+								</div>
+								<div class="setup-card-body border-t border-border px-4 py-3 text-xs text-text-muted">
+									{#if profile.error}
+										<span class="text-amber-700 dark:text-amber-300">Unreadable: {profile.error}</span>
+									{:else}
+										<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+											{#if profile.rule_count != null}<span>{profile.rule_count} rules</span>{/if}
+											{#if profile.category_count != null}
+												<span aria-hidden="true">·</span>
+												<span>{profile.category_count} categories</span>
+											{/if}
+											{#if profile.profile_type}
+												<span aria-hidden="true">·</span>
+												<span>{profile.profile_type}</span>
+											{/if}
+										</div>
+									{/if}
+								</div>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/if}
+
 		{#if loading && !library}
 			<Spinner />
 		{:else if !library}
@@ -610,4 +808,77 @@
 			: null}
 		onVersionChange={(versionId) => void handleDetailsModalVersionChange(versionId)}
 	/>
+
+	<Modal bind:open={localApplyOpen} title="Activate local profile">
+		{#if pendingLocal !== null}
+			{@const profile = pendingLocal}
+			<div class="flex flex-col gap-4">
+				<p class="text-sm text-text">
+					Activate <span class="font-semibold">{profile.name || profile.filename}</span>?
+				</p>
+				<p class="text-sm text-text-muted">Choose how bins should be initialized.</p>
+				<div class="flex flex-col gap-2 border border-border bg-bg p-3 text-sm text-text-muted">
+					<div>
+						<span class="font-medium text-text">Reset (dynamic)</span> — clear every bin;
+						categories are assigned as pieces arrive.
+					</div>
+					<div>
+						<span class="font-medium text-text">Pre-assign (rule order)</span> — seed bins in the
+						order of the profile's rules.
+					</div>
+				</div>
+				<div class="flex flex-wrap items-center justify-end gap-2 border-t border-border pt-3">
+					<button
+						type="button"
+						onclick={() => (localApplyOpen = false)}
+						class="border border-border bg-surface px-3 py-1.5 text-sm text-text hover:bg-bg"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onclick={() => void confirmApplyLocal('empty')}
+						class="border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-bg"
+					>
+						Reset bins
+					</button>
+					<button
+						type="button"
+						onclick={() => void confirmApplyLocal('rules')}
+						class="border border-primary bg-primary/10 px-3 py-1.5 text-sm font-medium text-primary hover:bg-primary/20"
+					>
+						Pre-assign from rules
+					</button>
+				</div>
+			</div>
+		{/if}
+	</Modal>
+
+	<Modal bind:open={localDeleteOpen} title="Delete local profile">
+		{#if pendingDelete !== null}
+			{@const profile = pendingDelete}
+			<div class="flex flex-col gap-4">
+				<p class="text-sm text-text">
+					Delete <span class="font-semibold">{profile.name || profile.filename}</span> from this
+					machine? This removes the saved JSON file.
+				</p>
+				<div class="flex items-center justify-end gap-2 border-t border-border pt-3">
+					<button
+						type="button"
+						onclick={() => (localDeleteOpen = false)}
+						class="border border-border bg-surface px-3 py-1.5 text-sm text-text hover:bg-bg"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onclick={() => void confirmDeleteLocal()}
+						class="border border-danger bg-danger/10 px-3 py-1.5 text-sm font-medium text-danger hover:bg-danger/20"
+					>
+						Delete
+					</button>
+				</div>
+			</div>
+		{/if}
+	</Modal>
 </div>

--- a/software/sorter/frontend/src/routes/settings/chute-aiming/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/chute-aiming/+page.svelte
@@ -312,7 +312,7 @@
 		try {
 			const p = await post('/api/hardware-config/chute/move-to-virtual-bin', {
 				num_sections: numSections,
-				bins_in_section: testBinsPerSection,
+				bins_in_section: selected.binCount,
 				section_index: selected.section,
 				bin_index: selected.bin
 			});

--- a/software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py
+++ b/software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py
@@ -300,7 +300,6 @@ def stage_write_env() -> None:
         "export DEBUG_LEVEL=2\n"
         "export PYTHONUNBUFFERED=1\n"
         'export MACHINE_SPECIFIC_PARAMS_PATH="../machine.toml"\n'
-        f'export SORTING_PROFILE_PATH="{SOFTWARE_DIR}/sorter/backend/sorting_profile.json"\n'
         "export SORTER_API_HOST=0.0.0.0\n"
         f'export SORTER_API_ALLOWED_ORIGINS="http://{hostname}:5173,http://localhost:5173"\n'
     )


### PR DESCRIPTION
Grab-bag of updates on this branch.

## Storage layers: allow 6 bins per layer
- Add `6` to `ALLOWED_STORAGE_LAYER_BIN_COUNTS` (single source of truth in `hardware.py`); the GET `/api/hardware-config` feeds the per-layer dropdown and the POST validates against it.
- Match the two frontend hardcoded fallbacks (`StorageLayerSettingsSection.svelte`, `ServoLayerCalibrator.svelte`).
- 6 divides evenly into the 6-section layout (1 bin/section), so the dropdown and validation work everywhere as-is.

## Local sorting profiles
- Upload + on-disk profile library; drop `SORTING_PROFILE_PATH`.

## Chute-aiming
- Fix undefined `testBinsPerSection` in test aim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)