### PR TITLE
Put machine name in the browser tab title

### DIFF
--- a/software/sorter/frontend/src/lib/components/MachineTitle.svelte
+++ b/software/sorter/frontend/src/lib/components/MachineTitle.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	// Decorates the browser tab title with the selected machine's name. Every route
+	// sets its own "Sorter - <page>" title via <svelte:head>; here we swap the
+	// "Sorter" brand token for the machine name (matching the header badge), e.g.
+	// "Sorter - Dashboard" -> "GBL Sorter - Dashboard". A MutationObserver keeps it
+	// applied across navigations and reactive per-page title changes without having
+	// to touch all ~34 page titles.
+	import { onMount } from 'svelte';
+	import { getMachinesContext } from '$lib/machines/context';
+
+	const manager = getMachinesContext();
+
+	const machineName = $derived(
+		manager.selectedMachine?.identity?.nickname ??
+			manager.selectedMachine?.identity?.machine_id.slice(0, 8) ??
+			null
+	);
+
+	// The undecorated title a page set for itself; we always re-derive from this so
+	// applying the machine name is idempotent.
+	let base = '';
+
+	function decorate(raw: string): string {
+		if (!machineName || !raw.includes('Sorter')) return raw;
+		return raw.replace('Sorter', machineName);
+	}
+
+	function render() {
+		const next = decorate(base);
+		if (document.title !== next) document.title = next;
+	}
+
+	onMount(() => {
+		const titleEl = document.querySelector('title');
+		if (!titleEl) return;
+
+		base = document.title;
+		render();
+
+		const observer = new MutationObserver(() => {
+			// Ignore our own writes; anything else is a page setting a fresh title.
+			if (document.title === decorate(base)) return;
+			base = document.title;
+			render();
+		});
+		observer.observe(titleEl, { childList: true, characterData: true, subtree: true });
+
+		return () => observer.disconnect();
+	});
+
+	// Re-decorate when the machine name arrives or changes (it loads asynchronously
+	// over the websocket after the page has already set its title).
+	$effect(() => {
+		machineName;
+		render();
+	});
+</script>

--- a/software/sorter/frontend/src/routes/+layout.svelte
+++ b/software/sorter/frontend/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import './layout.css';
 	import MachinesProvider from '$lib/components/MachinesProvider.svelte';
 	import MachineProvider from '$lib/components/MachineProvider.svelte';
+	import MachineTitle from '$lib/components/MachineTitle.svelte';
 	import BackendConnectionGuard from '$lib/components/BackendConnectionGuard.svelte';
 	import { settings } from '$lib/stores/settings';
 	import { loadThemeColor } from '$lib/stores/themeColor.svelte';
@@ -75,6 +76,7 @@
 <svelte:head><link rel="icon" type="image/x-icon" href="/favicon.ico" /></svelte:head>
 
 <MachinesProvider>
+	<MachineTitle />
 	<MachineProvider>
 		<BackendConnectionGuard />
 		{@render children()}


### PR DESCRIPTION
## What

The browser tab title is `Sorter - Dashboard` on every machine, so with multiple machines open in tabs you can't tell them apart. This puts the machine's name in the title, e.g. **GBL Sorter - Dashboard** for the gbl machine — matching the name badge already shown in the top nav header.

## How

Every route sets its own `Sorter - <page>` title via `<svelte:head>` (34 of them, inconsistent formats). Rather than editing all of them, this adds one small `MachineTitle.svelte` component mounted inside `MachinesProvider` that swaps the `Sorter` brand token for the selected machine's name — pulled from the same source as the header badge (`manager.selectedMachine?.identity?.nickname`, falling back to the machine id, then no change if unknown).

A `MutationObserver` on the `<title>` element keeps the decoration applied across client-side navigations and reactive per-page title changes, so no per-page edits are needed and it can't stack (`GBL GBL Sorter`) or fight the page's own title.

## Notes

- If no machine name is available (not connected / no nickname), the title is left as-is (`Sorter - Dashboard`).
- Frontend-only; `svelte-check` is clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)