### PR TITLE
Hive telemetry choke point: per-target upload permissions

### DIFF
--- a/software/sorter/backend/hive_telemetry.py
+++ b/software/sorter/backend/hive_telemetry.py
@@ -1,13 +1,14 @@
 """Single choke point for everything this machine uploads to Hive targets.
 
 Every upload request declares which telemetry fields it carries, and a field
-that is disabled in the settings blocks the request here — at send time, so a
+that is disabled for the target blocks the request here — at send time, so a
 toggle also applies to jobs that were already queued. No other module may talk
 to the Hive upload endpoints directly; tests/test_hive_telemetry.py fails if
 one does.
 
 The field registry below is the source of truth for what CAN leave the
-machine. Adding a new kind of upload means adding a field here and routing the
+machine. Settings are per Hive target, stored on the target entry in the hive
+config. Adding a new kind of upload means adding a field here and routing the
 request through HiveTelemetryClient with that field declared.
 """
 
@@ -38,12 +39,6 @@ TELEMETRY_FIELDS: tuple[dict[str, Any], ...] = (
         "description": "Classification results per piece (part, color, confidence, bin, timestamps) and set sorting progress.",
         "default": True,
     },
-    {
-        "key": "machine_status",
-        "label": "Machine status",
-        "description": "Hardware and machine status details. No status upload exists yet; the empty keep-alive ping that marks this machine online is always sent while a target is enabled.",
-        "default": False,
-    },
 )
 
 _TELEMETRY_FIELD_KEYS = tuple(field["key"] for field in TELEMETRY_FIELDS)
@@ -63,38 +58,57 @@ def normalizeTelemetrySettings(raw: Any) -> dict[str, bool]:
     return settings
 
 
-def getTelemetrySettings() -> dict[str, bool]:
-    from local_state import get_hive_telemetry
+def _findTarget(config: dict[str, Any] | None, target_id: str) -> dict[str, Any] | None:
+    targets = config.get("targets") if isinstance(config, dict) else None
+    if not isinstance(targets, list):
+        return None
+    for target in targets:
+        if isinstance(target, dict) and target.get("id") == target_id:
+            return target
+    return None
 
-    return normalizeTelemetrySettings(get_hive_telemetry())
+
+def getTargetTelemetrySettings(target_id: str) -> dict[str, bool]:
+    from local_state import get_hive_config
+
+    target = _findTarget(get_hive_config(), target_id)
+    return normalizeTelemetrySettings(target.get("telemetry") if target else None)
 
 
-def setTelemetrySettings(updates: dict[str, Any]) -> dict[str, bool]:
+def setTargetTelemetrySettings(target_id: str, updates: dict[str, Any]) -> dict[str, bool]:
     unknown = sorted(key for key in updates if key not in _TELEMETRY_FIELD_KEYS)
     if unknown:
         raise ValueError(f"Unknown telemetry fields: {', '.join(unknown)}")
 
-    from local_state import set_hive_telemetry
+    from local_state import get_hive_config, set_hive_config
 
-    settings = getTelemetrySettings()
+    config = get_hive_config() or {}
+    target = _findTarget(config, target_id)
+    if target is None:
+        raise ValueError(f"Unknown Hive target: {target_id}")
+
+    settings = normalizeTelemetrySettings(target.get("telemetry"))
     for key, value in updates.items():
         settings[key] = bool(value)
-    set_hive_telemetry(settings)
+    target["telemetry"] = settings
+    set_hive_config(config)
     return settings
 
 
-def telemetryAllows(field: str) -> bool:
-    return bool(getTelemetrySettings().get(field, False))
+def resetTargetTelemetrySettings(target_id: str) -> dict[str, bool]:
+    return setTargetTelemetrySettings(target_id, defaultTelemetrySettings())
+
+
+def telemetryAllows(target_id: str, field: str) -> bool:
+    return bool(getTargetTelemetrySettings(target_id).get(field, False))
 
 
 def telemetryFieldList() -> list[dict[str, Any]]:
-    settings = getTelemetrySettings()
     return [
         {
             "key": field["key"],
             "label": field["label"],
             "description": field["description"],
-            "enabled": settings[field["key"]],
         }
         for field in TELEMETRY_FIELDS
     ]
@@ -102,13 +116,14 @@ def telemetryFieldList() -> list[dict[str, Any]]:
 
 class TelemetryBlocked(Exception):
     def __init__(self, field: str) -> None:
-        super().__init__(f"Telemetry field '{field}' is disabled in the Hive upload settings.")
+        super().__init__(f"Telemetry field '{field}' is disabled for this Hive target.")
         self.field = field
 
 
 class HiveTelemetryClient:
-    def __init__(self, url: str, api_token: str) -> None:
+    def __init__(self, url: str, api_token: str, target_id: str) -> None:
         self._url = url.rstrip("/")
+        self._target_id = target_id
         self._session = requests.Session()
         self._session.headers["Authorization"] = f"Bearer {api_token}"
 
@@ -121,7 +136,7 @@ class HiveTelemetryClient:
         timeout: float,
         **kwargs: Any,
     ) -> requests.Response:
-        settings = getTelemetrySettings()
+        settings = getTargetTelemetrySettings(self._target_id)
         for field in fields:
             if not settings.get(field, False):
                 raise TelemetryBlocked(field)
@@ -190,7 +205,7 @@ class HiveTelemetryClient:
         # A sample IS a detection image plus its detection metadata, so the
         # whole request rides on detection_images; full-frame attachments are
         # stripped (not blocked) when full_frames is off.
-        settings = getTelemetrySettings()
+        settings = getTargetTelemetrySettings(self._target_id)
         if not settings.get("detection_images", False):
             raise TelemetryBlocked("detection_images")
         if not settings.get("full_frames", False):
@@ -268,7 +283,8 @@ class HiveTelemetryClient:
 
     def heartbeat(self) -> bool:
         # Empty keep-alive so target reachability shows in the UI; carries no
-        # machine data. A future status payload must be gated on machine_status.
+        # machine data. A future status upload must add a registry field and
+        # be gated on it.
         try:
             response = self._session.post(f"{self._url}/api/machine/heartbeat", timeout=10)
             return response.status_code < 500

