### PR TITLE
backend: unify pruning (logs + metric snapshots) into one system

### DIFF
--- a/software/sorter/backend/global_config.py
+++ b/software/sorter/backend/global_config.py
@@ -58,6 +58,7 @@ class GlobalConfig:
     classification_skew_dump_root: Optional[Path]
     max_log_bytes: int
     dump_logs_to_file: bool
+    metrics_retention_days: float
     def __init__(self):
         from runtime_stats import RuntimeStatsCollector
 
@@ -71,6 +72,11 @@ class GlobalConfig:
         # the directory fits under this, so the SD card can't fill with logs.
         self.max_log_bytes = 1 * 1024 ** 3
         self.dump_logs_to_file = False
+        # Age cap for the per-second metric snapshot tables in local_state.sqlite
+        # (runtime_perf + profiler). The pruner deletes rows older than this; the
+        # runtime-perf table writes one row/metric/second regardless of toggles,
+        # so without this the DB grows without bound (it hit 7 GB on one machine).
+        self.metrics_retention_days = 3.0
         self.disable_chute = False
         # On the restart branch we explicitly simulate the distributor: the
         # Waveshare layer-servo bus isn't reliably available, but C1-C4 must
@@ -169,10 +175,11 @@ def mkGlobalConfig() -> GlobalConfig:
     log_file = os.path.join(log_dir, datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + ".log")
     gc.dump_logs_to_file = os.getenv("DUMP_BACKEND_LOGS", "0") == "1"
     gc.logger = Logger(gc.debug_level, log_file=log_file if gc.dump_logs_to_file else None)
-    # Prune regardless of the flag so previously-accumulated logs still get
+    # Single background pruning system (logs + DB metric snapshots). Prune logs
+    # regardless of the dump flag so previously-accumulated logs still get
     # cleaned; only protect the live file when we are actually writing one.
-    from log_pruner import pruneOldLogsAsync
-    pruneOldLogsAsync(gc, log_dir, log_file if gc.dump_logs_to_file else None)
+    from pruner import runPruningAsync
+    runPruningAsync(gc, log_dir, log_file if gc.dump_logs_to_file else None)
     # Profiler enable lives in machine_params.toml ([profiler] enabled), toggled
     # from the Performance settings page. Defaults OFF: profiling adds per-call
     # timing overhead across hot loops (notably the frontend camera feed) and

