### PR TITLE
hive: machine data sync — piece records + images + admin fleet dashboard

### DIFF
--- a/software/hive/backend/alembic/versions/f1a2b3c4d5e6_add_machine_piece_sync.py
+++ b/software/hive/backend/alembic/versions/f1a2b3c4d5e6_add_machine_piece_sync.py
@@ -1,0 +1,101 @@
+"""add machine piece sync
+
+Revision ID: f1a2b3c4d5e6
+Revises: c4d5e6f7a8b9
+Create Date: 2026-07-08 12:00:00.000000
+
+Machine -> Hive sync of "known objects": the per-machine piece_records history
+and their captured crop images, plus a server-held watermark table so a machine
+can reconcile months of backlog without redundant re-uploads. Images that were
+already evicted from the machine's 500 MB local store ride up as metadata-only
+rows (image_key NULL, evicted_locally true).
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, None] = "c4d5e6f7a8b9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "machine_pieces",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("machine_id", sa.UUID(), nullable=False),
+        sa.Column("piece_uuid", sa.String(), nullable=False),
+        sa.Column("local_id", sa.BigInteger(), nullable=False),
+        sa.Column("run_id", sa.String(), nullable=True),
+        sa.Column("seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("classification_status", sa.String(), nullable=True),
+        sa.Column("part_id", sa.String(), nullable=True),
+        sa.Column("part_name", sa.String(), nullable=True),
+        sa.Column("color_id", sa.String(), nullable=True),
+        sa.Column("color_name", sa.String(), nullable=True),
+        sa.Column("category_id", sa.String(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("bin_x", sa.Integer(), nullable=True),
+        sa.Column("bin_y", sa.Integer(), nullable=True),
+        sa.Column("bin_z", sa.Integer(), nullable=True),
+        sa.Column("dead", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("brickognize_preview_url", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["machine_id"], ["machines.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("machine_id", "piece_uuid", name="uq_machine_pieces_machine_piece"),
+    )
+    op.create_index("ix_machine_pieces_machine_local_id", "machine_pieces", ["machine_id", "local_id"], unique=False)
+    op.create_index("ix_machine_pieces_machine_seen_at", "machine_pieces", ["machine_id", "seen_at"], unique=False)
+
+    op.create_table(
+        "machine_piece_images",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("machine_id", sa.UUID(), nullable=False),
+        sa.Column("piece_uuid", sa.String(), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("local_id", sa.BigInteger(), nullable=False),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("channel", sa.Integer(), nullable=True),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("captured_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("sharpness", sa.Float(), nullable=True),
+        sa.Column("bytes", sa.Integer(), nullable=True),
+        sa.Column("used", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("excluded_from_result", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("image_key", sa.String(), nullable=True),
+        sa.Column("evicted_locally", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["machine_id"], ["machines.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("machine_id", "piece_uuid", "seq", name="uq_machine_piece_images_machine_piece_seq"),
+    )
+    op.create_index("ix_machine_piece_images_machine_local_id", "machine_piece_images", ["machine_id", "local_id"], unique=False)
+    op.create_index("ix_machine_piece_images_machine_piece", "machine_piece_images", ["machine_id", "piece_uuid"], unique=False)
+
+    op.create_table(
+        "machine_sync_state",
+        sa.Column("machine_id", sa.UUID(), nullable=False),
+        sa.Column("data_type", sa.String(), nullable=False),
+        sa.Column("max_local_id", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["machine_id"], ["machines.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("machine_id", "data_type"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("machine_sync_state")
+    op.drop_index("ix_machine_piece_images_machine_piece", table_name="machine_piece_images")
+    op.drop_index("ix_machine_piece_images_machine_local_id", table_name="machine_piece_images")
+    op.drop_table("machine_piece_images")
+    op.drop_index("ix_machine_pieces_machine_seen_at", table_name="machine_pieces")
+    op.drop_index("ix_machine_pieces_machine_local_id", table_name="machine_pieces")
+    op.drop_table("machine_pieces")

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -18,6 +18,7 @@ from app.routers import (
     machine_lookup,
     machine_models,
     machine_parts,
+    machine_sync,
     machines,
     models as models_router,
     profiles,
@@ -73,6 +74,7 @@ app.include_router(admin_parts.router)
 app.include_router(machines.router)
 app.include_router(machine_config_backups.router)
 app.include_router(machine_lookup.router)
+app.include_router(machine_sync.router)
 app.include_router(profiles.router)
 app.include_router(upload.router)
 app.include_router(samples.router)

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -27,3 +27,6 @@ from app.models.detection_model import DetectionModel, DetectionModelVariant  # 
 from app.models.user_api_key import UserApiKey  # noqa: E402, F401
 from app.models.teacher_job import TeacherJob, TeacherJobItem  # noqa: E402, F401
 from app.models.teacher_prompt import TeacherPrompt  # noqa: E402, F401
+from app.models.machine_piece import MachinePiece  # noqa: E402, F401
+from app.models.machine_piece_image import MachinePieceImage  # noqa: E402, F401
+from app.models.machine_sync_state import MachineSyncState  # noqa: E402, F401

--- a/software/hive/backend/app/models/machine_piece.py
+++ b/software/hive/backend/app/models/machine_piece.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import Base
+
+
+class MachinePiece(Base):
+    __tablename__ = "machine_pieces"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    machine_id = Column(UUID(as_uuid=True), ForeignKey("machines.id", ondelete="CASCADE"), nullable=False)
+    # The machine's local piece uuid — natural key for idempotent upserts.
+    piece_uuid = Column(String, nullable=False)
+    # The machine's sqlite autoincrement id — drives the per-target sync watermark.
+    local_id = Column(BigInteger, nullable=False)
+    run_id = Column(String, nullable=True)
+    seen_at = Column(DateTime(timezone=True), nullable=True)
+    recorded_at = Column(DateTime(timezone=True), nullable=True)
+    classification_status = Column(String, nullable=True)
+    part_id = Column(String, nullable=True)
+    part_name = Column(String, nullable=True)
+    color_id = Column(String, nullable=True)
+    color_name = Column(String, nullable=True)
+    category_id = Column(String, nullable=True)
+    confidence = Column(Float, nullable=True)
+    bin_x = Column(Integer, nullable=True)
+    bin_y = Column(Integer, nullable=True)
+    bin_z = Column(Integer, nullable=True)
+    dead = Column(Boolean, nullable=False, default=False)
+    brickognize_preview_url = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint("machine_id", "piece_uuid", name="uq_machine_pieces_machine_piece"),
+        Index("ix_machine_pieces_machine_local_id", "machine_id", "local_id"),
+        Index("ix_machine_pieces_machine_seen_at", "machine_id", "seen_at"),
+    )

--- a/software/hive/backend/app/models/machine_piece_image.py
+++ b/software/hive/backend/app/models/machine_piece_image.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import Base
+
+
+class MachinePieceImage(Base):
+    __tablename__ = "machine_piece_images"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    machine_id = Column(UUID(as_uuid=True), ForeignKey("machines.id", ondelete="CASCADE"), nullable=False)
+    piece_uuid = Column(String, nullable=False)
+    seq = Column(Integer, nullable=False)
+    # The machine's sqlite autoincrement id — drives the per-target sync watermark.
+    local_id = Column(BigInteger, nullable=False)
+    source = Column(String, nullable=True)
+    channel = Column(Integer, nullable=True)
+    ts = Column(DateTime(timezone=True), nullable=True)
+    captured_at = Column(DateTime(timezone=True), nullable=True)
+    sharpness = Column(Float, nullable=True)
+    bytes = Column(Integer, nullable=True)
+    used = Column(Boolean, nullable=False, default=False)
+    excluded_from_result = Column(Boolean, nullable=False, default=False)
+    score = Column(Float, nullable=True)
+    # Object-storage key. NULL when the crop was already evicted from the
+    # machine's 500 MB local store before it could be synced — the row still
+    # rides up so Hive's record of "this piece had N crops" stays complete.
+    image_key = Column(String, nullable=True)
+    evicted_locally = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint("machine_id", "piece_uuid", "seq", name="uq_machine_piece_images_machine_piece_seq"),
+        Index("ix_machine_piece_images_machine_local_id", "machine_id", "local_id"),
+        Index("ix_machine_piece_images_machine_piece", "machine_id", "piece_uuid"),
+    )

--- a/software/hive/backend/app/models/machine_sync_state.py
+++ b/software/hive/backend/app/models/machine_sync_state.py
@@ -1,0 +1,18 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import Base
+
+
+class MachineSyncState(Base):
+    __tablename__ = "machine_sync_state"
+
+    # Server-held high-water mark: the max local_id this Hive has durably
+    # accepted for (machine, data_type). Advanced in the same commit as the
+    # batch upsert, so it always trails committed data.
+    machine_id = Column(UUID(as_uuid=True), ForeignKey("machines.id", ondelete="CASCADE"), primary_key=True)
+    data_type = Column(String, primary_key=True)
+    max_local_id = Column(BigInteger, nullable=False, default=0)
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))

--- a/software/hive/backend/app/routers/machine_sync.py
+++ b/software/hive/backend/app/routers/machine_sync.py
@@ -1,0 +1,237 @@
+import json
+import math
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
+from pydantic import BaseModel
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.orm import Session
+
+from app.deps import get_current_machine, get_db
+from app.errors import APIError
+from app.models.machine import Machine
+from app.models.machine_piece import MachinePiece
+from app.models.machine_piece_image import MachinePieceImage
+from app.models.machine_sync_state import MachineSyncState
+from app.services.storage import save_piece_image_file, validate_image
+
+router = APIRouter(prefix="/api/machine/sync", tags=["machine-sync"])
+limiter = Limiter(key_func=get_remote_address)
+
+DATA_TYPE_PIECE_RECORDS = "piece_records"
+DATA_TYPE_PIECE_IMAGES = "piece_images"
+
+# Columns updated on conflict — everything except the identity/immutable set
+# (id, machine_id, piece_uuid[, seq], created_at).
+_PIECE_UPDATE_COLS = (
+    "local_id", "run_id", "seen_at", "recorded_at", "classification_status",
+    "part_id", "part_name", "color_id", "color_name", "category_id", "confidence",
+    "bin_x", "bin_y", "bin_z", "dead", "brickognize_preview_url",
+)
+_IMAGE_UPDATE_COLS = (
+    "local_id", "source", "channel", "ts", "captured_at", "sharpness", "bytes",
+    "used", "excluded_from_result", "score", "image_key", "evicted_locally",
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ts(value: float | int | None) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(f):
+        return None
+    return datetime.fromtimestamp(f, tz=timezone.utc)
+
+
+def _upsert(db: Session, model, rows: list[dict[str, Any]], index_elements: list[str], update_cols) -> None:
+    if not rows:
+        return
+    ins = pg_insert if db.bind.dialect.name == "postgresql" else sqlite_insert
+    stmt = ins(model).values(rows)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=index_elements,
+        set_={col: getattr(stmt.excluded, col) for col in update_cols},
+    )
+    db.execute(stmt)
+
+
+def _advance_watermark(db: Session, machine_id: UUID, data_type: str, new_max: int) -> int:
+    row = (
+        db.query(MachineSyncState)
+        .filter(MachineSyncState.machine_id == machine_id, MachineSyncState.data_type == data_type)
+        .first()
+    )
+    if row is None:
+        row = MachineSyncState(machine_id=machine_id, data_type=data_type, max_local_id=new_max, updated_at=_now())
+        db.add(row)
+    else:
+        if new_max > row.max_local_id:
+            row.max_local_id = new_max
+        row.updated_at = _now()
+    return row.max_local_id
+
+
+class PieceRecordIn(BaseModel):
+    piece_uuid: str
+    local_id: int
+    run_id: str | None = None
+    seen_at: float | None = None
+    recorded_at: float | None = None
+    classification_status: str | None = None
+    part_id: str | None = None
+    part_name: str | None = None
+    color_id: str | None = None
+    color_name: str | None = None
+    category_id: str | None = None
+    confidence: float | None = None
+    bin_x: int | None = None
+    bin_y: int | None = None
+    bin_z: int | None = None
+    dead: bool = False
+    brickognize_preview_url: str | None = None
+
+
+class PieceRecordsBatch(BaseModel):
+    records: list[PieceRecordIn]
+
+
+class PieceImageMeta(BaseModel):
+    piece_uuid: str
+    seq: int
+    local_id: int
+    source: str | None = None
+    channel: int | None = None
+    ts: float | None = None
+    captured_at: float | None = None
+    sharpness: float | None = None
+    bytes: int | None = None
+    used: bool = False
+    excluded_from_result: bool = False
+    score: float | None = None
+
+
+@router.get("/state")
+def get_sync_state(
+    db: Session = Depends(get_db),
+    machine: Machine = Depends(get_current_machine),
+) -> dict[str, dict[str, int]]:
+    rows = db.query(MachineSyncState).filter(MachineSyncState.machine_id == machine.id).all()
+    by_type = {r.data_type: r.max_local_id for r in rows}
+    return {
+        DATA_TYPE_PIECE_RECORDS: {"max_local_id": by_type.get(DATA_TYPE_PIECE_RECORDS, 0)},
+        DATA_TYPE_PIECE_IMAGES: {"max_local_id": by_type.get(DATA_TYPE_PIECE_IMAGES, 0)},
+    }
+
+
+@router.post("/piece-records")
+@limiter.limit("300/minute")
+def sync_piece_records(
+    request: Request,
+    payload: PieceRecordsBatch,
+    db: Session = Depends(get_db),
+    machine: Machine = Depends(get_current_machine),
+) -> dict[str, int]:
+    if not payload.records:
+        row = (
+            db.query(MachineSyncState)
+            .filter(MachineSyncState.machine_id == machine.id, MachineSyncState.data_type == DATA_TYPE_PIECE_RECORDS)
+            .first()
+        )
+        return {"max_local_id": row.max_local_id if row else 0, "upserted": 0}
+
+    now = _now()
+    rows: list[dict[str, Any]] = []
+    batch_max = 0
+    for rec in payload.records:
+        batch_max = max(batch_max, rec.local_id)
+        rows.append(
+            {
+                "id": uuid4(),
+                "machine_id": machine.id,
+                "piece_uuid": rec.piece_uuid,
+                "local_id": rec.local_id,
+                "run_id": rec.run_id,
+                "seen_at": _ts(rec.seen_at),
+                "recorded_at": _ts(rec.recorded_at),
+                "classification_status": rec.classification_status,
+                "part_id": rec.part_id,
+                "part_name": rec.part_name,
+                "color_id": rec.color_id,
+                "color_name": rec.color_name,
+                "category_id": rec.category_id,
+                "confidence": rec.confidence,
+                "bin_x": rec.bin_x,
+                "bin_y": rec.bin_y,
+                "bin_z": rec.bin_z,
+                "dead": rec.dead,
+                "brickognize_preview_url": rec.brickognize_preview_url,
+                "created_at": now,
+            }
+        )
+
+    _upsert(db, MachinePiece, rows, ["machine_id", "piece_uuid"], _PIECE_UPDATE_COLS)
+    new_max = _advance_watermark(db, machine.id, DATA_TYPE_PIECE_RECORDS, batch_max)
+    machine.last_seen_at = now
+    db.commit()
+    return {"max_local_id": new_max, "upserted": len(rows)}
+
+
+@router.post("/piece-image")
+@limiter.limit("600/minute")
+def sync_piece_image(
+    request: Request,
+    metadata: str = Form(...),
+    image: UploadFile | None = File(default=None),
+    db: Session = Depends(get_db),
+    machine: Machine = Depends(get_current_machine),
+) -> dict[str, Any]:
+    try:
+        meta = PieceImageMeta.model_validate(json.loads(metadata))
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise APIError(400, f"Invalid metadata: {exc}", "INVALID_METADATA") from exc
+
+    image_key: str | None = None
+    evicted_locally = image is None
+    if image is not None:
+        suffix = validate_image(image)
+        image_key = save_piece_image_file(str(machine.id), meta.piece_uuid, meta.seq, meta.source, image, suffix)
+
+    now = _now()
+    row = {
+        "id": uuid4(),
+        "machine_id": machine.id,
+        "piece_uuid": meta.piece_uuid,
+        "seq": meta.seq,
+        "local_id": meta.local_id,
+        "source": meta.source,
+        "channel": meta.channel,
+        "ts": _ts(meta.ts),
+        "captured_at": _ts(meta.captured_at),
+        "sharpness": meta.sharpness,
+        "bytes": meta.bytes,
+        "used": meta.used,
+        "excluded_from_result": meta.excluded_from_result,
+        "score": meta.score,
+        "image_key": image_key,
+        "evicted_locally": evicted_locally,
+        "created_at": now,
+    }
+    # Metadata-only re-sends must not wipe a previously stored image_key.
+    update_cols = _IMAGE_UPDATE_COLS if image is not None else tuple(c for c in _IMAGE_UPDATE_COLS if c != "image_key")
+    _upsert(db, MachinePieceImage, [row], ["machine_id", "piece_uuid", "seq"], update_cols)
+    new_max = _advance_watermark(db, machine.id, DATA_TYPE_PIECE_IMAGES, meta.local_id)
+    machine.last_seen_at = now
+    db.commit()
+    return {"max_local_id": new_max, "image_stored": image is not None}

--- a/software/hive/backend/app/routers/machines.py
+++ b/software/hive/backend/app/routers/machines.py
@@ -134,6 +134,46 @@ def get_machine_stats(
     return result
 
 
+@router.get("/admin/machines")
+def admin_list_machines(
+    db: Session = Depends(get_db),
+    admin: User = Depends(require_role("admin")),
+):
+    """Every machine across ALL owners (admin-only fleet view)."""
+    machines = db.query(Machine).options(joinedload(Machine.owner)).order_by(Machine.created_at).all()
+    return [
+        {
+            "id": str(m.id),
+            "name": m.name,
+            "description": m.description,
+            "owner_id": str(m.owner_id),
+            "owner_email": m.owner.email if m.owner else None,
+            "owner_display_name": m.owner.display_name if m.owner else None,
+            "is_active": m.is_active,
+            "archived_at": m.archived_at.isoformat() if m.archived_at else None,
+            "last_seen_at": m.last_seen_at.isoformat() if m.last_seen_at else None,
+            "last_seen_ip": m.last_seen_ip,
+            "local_ui_port": m.local_ui_port,
+            "created_at": m.created_at.isoformat() if m.created_at else None,
+        }
+        for m in machines
+    ]
+
+
+@router.get("/admin/machines/stats")
+def admin_machine_stats(
+    db: Session = Depends(get_db),
+    admin: User = Depends(require_role("admin")),
+):
+    """Per-machine lifetime metrics (pieces, PPM, on-time %) across ALL machines.
+
+    Computed entirely from synced piece records — see app.services.machine_fleet.
+    """
+    from app.services.machine_fleet import get_fleet_stats
+
+    return get_fleet_stats(db)
+
+
 @router.post("/machines", response_model=MachineWithTokenResponse)
 def create_machine(
     data: MachineCreate,

--- a/software/hive/backend/app/services/machine_fleet.py
+++ b/software/hive/backend/app/services/machine_fleet.py
@@ -1,0 +1,124 @@
+import threading
+import time
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.machine_piece import MachinePiece
+
+# Two pieces more than this many seconds apart are treated as separate sorting
+# sessions, so the gap between them is NOT counted as active time. Tunable
+# against a machine whose real /records numbers we know.
+ACTIVE_GAP_IDLE_S = 60.0
+
+_CACHE_TTL_S = 60.0
+_cache_lock = threading.Lock()
+_cache: dict[str, Any] = {"at": 0.0, "value": None}
+
+
+def _active_seconds_by_machine(db: Session) -> dict[str, float]:
+    """Sum the gaps between consecutive pieces per machine, ignoring idle gaps.
+
+    Derived active sorting time — we intentionally don't sync the machine's real
+    powered/sorted seconds, so we infer activity from piece-timestamp density.
+    """
+    # Postgres: one windowed pass. Other dialects (sqlite test DB): compute in
+    # Python since test datasets are tiny.
+    if db.bind.dialect.name == "postgresql":
+        from sqlalchemy import text
+
+        result = db.execute(
+            text(
+                """
+                WITH g AS (
+                    SELECT machine_id,
+                           EXTRACT(EPOCH FROM (
+                               seen_at - LAG(seen_at) OVER (
+                                   PARTITION BY machine_id ORDER BY seen_at, local_id))) AS gap
+                    FROM machine_pieces
+                    WHERE seen_at IS NOT NULL)
+                SELECT machine_id,
+                       COALESCE(SUM(CASE WHEN gap > 0 AND gap <= :idle THEN gap ELSE 0 END), 0) AS active
+                FROM g GROUP BY machine_id
+                """
+            ),
+            {"idle": ACTIVE_GAP_IDLE_S},
+        )
+        return {str(mid): float(active) for mid, active in result}
+
+    active: dict[str, float] = {}
+    prev_mid = None
+    prev_seen = None
+    rows = (
+        db.query(MachinePiece.machine_id, MachinePiece.seen_at)
+        .filter(MachinePiece.seen_at.isnot(None))
+        .order_by(MachinePiece.machine_id, MachinePiece.seen_at, MachinePiece.local_id)
+        .all()
+    )
+    for mid, seen_at in rows:
+        mid_str = str(mid)
+        active.setdefault(mid_str, 0.0)
+        if prev_mid == mid_str and prev_seen is not None:
+            gap = (seen_at - prev_seen).total_seconds()
+            if 0 < gap <= ACTIVE_GAP_IDLE_S:
+                active[mid_str] += gap
+        prev_mid = mid_str
+        prev_seen = seen_at
+    return active
+
+
+def _compute(db: Session) -> dict[str, dict[str, Any]]:
+    agg = (
+        db.query(
+            MachinePiece.machine_id,
+            func.count().label("pieces_seen"),
+            func.count().filter(MachinePiece.bin_x.isnot(None)).label("distributed"),
+            func.count().filter(MachinePiece.classification_status == "classified").label("classified"),
+            func.count(func.distinct(MachinePiece.part_id)).label("unique_parts"),
+            func.count(func.distinct(MachinePiece.color_id)).label("unique_colors"),
+            func.min(MachinePiece.seen_at).label("first_seen"),
+            func.max(MachinePiece.seen_at).label("last_seen"),
+        )
+        .group_by(MachinePiece.machine_id)
+        .all()
+    )
+    active_by_machine = _active_seconds_by_machine(db)
+
+    result: dict[str, dict[str, Any]] = {}
+    for r in agg:
+        mid = str(r.machine_id)
+        active_s = active_by_machine.get(mid, 0.0)
+        distributed = r.distributed or 0
+        overall_ppm = (distributed * 60.0 / active_s) if active_s > 0 else 0.0
+        span_s = (
+            (r.last_seen - r.first_seen).total_seconds()
+            if r.first_seen and r.last_seen
+            else 0.0
+        )
+        ontime_pct = (active_s / span_s * 100.0) if span_s > 0 else 0.0
+        result[mid] = {
+            "pieces_seen": r.pieces_seen or 0,
+            "distributed": distributed,
+            "classified": r.classified or 0,
+            "unique_parts": r.unique_parts or 0,
+            "unique_colors": r.unique_colors or 0,
+            "first_seen": r.first_seen.isoformat() if r.first_seen else None,
+            "last_seen": r.last_seen.isoformat() if r.last_seen else None,
+            "active_seconds": active_s,
+            "overall_ppm": overall_ppm,
+            "ontime_pct": ontime_pct,
+        }
+    return result
+
+
+def get_fleet_stats(db: Session) -> dict[str, dict[str, Any]]:
+    now = time.monotonic()
+    with _cache_lock:
+        if _cache["value"] is not None and (now - _cache["at"]) < _CACHE_TTL_S:
+            return _cache["value"]
+    value = _compute(db)
+    with _cache_lock:
+        _cache["at"] = time.monotonic()
+        _cache["value"] = value
+    return value

--- a/software/hive/backend/app/services/storage.py
+++ b/software/hive/backend/app/services/storage.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import re
 import tempfile
 import uuid
 from pathlib import Path
@@ -36,6 +37,23 @@ def save_upload_file(
         _safe_path_component(session_id, "session id"),
         _safe_path_component(sample_id, "sample id"),
         f"{uuid.uuid4().hex}{suffix}",
+    )
+    file.file.seek(0)
+    get_backend().write_stream(key, file.file, content_type=file.content_type)
+    return key
+
+
+def save_piece_image_file(
+    machine_id: str, piece_uuid: str, seq: int, source: str | None, file: UploadFile, suffix: str
+) -> str:
+    # Deterministic key so a re-sent (piece_uuid, seq) overwrites in place
+    # instead of orphaning a random-uuid object each retry.
+    source_part = re.sub(r"[^a-z0-9_]", "", (source or "img").strip().lower()) or "img"
+    key = _join_key(
+        _safe_path_component(machine_id, "machine id"),
+        "pieces",
+        _safe_path_component(piece_uuid, "piece uuid"),
+        f"{int(seq):02d}_{source_part}{suffix}",
     )
     file.file.seek(0)
     get_backend().write_stream(key, file.file, content_type=file.content_type)

--- a/software/hive/backend/tests/test_machine_sync.py
+++ b/software/hive/backend/tests/test_machine_sync.py
@@ -1,0 +1,132 @@
+"""Machine -> Hive piece sync ingest + admin fleet stats (sqlite dialect path)."""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from tests.conftest import make_test_image
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_sync_state_starts_empty(client, machine_token):
+    resp = client.get("/api/machine/sync/state", headers=_bearer(machine_token))
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "piece_records": {"max_local_id": 0},
+        "piece_images": {"max_local_id": 0},
+    }
+
+
+def test_piece_records_upsert_is_idempotent(client, machine_token):
+    base = 1_760_000_000.0
+    records = [
+        {"piece_uuid": "p1", "local_id": 10, "seen_at": base, "recorded_at": base + 1,
+         "classification_status": "classified", "part_id": "3001", "color_id": "5",
+         "bin_x": 1, "bin_y": 0, "bin_z": 0},
+        {"piece_uuid": "p2", "local_id": 11, "seen_at": base + 5, "recorded_at": base + 6,
+         "classification_status": "classified", "part_id": "3002", "color_id": "5",
+         "bin_x": 1, "bin_y": 0, "bin_z": 0},
+    ]
+    r1 = client.post("/api/machine/sync/piece-records", headers=_bearer(machine_token), json={"records": records})
+    assert r1.status_code == 200, r1.text
+    assert r1.json() == {"max_local_id": 11, "upserted": 2}
+
+    # Re-send the same batch: idempotent, watermark unchanged, no duplicate rows.
+    r2 = client.post("/api/machine/sync/piece-records", headers=_bearer(machine_token), json={"records": records})
+    assert r2.json()["max_local_id"] == 11
+
+    state = client.get("/api/machine/sync/state", headers=_bearer(machine_token)).json()
+    assert state["piece_records"]["max_local_id"] == 11
+
+
+def test_piece_records_update_on_conflict(client, machine_token):
+    base = 1_760_000_000.0
+    client.post("/api/machine/sync/piece-records", headers=_bearer(machine_token),
+                json={"records": [{"piece_uuid": "p1", "local_id": 1, "classification_status": "unknown"}]})
+    # Same natural key, changed status -> upsert updates in place.
+    client.post("/api/machine/sync/piece-records", headers=_bearer(machine_token),
+                json={"records": [{"piece_uuid": "p1", "local_id": 1, "classification_status": "classified",
+                                   "part_id": "3001", "seen_at": base, "bin_x": 2, "bin_y": 0, "bin_z": 0}]})
+    from app.models.machine_piece import MachinePiece
+    from tests.conftest import TestingSessionLocal
+    s: Session = TestingSessionLocal()
+    rows = s.query(MachinePiece).filter(MachinePiece.piece_uuid == "p1").all()
+    s.close()
+    assert len(rows) == 1
+    assert rows[0].classification_status == "classified"
+    assert rows[0].part_id == "3001"
+
+
+def test_piece_image_with_and_without_file(client, machine_token, upload_dir):
+    img = make_test_image(fmt="jpeg")
+    meta = {"piece_uuid": "p1", "seq": 0, "local_id": 100, "source": "c4_burst", "channel": 4}
+    r = client.post(
+        "/api/machine/sync/piece-image",
+        headers=_bearer(machine_token),
+        data={"metadata": json.dumps(meta)},
+        files={"image": ("crop.jpg", img, "image/jpeg")},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json() == {"max_local_id": 100, "image_stored": True}
+
+    # Metadata-only (evicted locally): no file, still recorded.
+    meta2 = {"piece_uuid": "p2", "seq": 0, "local_id": 101, "source": "c2_match"}
+    r2 = client.post("/api/machine/sync/piece-image", headers=_bearer(machine_token),
+                     data={"metadata": json.dumps(meta2)})
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["image_stored"] is False
+
+    from app.models.machine_piece_image import MachinePieceImage
+    from tests.conftest import TestingSessionLocal
+    s: Session = TestingSessionLocal()
+    imgs = {i.piece_uuid: i for i in s.query(MachinePieceImage).all()}
+    s.close()
+    assert imgs["p1"].image_key and imgs["p1"].evicted_locally is False
+    assert imgs["p2"].image_key is None and imgs["p2"].evicted_locally is True
+
+
+def test_sync_requires_machine_token(client):
+    assert client.get("/api/machine/sync/state").status_code == 422  # missing Authorization
+    assert client.get("/api/machine/sync/state", headers=_bearer("bogus")).status_code == 401
+
+
+def test_admin_fleet_endpoints(client, db, machine_token, test_machine):
+    base = 1_760_000_000.0
+    records = [
+        {"piece_uuid": "a", "local_id": 1, "seen_at": base, "classification_status": "classified",
+         "part_id": "3001", "color_id": "5", "bin_x": 1, "bin_y": 0, "bin_z": 0},
+        {"piece_uuid": "b", "local_id": 2, "seen_at": base + 5, "classification_status": "classified",
+         "part_id": "3002", "color_id": "5", "bin_x": 1, "bin_y": 0, "bin_z": 0},
+        {"piece_uuid": "c", "local_id": 3, "seen_at": base + 999, "classification_status": "unknown"},
+    ]
+    client.post("/api/machine/sync/piece-records", headers=_bearer(machine_token), json={"records": records})
+
+    # Non-admin (the member test_user) is forbidden.
+    assert client.get("/api/admin/machines").status_code == 403
+
+    # Promote to admin and clear the fleet-stats cache so the new rows show.
+    user = db.query(User).filter(User.email == "member@test.com").first()
+    user.role = "admin"
+    db.commit()
+    from app.services import machine_fleet
+    machine_fleet._cache["value"] = None
+
+    machines = client.get("/api/admin/machines").json()
+    assert any(m["id"] == test_machine["id"] and m["owner_email"] == "member@test.com" for m in machines)
+
+    stats = client.get("/api/admin/machines/stats").json()
+    st = stats[test_machine["id"]]
+    assert st["pieces_seen"] == 3
+    assert st["distributed"] == 2
+    assert st["classified"] == 2
+    assert st["unique_parts"] == 2
+    assert st["unique_colors"] == 1
+    # Only the 5s gap counts as active (999s gap is idle) -> ppm = 2*60/5 = 24.
+    assert abs(st["active_seconds"] - 5.0) < 0.01
+    assert abs(st["overall_ppm"] - 24.0) < 0.01

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -56,6 +56,34 @@ export interface MachineStats {
 	parts_needed: number;
 }
 
+export interface FleetMachine {
+	id: string;
+	name: string;
+	description: string | null;
+	owner_id: string;
+	owner_email: string | null;
+	owner_display_name: string | null;
+	is_active: boolean;
+	archived_at: string | null;
+	last_seen_at: string | null;
+	last_seen_ip: string | null;
+	local_ui_port: string | null;
+	created_at: string | null;
+}
+
+export interface FleetMachineStats {
+	pieces_seen: number;
+	distributed: number;
+	classified: number;
+	unique_parts: number;
+	unique_colors: number;
+	first_seen: string | null;
+	last_seen: string | null;
+	active_seconds: number;
+	overall_ppm: number;
+	ontime_pct: number;
+}
+
 export interface MachineConfigBackupSummary {
 	id: string;
 	version: number;
@@ -772,6 +800,12 @@ export const api = {
 	},
 	getMachineStats() {
 		return request<Record<string, MachineStats>>('GET', '/api/machines/stats');
+	},
+	getAllMachines() {
+		return request<FleetMachine[]>('GET', '/api/admin/machines');
+	},
+	getAllMachineStats() {
+		return request<Record<string, FleetMachineStats>>('GET', '/api/admin/machines/stats');
 	},
 	createMachine(name: string, description?: string) {
 		return request<MachineWithToken>('POST', '/api/machines', { name, description });

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -160,6 +160,16 @@
 										Manage Users
 									</a>
 									<a
+										href="/admin/machines"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										onclick={() => { dropdownOpen = false; }}
+									>
+										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 0h.008v.008h-.008v-.008Zm-3 0h.008v.008h-.008v-.008Z" />
+										</svg>
+										All Machines
+									</a>
+									<a
 										href="/admin/teacher-jobs"
 										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
 										onclick={() => { dropdownOpen = false; }}

--- a/software/hive/frontend/src/routes/admin/machines/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/machines/+page.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import { auth } from '$lib/auth.svelte';
+	import { api, type FleetMachine, type FleetMachineStats } from '$lib/api';
+	import { goto } from '$app/navigation';
+	import Badge from '$lib/components/Badge.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
+
+	let machines = $state<FleetMachine[]>([]);
+	let stats = $state<Record<string, FleetMachineStats>>({});
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	$effect(() => {
+		if (!auth.isAdmin) {
+			goto('/');
+			return;
+		}
+		load();
+	});
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const [m, s] = await Promise.all([api.getAllMachines(), api.getAllMachineStats()]);
+			stats = s;
+			// Busiest machines first — the fleet view is about who's sorting.
+			machines = m.sort((a, b) => (stats[b.id]?.pieces_seen ?? 0) - (stats[a.id]?.pieces_seen ?? 0));
+		} catch (e: any) {
+			error = e.error || 'Failed to load machines';
+		} finally {
+			loading = false;
+		}
+	}
+
+	const EMPTY: FleetMachineStats = {
+		pieces_seen: 0, distributed: 0, classified: 0, unique_parts: 0, unique_colors: 0,
+		first_seen: null, last_seen: null, active_seconds: 0, overall_ppm: 0, ontime_pct: 0
+	};
+
+	function statOf(id: string): FleetMachineStats {
+		return stats[id] ?? EMPTY;
+	}
+
+	function num(n: number): string {
+		return Math.round(n).toLocaleString();
+	}
+	function ppm(n: number): string {
+		return n > 0 ? n.toFixed(1) : '—';
+	}
+	function pct(n: number): string {
+		return n > 0 ? `${n.toFixed(1)}%` : '—';
+	}
+	function hours(seconds: number): string {
+		if (!seconds || seconds <= 0) return '—';
+		return `${(seconds / 3600).toFixed(1)}h`;
+	}
+	function when(iso: string | null): string {
+		if (!iso) return '—';
+		return new Date(iso).toLocaleDateString();
+	}
+
+	const fleetPieces = $derived(machines.reduce((sum, m) => sum + statOf(m.id).pieces_seen, 0));
+</script>
+
+<svelte:head>
+	<title>All Machines - Hive</title>
+</svelte:head>
+
+<div class="mb-6 flex items-center justify-between">
+	<h1 class="text-2xl font-bold text-text">All Machines</h1>
+	<span class="text-sm text-text-muted">
+		{machines.length} machines · {num(fleetPieces)} pieces sorted
+	</span>
+</div>
+
+{#if error}
+	<div class="mb-4 bg-primary/8 p-3 text-sm text-primary">{error}</div>
+{/if}
+
+{#if loading}
+	<div class="flex justify-center py-12">
+		<Spinner />
+	</div>
+{:else if machines.length === 0}
+	<div class="border border-border bg-surface p-8 text-center text-sm text-text-muted">
+		No machines connected to this Hive yet.
+	</div>
+{:else}
+	<div class="overflow-x-auto border border-border bg-surface">
+		<table class="min-w-full divide-y divide-border">
+			<thead class="bg-bg">
+				<tr>
+					<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Machine</th>
+					<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Owner</th>
+					<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">Pieces</th>
+					<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">Distributed</th>
+					<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">PPM</th>
+					<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">On-time</th>
+					<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">Sorted</th>
+					<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">Parts</th>
+					<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">Colors</th>
+					<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Last seen</th>
+				</tr>
+			</thead>
+			<tbody class="divide-y divide-border">
+				{#each machines as machine (machine.id)}
+					{@const s = statOf(machine.id)}
+					<tr class="hover:bg-bg {machine.archived_at ? 'opacity-50' : ''}">
+						<td class="whitespace-nowrap px-4 py-3">
+							<div class="flex items-center gap-2">
+								<p class="text-sm font-medium text-text">{machine.name}</p>
+								{#if machine.archived_at}
+									<Badge text="Archived" variant="neutral" />
+								{:else if !machine.is_active}
+									<Badge text="Inactive" variant="danger" />
+								{/if}
+							</div>
+						</td>
+						<td class="whitespace-nowrap px-4 py-3">
+							<p class="text-sm text-text">{machine.owner_display_name || '—'}</p>
+							<p class="text-xs text-text-muted">{machine.owner_email || ''}</p>
+						</td>
+						<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-text tabular-nums">{num(s.pieces_seen)}</td>
+						<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-text-muted tabular-nums">{num(s.distributed)}</td>
+						<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-text tabular-nums">{ppm(s.overall_ppm)}</td>
+						<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-text-muted tabular-nums">{pct(s.ontime_pct)}</td>
+						<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-text-muted tabular-nums">{hours(s.active_seconds)}</td>
+						<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-text-muted tabular-nums">{num(s.unique_parts)}</td>
+						<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-text-muted tabular-nums">{num(s.unique_colors)}</td>
+						<td class="whitespace-nowrap px-4 py-3 text-sm text-text-muted">{when(machine.last_seen_at)}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+	<p class="mt-3 text-xs text-text-muted">
+		PPM and on-time % are derived from synced piece timestamps (active sorting inferred from
+		piece density), not the machine's exact powered/sorted clock.
+	</p>
+{/if}


### PR DESCRIPTION
Additive-only **receiving side** on the Hive so machines can sync their "known objects" (sorted piece history + captured crop images), plus an admin-only cross-user machines dashboard. This is the Hive half; the on-machine sender lives on `spencer/piece-images-01` (dev machine only).

## What's added (all additive — nothing existing is modified)
- **Tables:** `machine_pieces`, `machine_piece_images`, `machine_sync_state` — one Alembic migration off head `c4d5e6f7a8b9`.
- **Ingest router** `/api/machine/sync/{state,piece-records,piece-image}` (Bearer machine auth): dialect-aware upsert (idempotent by natural key) + per-(machine, data-type) watermarks so months of backlog sync without redundant re-uploads. Images ride up as metadata-only rows when the local crop was already evicted.
- **Admin fleet:** `GET /api/admin/machines` + `/stats` — every machine across all owners with lifetime pieces / PPM / on-time%, computed entirely from synced piece records.
- **Frontend:** admin-only `/admin/machines` page + nav gate + `api.ts` methods.

## Backward compatibility
Verified: zero lines removed from any existing file (main.py/machines.py/storage.py/models `__init__`/api.ts/+layout.svelte only *append*); the migration only `CREATE`s new tables. **Machines on the older Hive keep working unchanged.**

## Testing
`tests/test_machine_sync.py` (sqlite dialect path): idempotent upserts, watermark advance, on-conflict update, image with/without file, admin 403 gating, derived PPM. Also verified end-to-end against staging (kitbash → staging01): 844 records + 1.5k images synced, dashboard renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)