### PR TITLE
backend: make persistent log-file dumping opt-in (DUMP_BACKEND_LOGS)

### DIFF
--- a/software/sorter/backend/global_config.py
+++ b/software/sorter/backend/global_config.py
@@ -57,6 +57,7 @@ class GlobalConfig:
     classification_burst_dump_root: Optional[Path]
     classification_skew_dump_root: Optional[Path]
     max_log_bytes: int
+    dump_logs_to_file: bool
     def __init__(self):
         from runtime_stats import RuntimeStatsCollector
 
@@ -69,6 +70,7 @@ class GlobalConfig:
         # startup we delete whole old session .log files (oldest-first) until
         # the directory fits under this, so the SD card can't fill with logs.
         self.max_log_bytes = 1 * 1024 ** 3
+        self.dump_logs_to_file = False
         self.disable_chute = False
         # On the restart branch we explicitly simulate the distributor: the
         # Waveshare layer-servo bus isn't reliably available, but C1-C4 must
@@ -161,10 +163,16 @@ def mkGlobalConfig() -> GlobalConfig:
     # under software/logs/ that survives across runs by gc.run_id.
     if os.getenv("CLASSIFICATION_SKEW_DUMP_IMAGES", "0") == "1":
         gc.classification_skew_dump_root = Path(log_dir).resolve() / "classification_skew" / gc.run_id
+    # Persistent per-run .log dumping is opt-in (DUMP_BACKEND_LOGS=1). It is
+    # unconditional otherwise and, at DEBUG_LEVEL>=2, floods multi-GB files that
+    # have filled SD cards. journald already captures stdout, so default off.
     log_file = os.path.join(log_dir, datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + ".log")
-    gc.logger = Logger(gc.debug_level, log_file=log_file)
+    gc.dump_logs_to_file = os.getenv("DUMP_BACKEND_LOGS", "0") == "1"
+    gc.logger = Logger(gc.debug_level, log_file=log_file if gc.dump_logs_to_file else None)
+    # Prune regardless of the flag so previously-accumulated logs still get
+    # cleaned; only protect the live file when we are actually writing one.
     from log_pruner import pruneOldLogsAsync
-    pruneOldLogsAsync(gc, log_dir, log_file)
+    pruneOldLogsAsync(gc, log_dir, log_file if gc.dump_logs_to_file else None)
     # Profiler enable lives in machine_params.toml ([profiler] enabled), toggled
     # from the Performance settings page. Defaults OFF: profiling adds per-call
     # timing overhead across hot loops (notably the frontend camera feed) and

--- a/software/sorter/backend/log_pruner.py
+++ b/software/sorter/backend/log_pruner.py
@@ -4,7 +4,7 @@ import platform
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     from global_config import GlobalConfig
@@ -50,7 +50,7 @@ def _deprioritizeCurrentThread() -> None:
         pass
 
 
-def _pruneOldLogsBlocking(gc: "GlobalConfig", log_dir: Path, current_log: Path, max_bytes: int) -> None:
+def _pruneOldLogsBlocking(gc: "GlobalConfig", log_dir: Path, current_log: Optional[Path], max_bytes: int) -> None:
     _deprioritizeCurrentThread()
 
     entries: list[tuple[float, int, Path]] = []
@@ -66,10 +66,14 @@ def _pruneOldLogsBlocking(gc: "GlobalConfig", log_dir: Path, current_log: Path, 
     except OSError:
         return
 
-    try:
-        current_size = current_log.stat().st_size
-    except OSError:
-        current_size = 0
+    # current_log is None when file dumping is off — nothing live to protect,
+    # so we just trim the leftover .log files down to the cap.
+    current_size = 0
+    if current_log is not None:
+        try:
+            current_size = current_log.stat().st_size
+        except OSError:
+            current_size = 0
 
     # The live session is always kept; we only ever remove whole prior .log
     # files, oldest-first, until everything fits under the cap. Never truncate —
@@ -100,13 +104,13 @@ def _pruneOldLogsBlocking(gc: "GlobalConfig", log_dir: Path, current_log: Path, 
         )
 
 
-def pruneOldLogsAsync(gc: "GlobalConfig", log_dir: Union[str, Path], current_log: Union[str, Path]) -> None:
+def pruneOldLogsAsync(gc: "GlobalConfig", log_dir: Union[str, Path], current_log: Optional[Union[str, Path]]) -> None:
     max_bytes = getattr(gc, "max_log_bytes", DEFAULT_MAX_LOG_BYTES)
     if not max_bytes or max_bytes <= 0:
         return
     thread = threading.Thread(
         target=_pruneOldLogsBlocking,
-        args=(gc, Path(log_dir), Path(current_log), int(max_bytes)),
+        args=(gc, Path(log_dir), Path(current_log) if current_log is not None else None, int(max_bytes)),
         name="log-pruner",
         daemon=True,
     )


### PR DESCRIPTION
## What

Makes the backend's persistent `software/logs/<datetime>.log` dump **opt-in**. Default off.

## Why

The dump was **unconditional** — `global_config.py` always passed `log_file` to `Logger`, which always opens it, *independent of `DEBUG_LEVEL`*. At `DEBUG_LEVEL>=2` the `info()` hot-path flood grows these to multi-GB; on Chris' Orange Pi this filled the 29G SD card. stdout already goes to journald, so the file is redundant for normal runs.

## How

- New `DUMP_BACKEND_LOGS` env flag (matches the existing `*_DUMP_IMAGES` idiom) → `GlobalConfig.dump_logs_to_file`, default `False`. The `Logger` only opens the file when set.
- The #176 size-cap prune still runs when the flag is off, so logs accumulated *before* turning it off still get trimmed to the cap; `current_log` is `None` in that case (nothing live to protect, never truncates).

## Note (not addressed here)

journald on these machines is `Storage=volatile` + `SystemMaxUse=20M` — ~20 MB in RAM, wiped on reboot. With file dumps off, persistent log history is thin. Consider making journald persistent if a durable trail is wanted.

## Test

Smoke-tested both flag states: off → `current_log=None`, trims leftovers to cap oldest-first; on → live file protected and counted, never truncated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)