### PR TITLE
versions: settings tab with one-click git-based machine updates

### DIFF
--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -137,6 +137,7 @@ from server.routers.telemetry import router as telemetry_router
 from server.routers.tailscale import router as tailscale_router
 from server.routers.wifi import router as wifi_router
 from server.routers.firmware import router as firmware_router
+from server.routers.versions import router as versions_router
 
 app.include_router(hardware_router)
 app.include_router(steppers_router)
@@ -157,6 +158,7 @@ app.include_router(telemetry_router)
 app.include_router(tailscale_router)
 app.include_router(wifi_router)
 app.include_router(firmware_router)
+app.include_router(versions_router)
 
 # ---------------------------------------------------------------------------
 # Lifecycle

--- a/software/sorter/backend/server/routers/versions.py
+++ b/software/sorter/backend/server/routers/versions.py
@@ -1,0 +1,273 @@
+"""Software version listing and one-click git-based updates."""
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+RELEASE_TAG_PREFIX = "sorter/v"
+DEFAULT_BRANCH = "main"
+MAX_TAGS_LISTED = 20
+GIT_TIMEOUT_S = 30.0
+GIT_FETCH_TIMEOUT_S = 90.0
+REF_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+DEPENDENCY_FILES = (
+    "software/sorter/backend/pyproject.toml",
+    "software/sorter/backend/requirements.txt",
+    "software/sorter/frontend/package.json",
+)
+
+_repo_root_cache: Optional[Path] = None
+_update_lock = threading.Lock()
+_update_target: Optional[str] = None
+
+
+class UpdateRequest(BaseModel):
+    kind: str
+    name: str
+    restart: bool = True
+
+
+def _repoRoot() -> Path:
+    global _repo_root_cache
+    if _repo_root_cache is None:
+        backend_dir = Path(__file__).resolve().parents[2]
+        result = subprocess.run(
+            ["git", "-C", str(backend_dir), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_S,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Could not locate git repo root: {result.stderr.strip()}")
+        _repo_root_cache = Path(result.stdout.strip())
+    return _repo_root_cache
+
+
+def _git(*args: str, timeout: float = GIT_TIMEOUT_S) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(_repoRoot()), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _gitLine(*args: str) -> Optional[str]:
+    result = _git(*args)
+    if result.returncode != 0:
+        return None
+    line = result.stdout.strip()
+    return line if line else None
+
+
+def _commitInfo(ref: str) -> Optional[Dict[str, Any]]:
+    line = _gitLine("log", "-1", "--format=%h%x09%H%x09%ct%x09%s", ref)
+    if line is None:
+        return None
+    parts = line.split("\t", 3)
+    if len(parts) != 4:
+        return None
+    return {
+        "sha": parts[0],
+        "full_sha": parts[1],
+        "commit_unix": int(parts[2]),
+        "subject": parts[3],
+    }
+
+
+def _currentInfo() -> Dict[str, Any]:
+    branch = _gitLine("rev-parse", "--abbrev-ref", "HEAD") or "HEAD"
+    detached = branch == "HEAD"
+    head = _commitInfo("HEAD") or {}
+    describe = _gitLine("describe", "--tags", "--always") or head.get("sha", "unknown")
+    dirty_result = _git("status", "--porcelain", "--untracked-files=no")
+    dirty = bool(dirty_result.stdout.strip())
+    return {
+        "ref": describe if detached else branch,
+        "branch": None if detached else branch,
+        "detached": detached,
+        "describe": describe,
+        "dirty": dirty,
+        **head,
+    }
+
+
+def _branchEntries(current: Dict[str, Any]) -> List[Dict[str, Any]]:
+    names: List[str] = []
+    current_branch = current.get("branch")
+    if isinstance(current_branch, str) and current_branch:
+        names.append(current_branch)
+    if DEFAULT_BRANCH not in names:
+        names.append(DEFAULT_BRANCH)
+
+    entries: List[Dict[str, Any]] = []
+    for name in names:
+        info = _commitInfo(f"origin/{name}")
+        if info is None:
+            continue
+        entries.append(
+            {
+                "kind": "branch",
+                "name": name,
+                "sha": info["sha"],
+                "commit_unix": info["commit_unix"],
+                "subject": info["subject"],
+                "is_current": name == current_branch,
+                "up_to_date": info["full_sha"] == current.get("full_sha"),
+            }
+        )
+    return entries
+
+
+def _tagEntries(current: Dict[str, Any]) -> List[Dict[str, Any]]:
+    result = _git(
+        "tag",
+        "-l",
+        f"{RELEASE_TAG_PREFIX}*",
+        "--sort=-creatordate",
+        "--format=%(refname:strip=2)%09%(creatordate:unix)",
+    )
+    if result.returncode != 0:
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for line in result.stdout.strip().splitlines()[:MAX_TAGS_LISTED]:
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        name = parts[0]
+        info = _commitInfo(f"refs/tags/{name}")
+        if info is None:
+            continue
+        entries.append(
+            {
+                "kind": "tag",
+                "name": name,
+                "sha": info["sha"],
+                "commit_unix": info["commit_unix"],
+                "subject": info["subject"],
+                "is_current": info["full_sha"] == current.get("full_sha"),
+                "up_to_date": info["full_sha"] == current.get("full_sha"),
+            }
+        )
+    return entries
+
+
+def _changedDependencyFiles(old_sha: str, new_sha: str) -> List[str]:
+    if old_sha == new_sha:
+        return []
+    result = _git("diff", "--name-only", old_sha, new_sha, "--", *DEPENDENCY_FILES)
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.strip().splitlines() if line]
+
+
+def _deferredRestart() -> None:
+    def _exit() -> None:
+        time.sleep(0.5)
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    threading.Thread(target=_exit, daemon=True).start()
+
+
+@router.get("/api/system/versions")
+def get_versions(refresh: bool = False) -> Dict[str, Any]:
+    fetch_error: Optional[str] = None
+    if refresh:
+        result = _git(
+            "fetch", "--tags", "--prune", "--force", "origin",
+            timeout=GIT_FETCH_TIMEOUT_S,
+        )
+        if result.returncode != 0:
+            fetch_error = result.stderr.strip() or "git fetch failed"
+
+    current = _currentInfo()
+    available = _branchEntries(current) + _tagEntries(current)
+    return {
+        "ok": True,
+        "current": current,
+        "available": available,
+        "fetch_error": fetch_error,
+        "update_in_progress": _update_target,
+    }
+
+
+@router.post("/api/system/update")
+def update_version(req: UpdateRequest) -> Dict[str, Any]:
+    global _update_target
+
+    if req.kind not in ("branch", "tag"):
+        return {"ok": False, "message": f"Unknown ref kind: {req.kind}"}
+    if not REF_NAME_PATTERN.match(req.name) or ".." in req.name:
+        return {"ok": False, "message": f"Invalid ref name: {req.name}"}
+    if req.kind == "tag" and not req.name.startswith(RELEASE_TAG_PREFIX):
+        return {"ok": False, "message": f"Tags must start with {RELEASE_TAG_PREFIX}"}
+
+    if not _update_lock.acquire(blocking=False):
+        return {"ok": False, "message": f"Update already in progress: {_update_target}"}
+    try:
+        _update_target = f"{req.kind}:{req.name}"
+
+        fetch = _git(
+            "fetch", "--tags", "--prune", "--force", "origin",
+            timeout=GIT_FETCH_TIMEOUT_S,
+        )
+        if fetch.returncode != 0:
+            return {"ok": False, "message": f"git fetch failed: {fetch.stderr.strip()}"}
+
+        target_ref = f"origin/{req.name}" if req.kind == "branch" else f"refs/tags/{req.name}"
+        target = _commitInfo(target_ref)
+        if target is None:
+            return {"ok": False, "message": f"Ref not found on origin: {target_ref}"}
+
+        old = _commitInfo("HEAD") or {}
+        old_sha = old.get("full_sha", "")
+
+        # Never `git clean` here — gitignored machine config (machine.toml,
+        # .env, mine/, sqlite) must survive every update. Local tracked edits
+        # are stashed, not discarded, so nothing is ever silently lost.
+        dirty = bool(_git("status", "--porcelain", "--untracked-files=no").stdout.strip())
+        stashed = False
+        if dirty:
+            stash = _git("stash", "push", "-m", f"pre-update {time.strftime('%Y-%m-%d %H:%M:%S')}")
+            if stash.returncode != 0:
+                return {"ok": False, "message": f"git stash failed: {stash.stderr.strip()}"}
+            stashed = True
+
+        if req.kind == "branch":
+            checkout = _git("checkout", "-f", "-B", req.name, f"origin/{req.name}")
+        else:
+            checkout = _git("checkout", "-f", "--detach", f"refs/tags/{req.name}")
+        if checkout.returncode != 0:
+            return {"ok": False, "message": f"git checkout failed: {checkout.stderr.strip()}"}
+
+        deps_changed = _changedDependencyFiles(old_sha, target["full_sha"])
+
+        if req.restart:
+            _deferredRestart()
+
+        return {
+            "ok": True,
+            "old_sha": old.get("sha"),
+            "new_sha": target["sha"],
+            "changed": old_sha != target["full_sha"],
+            "stashed_local_changes": stashed,
+            "deps_changed": deps_changed,
+            "restarting": req.restart,
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {"ok": False, "message": f"git command timed out: {exc}"}
+    finally:
+        _update_target = None
+        _update_lock.release()

--- a/software/sorter/frontend/src/lib/components/settings/VersionsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/VersionsSection.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		machineHttpBaseUrlFromWsUrl,
+		getBackendHttpBase,
+		waitForBackend
+	} from '$lib/backend';
+	import { getMachineContext } from '$lib/machines/context';
+	import { Button, Alert } from '$lib/components/primitives';
+	import { GitBranch, Tag, RefreshCcw } from 'lucide-svelte';
+
+	const machine = getMachineContext();
+
+	type CurrentVersion = {
+		ref: string;
+		branch: string | null;
+		detached: boolean;
+		describe: string;
+		dirty: boolean;
+		sha?: string;
+		commit_unix?: number;
+		subject?: string;
+	};
+
+	type VersionEntry = {
+		kind: 'branch' | 'tag';
+		name: string;
+		sha: string;
+		commit_unix: number;
+		subject: string;
+		is_current: boolean;
+		up_to_date: boolean;
+	};
+
+	type VersionsPayload = {
+		ok: boolean;
+		current: CurrentVersion;
+		available: VersionEntry[];
+		fetch_error: string | null;
+		update_in_progress: string | null;
+	};
+
+	let payload = $state<VersionsPayload | null>(null);
+	let loading = $state(false);
+	let loadError = $state<string | null>(null);
+	let updatingRef = $state<string | null>(null);
+	let updateError = $state<string | null>(null);
+	let updateNotice = $state<string | null>(null);
+	let depsWarning = $state<string | null>(null);
+
+	function httpBase(): string {
+		return machineHttpBaseUrlFromWsUrl(machine.machine?.url) ?? getBackendHttpBase();
+	}
+
+	function formatDate(unix: number | undefined): string {
+		if (!unix) return '';
+		return new Date(unix * 1000).toLocaleString();
+	}
+
+	async function load(refresh: boolean) {
+		loading = true;
+		loadError = null;
+		try {
+			const res = await fetch(`${httpBase()}/api/system/versions?refresh=${refresh}`);
+			if (!res.ok) throw new Error(await res.text());
+			payload = await res.json();
+		} catch (e: any) {
+			loadError = e.message ?? 'Failed to load versions';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function applyUpdate(entry: VersionEntry) {
+		updatingRef = `${entry.kind}:${entry.name}`;
+		updateError = null;
+		updateNotice = null;
+		depsWarning = null;
+		try {
+			const res = await fetch(`${httpBase()}/api/system/update`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ kind: entry.kind, name: entry.name })
+			});
+			if (!res.ok) throw new Error(await res.text());
+			const data = await res.json();
+			if (!data.ok) {
+				updateError = data.message ?? 'Update failed';
+				return;
+			}
+			if (Array.isArray(data.deps_changed) && data.deps_changed.length > 0) {
+				depsWarning = `Dependency files changed (${data.deps_changed.join(', ')}). A manual dependency install and service restart may be needed.`;
+			}
+			updateNotice = data.changed
+				? `Updated ${data.old_sha} → ${data.new_sha}. Restarting backend...`
+				: 'Already at this version. Restarting backend...';
+			await waitForBackend(httpBase());
+			updateNotice = updateNotice.replace('Restarting backend...', 'Backend is back up.');
+			await load(false);
+		} catch (e: any) {
+			updateError = e.message ?? 'Update failed';
+		} finally {
+			updatingRef = null;
+		}
+	}
+
+	onMount(() => {
+		void load(true);
+	});
+</script>
+
+<div class="flex flex-col gap-4">
+	<div class="border border-border bg-surface px-3 py-3">
+		<div class="flex items-center gap-2">
+			<span class="text-sm font-medium text-text">Current version</span>
+			{#if payload?.current.dirty}
+				<span class="text-xs text-warning">local changes present</span>
+			{/if}
+			<button
+				type="button"
+				class="ml-auto inline-flex items-center gap-1 text-sm text-text-muted transition-colors hover:text-text"
+				title="Refresh from origin"
+				disabled={loading}
+				onclick={() => void load(true)}
+			>
+				<RefreshCcw size={14} class={loading ? 'animate-spin' : ''} />
+			</button>
+		</div>
+		{#if payload}
+			<div class="mt-2 flex flex-col gap-0.5">
+				<div class="text-sm text-text-muted">
+					{payload.current.detached ? 'Version' : 'Branch'}:
+					<span class="font-mono text-text">{payload.current.ref}</span>
+				</div>
+				<div class="text-sm text-text-muted">
+					Commit:
+					<span class="font-mono text-text">{payload.current.sha}</span>
+					{#if payload.current.subject}
+						<span class="text-text-muted"> — {payload.current.subject}</span>
+					{/if}
+				</div>
+				{#if payload.current.commit_unix}
+					<div class="text-sm text-text-muted">{formatDate(payload.current.commit_unix)}</div>
+				{/if}
+			</div>
+		{:else if loading}
+			<div class="mt-2 text-sm text-text-muted">Loading...</div>
+		{/if}
+	</div>
+
+	{#if payload?.fetch_error}
+		<Alert variant="warning">Could not fetch from origin: {payload.fetch_error}</Alert>
+	{/if}
+	{#if loadError}
+		<Alert variant="danger">{loadError}</Alert>
+	{/if}
+	{#if updateError}
+		<Alert variant="danger">{updateError}</Alert>
+	{/if}
+	{#if updateNotice}
+		<Alert variant="success">{updateNotice}</Alert>
+	{/if}
+	{#if depsWarning}
+		<Alert variant="warning">{depsWarning}</Alert>
+	{/if}
+
+	{#if payload && payload.available.length > 0}
+		<div class="border border-border">
+			<div class="border-b border-border bg-surface px-3 py-2">
+				<span class="text-sm font-medium text-text">Available versions</span>
+			</div>
+			<ul class="divide-y divide-border">
+				{#each payload.available as entry (entry.kind + entry.name)}
+					<li class="flex items-center gap-3 px-3 py-2.5">
+						{#if entry.kind === 'branch'}
+							<GitBranch size={14} class="shrink-0 text-text-muted" />
+						{:else}
+							<Tag size={14} class="shrink-0 text-text-muted" />
+						{/if}
+						<div class="min-w-0 flex-1">
+							<div class="flex items-center gap-2">
+								<span class="truncate font-mono text-sm text-text">{entry.name}</span>
+								{#if entry.is_current && entry.up_to_date}
+									<span class="shrink-0 text-xs text-success">up to date</span>
+								{:else if entry.is_current}
+									<span class="shrink-0 text-xs text-text-muted">current branch</span>
+								{/if}
+							</div>
+							<div class="truncate text-xs text-text-muted">
+								<span class="font-mono">{entry.sha}</span>
+								— {entry.subject} · {formatDate(entry.commit_unix)}
+							</div>
+						</div>
+						<Button
+							variant={entry.is_current && !entry.up_to_date ? 'primary' : 'secondary'}
+							size="sm"
+							disabled={updatingRef !== null || (entry.is_current && entry.up_to_date)}
+							loading={updatingRef === `${entry.kind}:${entry.name}`}
+							onclick={() => void applyUpdate(entry)}
+						>
+							{updatingRef === `${entry.kind}:${entry.name}`
+								? 'Updating...'
+								: entry.is_current
+									? 'Update'
+									: 'Switch'}
+						</Button>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+
+	<p class="text-sm text-text-muted">
+		Updating checks out the selected version on this machine and restarts the backend. Machine
+		config (machine.toml, .env, sorting data) is never touched; local code edits are stashed, not
+		lost.
+	</p>
+</div>

--- a/software/sorter/frontend/src/lib/settings/stations.ts
+++ b/software/sorter/frontend/src/lib/settings/stations.ts
@@ -5,6 +5,7 @@ import {
 	Cloud,
 	Cpu,
 	Gauge,
+	GitBranch,
 	Layers3,
 	Settings,
 	Shapes,
@@ -98,6 +99,12 @@ export const hiveModelsNavItem: SettingsNavItem = {
 	href: '/settings/hive/models',
 	label: 'Models',
 	icon: Cpu
+};
+
+export const versionsNavItem: SettingsNavItem = {
+	href: '/settings/versions',
+	label: 'Versions',
+	icon: GitBranch
 };
 
 export const chuteNavItem: SettingsNavItem = {
@@ -265,6 +272,7 @@ const baseSettingsNavItems: SettingsNavEntry[] = [
 	generalNavItem,
 	hiveNavItem,
 	hiveModelsNavItem,
+	versionsNavItem,
 	{ type: 'heading', label: 'Hardware' },
 	...stationPageConfigs,
 	chuteNavItem,

--- a/software/sorter/frontend/src/routes/settings/versions/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/versions/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import VersionsSection from '$lib/components/settings/VersionsSection.svelte';
+</script>
+
+<svelte:head><title>Sorter - Versions</title></svelte:head>
+
+<div class="flex flex-col gap-4 lg:max-w-4xl">
+	<header>
+		<h1 class="text-xl font-semibold text-text">Versions</h1>
+		<p class="mt-1 text-sm text-text-muted">
+			See which software version this machine is running and update it with one click.
+		</p>
+	</header>
+
+	<VersionsSection />
+</div>


### PR DESCRIPTION
Adds a **Versions** tab to settings for viewing and switching the machine's software version.

## Backend
- New router [versions.py](software/sorter/backend/server/routers/versions.py):
  - `GET /api/system/versions` — current checkout (branch/sha/subject/dirty) plus available versions from origin: the machine's current branch, `main`, and `sorter/v*` release tags.
  - `POST /api/system/update` — `git fetch`, stash any local tracked edits (never `git clean`, so gitignored machine config like `machine.toml`/`.env`/`mine/` always survives), `checkout -f` the target ref, then restart the backend via the existing SIGTERM path. Reports if dependency files changed between versions.

## Frontend
- `/settings/versions` page + nav item (top settings group).
- Current-version card, list of branches/tags with one-click Update/Switch, restart wait + auto-refresh after updating.

Branched off `spencer/hive-telemetry-choke-point` and includes a merge of its latest state, hence this PR targets that branch.

Verified on kitbash: endpoint returns correct data, update path exercised via branch switch + supervisor restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)