### PR TITLE
hive: slim the backend image (drop chown -R duplicate layer)

### DIFF
--- a/software/hive/Dockerfile.backend
+++ b/software/hive/Dockerfile.backend
@@ -8,17 +8,21 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN adduser --system --group --home /app app
-
-COPY backend/pyproject.toml backend/uv.lock ./
-RUN uv sync --frozen --no-dev --no-install-project
-
-COPY backend/ ./
-RUN chmod +x /app/docker-entrypoint.sh \
+# Create the runtime user and hand it /app + /data while both are still empty,
+# then build everything as that user. Avoids a final `chown -R app:app /app`,
+# which copied the entire .venv into a ~400 MB duplicate layer (and cost ~270s
+# to run). Everything below is app-owned from creation instead.
+RUN adduser --system --group --home /app app \
     && mkdir -p /data/uploads \
     && chown -R app:app /app /data
 
 USER app
+
+COPY --chown=app:app backend/pyproject.toml backend/uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY --chown=app:app backend/ ./
+RUN chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 8000
 


### PR DESCRIPTION
The `Dockerfile.backend` final step `RUN chown -R app:app /app /data` copied the **entire `.venv` into a ~400 MB duplicate layer** and cost **~270s** to run on every build (a big reason prod builds became painfully slow).

Fix: create the `app` user and chown `/app` + `/data` **up front while empty**, switch to `USER app`, then build the venv (`uv sync`) and copy code as that user with `COPY --chown`. Identical end-state ownership, no giant chown layer, no slow chown step.

**Result:** backend image **~421 MB → ~296 MB** (bigger saving in the overlay2 on-disk footprint on the servers), and the ~270s chown build step is gone.

**Verified** (amd64 build on Mac): builds clean; container runs as `app`; `fastapi/sqlalchemy/scipy/boto3/alembic` all import; app code + entrypoint intact.

Follow-up idea (not in this PR): the `.venv` is still ~716 MB (scipy/numpy/pillow) — worth checking whether all are actually needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)