### PR TITLE
distribution: log door-trigger failures (firmware rejects + per-dispense door config)

### DIFF
--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -562,8 +562,17 @@ class ServoMotor:
         self._gc.logger.info(f"Servo '{self._name}' ch{self._channel}: move_to {angle}° (from {self._current_angle}°)")
         payload = struct.pack("<H", angle * 10)  # Convert degrees to 0.1° units, 2 bytes uint16
         res = self._dev.send_command(InterfaceCommandCode.SERVO_MOVE_TO, self._channel, payload)
+        accepted = bool(res.payload[0])
+        if not accepted:
+            # Firmware rejected the move (servo not idle or disabled). The flap
+            # physically stays put, which otherwise leaves no trace — a piece
+            # can land in the wrong layer with an apparently clean log.
+            self._gc.logger.warning(
+                f"Servo '{self._name}' ch{self._channel}: move_to {angle}° REJECTED by firmware "
+                f"(servo busy or disabled) — flap did not move"
+            )
         self._current_angle = angle
-        return bool(res.payload[0])
+        return accepted
 
     def move_to_and_release(self, angle: int, max_duration_ms: int = 3500) -> bool:
         """Move the servo to a given angle and *guarantee* that PWM will stop.
@@ -593,9 +602,18 @@ class ServoMotor:
         # Wire format: position (0.1°) + max duration in milliseconds
         payload = struct.pack("<HH", angle * 10, max_duration_ms)
         res = self._dev.send_command(InterfaceCommandCode.SERVO_MOVE_TO_AND_RELEASE, self._channel, payload)
+        accepted = bool(res.payload[0])
+        if not accepted:
+            # Firmware rejected the move (servo not idle or disabled). The flap
+            # physically stays put, which otherwise leaves no trace — a piece
+            # can land in the wrong layer with an apparently clean log.
+            self._gc.logger.warning(
+                f"Servo '{self._name}' ch{self._channel}: move_to_and_release {angle}° REJECTED by firmware "
+                f"(servo busy or disabled) — flap did not move"
+            )
         self._current_angle = angle
         self._enabled = False  # Will be disabled once the move completes (or deadline hits)
-        return bool(res.payload[0])
+        return accepted
 
     @property
     def position(self) -> int:

--- a/software/sorter/backend/subsystems/distribution/positioning.py
+++ b/software/sorter/backend/subsystems/distribution/positioning.py
@@ -732,6 +732,7 @@ class Positioning(BaseState):
         # A dropped serial write, a partial move, or a mid-flight power
         # glitch can leave the physical flap out of sync without us
         # noticing until a piece lands in the wrong bin.
+        opened_layers: list[int] = []
         for i, servo in enumerate(self.irl.servos):
             if i == target_layer_index or not self._isLayerUsable(i):
                 continue
@@ -739,6 +740,7 @@ class Positioning(BaseState):
                 if hasattr(servo, "apply_open_speed"):
                     servo.apply_open_speed()
                 servo.open()
+                opened_layers.append(i)
             except Exception as exc:
                 self._markLayerUnavailable(
                     i,
@@ -756,6 +758,13 @@ class Positioning(BaseState):
             )
             return False
 
+        # Single line capturing the full intended door state for this dispense,
+        # so a wrong-layer piece can be traced to exactly what the controller
+        # commanded (vs. what the flaps physically did, which is open-loop).
+        self.logger.info(
+            f"Door config: closed layer-{target_layer_index} (target), "
+            f"opened parked layers {opened_layers}"
+        )
         return True
 
     def _findOrAssignBinForCategory(


### PR DESCRIPTION
## Why

A GBL field report ("did the layer assignment correctly but the flap did not close/open" → piece went to the previous layer) exposed a logging blind spot in the active door-trigger path.

The layer-door servos (`hardware/sorter_interface.py` `ServoMotor`, over the basically/MCU bus) are **open-loop** — the firmware reports a *simulated* motion profile, not real flap position. On top of that, a genuine command failure left almost no trace:

- `move_to` / `move_to_and_release` **discarded the firmware's accept/reject byte** (`payload[0]`). A rejected move (servo not idle / disabled) returned silently and the flap stayed put.
- At the orchestration level (`_selectDoor`), nothing summarized which door was actually commanded for a given dispense.

Net effect: a wrong-layer piece produced a perfectly clean log, so you couldn't tell from the journal whether software/firmware succeeded.

## What

- **Surface firmware rejects** as `WARN` in both `move_to` and `move_to_and_release`.
- **Per-dispense door-config line** in `_selectDoor`: `Door config: closed layer-N (target), opened parked layers [...]`, so a wrong-layer event can be traced to exactly what the controller commanded.

Logging only — no motion behavior change. Both files compile clean.

## What this still won't catch

Physical actuation failures (servo horn slipped/loose, jammed flap, PWM hard-deadline cutting power before the flap seats) remain invisible — these servos have no position feedback. Closing that gap needs feedback servos, per-flap endstops, or a downstream layer sensor; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)