### PR TITLE
Add SORTER_API_ALLOW_ANY_ORIGIN escape hatch

### DIFF
--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -179,12 +179,14 @@ def runServer(gc: GlobalConfig) -> None:
     from server.security import (
         compute_allowed_ui_origins,
         explicit_allowed_origins,
+        allow_any_origin,
         _this_device_hosts,
         _ui_port,
     )
 
     gc.logger.info(
         f"[server] binding host={host!r} port=8000 ui_port={_ui_port()!r} "
+        f"allow_any_origin={allow_any_origin()} "
         f"SORTER_API_ALLOWED_ORIGINS_override={explicit_allowed_origins()} "
         f"effective_allowed_origins={compute_allowed_ui_origins()} "
         f"device_hosts={sorted(_this_device_hosts())}"

--- a/software/sorter/backend/server/security.py
+++ b/software/sorter/backend/server/security.py
@@ -53,6 +53,13 @@ def _ui_port() -> str:
     return os.getenv("SORTER_UI_PORT", "5173").strip() or "5173"
 
 
+def allow_any_origin() -> bool:
+    # ESCAPE HATCH: SORTER_API_ALLOW_ANY_ORIGIN=1 accepts any origin (and any
+    # cross-origin websocket). Defeats the device-scoped allowlist entirely, so
+    # it's a temporary bring-up measure on a trusted LAN only, not a default.
+    return os.getenv("SORTER_API_ALLOW_ANY_ORIGIN", "").lower() in ("1", "true", "yes")
+
+
 def explicit_allowed_origins() -> list[str]:
     override = os.getenv("SORTER_API_ALLOWED_ORIGINS")
     if not override:
@@ -124,6 +131,8 @@ def is_ui_origin_allowed(origin: str | None) -> bool:
     normalized = normalize_origin(origin)
     if normalized is None:
         return False
+    if allow_any_origin():
+        return True
     if normalized.lower() in {item.lower() for item in explicit_allowed_origins()}:
         return True
     parsed = urlsplit(normalized.lower())


### PR DESCRIPTION
## Summary
Adds an env-gated wildcard for the origin allowlist as a temporary bring-up measure.

- `security.py` — `allow_any_origin()` returns true when `SORTER_API_ALLOW_ANY_ORIGIN=1`; `is_ui_origin_allowed` short-circuits to accept any origin. Covers both CORS fetches and websocket connections (both route through `is_ui_origin_allowed`). Off by default.
- `main.py` — startup log line now reports `allow_any_origin=` so an active escape hatch is visible in the log.

## Motivation
Unblocks a remote SorterOS machine where the proxy-served (port 80) Origin doesn't match the device-scoped allowlist, without per-machine `SORTER_API_ALLOWED_ORIGINS` tuning. Intended for trusted LAN use only — the device-scoped allowlist remains the secure default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)