### PR TITLE
Add request/probe/websocket connectivity diagnostics

### DIFF
--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -88,13 +88,27 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+# Set SORTER_LOG_REQUESTS=1 to log EVERY request (including GETs, which are
+# otherwise silent) with its Origin header and client address — needed to see
+# whether a remote browser's calls are even reaching the backend.
+_LOG_ALL_REQUESTS = os.environ.get("SORTER_LOG_REQUESTS", "").lower() in ("1", "true", "yes")
+
+
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        if request.method != "GET":
-            if shared_state.gc_ref is not None:
-                shared_state.gc_ref.logger.info(f"[API] {request.method} {request.url.path}")
-        response: Response = await call_next(request)
-        return response
+        gc = shared_state.gc_ref
+        if _LOG_ALL_REQUESTS and gc is not None:
+            client = request.client.host if request.client is not None else None
+            gc.logger.info(
+                f"[req] {request.method} {request.url.path} "
+                f"origin={request.headers.get('origin')!r} client={client!r}"
+            )
+            response: Response = await call_next(request)
+            gc.logger.info(f"[req] <- {response.status_code} {request.method} {request.url.path}")
+            return response
+        if request.method != "GET" and gc is not None:
+            gc.logger.info(f"[API] {request.method} {request.url.path}")
+        return await call_next(request)
 
 app.add_middleware(RequestLoggingMiddleware)
 

--- a/software/sorter/frontend/src/lib/api/ws.ts
+++ b/software/sorter/frontend/src/lib/api/ws.ts
@@ -9,7 +9,7 @@ export function connectWebSocket(
 	const ws = new WebSocket(url);
 
 	ws.onopen = () => {
-		console.log('WebSocket connected');
+		console.log('WebSocket connected', url);
 	};
 
 	ws.onmessage = (message) => {
@@ -18,12 +18,14 @@ export function connectWebSocket(
 	};
 
 	ws.onerror = (error) => {
-		console.error('WebSocket error:', error);
+		console.error('WebSocket error:', url, error);
 		onError?.(error);
 	};
 
-	ws.onclose = () => {
-		console.log('WebSocket disconnected');
+	ws.onclose = (event) => {
+		// code 1008 = policy violation (backend rejected the Origin); 1006 = abnormal
+		// close, usually the connection never reached the server (refused / blocked).
+		console.log('WebSocket disconnected', url, 'code=', event.code, 'reason=', event.reason);
 		onClose?.();
 	};
 

--- a/software/sorter/frontend/src/lib/backend.ts
+++ b/software/sorter/frontend/src/lib/backend.ts
@@ -139,7 +139,9 @@ export async function probeBackendConnection(
 				restartRequested: false
 			};
 		}
-	} catch {
+		console.warn(`[backend] /health probe returned non-ok status ${response.status} for ${backendBaseUrl}/health`);
+	} catch (err) {
+		console.warn(`[backend] /health probe failed for ${backendBaseUrl}/health:`, err);
 		// Try supervisor next.
 	}
 
@@ -161,7 +163,8 @@ export async function probeBackendConnection(
 					restartRequested: Boolean(data?.restart_requested)
 				};
 			}
-		} catch {
+		} catch (err) {
+			console.warn(`[backend] supervisor probe failed for ${supervisorBaseUrl}/api/supervisor/status:`, err);
 			// Supervisor unavailable too.
 		}
 	}

--- a/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
+++ b/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
@@ -160,6 +160,13 @@
 	}
 
 	onMount(() => {
+		console.info('[backend] resolved endpoints', {
+			location: window.location.href,
+			baseUrl: baseUrl(),
+			wsUrl: wsUrl(),
+			defaultHttpBase: getBackendHttpBase(),
+			defaultWsBase: getBackendWsBase()
+		});
 		void poll();
 		const interval = setInterval(() => void poll(), HEALTH_INTERVAL_MS);
 		return () => clearInterval(interval);


### PR DESCRIPTION
## Summary
Follow-up to #170/#171. Adds opt-in diagnostics for the "frontend can't reach backend / CORS" class of problem.

**Backend** (`server/api.py`): `SORTER_LOG_REQUESTS=1` logs every request — including GETs, which `RequestLoggingMiddleware` previously skipped — with the `Origin` header, client address, and response status. Confirms whether a remote browser's calls actually arrive.

**Frontend**:
- `backend.ts` — surface the previously silently-swallowed `/health` and supervisor probe errors to the console (with the target URL).
- `BackendConnectionGuard.svelte` — log the resolved backend/ws endpoints + `window.location` on mount.
- `api/ws.ts` — include the URL on open/error, and the close `code`/`reason` on close (1008 = origin rejected, 1006 = never reached the server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)