--- a/software/sorter/backend/hive_telemetry.py
+++ b/software/sorter/backend/hive_telemetry.py
@@ -1,0 +1,276 @@
+"""Single choke point for everything this machine uploads to Hive targets.
+
+Every upload request declares which telemetry fields it carries, and a field
+that is disabled in the settings blocks the request here — at send time, so a
+toggle also applies to jobs that were already queued. No other module may talk
+to the Hive upload endpoints directly; tests/test_hive_telemetry.py fails if
+one does.
+
+The field registry below is the source of truth for what CAN leave the
+machine. Adding a new kind of upload means adding a field here and routing the
+request through HiveTelemetryClient with that field declared.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import requests
+
+TELEMETRY_FIELDS: tuple[dict[str, Any], ...] = (
+    {
+        "key": "detection_images",
+        "label": "Detection images",
+        "description": "Cropped pictures of individual pieces: live training samples and the per-piece image history.",
+        "default": True,
+    },
+    {
+        "key": "full_frames",
+        "label": "Full camera frames",
+        "description": "Uncropped camera captures and detection overlay images attached to training samples.",
+        "default": True,
+    },
+    {
+        "key": "piece_metadata",
+        "label": "Piece metadata",
+        "description": "Classification results per piece (part, color, confidence, bin, timestamps) and set sorting progress.",
+        "default": True,
+    },
+    {
+        "key": "machine_status",
+        "label": "Machine status",
+        "description": "Hardware and machine status details. No status upload exists yet; the empty keep-alive ping that marks this machine online is always sent while a target is enabled.",
+        "default": False,
+    },
+)
+
+_TELEMETRY_FIELD_KEYS = tuple(field["key"] for field in TELEMETRY_FIELDS)
+
+
+def defaultTelemetrySettings() -> dict[str, bool]:
+    return {field["key"]: bool(field["default"]) for field in TELEMETRY_FIELDS}
+
+
+def normalizeTelemetrySettings(raw: Any) -> dict[str, bool]:
+    settings = defaultTelemetrySettings()
+    if isinstance(raw, dict):
+        for key in _TELEMETRY_FIELD_KEYS:
+            value = raw.get(key)
+            if isinstance(value, bool):
+                settings[key] = value
+    return settings
+
+
+def getTelemetrySettings() -> dict[str, bool]:
+    from local_state import get_hive_telemetry
+
+    return normalizeTelemetrySettings(get_hive_telemetry())
+
+
+def setTelemetrySettings(updates: dict[str, Any]) -> dict[str, bool]:
+    unknown = sorted(key for key in updates if key not in _TELEMETRY_FIELD_KEYS)
+    if unknown:
+        raise ValueError(f"Unknown telemetry fields: {', '.join(unknown)}")
+
+    from local_state import set_hive_telemetry
+
+    settings = getTelemetrySettings()
+    for key, value in updates.items():
+        settings[key] = bool(value)
+    set_hive_telemetry(settings)
+    return settings
+
+
+def telemetryAllows(field: str) -> bool:
+    return bool(getTelemetrySettings().get(field, False))
+
+
+def telemetryFieldList() -> list[dict[str, Any]]:
+    settings = getTelemetrySettings()
+    return [
+        {
+            "key": field["key"],
+            "label": field["label"],
+            "description": field["description"],
+            "enabled": settings[field["key"]],
+        }
+        for field in TELEMETRY_FIELDS
+    ]
+
+
+class TelemetryBlocked(Exception):
+    def __init__(self, field: str) -> None:
+        super().__init__(f"Telemetry field '{field}' is disabled in the Hive upload settings.")
+        self.field = field
+
+
+class HiveTelemetryClient:
+    def __init__(self, url: str, api_token: str) -> None:
+        self._url = url.rstrip("/")
+        self._session = requests.Session()
+        self._session.headers["Authorization"] = f"Bearer {api_token}"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        fields: tuple[str, ...],
+        timeout: float,
+        **kwargs: Any,
+    ) -> requests.Response:
+        settings = getTelemetrySettings()
+        for field in fields:
+            if not settings.get(field, False):
+                raise TelemetryBlocked(field)
+        response = self._session.request(method, f"{self._url}{path}", timeout=timeout, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def getSyncState(self) -> dict[str, Any]:
+        return self._request("GET", "/api/machine/sync/state", fields=(), timeout=15).json()
+
+    def pushPieceRecords(self, records: list[dict[str, Any]]) -> int:
+        response = self._request(
+            "POST",
+            "/api/machine/sync/piece-records",
+            fields=("piece_metadata",),
+            json={"records": records},
+            timeout=60,
+        )
+        return int(response.json()["max_local_id"])
+
+    def pushPieceImage(self, meta: dict[str, Any], file_path: Path | None) -> int:
+        files = None
+        if file_path is not None and file_path.is_file():
+            with open(file_path, "rb") as handle:
+                files = {"image": (file_path.name, handle.read(), "image/jpeg")}
+        response = self._request(
+            "POST",
+            "/api/machine/sync/piece-image",
+            fields=("detection_images",),
+            data={"metadata": json.dumps(meta)},
+            files=files,
+            timeout=60,
+        )
+        return int(response.json()["max_local_id"])
+
+    def pushSetProgress(self, payload: dict[str, Any]) -> None:
+        self._request(
+            "POST",
+            "/api/machine/set-progress",
+            fields=("piece_metadata",),
+            json=payload,
+            timeout=15,
+        )
+
+    def _sendSample(
+        self,
+        *,
+        method: str,
+        path: str,
+        source_session_id: str,
+        local_sample_id: str,
+        image_path: Path | None = None,
+        full_frame_path: Path | None = None,
+        overlay_path: Path | None = None,
+        source_role: str | None = None,
+        capture_reason: str | None = None,
+        captured_at: str | None = None,
+        session_name: str | None = None,
+        detection_algorithm: str | None = None,
+        detection_bboxes: Any = None,
+        detection_count: int | None = None,
+        detection_score: float | None = None,
+        sample_payload: dict[str, Any] | None = None,
+        extra_metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        # A sample IS a detection image plus its detection metadata, so the
+        # whole request rides on detection_images; full-frame attachments are
+        # stripped (not blocked) when full_frames is off.
+        settings = getTelemetrySettings()
+        if not settings.get("detection_images", False):
+            raise TelemetryBlocked("detection_images")
+        if not settings.get("full_frames", False):
+            full_frame_path = None
+            overlay_path = None
+
+        metadata: dict[str, Any] = {
+            "source_session_id": source_session_id,
+            "local_sample_id": local_sample_id,
+        }
+        for key, value in [
+            ("source_role", source_role),
+            ("capture_reason", capture_reason),
+            ("captured_at", captured_at),
+            ("session_name", session_name),
+            ("detection_algorithm", detection_algorithm),
+            ("detection_bboxes", detection_bboxes),
+            ("detection_count", detection_count),
+            ("detection_score", detection_score),
+            ("sample_payload", sample_payload),
+        ]:
+            if value is not None:
+                metadata[key] = value
+        if extra_metadata:
+            metadata["extra_metadata"] = extra_metadata
+
+        handles: list[Any] = []
+        try:
+            files: dict[str, Any] = {}
+            if image_path is not None:
+                image_fh = open(image_path, "rb")
+                handles.append(image_fh)
+                files["image"] = (image_path.name, image_fh, "image/jpeg")
+            if full_frame_path and full_frame_path.exists():
+                full_frame_fh = open(full_frame_path, "rb")
+                handles.append(full_frame_fh)
+                files["full_frame"] = (full_frame_path.name, full_frame_fh, "image/jpeg")
+            if overlay_path and overlay_path.exists():
+                overlay_fh = open(overlay_path, "rb")
+                handles.append(overlay_fh)
+                files["overlay"] = (overlay_path.name, overlay_fh, "image/jpeg")
+
+            response = self._request(
+                method,
+                path,
+                fields=("detection_images",),
+                data={"metadata": json.dumps(metadata)},
+                files=files or None,
+                timeout=30,
+            )
+            return response.json()
+        finally:
+            for handle in handles:
+                handle.close()
+
+    def uploadSample(self, *, source_session_id: str, local_sample_id: str, image_path: Path, **kwargs: Any) -> dict[str, Any]:
+        return self._sendSample(
+            method="POST",
+            path="/api/machine/upload",
+            source_session_id=source_session_id,
+            local_sample_id=local_sample_id,
+            image_path=image_path,
+            **kwargs,
+        )
+
+    def updateSample(self, *, source_session_id: str, local_sample_id: str, image_path: Path | None = None, **kwargs: Any) -> dict[str, Any]:
+        return self._sendSample(
+            method="PATCH",
+            path=f"/api/machine/upload/{source_session_id}/{local_sample_id}",
+            source_session_id=source_session_id,
+            local_sample_id=local_sample_id,
+            image_path=image_path,
+            **kwargs,
+        )
+
+    def heartbeat(self) -> bool:
+        # Empty keep-alive so target reachability shows in the UI; carries no
+        # machine data. A future status payload must be gated on machine_status.
+        try:
+            response = self._session.post(f"{self._url}/api/machine/heartbeat", timeout=10)
+            return response.status_code < 500
+        except requests.RequestException:
+            return False

--- a/software/sorter/backend/local_state.py
+++ b/software/sorter/backend/local_state.py
@@ -65,7 +65,6 @@ _STATE_KEY_BIN_LAYOUT = "bin_layout"
 _STATE_KEY_SERVO_CHANNEL_CALIBRATION = "servo_channel_calibration"
 _STATE_KEY_TAILSCALE_HOSTNAME = "tailscale_hostname"
 _STATE_KEY_SAMPLE_COLLECTION = "sample_collection"
-_STATE_KEY_HIVE_TELEMETRY = "hive_telemetry"
 
 _META_KEY_ACTIVE_SORTING_SESSION_ID = "active_sorting_session_id"
 _META_KEY_OPEN_BIN_SNAPSHOT_ID = "open_bin_snapshot_id"
@@ -235,6 +234,17 @@ def _normalize_hive_target(raw: Any, index: int) -> dict[str, Any] | None:
     }
     if isinstance(machine_id, str) and machine_id.strip():
         target["machine_id"] = machine_id.strip()
+    telemetry = raw.get("telemetry")
+    if isinstance(telemetry, dict):
+        # Per-target upload permissions; hive_telemetry owns the field set and
+        # defaults, so pass through any bool entries untouched.
+        normalized_telemetry = {
+            key: value
+            for key, value in telemetry.items()
+            if isinstance(key, str) and isinstance(value, bool)
+        }
+        if normalized_telemetry:
+            target["telemetry"] = normalized_telemetry
     return target
 
 
@@ -866,15 +876,6 @@ def set_sample_collection_state(state: dict[str, Any] | None) -> None:
             if isinstance(key, str) and value is not None
         }
     _write_state(_STATE_KEY_SAMPLE_COLLECTION, normalized)
-
-
-def get_hive_telemetry() -> dict[str, Any] | None:
-    value = _read_state(_STATE_KEY_HIVE_TELEMETRY)
-    return value if isinstance(value, dict) else None
-
-
-def set_hive_telemetry(settings: dict[str, Any]) -> None:
-    _write_state(_STATE_KEY_HIVE_TELEMETRY, settings)
 
 
 def get_hive_config() -> dict[str, Any] | None:

--- a/software/sorter/backend/local_state.py
+++ b/software/sorter/backend/local_state.py
@@ -65,6 +65,7 @@ _STATE_KEY_BIN_LAYOUT = "bin_layout"
 _STATE_KEY_SERVO_CHANNEL_CALIBRATION = "servo_channel_calibration"
 _STATE_KEY_TAILSCALE_HOSTNAME = "tailscale_hostname"
 _STATE_KEY_SAMPLE_COLLECTION = "sample_collection"
+_STATE_KEY_HIVE_TELEMETRY = "hive_telemetry"
 
 _META_KEY_ACTIVE_SORTING_SESSION_ID = "active_sorting_session_id"
 _META_KEY_OPEN_BIN_SNAPSHOT_ID = "open_bin_snapshot_id"
@@ -865,6 +866,15 @@ def set_sample_collection_state(state: dict[str, Any] | None) -> None:
             if isinstance(key, str) and value is not None
         }
     _write_state(_STATE_KEY_SAMPLE_COLLECTION, normalized)
+
+
+def get_hive_telemetry() -> dict[str, Any] | None:
+    value = _read_state(_STATE_KEY_HIVE_TELEMETRY)
+    return value if isinstance(value, dict) else None
+
+
+def set_hive_telemetry(settings: dict[str, Any]) -> None:
+    _write_state(_STATE_KEY_HIVE_TELEMETRY, settings)
 
 
 def get_hive_config() -> dict[str, Any] | None:

--- a/software/sorter/backend/server/hive_sync.py
+++ b/software/sorter/backend/server/hive_sync.py
@@ -13,18 +13,17 @@ so the same machine drains its full history into prod and staging independently.
 
 from __future__ import annotations
 
-import json
 import logging
 import threading
 import time
-from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import requests
 
 import piece_image_store
 import piece_records
 from blob_manager import getHiveConfig
+from hive_telemetry import HiveTelemetryClient, telemetryAllows
 
 log = logging.getLogger(__name__)
 
@@ -91,39 +90,6 @@ def _imageToMeta(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-class _SyncClient:
-    def __init__(self, url: str, token: str) -> None:
-        self._url = url.rstrip("/")
-        self._session = requests.Session()
-        self._session.headers["Authorization"] = f"Bearer {token}"
-
-    def getState(self) -> dict[str, Any]:
-        response = self._session.get(f"{self._url}/api/machine/sync/state", timeout=15)
-        response.raise_for_status()
-        return response.json()
-
-    def pushRecords(self, records: list[dict[str, Any]]) -> int:
-        response = self._session.post(
-            f"{self._url}/api/machine/sync/piece-records",
-            json={"records": records},
-            timeout=60,
-        )
-        response.raise_for_status()
-        return int(response.json()["max_local_id"])
-
-    def pushImage(self, meta: dict[str, Any], file_path: Optional[Path]) -> int:
-        url = f"{self._url}/api/machine/sync/piece-image"
-        data = {"metadata": json.dumps(meta)}
-        if file_path is not None and file_path.is_file():
-            with open(file_path, "rb") as handle:
-                files = {"image": (file_path.name, handle.read(), "image/jpeg")}
-            response = self._session.post(url, data=data, files=files, timeout=60)
-        else:
-            response = self._session.post(url, data=data, timeout=60)
-        response.raise_for_status()
-        return int(response.json()["max_local_id"])
-
-
 class HiveSyncWorker:
     def __init__(self, gc: Any) -> None:
         self._gc = gc
@@ -182,7 +148,7 @@ class HiveSyncWorker:
             }
             if enabled:
                 try:
-                    state["client"] = _SyncClient(url, token)
+                    state["client"] = HiveTelemetryClient(url, token)
                     log.info("Hive sync enabled: %s (%s)", state["name"], url)
                 except Exception as exc:
                     state["enabled"] = False
@@ -226,25 +192,31 @@ class HiveSyncWorker:
     def _ensureState(self, target: dict[str, Any]) -> None:
         if target["state_ok"] and target["wm"][DATA_TYPE_RECORDS] is not None:
             return
-        state = target["client"].getState()
+        state = target["client"].getSyncState()
         for data_type in (DATA_TYPE_RECORDS, DATA_TYPE_IMAGES):
             raw = state.get(data_type) if isinstance(state, dict) else None
             value = raw.get("max_local_id") if isinstance(raw, dict) else 0
             target["wm"][data_type] = int(value or 0)
 
     def _drainRecords(self, target: dict[str, Any]) -> bool:
+        if not telemetryAllows("piece_metadata"):
+            return False
         wm = int(target["wm"][DATA_TYPE_RECORDS] or 0)
         if piece_records.getMaxRecordId() <= wm:
             return False
         rows = piece_records.listRecordsAfter(wm, RECORDS_BATCH)
         if not rows:
             return False
-        new_max = target["client"].pushRecords([_recordToPayload(r) for r in rows])
+        new_max = target["client"].pushPieceRecords([_recordToPayload(r) for r in rows])
         target["wm"][DATA_TYPE_RECORDS] = max(wm, int(new_max), int(rows[-1]["id"]))
         time.sleep(RECORDS_THROTTLE_S)
         return True
 
     def _drainImages(self, target: dict[str, Any]) -> bool:
+        # Skip instead of pushing metadata-only rows: with images disabled the
+        # watermark freezes here and the backlog drains if re-enabled later.
+        if not telemetryAllows("detection_images"):
+            return False
         wm = int(target["wm"][DATA_TYPE_IMAGES] or 0)
         if piece_image_store.getMaxImageId() <= wm:
             return False
@@ -253,7 +225,7 @@ class HiveSyncWorker:
             return False
         for row in rows:
             file_path = None if row["evicted_locally"] else piece_image_store.getImageFileById(row["id"])
-            new_max = target["client"].pushImage(_imageToMeta(row), file_path)
+            new_max = target["client"].pushPieceImage(_imageToMeta(row), file_path)
             target["wm"][DATA_TYPE_IMAGES] = max(int(target["wm"][DATA_TYPE_IMAGES] or 0), int(new_max), int(row["id"]))
             time.sleep(IMAGES_THROTTLE_S)
         return True

--- a/software/sorter/backend/server/hive_sync.py
+++ b/software/sorter/backend/server/hive_sync.py
@@ -148,7 +148,7 @@ class HiveSyncWorker:
             }
             if enabled:
                 try:
-                    state["client"] = HiveTelemetryClient(url, token)
+                    state["client"] = HiveTelemetryClient(url, token, target_id)
                     log.info("Hive sync enabled: %s (%s)", state["name"], url)
                 except Exception as exc:
                     state["enabled"] = False
@@ -199,7 +199,7 @@ class HiveSyncWorker:
             target["wm"][data_type] = int(value or 0)
 
     def _drainRecords(self, target: dict[str, Any]) -> bool:
-        if not telemetryAllows("piece_metadata"):
+        if not telemetryAllows(target["id"], "piece_metadata"):
             return False
         wm = int(target["wm"][DATA_TYPE_RECORDS] or 0)
         if piece_records.getMaxRecordId() <= wm:
@@ -215,7 +215,7 @@ class HiveSyncWorker:
     def _drainImages(self, target: dict[str, Any]) -> bool:
         # Skip instead of pushing metadata-only rows: with images disabled the
         # watermark freezes here and the backlog drains if re-enabled later.
-        if not telemetryAllows("detection_images"):
+        if not telemetryAllows(target["id"], "detection_images"):
             return False
         wm = int(target["wm"][DATA_TYPE_IMAGES] or 0)
         if piece_image_store.getMaxImageId() <= wm:

--- a/software/sorter/backend/server/hive_uploader.py
+++ b/software/sorter/backend/server/hive_uploader.py
@@ -170,7 +170,7 @@ class HiveUploader:
 
             if enabled:
                 try:
-                    state["client"] = HiveTelemetryClient(url, token)
+                    state["client"] = HiveTelemetryClient(url, token, target_id)
                     state["server_reachable"] = bool(previous_state.get("server_reachable", True))
                     log.info("Hive uploader enabled: %s (%s)", state["name"], url)
                 except Exception as exc:
@@ -225,6 +225,15 @@ class HiveUploader:
         requested = {target_id for target_id in requested_target_ids if isinstance(target_id, str)}
         return [target_id for target_id in enabled_target_ids if target_id in requested]
 
+    def _resolve_upload_target_ids(self, target_ids: list[str] | None) -> list[str]:
+        with self._lock:
+            resolved = self._resolve_target_ids_locked(target_ids)
+        return [
+            target_id
+            for target_id in resolved
+            if telemetryAllows(target_id, "detection_images")
+        ]
+
     def enqueue(
         self,
         *,
@@ -237,12 +246,10 @@ class HiveUploader:
         overlay_path: str | None = None,
         target_ids: list[str] | None = None,
     ) -> None:
-        if not telemetryAllows("detection_images"):
+        resolved_target_ids = self._resolve_upload_target_ids(target_ids)
+        if not resolved_target_ids:
             return
         with self._lock:
-            resolved_target_ids = self._resolve_target_ids_locked(target_ids)
-            if not resolved_target_ids:
-                return
             for target_id in resolved_target_ids:
                 target = self._targets.get(target_id)
                 if target is not None:
@@ -276,12 +283,10 @@ class HiveUploader:
         overlay_path: str | None = None,
         target_ids: list[str] | None = None,
     ) -> None:
-        if not telemetryAllows("detection_images"):
+        resolved_target_ids = self._resolve_upload_target_ids(target_ids)
+        if not resolved_target_ids:
             return
         with self._lock:
-            resolved_target_ids = self._resolve_target_ids_locked(target_ids)
-            if not resolved_target_ids:
-                return
             for target_id in resolved_target_ids:
                 target = self._targets.get(target_id)
                 if target is not None:
@@ -309,12 +314,9 @@ class HiveUploader:
         session_ids: list[str] | None = None,
         target_ids: list[str] | None = None,
     ) -> dict[str, Any]:
-        if not telemetryAllows("detection_images"):
-            return {"ok": False, "error": "Detection image uploads are disabled in the Hive upload settings."}
-        with self._lock:
-            resolved_target_ids = self._resolve_target_ids_locked(target_ids)
-            if not resolved_target_ids:
-                return {"ok": False, "error": "No enabled Hive target is available."}
+        resolved_target_ids = self._resolve_upload_target_ids(target_ids)
+        if not resolved_target_ids:
+            return {"ok": False, "error": "No enabled Hive target allows detection image uploads."}
         if not training_root.exists():
             return {"ok": False, "error": "Training root does not exist."}
 
@@ -560,7 +562,7 @@ class HiveUploader:
             if candidate.exists():
                 overlay_path = candidate
 
-        if not telemetryAllows("full_frames"):
+        if not telemetryAllows(target_id, "full_frames"):
             full_frame_path = None
             overlay_path = None
 

--- a/software/sorter/backend/server/hive_uploader.py
+++ b/software/sorter/backend/server/hive_uploader.py
@@ -14,6 +14,7 @@ from typing import Any
 import requests
 
 from blob_manager import getHiveConfig
+from hive_telemetry import HiveTelemetryClient, TelemetryBlocked, telemetryAllows
 from server.sample_payloads import build_sample_payload
 
 log = logging.getLogger(__name__)
@@ -102,168 +103,6 @@ def _resolve_archived_file_path(
     return None
 
 
-class _HiveClient:
-    def __init__(self, api_url: str, api_token: str) -> None:
-        self._url = api_url.rstrip("/")
-        self._session = requests.Session()
-        self._session.headers["Authorization"] = f"Bearer {api_token}"
-
-    def _send_sample_request(
-        self,
-        *,
-        method: str,
-        url: str,
-        source_session_id: str,
-        local_sample_id: str,
-        image_path: Path | None = None,
-        full_frame_path: Path | None = None,
-        overlay_path: Path | None = None,
-        source_role: str | None = None,
-        capture_reason: str | None = None,
-        captured_at: str | None = None,
-        session_name: str | None = None,
-        detection_algorithm: str | None = None,
-        detection_bboxes: Any = None,
-        detection_count: int | None = None,
-        detection_score: float | None = None,
-        sample_payload: dict[str, Any] | None = None,
-        extra_metadata: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        metadata: dict[str, Any] = {
-            "source_session_id": source_session_id,
-            "local_sample_id": local_sample_id,
-        }
-        for key, value in [
-            ("source_role", source_role),
-            ("capture_reason", capture_reason),
-            ("captured_at", captured_at),
-            ("session_name", session_name),
-            ("detection_algorithm", detection_algorithm),
-            ("detection_bboxes", detection_bboxes),
-            ("detection_count", detection_count),
-            ("detection_score", detection_score),
-            ("sample_payload", sample_payload),
-        ]:
-            if value is not None:
-                metadata[key] = value
-        if extra_metadata:
-            metadata["extra_metadata"] = extra_metadata
-
-        handles: list[Any] = []
-        try:
-            files: dict[str, Any] = {}
-            if image_path is not None:
-                image_fh = open(image_path, "rb")
-                handles.append(image_fh)
-                files["image"] = (image_path.name, image_fh, "image/jpeg")
-            if full_frame_path and full_frame_path.exists():
-                full_frame_fh = open(full_frame_path, "rb")
-                handles.append(full_frame_fh)
-                files["full_frame"] = (full_frame_path.name, full_frame_fh, "image/jpeg")
-            if overlay_path and overlay_path.exists():
-                overlay_fh = open(overlay_path, "rb")
-                handles.append(overlay_fh)
-                files["overlay"] = (overlay_path.name, overlay_fh, "image/jpeg")
-
-            request = getattr(self._session, method.lower())
-            response = request(
-                url,
-                data={"metadata": json.dumps(metadata)},
-                files=files or None,
-                timeout=30,
-            )
-            response.raise_for_status()
-            return response.json()
-        finally:
-            for handle in handles:
-                handle.close()
-
-    def upload_sample(
-        self,
-        *,
-        source_session_id: str,
-        local_sample_id: str,
-        image_path: Path,
-        full_frame_path: Path | None = None,
-        overlay_path: Path | None = None,
-        source_role: str | None = None,
-        capture_reason: str | None = None,
-        captured_at: str | None = None,
-        session_name: str | None = None,
-        detection_algorithm: str | None = None,
-        detection_bboxes: Any = None,
-        detection_count: int | None = None,
-        detection_score: float | None = None,
-        sample_payload: dict[str, Any] | None = None,
-        extra_metadata: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        return self._send_sample_request(
-            method="POST",
-            url=f"{self._url}/api/machine/upload",
-            source_session_id=source_session_id,
-            local_sample_id=local_sample_id,
-            image_path=image_path,
-            full_frame_path=full_frame_path,
-            overlay_path=overlay_path,
-            source_role=source_role,
-            capture_reason=capture_reason,
-            captured_at=captured_at,
-            session_name=session_name,
-            detection_algorithm=detection_algorithm,
-            detection_bboxes=detection_bboxes,
-            detection_count=detection_count,
-            detection_score=detection_score,
-            sample_payload=sample_payload,
-            extra_metadata=extra_metadata,
-        )
-
-    def update_sample(
-        self,
-        *,
-        source_session_id: str,
-        local_sample_id: str,
-        image_path: Path | None = None,
-        full_frame_path: Path | None = None,
-        overlay_path: Path | None = None,
-        source_role: str | None = None,
-        capture_reason: str | None = None,
-        captured_at: str | None = None,
-        session_name: str | None = None,
-        detection_algorithm: str | None = None,
-        detection_bboxes: Any = None,
-        detection_count: int | None = None,
-        detection_score: float | None = None,
-        sample_payload: dict[str, Any] | None = None,
-        extra_metadata: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        return self._send_sample_request(
-            method="PATCH",
-            url=f"{self._url}/api/machine/upload/{source_session_id}/{local_sample_id}",
-            source_session_id=source_session_id,
-            local_sample_id=local_sample_id,
-            image_path=image_path,
-            full_frame_path=full_frame_path,
-            overlay_path=overlay_path,
-            source_role=source_role,
-            capture_reason=capture_reason,
-            captured_at=captured_at,
-            session_name=session_name,
-            detection_algorithm=detection_algorithm,
-            detection_bboxes=detection_bboxes,
-            detection_count=detection_count,
-            detection_score=detection_score,
-            sample_payload=sample_payload,
-            extra_metadata=extra_metadata,
-        )
-
-    def heartbeat(self) -> bool:
-        try:
-            response = self._session.post(f"{self._url}/api/machine/heartbeat", timeout=10)
-            return response.status_code < 500
-        except requests.RequestException:
-            return False
-
-
 def _is_transient(exc: Exception) -> bool:
     if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
         return True
@@ -331,7 +170,7 @@ class HiveUploader:
 
             if enabled:
                 try:
-                    state["client"] = _HiveClient(url, token)
+                    state["client"] = HiveTelemetryClient(url, token)
                     state["server_reachable"] = bool(previous_state.get("server_reachable", True))
                     log.info("Hive uploader enabled: %s (%s)", state["name"], url)
                 except Exception as exc:
@@ -398,6 +237,8 @@ class HiveUploader:
         overlay_path: str | None = None,
         target_ids: list[str] | None = None,
     ) -> None:
+        if not telemetryAllows("detection_images"):
+            return
         with self._lock:
             resolved_target_ids = self._resolve_target_ids_locked(target_ids)
             if not resolved_target_ids:
@@ -435,6 +276,8 @@ class HiveUploader:
         overlay_path: str | None = None,
         target_ids: list[str] | None = None,
     ) -> None:
+        if not telemetryAllows("detection_images"):
+            return
         with self._lock:
             resolved_target_ids = self._resolve_target_ids_locked(target_ids)
             if not resolved_target_ids:
@@ -466,6 +309,8 @@ class HiveUploader:
         session_ids: list[str] | None = None,
         target_ids: list[str] | None = None,
     ) -> dict[str, Any]:
+        if not telemetryAllows("detection_images"):
+            return {"ok": False, "error": "Detection image uploads are disabled in the Hive upload settings."}
         with self._lock:
             resolved_target_ids = self._resolve_target_ids_locked(target_ids)
             if not resolved_target_ids:
@@ -715,6 +560,10 @@ class HiveUploader:
             if candidate.exists():
                 overlay_path = candidate
 
+        if not telemetryAllows("full_frames"):
+            full_frame_path = None
+            overlay_path = None
+
         metadata = job["metadata"]
         skip_keys = {
             "source_role",
@@ -787,11 +636,11 @@ class HiveUploader:
                     "extra_metadata": extra_metadata or None,
                 }
                 if operation == "update":
-                    client.update_sample(**request_kwargs)
+                    client.updateSample(**request_kwargs)
                 else:
                     if image_path is None:
                         raise FileNotFoundError("Upload job is missing the primary image path.")
-                    client.upload_sample(**request_kwargs)  # type: ignore[arg-type]
+                    client.uploadSample(**request_kwargs)  # type: ignore[arg-type]
                 with self._lock:
                     target = self._targets.get(target_id)
                     if target is not None:
@@ -801,6 +650,13 @@ class HiveUploader:
                         target["retry_after"] = 0.0
                         target["backoff_s"] = SERVER_DOWN_BACKOFF_S
                         self._decrement_queue_locked(target_id)
+                return
+            except TelemetryBlocked as exc:
+                # The field was toggled off after this job was queued — drop
+                # it silently, matching what enqueue() would have done.
+                with self._lock:
+                    self._decrement_queue_locked(target_id)
+                log.debug("Hive upload dropped for %s/%s: %s", job["session_id"], job["sample_id"], exc)
                 return
             except Exception as exc:
                 retry_missing_sample = (

--- a/software/sorter/backend/server/routers/detection.py
+++ b/software/sorter/backend/server/routers/detection.py
@@ -29,7 +29,12 @@ from blob_manager import (
     setFeederDetectionConfig,
     setHiveConfig,
 )
-from hive_telemetry import setTelemetrySettings, telemetryFieldList
+from hive_telemetry import (
+    getTargetTelemetrySettings,
+    resetTargetTelemetrySettings,
+    setTargetTelemetrySettings,
+    telemetryFieldList,
+)
 from perception.overlay import drawChannelZones
 from server import shared_state
 from server.classification_training import getClassificationTrainingManager
@@ -678,6 +683,7 @@ def get_hive_config() -> Dict[str, Any]:
                 "api_token_masked": _mask_hive_token(target.get("api_token")),
                 "enabled": bool(target.get("enabled", False)),
                 "is_primary": target["id"] == primary_target_id,
+                "telemetry": getTargetTelemetrySettings(target["id"]),
                 "uploader": (
                     dict(uploader_by_id[target["id"]])
                     if target["id"] in uploader_by_id
@@ -716,6 +722,8 @@ def save_hive_config(payload: HiveTargetPayload) -> Dict[str, Any]:
         "machine_id": existing.get("machine_id") if existing else None,
         "enabled": payload.enabled,
     }
+    if existing and isinstance(existing.get("telemetry"), dict):
+        next_target["telemetry"] = existing["telemetry"]
 
     if existing is None:
         targets.append(next_target)
@@ -745,16 +753,21 @@ def clear_hive_config(target_id: str | None = Query(default=None)) -> Dict[str, 
 
 
 class HiveTelemetryPayload(BaseModel):
-    fields: Dict[str, bool]
+    target_id: str
+    fields: Dict[str, bool] = {}
+    reset: bool = False
 
 
 @router.post("/api/settings/hive/telemetry")
 def save_hive_telemetry(payload: HiveTelemetryPayload) -> Dict[str, Any]:
     try:
-        setTelemetrySettings(payload.fields)
+        if payload.reset:
+            settings = resetTargetTelemetrySettings(payload.target_id)
+        else:
+            settings = setTargetTelemetrySettings(payload.target_id, payload.fields)
     except ValueError as exc:
         raise HTTPException(400, str(exc))
-    return {"ok": True, "telemetry_fields": telemetryFieldList()}
+    return {"ok": True, "target_id": payload.target_id, "telemetry": settings}
 
 
 class HivePrimaryPayload(BaseModel):

--- a/software/sorter/backend/server/routers/detection.py
+++ b/software/sorter/backend/server/routers/detection.py
@@ -29,6 +29,7 @@ from blob_manager import (
     setFeederDetectionConfig,
     setHiveConfig,
 )
+from hive_telemetry import setTelemetrySettings, telemetryFieldList
 from perception.overlay import drawChannelZones
 from server import shared_state
 from server.classification_training import getClassificationTrainingManager
@@ -667,6 +668,7 @@ def get_hive_config() -> Dict[str, Any]:
         "configured_count": len(targets),
         "enabled_count": sum(1 for target in targets if bool(target.get("enabled", False))),
         "primary_target_id": primary_target_id,
+        "telemetry_fields": telemetryFieldList(),
         "targets": [
             {
                 "id": target["id"],
@@ -740,6 +742,19 @@ def clear_hive_config(target_id: str | None = Query(default=None)) -> Dict[str, 
     _save_hive_targets(next_targets)
     _reloadHiveConsumers()
     return {"ok": True, "message": "Hive target removed."}
+
+
+class HiveTelemetryPayload(BaseModel):
+    fields: Dict[str, bool]
+
+
+@router.post("/api/settings/hive/telemetry")
+def save_hive_telemetry(payload: HiveTelemetryPayload) -> Dict[str, Any]:
+    try:
+        setTelemetrySettings(payload.fields)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+    return {"ok": True, "telemetry_fields": telemetryFieldList()}
 
 
 class HivePrimaryPayload(BaseModel):

--- a/software/sorter/backend/server/set_progress_sync.py
+++ b/software/sorter/backend/server/set_progress_sync.py
@@ -5,9 +5,8 @@ import logging
 import threading
 from typing import Any
 
-import requests
-
 from blob_manager import getHiveConfig, getSortingProfileSyncState, setSortingProfileSyncState
+from hive_telemetry import HiveTelemetryClient, telemetryAllows
 from server import shared_state
 
 log = logging.getLogger(__name__)
@@ -79,6 +78,10 @@ class SetProgressSyncWorker:
             self._wake_event.clear()
 
     def _sync_once(self) -> None:
+        # Reset the signature while blocked so re-enabling resends current state.
+        if not telemetryAllows("piece_metadata"):
+            self._last_sent_signature = None
+            return
         report = self._build_report()
         if report is None:
             self._last_sent_signature = None
@@ -86,17 +89,8 @@ class SetProgressSyncWorker:
         if report["signature"] == self._last_sent_signature:
             return
 
-        response = requests.post(
-            report["url"],
-            json=report["payload"],
-            headers={
-                "Authorization": f"Bearer {report['api_token']}",
-                "Content-Type": "application/json",
-            },
-            timeout=15,
-        )
-        if not response.ok:
-            raise RuntimeError(f"Progress sync failed: HTTP {response.status_code} {response.text}")
+        client = HiveTelemetryClient(report["url"], report["api_token"])
+        client.pushSetProgress(report["payload"])
         self._last_sent_signature = report["signature"]
         self._record_success()
 
@@ -149,7 +143,7 @@ class SetProgressSyncWorker:
             return None
 
         return {
-            "url": f"{str(target['url']).rstrip('/')}/api/machine/set-progress",
+            "url": str(target["url"]),
             "api_token": str(target["api_token"]),
             "payload": {
                 "version_id": version_id,

--- a/software/sorter/backend/server/set_progress_sync.py
+++ b/software/sorter/backend/server/set_progress_sync.py
@@ -78,10 +78,6 @@ class SetProgressSyncWorker:
             self._wake_event.clear()
 
     def _sync_once(self) -> None:
-        # Reset the signature while blocked so re-enabling resends current state.
-        if not telemetryAllows("piece_metadata"):
-            self._last_sent_signature = None
-            return
         report = self._build_report()
         if report is None:
             self._last_sent_signature = None
@@ -89,7 +85,7 @@ class SetProgressSyncWorker:
         if report["signature"] == self._last_sent_signature:
             return
 
-        client = HiveTelemetryClient(report["url"], report["api_token"])
+        client = HiveTelemetryClient(report["url"], report["api_token"], report["target_id"])
         client.pushSetProgress(report["payload"])
         self._last_sent_signature = report["signature"]
         self._record_success()
@@ -119,6 +115,11 @@ class SetProgressSyncWorker:
         if target is None:
             return None
 
+        # Report None while blocked so the signature resets and re-enabling
+        # resends the current state.
+        if not telemetryAllows(target_id, "piece_metadata"):
+            return None
+
         controller = shared_state.controller_ref
         sorting_profile = getattr(getattr(controller, "coordinator", None), "sorting_profile", None)
         tracker = getattr(shared_state.gc_ref, "set_progress_tracker", None) if shared_state.gc_ref else None
@@ -145,6 +146,7 @@ class SetProgressSyncWorker:
         return {
             "url": str(target["url"]),
             "api_token": str(target["api_token"]),
+            "target_id": target_id,
             "payload": {
                 "version_id": version_id,
                 "artifact_hash": artifact_hash,

--- a/software/sorter/backend/tests/test_hive_telemetry.py
+++ b/software/sorter/backend/tests/test_hive_telemetry.py
@@ -1,0 +1,234 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import hive_telemetry
+from hive_telemetry import (
+    HiveTelemetryClient,
+    TELEMETRY_FIELDS,
+    TelemetryBlocked,
+    defaultTelemetrySettings,
+    getTelemetrySettings,
+    normalizeTelemetrySettings,
+    setTelemetrySettings,
+    telemetryAllows,
+    telemetryFieldList,
+)
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+UPLOAD_ENDPOINT_MARKERS = (
+    "/api/machine/upload",
+    "/api/machine/sync",
+    "/api/machine/set-progress",
+    "/api/machine/heartbeat",
+)
+
+CHOKE_POINT_ALLOWLIST = {
+    Path("hive_telemetry.py"),
+    Path("tests/test_hive_telemetry.py"),
+}
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _RecordingSession:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.calls: list[dict] = []
+        self.headers: dict = {}
+
+    def request(self, method: str, url: str, **kwargs) -> _FakeResponse:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return _FakeResponse(self.payload)
+
+
+def _client_with_session(payload: dict | None = None) -> tuple[HiveTelemetryClient, _RecordingSession]:
+    client = HiveTelemetryClient("https://hive.example", "token")
+    session = _RecordingSession(payload or {"max_local_id": 1})
+    client._session = session  # type: ignore[assignment]
+    return client, session
+
+
+def _settings(**overrides: bool) -> dict[str, bool]:
+    settings = defaultTelemetrySettings()
+    settings.update(overrides)
+    return settings
+
+
+class TelemetrySettingsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._old_db = os.environ.get("LOCAL_STATE_DB_PATH")
+        self._tmpdir = tempfile.TemporaryDirectory()
+        os.environ["LOCAL_STATE_DB_PATH"] = str(Path(self._tmpdir.name) / "state.sqlite")
+
+    def tearDown(self) -> None:
+        if self._old_db is None:
+            os.environ.pop("LOCAL_STATE_DB_PATH", None)
+        else:
+            os.environ["LOCAL_STATE_DB_PATH"] = self._old_db
+        self._tmpdir.cleanup()
+
+    def test_defaults_match_registry(self) -> None:
+        defaults = defaultTelemetrySettings()
+        self.assertEqual(
+            {field["key"] for field in TELEMETRY_FIELDS},
+            set(defaults.keys()),
+        )
+        self.assertFalse(defaults["machine_status"])
+        self.assertTrue(defaults["detection_images"])
+
+    def test_normalize_ignores_junk(self) -> None:
+        normalized = normalizeTelemetrySettings(
+            {"detection_images": False, "full_frames": "yes", "bogus": True}
+        )
+        self.assertFalse(normalized["detection_images"])
+        self.assertEqual(normalized["full_frames"], defaultTelemetrySettings()["full_frames"])
+        self.assertNotIn("bogus", normalized)
+
+    def test_set_and_get_roundtrip(self) -> None:
+        setTelemetrySettings({"detection_images": False, "machine_status": True})
+        settings = getTelemetrySettings()
+        self.assertFalse(settings["detection_images"])
+        self.assertTrue(settings["machine_status"])
+        self.assertFalse(telemetryAllows("detection_images"))
+        self.assertTrue(telemetryAllows("piece_metadata"))
+
+    def test_set_rejects_unknown_fields(self) -> None:
+        with self.assertRaises(ValueError):
+            setTelemetrySettings({"nope": True})
+
+    def test_field_list_reflects_settings(self) -> None:
+        setTelemetrySettings({"full_frames": False})
+        by_key = {field["key"]: field for field in telemetryFieldList()}
+        self.assertFalse(by_key["full_frames"]["enabled"])
+        self.assertTrue(by_key["detection_images"]["enabled"])
+        for field in by_key.values():
+            self.assertTrue(field["label"])
+            self.assertTrue(field["description"])
+
+
+class TelemetryClientGatingTests(unittest.TestCase):
+    def test_push_piece_records_blocked(self) -> None:
+        client, session = _client_with_session()
+        with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(piece_metadata=False)):
+            with self.assertRaises(TelemetryBlocked) as ctx:
+                client.pushPieceRecords([{"piece_uuid": "x"}])
+        self.assertEqual("piece_metadata", ctx.exception.field)
+        self.assertEqual([], session.calls)
+
+    def test_push_piece_image_blocked(self) -> None:
+        client, session = _client_with_session()
+        with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(detection_images=False)):
+            with self.assertRaises(TelemetryBlocked):
+                client.pushPieceImage({"piece_uuid": "x"}, None)
+        self.assertEqual([], session.calls)
+
+    def test_push_set_progress_blocked(self) -> None:
+        client, session = _client_with_session()
+        with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(piece_metadata=False)):
+            with self.assertRaises(TelemetryBlocked):
+                client.pushSetProgress({"version_id": "v"})
+        self.assertEqual([], session.calls)
+
+    def test_upload_sample_blocked_without_detection_images(self) -> None:
+        client, session = _client_with_session()
+        with tempfile.TemporaryDirectory() as tmp:
+            image = Path(tmp) / "crop.jpg"
+            image.write_bytes(b"jpg")
+            with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(detection_images=False)):
+                with self.assertRaises(TelemetryBlocked):
+                    client.uploadSample(
+                        source_session_id="s",
+                        local_sample_id="a",
+                        image_path=image,
+                    )
+        self.assertEqual([], session.calls)
+
+    def test_upload_sample_strips_full_frames_when_disabled(self) -> None:
+        client, session = _client_with_session(payload={"ok": True})
+        with tempfile.TemporaryDirectory() as tmp:
+            image = Path(tmp) / "crop.jpg"
+            frame = Path(tmp) / "frame.jpg"
+            overlay = Path(tmp) / "overlay.jpg"
+            for path in (image, frame, overlay):
+                path.write_bytes(b"jpg")
+            with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(full_frames=False)):
+                client.uploadSample(
+                    source_session_id="s",
+                    local_sample_id="a",
+                    image_path=image,
+                    full_frame_path=frame,
+                    overlay_path=overlay,
+                )
+        self.assertEqual(1, len(session.calls))
+        files = session.calls[0]["files"]
+        self.assertIn("image", files)
+        self.assertNotIn("full_frame", files)
+        self.assertNotIn("overlay", files)
+
+    def test_upload_sample_includes_full_frames_when_enabled(self) -> None:
+        client, session = _client_with_session(payload={"ok": True})
+        with tempfile.TemporaryDirectory() as tmp:
+            image = Path(tmp) / "crop.jpg"
+            frame = Path(tmp) / "frame.jpg"
+            for path in (image, frame):
+                path.write_bytes(b"jpg")
+            with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings()):
+                client.uploadSample(
+                    source_session_id="s",
+                    local_sample_id="a",
+                    image_path=image,
+                    full_frame_path=frame,
+                )
+        files = session.calls[0]["files"]
+        self.assertIn("image", files)
+        self.assertIn("full_frame", files)
+
+    def test_get_sync_state_is_not_gated(self) -> None:
+        client, session = _client_with_session(payload={"piece_records": {"max_local_id": 0}})
+        all_off = {key: False for key in defaultTelemetrySettings()}
+        with patch.object(hive_telemetry, "getTelemetrySettings", return_value=all_off):
+            client.getSyncState()
+        self.assertEqual(1, len(session.calls))
+
+
+class ChokePointTests(unittest.TestCase):
+    def test_upload_endpoints_only_referenced_in_hive_telemetry(self) -> None:
+        offenders: list[str] = []
+        for path in BACKEND_ROOT.rglob("*.py"):
+            relative = path.relative_to(BACKEND_ROOT)
+            if relative in CHOKE_POINT_ALLOWLIST:
+                continue
+            if relative.parts and relative.parts[0] in (".venv", "venv", "__pycache__"):
+                continue
+            try:
+                source = path.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+            for marker in UPLOAD_ENDPOINT_MARKERS:
+                if marker in source:
+                    offenders.append(f"{relative}: {marker}")
+        self.assertEqual(
+            [],
+            offenders,
+            "Hive upload endpoints must only be called through hive_telemetry.HiveTelemetryClient "
+            "so telemetry settings cannot be bypassed. Move these requests behind the choke point: "
+            + "; ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/sorter/backend/tests/test_hive_telemetry.py
+++ b/software/sorter/backend/tests/test_hive_telemetry.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -10,9 +9,10 @@ from hive_telemetry import (
     TELEMETRY_FIELDS,
     TelemetryBlocked,
     defaultTelemetrySettings,
-    getTelemetrySettings,
+    getTargetTelemetrySettings,
     normalizeTelemetrySettings,
-    setTelemetrySettings,
+    resetTargetTelemetrySettings,
+    setTargetTelemetrySettings,
     telemetryAllows,
     telemetryFieldList,
 )
@@ -56,7 +56,7 @@ class _RecordingSession:
 
 
 def _client_with_session(payload: dict | None = None) -> tuple[HiveTelemetryClient, _RecordingSession]:
-    client = HiveTelemetryClient("https://hive.example", "token")
+    client = HiveTelemetryClient("https://hive.example", "token", "target-a")
     session = _RecordingSession(payload or {"max_local_id": 1})
     client._session = session  # type: ignore[assignment]
     return client, session
@@ -68,18 +68,40 @@ def _settings(**overrides: bool) -> dict[str, bool]:
     return settings
 
 
+class _InMemoryHiveConfig:
+    def __init__(self, config: dict) -> None:
+        self.config = config
+
+    def get(self) -> dict:
+        return self.config
+
+    def set(self, config: dict) -> None:
+        self.config = config
+
+
 class TelemetrySettingsTests(unittest.TestCase):
     def setUp(self) -> None:
-        self._old_db = os.environ.get("LOCAL_STATE_DB_PATH")
-        self._tmpdir = tempfile.TemporaryDirectory()
-        os.environ["LOCAL_STATE_DB_PATH"] = str(Path(self._tmpdir.name) / "state.sqlite")
+        store = _InMemoryHiveConfig(
+            {
+                "targets": [
+                    {"id": "target-a", "url": "https://a.example", "api_token": "t", "enabled": True},
+                    {"id": "target-b", "url": "https://b.example", "api_token": "t", "enabled": True},
+                ],
+                "primary_target_id": "target-a",
+            }
+        )
+        import local_state
+
+        self._patchers = [
+            patch.object(local_state, "get_hive_config", store.get),
+            patch.object(local_state, "set_hive_config", store.set),
+        ]
+        for patcher in self._patchers:
+            patcher.start()
 
     def tearDown(self) -> None:
-        if self._old_db is None:
-            os.environ.pop("LOCAL_STATE_DB_PATH", None)
-        else:
-            os.environ["LOCAL_STATE_DB_PATH"] = self._old_db
-        self._tmpdir.cleanup()
+        for patcher in self._patchers:
+            patcher.stop()
 
     def test_defaults_match_registry(self) -> None:
         defaults = defaultTelemetrySettings()
@@ -87,43 +109,53 @@ class TelemetrySettingsTests(unittest.TestCase):
             {field["key"] for field in TELEMETRY_FIELDS},
             set(defaults.keys()),
         )
-        self.assertFalse(defaults["machine_status"])
-        self.assertTrue(defaults["detection_images"])
+        self.assertTrue(all(defaults.values()))
+        self.assertNotIn("machine_status", defaults)
 
     def test_normalize_ignores_junk(self) -> None:
         normalized = normalizeTelemetrySettings(
             {"detection_images": False, "full_frames": "yes", "bogus": True}
         )
         self.assertFalse(normalized["detection_images"])
-        self.assertEqual(normalized["full_frames"], defaultTelemetrySettings()["full_frames"])
+        self.assertTrue(normalized["full_frames"])
         self.assertNotIn("bogus", normalized)
 
-    def test_set_and_get_roundtrip(self) -> None:
-        setTelemetrySettings({"detection_images": False, "machine_status": True})
-        settings = getTelemetrySettings()
-        self.assertFalse(settings["detection_images"])
-        self.assertTrue(settings["machine_status"])
-        self.assertFalse(telemetryAllows("detection_images"))
-        self.assertTrue(telemetryAllows("piece_metadata"))
+    def test_unknown_target_gets_defaults(self) -> None:
+        self.assertEqual(defaultTelemetrySettings(), getTargetTelemetrySettings("nope"))
+
+    def test_set_and_get_are_per_target(self) -> None:
+        setTargetTelemetrySettings("target-a", {"detection_images": False})
+        self.assertFalse(telemetryAllows("target-a", "detection_images"))
+        self.assertTrue(telemetryAllows("target-b", "detection_images"))
+        self.assertTrue(telemetryAllows("target-a", "piece_metadata"))
 
     def test_set_rejects_unknown_fields(self) -> None:
         with self.assertRaises(ValueError):
-            setTelemetrySettings({"nope": True})
+            setTargetTelemetrySettings("target-a", {"nope": True})
 
-    def test_field_list_reflects_settings(self) -> None:
-        setTelemetrySettings({"full_frames": False})
-        by_key = {field["key"]: field for field in telemetryFieldList()}
-        self.assertFalse(by_key["full_frames"]["enabled"])
-        self.assertTrue(by_key["detection_images"]["enabled"])
-        for field in by_key.values():
+    def test_set_rejects_unknown_target(self) -> None:
+        with self.assertRaises(ValueError):
+            setTargetTelemetrySettings("nope", {"detection_images": False})
+
+    def test_reset_restores_defaults(self) -> None:
+        setTargetTelemetrySettings("target-a", {"detection_images": False, "full_frames": False})
+        settings = resetTargetTelemetrySettings("target-a")
+        self.assertEqual(defaultTelemetrySettings(), settings)
+        self.assertEqual(defaultTelemetrySettings(), getTargetTelemetrySettings("target-a"))
+
+    def test_field_list_is_registry(self) -> None:
+        fields = telemetryFieldList()
+        self.assertEqual([f["key"] for f in TELEMETRY_FIELDS], [f["key"] for f in fields])
+        for field in fields:
             self.assertTrue(field["label"])
             self.assertTrue(field["description"])
+            self.assertNotIn("enabled", field)
 
 
 class TelemetryClientGatingTests(unittest.TestCase):
     def test_push_piece_records_blocked(self) -> None:
         client, session = _client_with_session()
-        with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(piece_metadata=False)):
+        with patch.object(hive_telemetry, "getTargetTelemetrySettings", return_value=_settings(piece_metadata=False)):
             with self.assertRaises(TelemetryBlocked) as ctx:
                 client.pushPieceRecords([{"piece_uuid": "x"}])
         self.assertEqual("piece_metadata", ctx.exception.field)
@@ -131,14 +163,14 @@ class TelemetryClientGatingTests(unittest.TestCase):
 
     def test_push_piece_image_blocked(self) -> None:
         client, session = _client_with_session()
-        with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(detection_images=False)):
+        with patch.object(hive_telemetry, "getTargetTelemetrySettings", return_value=_settings(detection_images=False)):
             with self.assertRaises(TelemetryBlocked):
                 client.pushPieceImage({"piece_uuid": "x"}, None)
         self.assertEqual([], session.calls)
 
     def test_push_set_progress_blocked(self) -> None:
         client, session = _client_with_session()
-        with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(piece_metadata=False)):
+        with patch.object(hive_telemetry, "getTargetTelemetrySettings", return_value=_settings(piece_metadata=False)):
             with self.assertRaises(TelemetryBlocked):
                 client.pushSetProgress({"version_id": "v"})
         self.assertEqual([], session.calls)
@@ -148,7 +180,7 @@ class TelemetryClientGatingTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             image = Path(tmp) / "crop.jpg"
             image.write_bytes(b"jpg")
-            with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(detection_images=False)):
+            with patch.object(hive_telemetry, "getTargetTelemetrySettings", return_value=_settings(detection_images=False)):
                 with self.assertRaises(TelemetryBlocked):
                     client.uploadSample(
                         source_session_id="s",
@@ -165,7 +197,7 @@ class TelemetryClientGatingTests(unittest.TestCase):
             overlay = Path(tmp) / "overlay.jpg"
             for path in (image, frame, overlay):
                 path.write_bytes(b"jpg")
-            with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings(full_frames=False)):
+            with patch.object(hive_telemetry, "getTargetTelemetrySettings", return_value=_settings(full_frames=False)):
                 client.uploadSample(
                     source_session_id="s",
                     local_sample_id="a",
@@ -186,7 +218,7 @@ class TelemetryClientGatingTests(unittest.TestCase):
             frame = Path(tmp) / "frame.jpg"
             for path in (image, frame):
                 path.write_bytes(b"jpg")
-            with patch.object(hive_telemetry, "getTelemetrySettings", return_value=_settings()):
+            with patch.object(hive_telemetry, "getTargetTelemetrySettings", return_value=_settings()):
                 client.uploadSample(
                     source_session_id="s",
                     local_sample_id="a",
@@ -200,7 +232,7 @@ class TelemetryClientGatingTests(unittest.TestCase):
     def test_get_sync_state_is_not_gated(self) -> None:
         client, session = _client_with_session(payload={"piece_records": {"max_local_id": 0}})
         all_off = {key: False for key in defaultTelemetrySettings()}
-        with patch.object(hive_telemetry, "getTelemetrySettings", return_value=all_off):
+        with patch.object(hive_telemetry, "getTargetTelemetrySettings", return_value=all_off):
             client.getSyncState()
         self.assertEqual(1, len(session.calls))
 

--- a/software/sorter/frontend/src/lib/components/settings/HiveSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/HiveSection.svelte
@@ -49,7 +49,16 @@
 		uploader?: UploaderStatus | null;
 	};
 
+	type TelemetryField = {
+		key: string;
+		label: string;
+		description: string;
+		enabled: boolean;
+	};
+
 	let config = $state<HiveConfig | null>(null);
+	let telemetryFields = $state<TelemetryField[]>([]);
+	let telemetryTogglingKey = $state<string | null>(null);
 	let loading = $state(true);
 	let statusMsg = $state<string | null>(null);
 	let errorMsg = $state<string | null>(null);
@@ -221,13 +230,33 @@
 		regMachineDescription = '';
 	}
 
+	function parseTelemetryFields(raw: unknown): TelemetryField[] {
+		const data = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+		if (!Array.isArray(data.telemetry_fields)) return [];
+		return data.telemetry_fields.flatMap((entry) => {
+			if (!entry || typeof entry !== 'object') return [];
+			const field = entry as Record<string, unknown>;
+			if (typeof field.key !== 'string' || typeof field.label !== 'string') return [];
+			return [
+				{
+					key: field.key,
+					label: field.label,
+					description: typeof field.description === 'string' ? field.description : '',
+					enabled: field.enabled === true
+				}
+			];
+		});
+	}
+
 	async function loadConfig() {
 		loading = true;
 		errorMsg = null;
 		try {
 			const res = await fetch(`${currentBackendBaseUrl()}/api/settings/hive`);
 			if (!res.ok) throw new Error(await res.text());
-			config = normalizeConfig(await res.json());
+			const raw = await res.json();
+			config = normalizeConfig(raw);
+			telemetryFields = parseTelemetryFields(raw);
 
 			if (editingTargetId) {
 				resetTargetForm(getTarget(editingTargetId));
@@ -236,6 +265,24 @@
 			errorMsg = e.message ?? 'Failed to load Hive config.';
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function handleToggleTelemetry(field: TelemetryField) {
+		telemetryTogglingKey = field.key;
+		clearMessages();
+		try {
+			const res = await fetch(`${currentBackendBaseUrl()}/api/settings/hive/telemetry`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ fields: { [field.key]: !field.enabled } })
+			});
+			if (!res.ok) throw new Error(await res.text());
+			telemetryFields = parseTelemetryFields(await res.json());
+		} catch (e: any) {
+			errorMsg = e.message ?? 'Failed to update upload settings.';
+		} finally {
+			telemetryTogglingKey = null;
 		}
 	}
 
@@ -567,6 +614,35 @@
 				</button>
 			</div>
 		</div>
+
+		{#if telemetryFields.length > 0}
+			<div class="border border-border bg-surface px-3 py-3">
+				<div class="text-xs font-semibold uppercase tracking-wider text-text-muted">
+					What gets uploaded
+				</div>
+				<div class="mt-1 text-sm text-text-muted">
+					Applies to every Hive target on this machine. Anything unchecked never leaves the
+					machine.
+				</div>
+				<div class="mt-3 grid gap-2.5">
+					{#each telemetryFields as field (field.key)}
+						<label class="flex cursor-pointer items-start gap-2.5">
+							<input
+								type="checkbox"
+								checked={field.enabled}
+								disabled={telemetryTogglingKey === field.key}
+								onchange={() => void handleToggleTelemetry(field)}
+								class="mt-0.5 h-4 w-4 border-border"
+							/>
+							<span class="min-w-0">
+								<span class="text-sm font-medium text-text">{field.label}</span>
+								<span class="block text-sm text-text-muted">{field.description}</span>
+							</span>
+						</label>
+					{/each}
+				</div>
+			</div>
+		{/if}
 
 		{#if targets.length === 0}
 			<div class="border border-border bg-surface px-3 py-3">

--- a/software/sorter/frontend/src/lib/components/settings/HiveSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/HiveSection.svelte
@@ -8,7 +8,8 @@
 		DEFAULT_HIVE_URL,
 		defaultHiveTargetName
 	} from '$lib/hive/link-flow';
-	import { Cloud, Link2, Pencil, Plus, RefreshCw, Star, Trash2, Upload } from 'lucide-svelte';
+	import { Cloud, Link2, Pencil, Plus, RefreshCw, Shield, Star, Trash2, Upload } from 'lucide-svelte';
+	import Modal from '$lib/components/Modal.svelte';
 
 	const machine = getMachineContext();
 
@@ -30,6 +31,7 @@
 		api_token_masked: string | null;
 		enabled: boolean;
 		is_primary: boolean;
+		telemetry: Record<string, boolean>;
 		uploader: UploaderStatus;
 	};
 
@@ -53,12 +55,12 @@
 		key: string;
 		label: string;
 		description: string;
-		enabled: boolean;
 	};
 
 	let config = $state<HiveConfig | null>(null);
 	let telemetryFields = $state<TelemetryField[]>([]);
-	let telemetryTogglingKey = $state<string | null>(null);
+	let uploadsTargetId = $state<string | null>(null);
+	let telemetrySaving = $state(false);
 	let loading = $state(true);
 	let statusMsg = $state<string | null>(null);
 	let errorMsg = $state<string | null>(null);
@@ -94,6 +96,15 @@
 	let pairMachineName = $state('');
 
 	const targets = $derived(config?.targets ?? []);
+
+	function normalizeTelemetry(raw: unknown): Record<string, boolean> {
+		if (!raw || typeof raw !== 'object') return {};
+		return Object.fromEntries(
+			Object.entries(raw as Record<string, unknown>).filter(
+				([, value]) => typeof value === 'boolean'
+			)
+		) as Record<string, boolean>;
+	}
 
 	function emptyUploaderStatus(enabled: boolean): UploaderStatus {
 		return {
@@ -140,6 +151,7 @@
 							typeof target.api_token_masked === 'string' ? target.api_token_masked : null,
 						enabled,
 						is_primary: Boolean(target.is_primary),
+						telemetry: normalizeTelemetry(target.telemetry),
 						uploader: {
 							...emptyUploaderStatus(enabled),
 							...(uploaderRaw ?? {})
@@ -187,6 +199,7 @@
 						typeof legacy.api_token_masked === 'string' ? legacy.api_token_masked : null,
 					enabled,
 					is_primary: true,
+					telemetry: {},
 					uploader: {
 						...emptyUploaderStatus(enabled),
 						...(legacy.uploader ?? {})
@@ -241,11 +254,46 @@
 				{
 					key: field.key,
 					label: field.label,
-					description: typeof field.description === 'string' ? field.description : '',
-					enabled: field.enabled === true
+					description: typeof field.description === 'string' ? field.description : ''
 				}
 			];
 		});
+	}
+
+	function targetAllows(target: HiveTarget, key: string): boolean {
+		return target.telemetry[key] !== false;
+	}
+
+	async function postTelemetry(target: HiveTarget, body: Record<string, unknown>) {
+		telemetrySaving = true;
+		try {
+			const res = await fetch(`${currentBackendBaseUrl()}/api/settings/hive/telemetry`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ target_id: target.id, ...body })
+			});
+			if (!res.ok) throw new Error(await res.text());
+			const data = await res.json();
+			const telemetry = normalizeTelemetry(data?.telemetry);
+			if (config) {
+				config = {
+					...config,
+					targets: config.targets.map((t) => (t.id === target.id ? { ...t, telemetry } : t))
+				};
+			}
+		} catch (e: any) {
+			errorMsg = e.message ?? 'Failed to update upload settings.';
+		} finally {
+			telemetrySaving = false;
+		}
+	}
+
+	function handleToggleTelemetry(target: HiveTarget, field: TelemetryField) {
+		void postTelemetry(target, { fields: { [field.key]: !targetAllows(target, field.key) } });
+	}
+
+	function handleResetTelemetry(target: HiveTarget) {
+		void postTelemetry(target, { reset: true });
 	}
 
 	async function loadConfig() {
@@ -265,24 +313,6 @@
 			errorMsg = e.message ?? 'Failed to load Hive config.';
 		} finally {
 			loading = false;
-		}
-	}
-
-	async function handleToggleTelemetry(field: TelemetryField) {
-		telemetryTogglingKey = field.key;
-		clearMessages();
-		try {
-			const res = await fetch(`${currentBackendBaseUrl()}/api/settings/hive/telemetry`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ fields: { [field.key]: !field.enabled } })
-			});
-			if (!res.ok) throw new Error(await res.text());
-			telemetryFields = parseTelemetryFields(await res.json());
-		} catch (e: any) {
-			errorMsg = e.message ?? 'Failed to update upload settings.';
-		} finally {
-			telemetryTogglingKey = null;
 		}
 	}
 
@@ -615,35 +645,6 @@
 			</div>
 		</div>
 
-		{#if telemetryFields.length > 0}
-			<div class="border border-border bg-surface px-3 py-3">
-				<div class="text-xs font-semibold uppercase tracking-wider text-text-muted">
-					What gets uploaded
-				</div>
-				<div class="mt-1 text-sm text-text-muted">
-					Applies to every Hive target on this machine. Anything unchecked never leaves the
-					machine.
-				</div>
-				<div class="mt-3 grid gap-2.5">
-					{#each telemetryFields as field (field.key)}
-						<label class="flex cursor-pointer items-start gap-2.5">
-							<input
-								type="checkbox"
-								checked={field.enabled}
-								disabled={telemetryTogglingKey === field.key}
-								onchange={() => void handleToggleTelemetry(field)}
-								class="mt-0.5 h-4 w-4 border-border"
-							/>
-							<span class="min-w-0">
-								<span class="text-sm font-medium text-text">{field.label}</span>
-								<span class="block text-sm text-text-muted">{field.description}</span>
-							</span>
-						</label>
-					{/each}
-				</div>
-			</div>
-		{/if}
-
 		{#if targets.length === 0}
 			<div class="border border-border bg-surface px-3 py-3">
 				<div class="text-sm text-text-muted">
@@ -696,6 +697,18 @@
 								>
 									<Pencil size={12} />
 									Edit
+								</button>
+								<button
+									type="button"
+									onclick={() => {
+										clearMessages();
+										uploadsTargetId = target.id;
+									}}
+									class="inline-flex items-center gap-1.5 border border-border bg-bg px-3 py-1.5 text-xs text-text transition-colors hover:bg-surface"
+									title="Choose what this Sorter uploads to this Hive"
+								>
+									<Shield size={12} />
+									Uploads
 								</button>
 								<button
 									type="button"
@@ -805,13 +818,15 @@
 			</div>
 		{/if}
 
-		{#if editingTargetId}
-			<div class="grid gap-3 border border-border bg-surface px-3 py-3">
-				<div class="text-sm font-medium text-text">
-					{editingTargetId === 'new'
-						? 'Add Hive Target'
-						: `Edit ${getTarget(editingTargetId)?.name ?? 'Hive Target'}`}
-				</div>
+		{#if editingTargetId !== null}
+			<Modal
+				open={true}
+				title={editingTargetId === 'new'
+					? 'Add Hive Target'
+					: `Edit ${getTarget(editingTargetId)?.name ?? 'Hive Target'}`}
+				on:close={closeForms}
+			>
+				<div class="grid gap-3">
 				<input
 					bind:value={targetName}
 					type="text"
@@ -833,11 +848,7 @@
 					class="border border-border bg-bg px-2 py-1.5 font-mono text-sm text-text"
 				/>
 				<label class="flex items-center gap-2 text-xs text-text-muted">
-					<input
-						bind:checked={targetEnabled}
-						type="checkbox"
-						class="h-4 w-4 rounded border-border"
-					/>
+					<input bind:checked={targetEnabled} type="checkbox" class="h-4 w-4 border-border" />
 					Send live samples to this target immediately
 				</label>
 				<div class="flex justify-end gap-2">
@@ -860,6 +871,57 @@
 					</button>
 				</div>
 			</div>
+		</Modal>
+		{/if}
+
+		{#if getTarget(uploadsTargetId)}
+			{@const uploadsTarget = getTarget(uploadsTargetId)!}
+			<Modal
+				open={true}
+				title={`Uploads to ${uploadsTarget.name}`}
+				on:close={() => (uploadsTargetId = null)}
+			>
+				<div class="grid gap-3">
+					<div class="text-sm text-text-muted">
+						Choose what this Sorter is allowed to upload to this Hive. Anything unchecked never
+						leaves the machine. Changes apply immediately, including to uploads already queued.
+					</div>
+					<div class="grid gap-2.5">
+						{#each telemetryFields as field (field.key)}
+							<label class="flex cursor-pointer items-start gap-2.5">
+								<input
+									type="checkbox"
+									checked={targetAllows(uploadsTarget, field.key)}
+									disabled={telemetrySaving}
+									onchange={() => handleToggleTelemetry(uploadsTarget, field)}
+									class="mt-0.5 h-4 w-4 border-border"
+								/>
+								<span class="min-w-0">
+									<span class="text-sm font-medium text-text">{field.label}</span>
+									<span class="block text-sm text-text-muted">{field.description}</span>
+								</span>
+							</label>
+						{/each}
+					</div>
+					<div class="flex items-center justify-between gap-2 border-t border-border pt-3">
+						<button
+							type="button"
+							onclick={() => handleResetTelemetry(uploadsTarget)}
+							disabled={telemetrySaving}
+							class="border border-border bg-bg px-3 py-1.5 text-xs text-text transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
+						>
+							Reset to defaults
+						</button>
+						<button
+							type="button"
+							onclick={() => (uploadsTargetId = null)}
+							class="border border-border bg-bg px-3 py-1.5 text-xs text-text transition-colors hover:bg-surface"
+						>
+							Done
+						</button>
+					</div>
+				</div>
+			</Modal>
 		{/if}
 
 		{#if showPairForm}


### PR DESCRIPTION
## What

Routes **all** machine→Hive uploads through one module (`hive_telemetry.HiveTelemetryClient`) so there is a single, auditable place that decides what leaves the machine, and gives each Hive target its own upload permissions surfaced in the UI.

Motivation: the machine already uploads detection images (piece crops), full camera frames, and piece metadata, but that wasn't made clear in the UI — someone pulling `main` and running it wouldn't know those pictures were being uploaded. This makes it explicit and controllable, per Hive instance.

## How

- **`hive_telemetry.py`** — new module owning the only HTTP clients to the Hive upload endpoints. A `TELEMETRY_FIELDS` registry (`detection_images`, `full_frames`, `piece_metadata`) is the source of truth for what *can* be uploaded. Every request declares which fields it carries; a disabled field blocks the request at send time, so a toggle also applies to jobs already queued.
- **Per-target settings** — permissions live on each target entry in the hive config (not a machine-global dict), so a machine syncing to prod + staging can grant each a different subset. Defaults are all-on.
- **Callers refactored** — `hive_uploader`, `hive_sync`, and `set_progress_sync` lost their private `requests` clients and now go through the choke point with the target id.
- **Choke-point guard** — `test_hive_telemetry.py` scans the backend source for the Hive upload endpoint paths and fails if they appear anywhere outside `hive_telemetry.py`, so future code can't bypass the gate.
- **UI** — the target edit form and a new per-target **Uploads** modal (shield icon) move into the shared `Modal` component. The modal has a checkbox per field plus reset-to-defaults. Capturing samples locally and uploading them remain separate: unchecking a field stops the upload, local capture is unaffected.

## Notes

- `machine_status` is intentionally **not** a field yet — no status upload exists. The empty heartbeat keep-alive (marks the machine online, carries no data) is always sent while a target is enabled; a future status upload must add a registry field and gate on it.
- Disabling `detection_images` freezes that target's piece-image sync watermark, so re-enabling later drains the backlog rather than losing it. Disabling `full_frames` strips frame/overlay attachments from samples but still sends the crop.

## Testing

- `test_hive_telemetry.py`: 24 tests — per-target get/set/reset, field gating on every client method, full-frame stripping, and the choke-point source scan.
- Full backend suite: no telemetry-related failures (pre-existing Mac-env failures unchanged).
- Frontend `svelte-check`: no new errors in `HiveSection`.
- Deployed to the kitbash dev machine and verified end-to-end: per-target toggle + reset round-trip through `/api/settings/hive/telemetry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)