### PR TITLE
docs: add copy button to all code blocks site-wide

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -83,5 +83,6 @@
         </p>
       </footer>
     </div>
+    <script src="{{ '/assets/copy-code.js' | relative_url }}" defer></script>
   </body>
 </html>

--- a/docs/assets/copy-code.js
+++ b/docs/assets/copy-code.js
@@ -1,0 +1,73 @@
+// Adds a "Copy" button to every fenced code block on the docs site.
+// Hooks `div.highlighter-rouge` (the Rouge block wrapper). Inline code is a
+// bare <code> with the same class, so the `div.` qualifier excludes it.
+(function () {
+  function codeText(block) {
+    var code = block.querySelector('pre code') || block.querySelector('pre');
+    var text = code ? code.innerText : block.innerText;
+    return text.replace(/\n+$/, '');
+  }
+
+  function fallbackCopy(text) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      document.execCommand('copy');
+    } catch (e) {
+      /* no-op */
+    }
+    document.body.removeChild(ta);
+  }
+
+  function attach(block) {
+    if (block.dataset.copyAttached) return;
+    block.dataset.copyAttached = 'true';
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'copy-code-button';
+    btn.textContent = 'Copy';
+    btn.setAttribute('aria-label', 'Copy code to clipboard');
+
+    var resetTimer;
+    btn.addEventListener('click', function () {
+      var text = codeText(block);
+      var markCopied = function () {
+        btn.textContent = 'Copied';
+        btn.classList.add('is-copied');
+        clearTimeout(resetTimer);
+        resetTimer = setTimeout(function () {
+          btn.textContent = 'Copy';
+          btn.classList.remove('is-copied');
+        }, 2000);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(markCopied, function () {
+          fallbackCopy(text);
+          markCopied();
+        });
+      } else {
+        fallbackCopy(text);
+        markCopied();
+      }
+    });
+
+    block.appendChild(btn);
+  }
+
+  function init() {
+    var blocks = document.querySelectorAll('div.highlighter-rouge');
+    Array.prototype.forEach.call(blocks, attach);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/docs/assets/copy-code.js
+++ b/docs/assets/copy-code.js
@@ -2,6 +2,11 @@
 // Hooks `div.highlighter-rouge` (the Rouge block wrapper). Inline code is a
 // bare <code> with the same class, so the `div.` qualifier excludes it.
 (function () {
+  var COPY_ICON =
+    '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" stroke-linejoin="miter" aria-hidden="true"><rect x="9" y="9" width="12" height="12"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+  var CHECK_ICON =
+    '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="square" stroke-linejoin="miter" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+
   function codeText(block) {
     var code = block.querySelector('pre code') || block.querySelector('pre');
     var text = code ? code.innerText : block.innerText;
@@ -31,19 +36,22 @@
     var btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'copy-code-button';
-    btn.textContent = 'Copy';
+    btn.innerHTML = COPY_ICON;
     btn.setAttribute('aria-label', 'Copy code to clipboard');
+    btn.setAttribute('title', 'Copy');
 
     var resetTimer;
     btn.addEventListener('click', function () {
       var text = codeText(block);
       var markCopied = function () {
-        btn.textContent = 'Copied';
+        btn.innerHTML = CHECK_ICON;
         btn.classList.add('is-copied');
+        btn.setAttribute('title', 'Copied');
         clearTimeout(resetTimer);
         resetTimer = setTimeout(function () {
-          btn.textContent = 'Copy';
+          btn.innerHTML = COPY_ICON;
           btn.classList.remove('is-copied');
+          btn.setAttribute('title', 'Copy');
         }, 2000);
       };
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -330,6 +330,47 @@ pre code {
   font-size: inherit;
 }
 
+div.highlighter-rouge {
+  position: relative;
+}
+
+.copy-code-button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #cbcac6;
+  background: rgba(245, 244, 241, 0.08);
+  border: 1px solid rgba(245, 244, 241, 0.22);
+  padding: 3px 9px;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease,
+    border-color 0.12s ease;
+}
+
+div.highlighter-rouge:hover .copy-code-button,
+.copy-code-button:focus-visible {
+  opacity: 1;
+}
+
+.copy-code-button:hover {
+  color: #ffffff;
+  background: rgba(245, 244, 241, 0.16);
+  border-color: rgba(245, 244, 241, 0.45);
+}
+
+.copy-code-button.is-copied {
+  opacity: 1;
+  color: #ffffff;
+  background: rgba(0, 133, 43, 0.85);
+  border-color: rgba(0, 133, 43, 0.9);
+}
+
 blockquote {
   margin: 1.2rem 0;
   padding: 12px 16px;

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -339,18 +339,23 @@ div.highlighter-rouge {
   top: 6px;
   right: 6px;
   z-index: 2;
-  font-family: "IBM Plex Sans", system-ui, sans-serif;
-  font-size: 0.68rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   color: #cbcac6;
   background: rgba(245, 244, 241, 0.08);
   border: 1px solid rgba(245, 244, 241, 0.22);
-  padding: 3px 9px;
   cursor: pointer;
-  opacity: 0.5;
+  opacity: 0.55;
   transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease,
     border-color 0.12s ease;
+}
+
+.copy-code-button svg {
+  display: block;
 }
 
 div.highlighter-rouge:hover .copy-code-button,


### PR DESCRIPTION
## What

Adds an unobtrusive **Copy** button to every fenced code block across the docs site.

- New `assets/copy-code.js` hooks `div.highlighter-rouge` (the Rouge block wrapper) and appends a copy button. Inline code is a bare `<code>` with the same class, so the `div.` qualifier excludes it.
- Button sits subtly at the top-right, goes solid on block hover / keyboard focus, and flashes **Copied** (green) for 2s on click.
- Uses the async Clipboard API with an `execCommand` textarea fallback for older/insecure contexts.
- Styles added to `assets/site.css`; script wired into the shared `_layouts/default.html`, so it applies to every page automatically.

## Verification
- Built locally with Jekyll: script tag renders on pages, `/assets/copy-code.js` serves 200, CSS rules present.
- Chrome automation wasn't available this session, so the on-page click was not screenshotted — easy to eyeball at `http://localhost:4000/sorter/troubleshooting/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)