--- a/software/sorter/backend/local_state.py
+++ b/software/sorter/backend/local_state.py
@@ -639,6 +639,42 @@ def record_runtime_perf_metric_snapshot(
         conn.commit()
 
 
+# Per-second snapshot tables that grow unbounded; the pruner trims these by age.
+_METRIC_SNAPSHOT_TABLES = ("runtime_perf_metric_snapshots", "profiler_metric_snapshots")
+
+
+def prune_metric_snapshots(
+    cutoff_recorded_at: float,
+    batch_size: int = 5000,
+    pacing_s: float = 0.05,
+) -> dict[str, int]:
+    initialize_local_state()
+    deleted: dict[str, int] = {}
+    for table in _METRIC_SNAPSHOT_TABLES:
+        removed = 0
+        while True:
+            # Oldest rows have the lowest ids and sort first, so the LIMIT
+            # subquery finds expired rows at the front of the scan — batched and
+            # committed per-batch so we never hold a long write lock or build a
+            # huge WAL. Table name is a fixed constant, not user input.
+            with _connection() as conn:
+                cur = conn.execute(
+                    f"DELETE FROM {table} WHERE id IN ("
+                    f"SELECT id FROM {table} WHERE recorded_at < ? LIMIT ?)",
+                    (float(cutoff_recorded_at), int(batch_size)),
+                )
+                n = cur.rowcount
+                conn.commit()
+            if n and n > 0:
+                removed += n
+            if not n or n < batch_size:
+                break
+            if pacing_s and pacing_s > 0:
+                time.sleep(pacing_s)
+        deleted[table] = removed
+    return deleted
+
+
 def get_machine_id() -> str | None:
     value = _read_state(_STATE_KEY_MACHINE_ID)
     return value if isinstance(value, str) and value.strip() else None

--- a/software/sorter/backend/pruner.py
+++ b/software/sorter/backend/pruner.py
@@ -9,13 +9,21 @@ from typing import TYPE_CHECKING, Optional, Union
 if TYPE_CHECKING:
     from global_config import GlobalConfig
 
-DEFAULT_MAX_LOG_BYTES = 1 * 1024 ** 3
+# Single background pruning system for everything that grows unbounded on the
+# machine: the software/logs/ run logs and the per-second metric snapshot tables
+# in local_state.sqlite. One daemon thread runs every _PRUNE_INTERVAL_S so long
+# sessions stay bounded (the runtime-perf snapshot writes one row/metric/second
+# regardless of any toggle), and it drops itself to idle I/O + CPU priority and
+# paces its deletes so a multi-GB cleanup can never choke the camera / hardware
+# hot loops.
 
-# Deleting several multi-GB run logs off the SD card at once can saturate disk
-# I/O and stall the camera / hardware hot loops. The prune therefore runs on a
-# detached daemon thread, drops itself to idle I/O + CPU priority, and paces
-# each unlink so it can never starve the live session of disk bandwidth.
-_DELETE_PACING_S = 0.1
+DEFAULT_MAX_LOG_BYTES = 1 * 1024 ** 3
+DEFAULT_METRICS_RETENTION_DAYS = 3.0
+
+_PRUNE_INTERVAL_S = 3600
+_LOG_DELETE_PACING_S = 0.1
+_DB_DELETE_BATCH = 5000
+_DB_DELETE_PACING_S = 0.05
 
 # Arch-specific __NR_ioprio_set — glibc ships no wrapper for it, so we go
 # straight through syscall(). Numbers differ per ABI; the Orange Pi is aarch64.
@@ -50,8 +58,9 @@ def _deprioritizeCurrentThread() -> None:
         pass
 
 
-def _pruneOldLogsBlocking(gc: "GlobalConfig", log_dir: Path, current_log: Optional[Path], max_bytes: int) -> None:
-    _deprioritizeCurrentThread()
+def _pruneLogs(gc: "GlobalConfig", log_dir: Path, current_log: Optional[Path], max_bytes: int) -> None:
+    if not max_bytes or max_bytes <= 0:
+        return
 
     entries: list[tuple[float, int, Path]] = []
     try:
@@ -95,7 +104,7 @@ def _pruneOldLogsBlocking(gc: "GlobalConfig", log_dir: Path, current_log: Option
         total -= size
         freed += size
         deleted += 1
-        time.sleep(_DELETE_PACING_S)
+        time.sleep(_LOG_DELETE_PACING_S)
 
     if deleted:
         gc.logger.info(
@@ -104,14 +113,62 @@ def _pruneOldLogsBlocking(gc: "GlobalConfig", log_dir: Path, current_log: Option
         )
 
 
-def pruneOldLogsAsync(gc: "GlobalConfig", log_dir: Union[str, Path], current_log: Optional[Union[str, Path]]) -> None:
-    max_bytes = getattr(gc, "max_log_bytes", DEFAULT_MAX_LOG_BYTES)
-    if not max_bytes or max_bytes <= 0:
+def _pruneMetrics(gc: "GlobalConfig", retention_days: float) -> None:
+    if not retention_days or retention_days <= 0:
         return
+    from local_state import prune_metric_snapshots
+
+    cutoff = time.time() - retention_days * 86400.0
+    deleted = prune_metric_snapshots(
+        cutoff, batch_size=_DB_DELETE_BATCH, pacing_s=_DB_DELETE_PACING_S
+    )
+    total = sum(deleted.values())
+    if total:
+        detail = ", ".join(f"{name}={count}" for name, count in deleted.items() if count)
+        gc.logger.info(
+            f"metrics prune: removed {total} snapshot row(s) older than {retention_days}d ({detail})"
+        )
+
+
+def _run(
+    gc: "GlobalConfig",
+    log_dir: Path,
+    current_log: Optional[Path],
+    max_bytes: int,
+    retention_days: float,
+) -> None:
+    _deprioritizeCurrentThread()
+    while True:
+        try:
+            _pruneLogs(gc, log_dir, current_log, max_bytes)
+        except Exception as exc:
+            try:
+                gc.logger.error(f"log prune failed: {exc}")
+            except Exception:
+                pass
+        try:
+            _pruneMetrics(gc, retention_days)
+        except Exception as exc:
+            try:
+                gc.logger.error(f"metrics prune failed: {exc}")
+            except Exception:
+                pass
+        time.sleep(_PRUNE_INTERVAL_S)
+
+
+def runPruningAsync(gc: "GlobalConfig", log_dir: Union[str, Path], current_log: Optional[Union[str, Path]]) -> None:
+    max_bytes = int(getattr(gc, "max_log_bytes", DEFAULT_MAX_LOG_BYTES) or 0)
+    retention_days = float(getattr(gc, "metrics_retention_days", DEFAULT_METRICS_RETENTION_DAYS) or 0.0)
     thread = threading.Thread(
-        target=_pruneOldLogsBlocking,
-        args=(gc, Path(log_dir), Path(current_log) if current_log is not None else None, int(max_bytes)),
-        name="log-pruner",
+        target=_run,
+        args=(
+            gc,
+            Path(log_dir),
+            Path(current_log) if current_log is not None else None,
+            max_bytes,
+            retention_days,
+        ),
+        name="pruner",
         daemon=True,
     )
     thread.start()


### PR DESCRIPTION
## What

Consolidates all the machine's housekeeping into a **single pruning system** (`pruner.py`, replacing `log_pruner.py`). It now prunes:

1. **Run logs** under `software/logs/` — by size cap (`GlobalConfig.max_log_bytes`, 1 GiB), oldest whole sessions first (from #176).
2. **Metric snapshot tables** in `local_state.sqlite` — `runtime_perf_metric_snapshots` + `profiler_metric_snapshots`, by age (`GlobalConfig.metrics_retention_days`, default **3**).

## Why

`record_runtime_perf_metric_snapshot` runs **every second, unconditionally** (`main.py:861`, not gated on the profiler) — one row per metric name. That grew `local_state.sqlite` to **7 GB** on Chris' machine (5.1 GB `runtime_perf` + 2 GB `profiler`). Turning off the profiler only stops the smaller table, so a pruner is required for the bigger one.

## How

- One daemon thread runs **every hour** (`_PRUNE_INTERVAL_S`), not just at startup — a long session writes metrics continuously, so startup-only pruning wouldn't bound it.
- Drops itself to **idle I/O + `nice(19)`** (arch-aware `ioprio_set`, verified aarch64=30).
- `local_state.prune_metric_snapshots()` deletes in **id-ordered batches with per-batch commits** — never a long write lock, never a giant WAL (important: a single bulk delete of millions of rows could spike WAL past free space). Paced between batches.
- Deleting rows (no `VACUUM`) lets the file plateau and reuse pages — correct for ongoing pruning. (The one-time 7 GB reclaim is a separate manual `VACUUM`.)

## Test

- Metrics prune against a real temp sqlite: 1000 old rows/table removed, 100 fresh kept, batched. ✅
- Log prune (moved verbatim): live session protected, oldest-first to cap, flag-off path. ✅
- `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)