### PR TITLE
Log CORS/WebSocket origin rejections for diagnosis

### DIFF
--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -70,7 +70,12 @@ app = FastAPI(title="Sorter API", version="0.0.1")
 # this machine's own addresses (plus any SORTER_API_ALLOWED_ORIGINS override).
 class _DeviceCORSMiddleware(CORSMiddleware):
     def is_allowed_origin(self, origin: str) -> bool:
-        return is_ui_origin_allowed(origin)
+        allowed = is_ui_origin_allowed(origin)
+        if not allowed and shared_state.gc_ref is not None:
+            from server.security import describe_origin_decision
+
+            shared_state.gc_ref.logger.info(f"[CORS reject] {describe_origin_decision(origin)}")
+        return allowed
 
 
 app.add_middleware(
@@ -566,6 +571,12 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         websocket.headers.get("Origin"),
         client_host,
     ):
+        if shared_state.gc_ref is not None:
+            from server.security import describe_origin_decision
+
+            shared_state.gc_ref.logger.info(
+                f"[WS reject] client_host={client_host!r} {describe_origin_decision(websocket.headers.get('Origin'))}"
+            )
         await websocket.close(
             code=status.WS_1008_POLICY_VIOLATION,
             reason="WebSocket origin not allowed.",

--- a/software/sorter/backend/server/security.py
+++ b/software/sorter/backend/server/security.py
@@ -142,6 +142,29 @@ def is_ui_origin_allowed(origin: str | None) -> bool:
     return host in _allowed_hosts()
 
 
+def describe_origin_decision(origin: str | None) -> str:
+    # Diagnostic for CORS/websocket rejections: shows the raw origin, how it
+    # normalized, the parsed host/port, and everything the allowlist compares
+    # against, so a remote "CORS error" can be diagnosed from the backend log.
+    normalized = normalize_origin(origin)
+    allowed = is_ui_origin_allowed(origin)
+    host = ""
+    port_str = ""
+    if normalized is not None:
+        parsed = urlsplit(normalized.lower())
+        host = parsed.hostname or ""
+        try:
+            port = parsed.port
+            port_str = str(port) if port is not None else ("443" if parsed.scheme == "https" else "80")
+        except ValueError:
+            port_str = "<invalid>"
+    return (
+        f"allowed={allowed} origin={origin!r} normalized={normalized!r} "
+        f"host={host!r} port={port_str!r} ui_port={_ui_port()!r} "
+        f"explicit_overrides={explicit_allowed_origins()} device_hosts={sorted(_this_device_hosts())}"
+    )
+
+
 def websocket_connection_allowed(
     origin: str | None,
     client_host: str | None,


### PR DESCRIPTION
## Summary
Adds backend logging whenever an HTTP CORS or WebSocket connection is rejected by the origin allowlist, so remote "CORS error" reports can be diagnosed from `journalctl` without guesswork.

- `server/security.py` — new `describe_origin_decision()` helper that reports the raw origin, normalized form, parsed host/port, configured `SORTER_UI_PORT`, any `SORTER_API_ALLOWED_ORIGINS` overrides, and the current device allowlist.
- `server/api.py` — logs `[CORS reject]` in `_DeviceCORSMiddleware` and `[WS reject]` in the `/ws` endpoint.

## Motivation
A SorterOS install served the Svelte frontend via a port-80 reverse proxy. The browser's `Origin` then carries the implicit port 80, but `is_ui_origin_allowed` requires the port to equal `SORTER_UI_PORT` (default 5173), so every backend call was rejected as a CORS error. This logging makes the exact mismatch (parsed `port` vs `ui_port`, host vs `device_hosts`) visible in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)