### PR TITLE
hive: admin per-machine pieces page (images + predictions)

### DIFF
--- a/software/hive/backend/app/routers/machines.py
+++ b/software/hive/backend/app/routers/machines.py
@@ -12,6 +12,8 @@ from sqlalchemy.orm import Session, joinedload
 from app.deps import get_current_machine, get_current_user, get_db, require_role, verify_csrf
 from app.errors import APIError
 from app.models.machine import Machine
+from app.models.machine_piece import MachinePiece
+from app.models.machine_piece_image import MachinePieceImage
 from app.models.user import User
 from app.schemas.machine import (
     MachineCreate,
@@ -23,7 +25,7 @@ from app.schemas.machine import (
 )
 from app.services.auth import generate_machine_token, verify_password
 from app.services.machine_set_progress import build_set_progress_inventory_index, summarize_machine_set_progress
-from app.services.storage import delete_machine_files
+from app.services.storage import delete_machine_files, serve_stored_file
 
 router = APIRouter(prefix="/api", tags=["machines"])
 limiter = Limiter(key_func=get_remote_address)
@@ -172,6 +174,132 @@ def admin_machine_stats(
     from app.services.machine_fleet import get_fleet_stats
 
     return get_fleet_stats(db)
+
+
+PIECE_IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+def _serialize_machine_piece(piece: MachinePiece, images: list[MachinePieceImage]) -> dict[str, Any]:
+    return {
+        "piece_uuid": piece.piece_uuid,
+        "local_id": piece.local_id,
+        "run_id": piece.run_id,
+        "seen_at": piece.seen_at.isoformat() if piece.seen_at else None,
+        "recorded_at": piece.recorded_at.isoformat() if piece.recorded_at else None,
+        "classification_status": piece.classification_status,
+        "part_id": piece.part_id,
+        "part_name": piece.part_name,
+        "color_id": piece.color_id,
+        "color_name": piece.color_name,
+        "category_id": piece.category_id,
+        "confidence": piece.confidence,
+        "bin": {"x": piece.bin_x, "y": piece.bin_y, "z": piece.bin_z},
+        "dead": piece.dead,
+        "brickognize_preview_url": piece.brickognize_preview_url,
+        "images": [
+            {
+                "seq": im.seq,
+                "source": im.source,
+                "channel": im.channel,
+                "sharpness": im.sharpness,
+                "bytes": im.bytes,
+                "used": im.used,
+                "excluded_from_result": im.excluded_from_result,
+                "score": im.score,
+                # image_key is NULL once the crop was evicted from the machine's
+                # local store before syncing — the row rides up regardless, so
+                # the UI still knows the piece had N crops but can't show them.
+                "available": im.image_key is not None,
+                "evicted_locally": im.evicted_locally,
+            }
+            for im in images
+        ],
+    }
+
+
+@router.get("/admin/machines/{machine_id}/pieces")
+def admin_list_machine_pieces(
+    machine_id: UUID,
+    limit: int = Query(60, ge=1, le=200),
+    cursor: int | None = Query(None),
+    db: Session = Depends(get_db),
+    admin: User = Depends(require_role("admin")),
+):
+    """Every synced piece for one machine, newest first — the fleet analogue of
+    the on-machine /records page. Keyset-paginated on the machine's local_id."""
+    machine = db.query(Machine).filter(Machine.id == machine_id).first()
+    if machine is None:
+        raise APIError(404, "Machine not found", "MACHINE_NOT_FOUND")
+
+    query = db.query(MachinePiece).filter(MachinePiece.machine_id == machine_id)
+    if cursor is not None:
+        query = query.filter(MachinePiece.local_id < cursor)
+    pieces = query.order_by(MachinePiece.local_id.desc()).limit(limit + 1).all()
+
+    has_more = len(pieces) > limit
+    pieces = pieces[:limit]
+    next_cursor = pieces[-1].local_id if (has_more and pieces) else None
+
+    images_by_piece: dict[str, list[MachinePieceImage]] = {}
+    piece_uuids = [p.piece_uuid for p in pieces]
+    if piece_uuids:
+        images = (
+            db.query(MachinePieceImage)
+            .filter(
+                MachinePieceImage.machine_id == machine_id,
+                MachinePieceImage.piece_uuid.in_(piece_uuids),
+            )
+            .order_by(MachinePieceImage.seq.asc())
+            .all()
+        )
+        for im in images:
+            images_by_piece.setdefault(im.piece_uuid, []).append(im)
+
+    total = (
+        db.query(func.count(MachinePiece.id))
+        .filter(MachinePiece.machine_id == machine_id)
+        .scalar()
+        or 0
+    )
+
+    return {
+        "machine": {
+            "id": str(machine.id),
+            "name": machine.name,
+            "owner_email": machine.owner.email if machine.owner else None,
+        },
+        "items": [
+            _serialize_machine_piece(p, images_by_piece.get(p.piece_uuid, []))
+            for p in pieces
+        ],
+        "next_cursor": next_cursor,
+        "total": total,
+    }
+
+
+@router.get("/admin/machines/{machine_id}/pieces/{piece_uuid}/images/{seq}")
+def admin_get_machine_piece_image(
+    machine_id: UUID,
+    piece_uuid: str,
+    seq: int,
+    db: Session = Depends(get_db),
+    admin: User = Depends(require_role("admin")),
+):
+    """Stream one synced crop's bytes from object storage. Cookie-session admin
+    auth is enough for an <img> tag on a same-origin page."""
+    image = (
+        db.query(MachinePieceImage)
+        .filter(
+            MachinePieceImage.machine_id == machine_id,
+            MachinePieceImage.piece_uuid == piece_uuid,
+            MachinePieceImage.seq == seq,
+        )
+        .first()
+    )
+    if image is None or not image.image_key:
+        raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
+
+    return serve_stored_file(image.image_key, headers={"Cache-Control": PIECE_IMAGE_CACHE_CONTROL})
 
 
 @router.post("/machines", response_model=MachineWithTokenResponse)

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -84,6 +84,45 @@ export interface FleetMachineStats {
 	ontime_pct: number;
 }
 
+export interface MachinePieceImageInfo {
+	seq: number;
+	source: string | null;
+	channel: number | null;
+	sharpness: number | null;
+	bytes: number | null;
+	used: boolean;
+	excluded_from_result: boolean;
+	score: number | null;
+	available: boolean;
+	evicted_locally: boolean;
+}
+
+export interface MachinePieceRecord {
+	piece_uuid: string;
+	local_id: number;
+	run_id: string | null;
+	seen_at: string | null;
+	recorded_at: string | null;
+	classification_status: string | null;
+	part_id: string | null;
+	part_name: string | null;
+	color_id: string | null;
+	color_name: string | null;
+	category_id: string | null;
+	confidence: number | null;
+	bin: { x: number | null; y: number | null; z: number | null };
+	dead: boolean;
+	brickognize_preview_url: string | null;
+	images: MachinePieceImageInfo[];
+}
+
+export interface MachinePiecesPage {
+	machine: { id: string; name: string; owner_email: string | null };
+	items: MachinePieceRecord[];
+	next_cursor: number | null;
+	total: number;
+}
+
 export interface MachineConfigBackupSummary {
 	id: string;
 	version: number;
@@ -806,6 +845,21 @@ export const api = {
 	},
 	getAllMachineStats() {
 		return request<Record<string, FleetMachineStats>>('GET', '/api/admin/machines/stats');
+	},
+	getMachinePieces(machineId: string, opts: { limit?: number; cursor?: number | null } = {}) {
+		const params = new URLSearchParams();
+		if (opts.limit) params.set('limit', String(opts.limit));
+		if (opts.cursor != null) params.set('cursor', String(opts.cursor));
+		const qs = params.toString();
+		return request<MachinePiecesPage>(
+			'GET',
+			`/api/admin/machines/${machineId}/pieces${qs ? `?${qs}` : ''}`
+		);
+	},
+	machinePieceImageUrl(machineId: string, pieceUuid: string, seq: number) {
+		return resolveApiPath(
+			`/api/admin/machines/${machineId}/pieces/${encodeURIComponent(pieceUuid)}/images/${seq}`
+		);
 	},
 	createMachine(name: string, description?: string) {
 		return request<MachineWithToken>('POST', '/api/machines', { name, description });

--- a/software/hive/frontend/src/routes/admin/machines/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/machines/+page.svelte
@@ -109,7 +109,10 @@
 					<tr class="hover:bg-bg {machine.archived_at ? 'opacity-50' : ''}">
 						<td class="whitespace-nowrap px-4 py-3">
 							<div class="flex items-center gap-2">
-								<p class="text-sm font-medium text-text">{machine.name}</p>
+								<a
+										href={`/admin/machines/${machine.id}`}
+										class="text-sm font-medium text-primary hover:underline"
+									>{machine.name}</a>
 								{#if machine.archived_at}
 									<Badge text="Archived" variant="neutral" />
 								{:else if !machine.is_active}

--- a/software/hive/frontend/src/routes/admin/machines/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/machines/[id]/+page.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { auth } from '$lib/auth.svelte';
+	import { api, type MachinePieceRecord } from '$lib/api';
+	import Badge from '$lib/components/Badge.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import { Button } from '$lib/components/primitives';
+
+	const PAGE_SIZE = 60;
+
+	const machineId = $derived(page.params.id ?? '');
+
+	let machineName = $state<string>('');
+	let pieces = $state<MachinePieceRecord[]>([]);
+	let total = $state(0);
+	let nextCursor = $state<number | null>(null);
+	let loading = $state(true);
+	let loadingMore = $state(false);
+	let error = $state<string | null>(null);
+	let sentinel = $state<HTMLDivElement | null>(null);
+
+	$effect(() => {
+		if (!auth.isAdmin) {
+			goto('/');
+			return;
+		}
+		// Re-run the initial load whenever the route id changes.
+		void machineId;
+		void loadInitial();
+	});
+
+	// Auto-load the next page when the sentinel scrolls into view, so the list
+	// behaves like the on-machine /records page (scroll, don't click).
+	$effect(() => {
+		const el = sentinel;
+		if (!el) return;
+		const observer = new IntersectionObserver((entries) => {
+			if (entries.some((e) => e.isIntersecting)) void loadMore();
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	});
+
+	async function loadInitial() {
+		if (!machineId) return;
+		loading = true;
+		error = null;
+		pieces = [];
+		nextCursor = null;
+		try {
+			const res = await api.getMachinePieces(machineId, { limit: PAGE_SIZE });
+			machineName = res.machine.name;
+			pieces = res.items;
+			total = res.total;
+			nextCursor = res.next_cursor;
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to load pieces');
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadMore() {
+		if (loadingMore || loading || nextCursor == null) return;
+		loadingMore = true;
+		try {
+			const res = await api.getMachinePieces(machineId, {
+				limit: PAGE_SIZE,
+				cursor: nextCursor
+			});
+			pieces = [...pieces, ...res.items];
+			nextCursor = res.next_cursor;
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to load more pieces');
+		} finally {
+			loadingMore = false;
+		}
+	}
+
+	function errMsg(e: unknown, fallback: string): string {
+		return e && typeof e === 'object' && 'error' in e
+			? String((e as { error: unknown }).error)
+			: fallback;
+	}
+
+	function statusVariant(status: string | null): 'success' | 'warning' | 'danger' | 'info' | 'neutral' {
+		switch (status) {
+			case 'classified':
+				return 'success';
+			case 'failed':
+			case 'not_found':
+			case 'multi_drop_fail':
+				return 'danger';
+			case 'unknown':
+				return 'warning';
+			case 'pending':
+			case 'classifying':
+				return 'info';
+			default:
+				return 'neutral';
+		}
+	}
+
+	function conf(c: number | null): string {
+		return c != null ? `${Math.round(c * 100)}%` : '—';
+	}
+
+	function when(iso: string | null): string {
+		if (!iso) return '—';
+		return new Date(iso).toLocaleString();
+	}
+
+	function binLabel(bin: { x: number | null; y: number | null; z: number | null }): string | null {
+		if (bin.x == null && bin.y == null && bin.z == null) return null;
+		return `${bin.x ?? '·'}, ${bin.y ?? '·'}, ${bin.z ?? '·'}`;
+	}
+</script>
+
+<svelte:head>
+	<title>{machineName ? `${machineName} — Pieces` : 'Machine Pieces'} - Hive</title>
+</svelte:head>
+
+<div class="mb-4">
+	<a href="/admin/machines" class="text-sm text-text-muted hover:text-text">← All machines</a>
+</div>
+
+<div class="mb-6 flex items-end justify-between">
+	<div>
+		<h1 class="text-2xl font-bold text-text">{machineName || 'Machine'}</h1>
+		<p class="text-sm text-text-muted">Pieces synced from this machine</p>
+	</div>
+	{#if !loading}
+		<span class="text-sm text-text-muted">
+			{pieces.length.toLocaleString()} of {total.toLocaleString()} loaded
+		</span>
+	{/if}
+</div>
+
+{#if error}
+	<div class="mb-4 bg-primary/8 p-3 text-sm text-primary">{error}</div>
+{/if}
+
+{#if loading}
+	<div class="flex justify-center py-12">
+		<Spinner />
+	</div>
+{:else if pieces.length === 0}
+	<div class="border border-border bg-surface p-8 text-center text-sm text-text-muted">
+		No pieces synced from this machine yet.
+	</div>
+{:else}
+	<div class="flex flex-col gap-2">
+		{#each pieces as piece (piece.piece_uuid)}
+			{@const bin = binLabel(piece.bin)}
+			<div class="flex gap-4 border border-border bg-surface p-3">
+				<!-- Left: crops from the machine -->
+				<div class="flex shrink-0 flex-wrap items-start gap-1.5" style="max-width: 15rem">
+					{#if piece.images.length === 0}
+						<div class="flex h-16 w-16 items-center justify-center border border-border bg-bg text-[10px] text-text-muted">
+							no images
+						</div>
+					{:else}
+						{#each piece.images as img (img.seq)}
+							{#if img.available}
+								<img
+									src={api.machinePieceImageUrl(machineId, piece.piece_uuid, img.seq)}
+									alt={`crop ${img.seq}`}
+									loading="lazy"
+									title={`seq ${img.seq}${img.source ? ` · ${img.source}` : ''}${img.score != null ? ` · score ${(img.score * 100).toFixed(0)}%` : ''}`}
+									class="h-16 w-16 border-2 object-cover {img.used
+										? 'border-success'
+										: img.excluded_from_result
+											? 'border-primary'
+											: 'border-border'}"
+								/>
+							{:else}
+								<div
+									class="flex h-16 w-16 items-center justify-center border border-dashed border-border bg-bg text-center text-[9px] text-text-muted"
+									title={`seq ${img.seq} · evicted before sync`}
+								>
+									evicted
+								</div>
+							{/if}
+						{/each}
+					{/if}
+				</div>
+
+				<!-- Middle: classification -->
+				<div class="min-w-0 flex-1">
+					<div class="flex flex-wrap items-center gap-2">
+						<Badge text={piece.classification_status ?? 'unknown'} variant={statusVariant(piece.classification_status)} />
+						<span class="text-sm font-medium text-text">
+							{piece.part_name || piece.part_id || 'Unidentified'}
+						</span>
+						{#if piece.part_id}
+							<span class="text-xs text-text-muted">#{piece.part_id}</span>
+						{/if}
+						{#if piece.dead}
+							<Badge text="dead" variant="danger" />
+						{/if}
+					</div>
+
+					<div class="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-muted">
+						<span>Color: <span class="text-text">{piece.color_name || piece.color_id || '—'}</span></span>
+						<span>Conf: <span class="text-text tabular-nums">{conf(piece.confidence)}</span></span>
+						{#if bin}
+							<span>Bin: <span class="text-text tabular-nums">{bin}</span></span>
+						{/if}
+						{#if piece.run_id}
+							<span class="truncate">Run: <span class="text-text">{piece.run_id}</span></span>
+						{/if}
+					</div>
+
+					<div class="mt-1 text-xs text-text-muted">
+						Seen {when(piece.seen_at)}
+						{#if piece.recorded_at} · Recorded {when(piece.recorded_at)}{/if}
+					</div>
+				</div>
+
+				<!-- Right: Brickognize reference -->
+				{#if piece.brickognize_preview_url}
+					<div class="shrink-0">
+						<img
+							src={piece.brickognize_preview_url}
+							alt="reference"
+							loading="lazy"
+							title="Brickognize reference"
+							class="h-16 w-16 border border-border object-contain"
+						/>
+					</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+
+	<div bind:this={sentinel} class="h-px"></div>
+
+	<div class="flex justify-center py-6">
+		{#if loadingMore}
+			<Spinner />
+		{:else if nextCursor != null}
+			<Button variant="secondary" size="sm" onclick={loadMore}>Load more</Button>
+		{:else}
+			<span class="text-xs text-text-muted">End of list · {total.toLocaleString()} pieces total</span>
+		{/if}
+	</div>
+{/if}


### PR DESCRIPTION
Adds an admin-only detail page at `/admin/machines/[id]` listing every piece a machine has synced to Hive — its crops, color prediction, and part-type prediction — mirroring the on-machine `/records` page.

**Backend** (`machines` router):
- `GET /api/admin/machines/{id}/pieces` — keyset-paginated (on `local_id`, newest first) list of `MachinePiece` rows with their `MachinePieceImage` metadata attached in one batched query.
- `GET /api/admin/machines/{id}/pieces/{piece_uuid}/images/{seq}` — streams a crop's bytes from object storage; cookie-session admin auth suffices for a same-origin `<img>`.

**Frontend**:
- New `[id]/+page.svelte`: infinite-scroll list of piece cards (crops with used/excluded ring, classification, color, confidence, bin, timestamps, Brickognize reference). Evicted-before-sync crops render as placeholders.
- Machine name on `/admin/machines` now links to the detail page.
- `api.ts`: `MachinePieceRecord`/`MachinePiecesPage` types + `getMachinePieces` and `machinePieceImageUrl` helpers.

No DB migration (uses existing `machine_pieces`/`machine_piece_images` tables). `pnpm check` + `pnpm build` green. Already deployed to and verified on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)