### PR TITLE
backend: cap software/logs size and prune old session logs

### DIFF
--- a/software/sorter/backend/global_config.py
+++ b/software/sorter/backend/global_config.py
@@ -56,6 +56,7 @@ class GlobalConfig:
     brickognize_dump_root: Optional[Path]
     classification_burst_dump_root: Optional[Path]
     classification_skew_dump_root: Optional[Path]
+    max_log_bytes: int
     def __init__(self):
         from runtime_stats import RuntimeStatsCollector
 
@@ -64,6 +65,10 @@ class GlobalConfig:
         self.brickognize_dump_root: Optional[Path] = None
         self.classification_burst_dump_root: Optional[Path] = None
         self.classification_skew_dump_root: Optional[Path] = None
+        # Cap on the total size of run logs kept under software/logs/. At each
+        # startup we delete whole old session .log files (oldest-first) until
+        # the directory fits under this, so the SD card can't fill with logs.
+        self.max_log_bytes = 1 * 1024 ** 3
         self.disable_chute = False
         # On the restart branch we explicitly simulate the distributor: the
         # Waveshare layer-servo bus isn't reliably available, but C1-C4 must
@@ -158,6 +163,8 @@ def mkGlobalConfig() -> GlobalConfig:
         gc.classification_skew_dump_root = Path(log_dir).resolve() / "classification_skew" / gc.run_id
     log_file = os.path.join(log_dir, datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + ".log")
     gc.logger = Logger(gc.debug_level, log_file=log_file)
+    from log_pruner import pruneOldLogsAsync
+    pruneOldLogsAsync(gc, log_dir, log_file)
     # Profiler enable lives in machine_params.toml ([profiler] enabled), toggled
     # from the Performance settings page. Defaults OFF: profiling adds per-call
     # timing overhead across hot loops (notably the frontend camera feed) and

--- a/software/sorter/backend/log_pruner.py
+++ b/software/sorter/backend/log_pruner.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+import os
+import platform
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from global_config import GlobalConfig
+
+DEFAULT_MAX_LOG_BYTES = 1 * 1024 ** 3
+
+# Deleting several multi-GB run logs off the SD card at once can saturate disk
+# I/O and stall the camera / hardware hot loops. The prune therefore runs on a
+# detached daemon thread, drops itself to idle I/O + CPU priority, and paces
+# each unlink so it can never starve the live session of disk bandwidth.
+_DELETE_PACING_S = 0.1
+
+# Arch-specific __NR_ioprio_set — glibc ships no wrapper for it, so we go
+# straight through syscall(). Numbers differ per ABI; the Orange Pi is aarch64.
+_IOPRIO_SET_SYSCALL = {
+    "x86_64": 251,
+    "aarch64": 30,
+    "armv7l": 289,
+    "armv6l": 289,
+    "i686": 289,
+}
+_IOPRIO_CLASS_IDLE = 3
+_IOPRIO_CLASS_SHIFT = 13
+_IOPRIO_WHO_PROCESS = 1
+
+
+def _deprioritizeCurrentThread() -> None:
+    try:
+        os.nice(19)
+    except Exception:
+        pass
+    syscall_nr = _IOPRIO_SET_SYSCALL.get(platform.machine())
+    if syscall_nr is None:
+        return
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        tid = threading.get_native_id()
+        prio = _IOPRIO_CLASS_IDLE << _IOPRIO_CLASS_SHIFT
+        libc.syscall(syscall_nr, _IOPRIO_WHO_PROCESS, tid, prio)
+    except Exception:
+        pass
+
+
+def _pruneOldLogsBlocking(gc: "GlobalConfig", log_dir: Path, current_log: Path, max_bytes: int) -> None:
+    _deprioritizeCurrentThread()
+
+    entries: list[tuple[float, int, Path]] = []
+    try:
+        for path in log_dir.glob("*.log"):
+            if path == current_log:
+                continue
+            try:
+                st = path.stat()
+            except OSError:
+                continue
+            entries.append((st.st_mtime, st.st_size, path))
+    except OSError:
+        return
+
+    try:
+        current_size = current_log.stat().st_size
+    except OSError:
+        current_size = 0
+
+    # The live session is always kept; we only ever remove whole prior .log
+    # files, oldest-first, until everything fits under the cap. Never truncate —
+    # a partial file would be a partial session, which we explicitly avoid.
+    entries.sort(key=lambda e: e[0])
+    total = current_size + sum(size for _, size, _ in entries)
+    if total <= max_bytes:
+        return
+
+    freed = 0
+    deleted = 0
+    for _, size, path in entries:
+        if total <= max_bytes:
+            break
+        try:
+            path.unlink()
+        except OSError:
+            continue
+        total -= size
+        freed += size
+        deleted += 1
+        time.sleep(_DELETE_PACING_S)
+
+    if deleted:
+        gc.logger.info(
+            f"log prune: removed {deleted} old session log(s), "
+            f"freed {freed / 1024 ** 2:.0f} MiB (cap {max_bytes / 1024 ** 2:.0f} MiB)"
+        )
+
+
+def pruneOldLogsAsync(gc: "GlobalConfig", log_dir: Union[str, Path], current_log: Union[str, Path]) -> None:
+    max_bytes = getattr(gc, "max_log_bytes", DEFAULT_MAX_LOG_BYTES)
+    if not max_bytes or max_bytes <= 0:
+        return
+    thread = threading.Thread(
+        target=_pruneOldLogsBlocking,
+        args=(gc, Path(log_dir), Path(current_log), int(max_bytes)),
+        name="log-pruner",
+        daemon=True,
+    )
+    thread.start()


### PR DESCRIPTION
## What

Caps the total size of run logs under `software/logs/` and prunes old ones at startup.

Run logs are written one file per `main.py` start (`global_config.py` opens a `<datetime>.log` via `Logger`). They grew unbounded — on Chris' Orange Pi this filled the 29G SD card to 100% (7.4G of logs, single files up to 2.2G).

## How

- New `GlobalConfig.max_log_bytes` param (default **1 GiB**, hardcoded — no toml/env knob, per request).
- At each startup, `pruneOldLogsAsync` deletes whole old session `.log` files **oldest-first** until the directory fits under the cap.
- **By session, never partial:** one `.log` = one run = one session. We only ever `unlink` complete files — never truncate — and the **live session is always kept** (and never counted against itself for deletion).
- **Can't choke the system:** runs on a detached daemon thread that drops itself to **idle I/O priority** (`ioprio_set`, arch-aware syscall — verified `aarch64`=30 on the Pi) plus `nice(19)`, and **paces each unlink** (0.1s) so a multi-GB cleanup can't starve the camera / hardware hot loops. All best-effort and wrapped — no-ops on macOS, never raises into startup.

## Test

Functional self-test run on Chris' aarch64 Pi under its backend venv: keeps the live log, deletes oldest-first to fit the cap, never truncates, idle-priority path applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)