### PR TITLE
stallguard: add DISABLE_STALLGUARD env kill switch

### DIFF
--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -5,11 +5,19 @@
 # Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 
+import os
 import time
 import json
 from .bus import MCUDevice, BaseCommandCode
 import struct
 from global_config import GlobalConfig
+
+# Kill switch for the firmware StallGuard/DIAG path. When set, the backend never
+# sends ENABLE_STALL_DETECTION / GET_STALL_STATUS / CLEAR_STALL (0x1A/0x1B/0x1C)
+# and never writes SGTHRS/TCOOLTHRS — for boards (e.g. basically v1-1) whose DIAG
+# isn't wired, where the v0.6.0 stallguard polling returns corrupt/partial frames
+# and fails moves. Read once at import; set in the machine .env before start.
+DISABLE_STALLGUARD = os.getenv("DISABLE_STALLGUARD", "0") == "1"
 
 class InterfaceCommandCode(BaseCommandCode):
     """Command codes specific to the Sorter Interface."""
@@ -374,10 +382,14 @@ class StepperMotor:
         self._dev.send_command(InterfaceCommandCode.STEPPER_DRV_WRITE_REGISTER, self._channel, payload)
 
     def enable_stall_detection(self, enable: bool) -> None:
+        if DISABLE_STALLGUARD:
+            return
         payload = struct.pack("<?", enable)
         self._dev.send_command(InterfaceCommandCode.STEPPER_ENABLE_STALL_DETECTION, self._channel, payload)
 
     def clear_stall(self) -> None:
+        if DISABLE_STALLGUARD:
+            return
         self._dev.send_command(InterfaceCommandCode.STEPPER_CLEAR_STALL, self._channel, b'')
 
     @property
@@ -791,6 +803,8 @@ class SorterInterface(MCUDevice):
         """Return this board's stall bitmask: bit i set => stepper channel i is
         latched-stalled. One bus round-trip covers every channel on the board.
         Channel arg is ignored by the firmware, so we send 0."""
+        if DISABLE_STALLGUARD:
+            return 0
         res = self.send_command(InterfaceCommandCode.STEPPER_GET_STALL_STATUS, 0, b"")
         return res.payload[0] if res.payload else 0
 

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -966,6 +966,14 @@ def applyStepperStallguard(
     slower than cruise, below the TCOOLTHRS velocity floor where DIAG is inactive.)
     Steppers with no entry, or enabled=false, are simply left off.
     """
+    from hardware.sorter_interface import DISABLE_STALLGUARD
+
+    if DISABLE_STALLGUARD:
+        gc.logger.info(
+            f"Stepper '{stepper_name}' StallGuard skipped (DISABLE_STALLGUARD=1)."
+        )
+        return
+
     config = configs.get(stepper_name)
     if config is None:
         return

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -627,13 +627,17 @@ def main() -> None:
     # `stepper_stall` incident on a stall. Detection is on for all moves (armed at
     # hardware init), so this watcher needs no machine-state gating. Off the main
     # loop so the UART reads never hitch operation.
-    if not _noPowerModeActive(gc):
+    from hardware.sorter_interface import DISABLE_STALLGUARD
+
+    if not _noPowerModeActive(gc) and not DISABLE_STALLGUARD:
         stall_monitor = StepperStallMonitor(gc)
         threading.Thread(
             target=stall_monitor.run,
             daemon=True,
             name="stall-monitor",
         ).start()
+    elif DISABLE_STALLGUARD:
+        gc.logger.info("StallGuard monitor not started (DISABLE_STALLGUARD=1).")
 
     last_heartbeat = time.time()
     last_frame_record = time.time()


### PR DESCRIPTION
Adds a `DISABLE_STALLGUARD=1` env var that skips all StallGuard/DIAG paths at runtime — no stall detection enable/disable, no SGTHRS/TCOOLTHRS writes, no stall status polling, no stall monitor thread.

Needed for boards (e.g. basically v1-1) whose DIAG pin isn't wired, where the v0.6.0 stallguard polling was returning corrupt/partial frames and failing moves.

**TODO:** still needs testing on boards without diag wiring — was having trouble on Chris' machine and added this to reduce potential variables.