### PR TITLE
Update-available notifications + stable/canary release channels

### DIFF
--- a/software/sorter/backend/server/routers/versions.py
+++ b/software/sorter/backend/server/routers/versions.py
@@ -15,8 +15,11 @@ from pydantic import BaseModel
 
 router = APIRouter()
 
-RELEASE_TAG_PREFIX = "sorter/v"
-DEFAULT_BRANCH = "main"
+# Release channels are tag namespaces. A machine "on" a channel is sitting on
+# one of the channel's tags; updating moves it to that channel's newest tag.
+STABLE_TAG_PREFIX = "sorter/stable/v"
+CANARY_TAG_PREFIX = "sorter/canary/v"
+RELEASE_CHANNELS = (("stable", STABLE_TAG_PREFIX), ("canary", CANARY_TAG_PREFIX))
 MAX_TAGS_LISTED = 20
 GIT_TIMEOUT_S = 30.0
 GIT_FETCH_TIMEOUT_S = 90.0
@@ -104,61 +107,64 @@ def _currentInfo() -> Dict[str, Any]:
 
 
 def _branchEntries(current: Dict[str, Any]) -> List[Dict[str, Any]]:
-    names: List[str] = []
+    # Only the branch the machine is actually on — no `main` unless that's it.
     current_branch = current.get("branch")
-    if isinstance(current_branch, str) and current_branch:
-        names.append(current_branch)
-    if DEFAULT_BRANCH not in names:
-        names.append(DEFAULT_BRANCH)
-
-    entries: List[Dict[str, Any]] = []
-    for name in names:
-        info = _commitInfo(f"origin/{name}")
-        if info is None:
-            continue
-        entries.append(
-            {
-                "kind": "branch",
-                "name": name,
-                "sha": info["sha"],
-                "commit_unix": info["commit_unix"],
-                "subject": info["subject"],
-                "is_current": name == current_branch,
-                "up_to_date": info["full_sha"] == current.get("full_sha"),
-            }
-        )
-    return entries
+    if not isinstance(current_branch, str) or not current_branch:
+        return []
+    info = _commitInfo(f"origin/{current_branch}")
+    if info is None:
+        return []
+    return [
+        {
+            "kind": "branch",
+            "name": current_branch,
+            "sha": info["sha"],
+            "commit_unix": info["commit_unix"],
+            "subject": info["subject"],
+            "is_current": True,
+            "up_to_date": info["full_sha"] == current.get("full_sha"),
+        }
+    ]
 
 
-def _tagEntries(current: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _tagsForPrefix(prefix: str) -> List[Dict[str, Any]]:
     result = _git(
         "tag",
         "-l",
-        f"{RELEASE_TAG_PREFIX}*",
+        f"{prefix}*",
         "--sort=-creatordate",
-        "--format=%(refname:strip=2)%09%(creatordate:unix)",
+        "--format=%(refname:strip=2)",
     )
     if result.returncode != 0:
         return []
-
-    entries: List[Dict[str, Any]] = []
-    for line in result.stdout.strip().splitlines()[:MAX_TAGS_LISTED]:
-        parts = line.split("\t")
-        if len(parts) != 2:
-            continue
-        name = parts[0]
+    tags: List[Dict[str, Any]] = []
+    for name in result.stdout.strip().splitlines()[:MAX_TAGS_LISTED]:
         info = _commitInfo(f"refs/tags/{name}")
         if info is None:
             continue
+        tags.append({"name": name, **info})
+    return tags
+
+
+def _channelEntries(current: Dict[str, Any]) -> List[Dict[str, Any]]:
+    head_full = current.get("full_sha")
+    entries: List[Dict[str, Any]] = []
+    for channel, prefix in RELEASE_CHANNELS:
+        tags = _tagsForPrefix(prefix)
+        if not tags:
+            continue
+        latest = tags[0]
+        on_channel = any(tag["full_sha"] == head_full for tag in tags)
         entries.append(
             {
                 "kind": "tag",
-                "name": name,
-                "sha": info["sha"],
-                "commit_unix": info["commit_unix"],
-                "subject": info["subject"],
-                "is_current": info["full_sha"] == current.get("full_sha"),
-                "up_to_date": info["full_sha"] == current.get("full_sha"),
+                "channel": channel,
+                "name": latest["name"],
+                "sha": latest["sha"],
+                "commit_unix": latest["commit_unix"],
+                "subject": latest["subject"],
+                "is_current": on_channel,
+                "up_to_date": on_channel and latest["full_sha"] == head_full,
             }
         )
     return entries
@@ -193,7 +199,7 @@ def get_versions(refresh: bool = False) -> Dict[str, Any]:
             fetch_error = result.stderr.strip() or "git fetch failed"
 
     current = _currentInfo()
-    available = _branchEntries(current) + _tagEntries(current)
+    available = _branchEntries(current) + _channelEntries(current)
     return {
         "ok": True,
         "current": current,
@@ -211,8 +217,11 @@ def update_version(req: UpdateRequest) -> Dict[str, Any]:
         return {"ok": False, "message": f"Unknown ref kind: {req.kind}"}
     if not REF_NAME_PATTERN.match(req.name) or ".." in req.name:
         return {"ok": False, "message": f"Invalid ref name: {req.name}"}
-    if req.kind == "tag" and not req.name.startswith(RELEASE_TAG_PREFIX):
-        return {"ok": False, "message": f"Tags must start with {RELEASE_TAG_PREFIX}"}
+    if req.kind == "tag" and not any(
+        req.name.startswith(prefix) for _, prefix in RELEASE_CHANNELS
+    ):
+        allowed = " or ".join(prefix for _, prefix in RELEASE_CHANNELS)
+        return {"ok": False, "message": f"Release tags must start with {allowed}"}
 
     if not _update_lock.acquire(blocking=False):
         return {"ok": False, "message": f"Update already in progress: {_update_target}"}

--- a/software/sorter/backend/server/routers/versions.py
+++ b/software/sorter/backend/server/routers/versions.py
@@ -128,11 +128,13 @@ def _branchEntries(current: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 def _tagsForPrefix(prefix: str) -> List[Dict[str, Any]]:
+    # Version-descending so the channel's newest *release number* is first,
+    # independent of commit/tag dates (v1.10.0 > v1.9.0, not lexical).
     result = _git(
         "tag",
         "-l",
         f"{prefix}*",
-        "--sort=-creatordate",
+        "--sort=-v:refname",
         "--format=%(refname:strip=2)",
     )
     if result.returncode != 0:

--- a/software/sorter/frontend/src/lib/components/AppHeader.svelte
+++ b/software/sorter/frontend/src/lib/components/AppHeader.svelte
@@ -9,8 +9,10 @@
 		waitForBackend
 	} from '$lib/backend';
 	import Modal from '$lib/components/Modal.svelte';
+	import NotificationsIndicator from '$lib/components/NotificationsIndicator.svelte';
 	import SortingProfileDropdown from '$lib/components/SortingProfileDropdown.svelte';
 	import { getMachinesContext } from '$lib/machines/context';
+	import { userConfig } from '$lib/stores/userConfig.svelte';
 	import {
 		AlertTriangle,
 		ChevronDown,
@@ -73,11 +75,17 @@
 		});
 	}
 
-	const machineName = $derived(
+	const liveMachineName = $derived(
 		manager.selectedMachine?.identity?.nickname ??
 			manager.selectedMachine?.identity?.machine_id.slice(0, 8) ??
 			null
 	);
+	// Show the cached name instantly on load; swap to the live one once the
+	// WebSocket identity arrives, and cache it for next time.
+	const machineName = $derived(liveMachineName ?? userConfig.machineName);
+	$effect(() => {
+		if (liveMachineName) userConfig.setMachineName(liveMachineName);
+	});
 	const machineState = $derived(manager.selectedMachine?.sorterState?.state ?? 'initializing');
 	const activeIncidentKind = $derived(
 		(
@@ -413,6 +421,7 @@
 			</div>
 		</div>
 		<div class="flex items-center gap-2">
+			<NotificationsIndicator />
 			{#if machineName}
 				<span
 					class="flex items-center self-stretch border border-border px-2.5 text-sm font-medium text-text-muted"

--- a/software/sorter/frontend/src/lib/components/NotificationsIndicator.svelte
+++ b/software/sorter/frontend/src/lib/components/NotificationsIndicator.svelte
@@ -31,11 +31,19 @@
 		}, 160);
 	}
 
+	// Washed-out token style (thin border + faint tint), matching the Alert /
+	// "Active" pills used across the site. The icon carries the saturated color.
 	const boxClass: Record<NotificationColor, string> = {
-		success: 'bg-success text-white hover:bg-success-hover',
-		primary: 'bg-primary text-primary-contrast hover:bg-primary-hover',
-		warning: 'bg-warning text-black',
-		danger: 'bg-danger text-white hover:bg-danger-hover'
+		success: 'border border-success/40 bg-success/[0.08] text-text hover:bg-success/[0.14]',
+		primary: 'border border-primary/40 bg-primary/[0.08] text-text hover:bg-primary/[0.14]',
+		warning: 'border border-warning/50 bg-warning/[0.1] text-text hover:bg-warning/[0.16]',
+		danger: 'border border-danger/40 bg-danger/[0.08] text-text hover:bg-danger/[0.14]'
+	};
+	const iconClass: Record<NotificationColor, string> = {
+		success: 'text-success',
+		primary: 'text-primary',
+		warning: 'text-warning',
+		danger: 'text-danger'
 	};
 
 	function activate(n: AppNotification): void {
@@ -59,7 +67,7 @@
 		<div class="group relative flex">
 			<button
 				type="button"
-				class="flex items-center gap-1.5 px-2.5 py-1 text-sm font-medium transition-colors {boxClass[
+				class="flex items-center gap-1.5 px-2.5 py-1 text-sm transition-colors {boxClass[
 					primary.color
 				]}"
 				title={primary.content ?? primary.title}
@@ -67,11 +75,11 @@
 			>
 				{#if primary.icon}
 					{@const Icon = primary.icon}
-					<Icon size={15} />
+					<Icon size={15} class={iconClass[primary.color]} />
 				{/if}
 				{primary.title}
 				{#if rest.length > 0}
-					<span class="ml-0.5 flex items-center gap-0.5 border-l border-white/30 pl-1.5">
+					<span class="ml-0.5 flex items-center gap-0.5 border-l border-border pl-1.5 text-text-muted">
 						+{rest.length}
 						<ChevronDown size={12} />
 					</span>

--- a/software/sorter/frontend/src/lib/components/NotificationsIndicator.svelte
+++ b/software/sorter/frontend/src/lib/components/NotificationsIndicator.svelte
@@ -5,77 +5,103 @@
 		type AppNotification,
 		type NotificationColor
 	} from '$lib/stores/notifications.svelte';
-	import { Bell, X } from 'lucide-svelte';
-
-	let open = $state(false);
+	import { ChevronDown, X } from 'lucide-svelte';
 
 	const active = $derived(notifications.active);
-	const count = $derived(active.length);
-	const single = $derived(count === 1 ? active[0] : null);
+	const primary = $derived(active[0] ?? null);
+	const rest = $derived(active.slice(1));
 
-	const colorText: Record<NotificationColor, string> = {
-		success: 'text-success',
-		primary: 'text-primary',
-		warning: 'text-warning',
-		danger: 'text-danger'
-	};
+	// The dropdown (for the extra notifications) closes on a short delay so moving
+	// the mouse from the box across the small gap into the menu doesn't dismiss it.
+	let menuOpen = $state(false);
+	let closeTimer: ReturnType<typeof setTimeout> | null = null;
 
-	const TriggerIcon = $derived(single?.icon ?? Bell);
-	const triggerColor = $derived(single ? colorText[single.color] : 'text-text-muted');
-
-	function activate(n: AppNotification): void {
-		open = false;
-		if (n.href) void goto(n.href);
+	function openMenu(): void {
+		if (closeTimer) {
+			clearTimeout(closeTimer);
+			closeTimer = null;
+		}
+		menuOpen = true;
+	}
+	function scheduleClose(): void {
+		if (closeTimer) clearTimeout(closeTimer);
+		closeTimer = setTimeout(() => {
+			menuOpen = false;
+			closeTimer = null;
+		}, 160);
 	}
 
+	const boxClass: Record<NotificationColor, string> = {
+		success: 'bg-success text-white hover:bg-success-hover',
+		primary: 'bg-primary text-primary-contrast hover:bg-primary-hover',
+		warning: 'bg-warning text-black',
+		danger: 'bg-danger text-white hover:bg-danger-hover'
+	};
+
+	function activate(n: AppNotification): void {
+		menuOpen = false;
+		if (n.href) void goto(n.href);
+	}
 	function dismiss(event: MouseEvent, n: AppNotification): void {
 		event.stopPropagation();
 		notifications.dismiss(n.id);
-		if (notifications.active.length === 0) open = false;
+		if (notifications.active.length === 0) menuOpen = false;
 	}
 </script>
 
-{#if count > 0}
+{#if primary}
 	<div
 		class="relative flex"
 		role="presentation"
-		onmouseenter={() => (open = true)}
-		onmouseleave={() => (open = false)}
+		onmouseenter={openMenu}
+		onmouseleave={scheduleClose}
 	>
-		<button
-			type="button"
-			class="relative flex items-center p-2 transition-colors hover:bg-bg {triggerColor}"
-			title={single ? single.title : `${count} notifications`}
-			onclick={() => (single ? activate(single) : (open = !open))}
-		>
-			<TriggerIcon size={18} />
-			{#if count > 1}
-				<span
-					class="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center bg-primary px-1 text-xs font-semibold text-primary-contrast"
-				>
-					{count}
-				</span>
-			{/if}
-		</button>
+		<div class="group relative flex">
+			<button
+				type="button"
+				class="flex items-center gap-1.5 px-2.5 py-1 text-sm font-medium transition-colors {boxClass[
+					primary.color
+				]}"
+				title={primary.content ?? primary.title}
+				onclick={() => activate(primary)}
+			>
+				{#if primary.icon}
+					{@const Icon = primary.icon}
+					<Icon size={15} />
+				{/if}
+				{primary.title}
+				{#if rest.length > 0}
+					<span class="ml-0.5 flex items-center gap-0.5 border-l border-white/30 pl-1.5">
+						+{rest.length}
+						<ChevronDown size={12} />
+					</span>
+				{/if}
+			</button>
 
-		{#if open}
-			<div class="absolute top-full right-0 z-50 mt-1 w-[300px] border border-border bg-surface shadow-lg">
-				<div
-					class="px-3 pt-2.5 pb-1.5 text-xs font-semibold tracking-wider text-text-muted uppercase"
-				>
-					Notifications
-				</div>
+			<!-- Hover-reveal dismiss for the primary notification. -->
+			<button
+				type="button"
+				class="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center border border-border bg-surface text-text opacity-0 transition-opacity hover:bg-bg group-hover:opacity-100 focus:opacity-100"
+				title="Dismiss"
+				onclick={(event) => dismiss(event, primary)}
+			>
+				<X size={11} />
+			</button>
+		</div>
+
+		{#if menuOpen && rest.length > 0}
+			<div class="absolute top-full right-0 z-50 mt-1 w-[280px] border border-border bg-surface shadow-lg">
 				<ul class="flex flex-col">
-					{#each active as n (n.id)}
+					{#each rest as n (n.id)}
 						{@const Icon = n.icon}
-						<li class="flex items-start gap-2.5 border-t border-border px-3 py-2.5">
+						<li class="flex items-start gap-2.5 border-b border-border px-3 py-2.5 last:border-b-0">
 							<button
 								type="button"
 								class="flex min-w-0 flex-1 items-start gap-2.5 text-left"
 								onclick={() => activate(n)}
 							>
 								{#if Icon}
-									<Icon size={16} class="mt-0.5 shrink-0 {colorText[n.color]}" />
+									<Icon size={16} class="mt-0.5 shrink-0 text-text-muted" />
 								{/if}
 								<span class="min-w-0 flex-1">
 									<span class="block text-sm font-medium text-text">{n.title}</span>

--- a/software/sorter/frontend/src/lib/components/NotificationsIndicator.svelte
+++ b/software/sorter/frontend/src/lib/components/NotificationsIndicator.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import {
+		notifications,
+		type AppNotification,
+		type NotificationColor
+	} from '$lib/stores/notifications.svelte';
+	import { Bell, X } from 'lucide-svelte';
+
+	let open = $state(false);
+
+	const active = $derived(notifications.active);
+	const count = $derived(active.length);
+	const single = $derived(count === 1 ? active[0] : null);
+
+	const colorText: Record<NotificationColor, string> = {
+		success: 'text-success',
+		primary: 'text-primary',
+		warning: 'text-warning',
+		danger: 'text-danger'
+	};
+
+	const TriggerIcon = $derived(single?.icon ?? Bell);
+	const triggerColor = $derived(single ? colorText[single.color] : 'text-text-muted');
+
+	function activate(n: AppNotification): void {
+		open = false;
+		if (n.href) void goto(n.href);
+	}
+
+	function dismiss(event: MouseEvent, n: AppNotification): void {
+		event.stopPropagation();
+		notifications.dismiss(n.id);
+		if (notifications.active.length === 0) open = false;
+	}
+</script>
+
+{#if count > 0}
+	<div
+		class="relative flex"
+		role="presentation"
+		onmouseenter={() => (open = true)}
+		onmouseleave={() => (open = false)}
+	>
+		<button
+			type="button"
+			class="relative flex items-center p-2 transition-colors hover:bg-bg {triggerColor}"
+			title={single ? single.title : `${count} notifications`}
+			onclick={() => (single ? activate(single) : (open = !open))}
+		>
+			<TriggerIcon size={18} />
+			{#if count > 1}
+				<span
+					class="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center bg-primary px-1 text-xs font-semibold text-primary-contrast"
+				>
+					{count}
+				</span>
+			{/if}
+		</button>
+
+		{#if open}
+			<div class="absolute top-full right-0 z-50 mt-1 w-[300px] border border-border bg-surface shadow-lg">
+				<div
+					class="px-3 pt-2.5 pb-1.5 text-xs font-semibold tracking-wider text-text-muted uppercase"
+				>
+					Notifications
+				</div>
+				<ul class="flex flex-col">
+					{#each active as n (n.id)}
+						{@const Icon = n.icon}
+						<li class="flex items-start gap-2.5 border-t border-border px-3 py-2.5">
+							<button
+								type="button"
+								class="flex min-w-0 flex-1 items-start gap-2.5 text-left"
+								onclick={() => activate(n)}
+							>
+								{#if Icon}
+									<Icon size={16} class="mt-0.5 shrink-0 {colorText[n.color]}" />
+								{/if}
+								<span class="min-w-0 flex-1">
+									<span class="block text-sm font-medium text-text">{n.title}</span>
+									{#if n.content}
+										<span class="mt-0.5 block text-sm text-text-muted">{n.content}</span>
+									{/if}
+								</span>
+							</button>
+							<button
+								type="button"
+								class="shrink-0 p-0.5 text-text-muted transition-colors hover:text-text"
+								title="Dismiss"
+								onclick={(event) => dismiss(event, n)}
+							>
+								<X size={14} />
+							</button>
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/software/sorter/frontend/src/lib/components/primitives/Button.svelte
+++ b/software/sorter/frontend/src/lib/components/primitives/Button.svelte
@@ -31,7 +31,7 @@
 		secondary:
 			'border border-border bg-surface text-text hover:bg-bg',
 		success:
-			'border border-success bg-success text-white hover:border-success-hover hover:bg-success-hover',
+			'border border-success/50 bg-success/15 text-success hover:bg-success/25',
 		danger:
 			'border border-danger bg-danger text-primary-contrast hover:border-danger-hover hover:bg-danger-hover',
 		ghost:

--- a/software/sorter/frontend/src/lib/components/primitives/Button.svelte
+++ b/software/sorter/frontend/src/lib/components/primitives/Button.svelte
@@ -2,7 +2,7 @@
 	import type { Snippet } from 'svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 
-	type Variant = 'primary' | 'secondary' | 'danger' | 'ghost';
+	type Variant = 'primary' | 'secondary' | 'success' | 'danger' | 'ghost';
 	type Size = 'sm' | 'md';
 
 	let {
@@ -30,6 +30,8 @@
 			'border border-primary bg-primary text-primary-contrast hover:border-primary-hover hover:bg-primary-hover',
 		secondary:
 			'border border-border bg-surface text-text hover:bg-bg',
+		success:
+			'border border-success bg-success text-white hover:border-success-hover hover:bg-success-hover',
 		danger:
 			'border border-danger bg-danger text-primary-contrast hover:border-danger-hover hover:bg-danger-hover',
 		ghost:

--- a/software/sorter/frontend/src/lib/components/settings/VersionsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/VersionsSection.svelte
@@ -152,20 +152,12 @@
 		{:else if loading}
 			<div class="mt-2 text-sm text-text-muted">Loading...</div>
 		{/if}
-	</div>
-
-	{#if currentUpdate}
-		<Alert variant="success">
-			<div class="flex items-center justify-between gap-3">
-				<div class="min-w-0">
-					<div class="font-medium text-text">Update available</div>
-					<div class="truncate text-text-muted">
-						{currentUpdate.name} → <span class="font-mono">{currentUpdate.sha}</span>
-						{#if currentUpdate.subject}
-							· {currentUpdate.subject}
-						{/if}
-					</div>
-				</div>
+		{#if currentUpdate}
+			<div class="mt-3 flex items-center justify-between gap-3 border-t border-border pt-3">
+				<span class="text-sm text-text-muted">
+					New version available —
+					<span class="font-mono text-text">{currentUpdate.sha}</span>
+				</span>
 				<Button
 					variant="success"
 					disabled={updatingRef !== null}
@@ -175,8 +167,8 @@
 					Update
 				</Button>
 			</div>
-		</Alert>
-	{/if}
+		{/if}
+	</div>
 
 	{#if payload?.fetch_error}
 		<Alert variant="warning">Could not fetch from origin: {payload.fetch_error}</Alert>
@@ -197,7 +189,7 @@
 	{#if payload && payload.available.length > 0}
 		<div class="border border-border">
 			<div class="border-b border-border bg-surface px-3 py-2">
-				<span class="text-sm font-medium text-text">Available versions</span>
+				<span class="text-sm font-medium text-text">Release channels</span>
 			</div>
 			<ul class="divide-y divide-border">
 				{#each payload.available as entry (entry.kind + entry.name)}
@@ -221,19 +213,17 @@
 								— {entry.subject} · {formatDate(entry.commit_unix)}
 							</div>
 						</div>
-						<Button
-							variant={entry.is_current && !entry.up_to_date ? 'primary' : 'secondary'}
-							size="sm"
-							disabled={updatingRef !== null || (entry.is_current && entry.up_to_date)}
-							loading={updatingRef === `${entry.kind}:${entry.name}`}
-							onclick={() => void applyUpdate(entry)}
-						>
-							{updatingRef === `${entry.kind}:${entry.name}`
-								? 'Updating...'
-								: entry.is_current
-									? 'Update'
-									: 'Switch'}
-						</Button>
+						{#if !entry.is_current}
+							<Button
+								variant="secondary"
+								size="sm"
+								disabled={updatingRef !== null}
+								loading={updatingRef === `${entry.kind}:${entry.name}`}
+								onclick={() => void applyUpdate(entry)}
+							>
+								{updatingRef === `${entry.kind}:${entry.name}` ? 'Switching...' : 'Switch'}
+							</Button>
+						{/if}
 					</li>
 				{/each}
 			</ul>

--- a/software/sorter/frontend/src/lib/components/settings/VersionsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/VersionsSection.svelte
@@ -48,6 +48,12 @@
 	let updateNotice = $state<string | null>(null);
 	let depsWarning = $state<string | null>(null);
 
+	// The ref this machine is on (branch or tag) that has moved on origin —
+	// i.e. an update is available for whatever variant you're currently running.
+	const currentUpdate = $derived(
+		payload?.available.find((e) => e.is_current && !e.up_to_date) ?? null
+	);
+
 	function httpBase(): string {
 		return machineHttpBaseUrlFromWsUrl(machine.machine?.url) ?? getBackendHttpBase();
 	}
@@ -147,6 +153,30 @@
 			<div class="mt-2 text-sm text-text-muted">Loading...</div>
 		{/if}
 	</div>
+
+	{#if currentUpdate}
+		<Alert variant="success">
+			<div class="flex items-center justify-between gap-3">
+				<div class="min-w-0">
+					<div class="font-medium text-text">Update available</div>
+					<div class="truncate text-text-muted">
+						{currentUpdate.name} → <span class="font-mono">{currentUpdate.sha}</span>
+						{#if currentUpdate.subject}
+							· {currentUpdate.subject}
+						{/if}
+					</div>
+				</div>
+				<Button
+					variant="success"
+					disabled={updatingRef !== null}
+					loading={updatingRef === `${currentUpdate.kind}:${currentUpdate.name}`}
+					onclick={() => void applyUpdate(currentUpdate)}
+				>
+					Update
+				</Button>
+			</div>
+		</Alert>
+	{/if}
 
 	{#if payload?.fetch_error}
 		<Alert variant="warning">Could not fetch from origin: {payload.fetch_error}</Alert>

--- a/software/sorter/frontend/src/lib/components/settings/VersionsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/VersionsSection.svelte
@@ -24,6 +24,7 @@
 
 	type VersionEntry = {
 		kind: 'branch' | 'tag';
+		channel?: string;
 		name: string;
 		sha: string;
 		commit_unix: number;
@@ -52,6 +53,10 @@
 	// i.e. an update is available for whatever variant you're currently running.
 	const currentUpdate = $derived(
 		payload?.available.find((e) => e.is_current && !e.up_to_date) ?? null
+	);
+	// Which release channel (if any) the machine is currently sitting on.
+	const currentChannel = $derived(
+		payload?.available.find((e) => e.is_current && e.channel)?.channel ?? null
 	);
 
 	function httpBase(): string {
@@ -135,8 +140,12 @@
 		{#if payload}
 			<div class="mt-2 flex flex-col gap-0.5">
 				<div class="text-sm text-text-muted">
-					{payload.current.detached ? 'Version' : 'Branch'}:
-					<span class="font-mono text-text">{payload.current.ref}</span>
+					{#if currentChannel}
+						Channel: <span class="text-text capitalize">{currentChannel}</span>
+					{:else}
+						{payload.current.detached ? 'Version' : 'Branch'}:
+						<span class="font-mono text-text">{payload.current.ref}</span>
+					{/if}
 				</div>
 				<div class="text-sm text-text-muted">
 					Commit:
@@ -201,11 +210,16 @@
 						{/if}
 						<div class="min-w-0 flex-1">
 							<div class="flex items-center gap-2">
-								<span class="truncate font-mono text-sm text-text">{entry.name}</span>
+								{#if entry.channel}
+									<span class="shrink-0 text-sm font-medium text-text capitalize">{entry.channel}</span>
+									<span class="truncate font-mono text-xs text-text-muted">{entry.name}</span>
+								{:else}
+									<span class="truncate font-mono text-sm text-text">{entry.name}</span>
+								{/if}
 								{#if entry.is_current && entry.up_to_date}
 									<span class="shrink-0 text-xs text-success">up to date</span>
 								{:else if entry.is_current}
-									<span class="shrink-0 text-xs text-text-muted">current branch</span>
+									<span class="shrink-0 text-xs text-text-muted">current</span>
 								{/if}
 							</div>
 							<div class="truncate text-xs text-text-muted">

--- a/software/sorter/frontend/src/lib/stores/notifications.svelte.ts
+++ b/software/sorter/frontend/src/lib/stores/notifications.svelte.ts
@@ -1,0 +1,62 @@
+/**
+ * App-wide notification store.
+ *
+ * Notifications are keyed by a stable `id`. Dismissing one records the id in
+ * `userConfig` (persisted), so it never shows again — even across reloads or a
+ * re-`push` of the same id. To make a notification re-appear after some change
+ * (e.g. a newer software version), give it an id that encodes that change so the
+ * new id is not in the dismissed set.
+ *
+ * The top-bar indicator renders `notifications.active`.
+ */
+
+import { Bell } from 'lucide-svelte';
+import { userConfig } from './userConfig.svelte';
+
+// Matches the repo convention for lucide icon props (see settings/stations.ts).
+export type LucideIcon = typeof Bell;
+
+export type NotificationColor = 'success' | 'primary' | 'warning' | 'danger';
+
+export interface AppNotification {
+	id: string;
+	title: string;
+	content?: string;
+	icon?: LucideIcon;
+	color: NotificationColor;
+	/** If set, clicking the notification navigates here. */
+	href?: string;
+}
+
+let items = $state<AppNotification[]>([]);
+
+export const notifications = {
+	get active(): AppNotification[] {
+		return items.filter((n) => !userConfig.isDismissed(n.id));
+	},
+
+	push(n: AppNotification): void {
+		if (userConfig.isDismissed(n.id)) return;
+		const idx = items.findIndex((x) => x.id === n.id);
+		if (idx >= 0) {
+			items[idx] = n;
+		} else {
+			items = [...items, n];
+		}
+	},
+
+	/** Remove a notification from the list without marking it dismissed. */
+	remove(id: string): void {
+		items = items.filter((n) => n.id !== id);
+	},
+
+	removeByPrefix(prefix: string): void {
+		items = items.filter((n) => !n.id.startsWith(prefix));
+	},
+
+	/** User closed it — hide now and remember so it stays hidden. */
+	dismiss(id: string): void {
+		userConfig.dismiss(id);
+		items = items.filter((n) => n.id !== id);
+	}
+};

--- a/software/sorter/frontend/src/lib/stores/themeColor.svelte.ts
+++ b/software/sorter/frontend/src/lib/stores/themeColor.svelte.ts
@@ -14,8 +14,16 @@
 
 import { getBackendHttpBase } from '$lib/backend';
 import { applyLegoColorVars, DEFAULT_COLOR_ID, getLegoColor } from '$lib/lego-colors';
+import { userConfig } from '$lib/stores/userConfig.svelte';
 
-let currentColorId = $state(DEFAULT_COLOR_ID);
+// Start from the last color the backend gave us (cached in localStorage) so the
+// UI paints the right primary immediately — no flash of the default blue while
+// we wait for `/api/settings/theme`. Falls back to the default on first-ever load.
+let currentColorId = $state(userConfig.colorId ?? DEFAULT_COLOR_ID);
+
+if (typeof document !== 'undefined') {
+	applyLegoColorVars(getLegoColor(currentColorId));
+}
 
 export function getCurrentThemeColorId(): string {
 	return currentColorId;
@@ -40,14 +48,13 @@ export async function loadThemeColor(): Promise<void> {
 	if (typeof window === 'undefined') return;
 	try {
 		const response = await fetch(`${getBackendHttpBase()}/api/settings/theme`);
-		if (!response.ok) {
-			applyColorIdLocally(DEFAULT_COLOR_ID);
-			return;
-		}
+		if (!response.ok) return; // keep the cached color rather than flashing to default
 		const data = (await response.json()) as { color_id?: string };
-		applyColorIdLocally(typeof data.color_id === 'string' ? data.color_id : DEFAULT_COLOR_ID);
+		const colorId = typeof data.color_id === 'string' ? data.color_id : DEFAULT_COLOR_ID;
+		if (colorId !== currentColorId) applyColorIdLocally(colorId);
+		userConfig.setColorId(colorId);
 	} catch {
-		applyColorIdLocally(DEFAULT_COLOR_ID);
+		// Offline / backend down — keep whatever we already applied (cached value).
 	}
 }
 
@@ -58,6 +65,7 @@ export async function loadThemeColor(): Promise<void> {
  */
 export async function setThemeColor(colorId: string): Promise<void> {
 	applyColorIdLocally(colorId);
+	userConfig.setColorId(colorId);
 	if (typeof window === 'undefined') return;
 	try {
 		await fetch(`${getBackendHttpBase()}/api/settings/theme`, {

--- a/software/sorter/frontend/src/lib/stores/userConfig.svelte.ts
+++ b/software/sorter/frontend/src/lib/stores/userConfig.svelte.ts
@@ -1,0 +1,90 @@
+/**
+ * Global cached user config, mirrored to localStorage.
+ *
+ * This is the app's small "instant" cache: values we don't want to re-request
+ * on every load and would rather show immediately from disk, then reconcile
+ * with the backend once connected. Right now that's the user-chosen theme color
+ * and the machine name (so the top bar paints correctly before the WebSocket
+ * identity arrives), plus the set of notification ids the user has dismissed.
+ *
+ * Hydration is synchronous at import (reads localStorage once) so consumers can
+ * read the cached value before the first paint. Every setter is equality-guarded
+ * and persists on change — no `$effect`, so there is no re-entrancy / loop risk.
+ */
+
+const STORAGE_KEY = 'sorter.userConfig';
+
+export interface UserConfigData {
+	machineName: string | null;
+	colorId: string | null;
+	dismissedNotifications: string[];
+}
+
+const DEFAULTS: UserConfigData = {
+	machineName: null,
+	colorId: null,
+	dismissedNotifications: []
+};
+
+function readStored(): UserConfigData {
+	if (typeof window === 'undefined') return { ...DEFAULTS };
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (!raw) return { ...DEFAULTS };
+		const parsed = JSON.parse(raw) as Partial<UserConfigData>;
+		return {
+			machineName: typeof parsed.machineName === 'string' ? parsed.machineName : null,
+			colorId: typeof parsed.colorId === 'string' ? parsed.colorId : null,
+			dismissedNotifications: Array.isArray(parsed.dismissedNotifications)
+				? parsed.dismissedNotifications.filter((x): x is string => typeof x === 'string')
+				: []
+		};
+	} catch {
+		return { ...DEFAULTS };
+	}
+}
+
+let data = $state<UserConfigData>(readStored());
+
+function persist(): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+	} catch (e) {
+		console.error('Failed to persist user config', e);
+	}
+}
+
+export const userConfig = {
+	get machineName(): string | null {
+		return data.machineName;
+	},
+	get colorId(): string | null {
+		return data.colorId;
+	},
+	get dismissedNotifications(): readonly string[] {
+		return data.dismissedNotifications;
+	},
+
+	setMachineName(name: string | null): void {
+		if (data.machineName === name) return;
+		data.machineName = name;
+		persist();
+	},
+
+	setColorId(colorId: string | null): void {
+		if (data.colorId === colorId) return;
+		data.colorId = colorId;
+		persist();
+	},
+
+	isDismissed(id: string): boolean {
+		return data.dismissedNotifications.includes(id);
+	},
+
+	dismiss(id: string): void {
+		if (data.dismissedNotifications.includes(id)) return;
+		data.dismissedNotifications = [...data.dismissedNotifications, id];
+		persist();
+	}
+};

--- a/software/sorter/frontend/src/lib/updates/updateChecker.ts
+++ b/software/sorter/frontend/src/lib/updates/updateChecker.ts
@@ -1,0 +1,64 @@
+/**
+ * Background software-update checker.
+ *
+ * Every few minutes we ask the backend (with `refresh=true`, which does a real
+ * `git fetch`) whether the ref this machine is currently on — branch or tag —
+ * has moved on origin. The backend already computes this per available version:
+ * the entry with `is_current: true` and `up_to_date: false` means "you are behind
+ * the thing you're tracking". When that's the case we raise a green
+ * "Update available" notification linking to the Versions page.
+ *
+ * The notification id encodes the target sha, so a *newer* update re-notifies
+ * even if the user dismissed an earlier one, while re-checking the same target
+ * every interval does not resurface a dismissed notification.
+ */
+
+import { Download } from 'lucide-svelte';
+import { getBackendHttpBase } from '$lib/backend';
+import { notifications } from '$lib/stores/notifications.svelte';
+
+const UPDATE_ID_PREFIX = 'update:';
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+
+type VersionEntry = {
+	kind: 'branch' | 'tag';
+	name: string;
+	sha: string;
+	is_current: boolean;
+	up_to_date: boolean;
+};
+
+async function checkForUpdates(): Promise<void> {
+	if (typeof window === 'undefined') return;
+	try {
+		const res = await fetch(`${getBackendHttpBase()}/api/system/versions?refresh=true`);
+		if (!res.ok) return;
+		const data = (await res.json()) as { available?: VersionEntry[] };
+		const current = (data.available ?? []).find((e) => e.is_current);
+
+		if (current && !current.up_to_date) {
+			// Single update notification reflecting the latest target sha.
+			notifications.removeByPrefix(UPDATE_ID_PREFIX);
+			notifications.push({
+				id: `${UPDATE_ID_PREFIX}${current.kind}:${current.name}:${current.sha}`,
+				title: 'Update available',
+				content: `${current.name} → ${current.sha}`,
+				icon: Download,
+				color: 'success',
+				href: '/settings/versions'
+			});
+		} else {
+			// On this ref and up to date (or nothing current) — clear any stale one.
+			notifications.removeByPrefix(UPDATE_ID_PREFIX);
+		}
+	} catch {
+		// Network hiccup — leave any existing notification as-is.
+	}
+}
+
+export function startUpdateChecker(intervalMs: number = DEFAULT_INTERVAL_MS): () => void {
+	if (typeof window === 'undefined') return () => {};
+	void checkForUpdates();
+	const timer = window.setInterval(() => void checkForUpdates(), intervalMs);
+	return () => window.clearInterval(timer);
+}

--- a/software/sorter/frontend/src/lib/updates/updateChecker.ts
+++ b/software/sorter/frontend/src/lib/updates/updateChecker.ts
@@ -22,6 +22,7 @@ const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
 
 type VersionEntry = {
 	kind: 'branch' | 'tag';
+	channel?: string;
 	name: string;
 	sha: string;
 	is_current: boolean;
@@ -39,10 +40,11 @@ async function checkForUpdates(): Promise<void> {
 		if (current && !current.up_to_date) {
 			// Single update notification reflecting the latest target sha.
 			notifications.removeByPrefix(UPDATE_ID_PREFIX);
+			const label = current.channel ? `${current.channel} ${current.name}` : current.name;
 			notifications.push({
 				id: `${UPDATE_ID_PREFIX}${current.kind}:${current.name}:${current.sha}`,
 				title: 'Update available',
-				content: `${current.name} → ${current.sha}`,
+				content: `${label} → ${current.sha}`,
 				icon: Download,
 				color: 'success',
 				href: '/settings/versions'

--- a/software/sorter/frontend/src/routes/+layout.svelte
+++ b/software/sorter/frontend/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import BackendConnectionGuard from '$lib/components/BackendConnectionGuard.svelte';
 	import { settings } from '$lib/stores/settings';
 	import { loadThemeColor } from '$lib/stores/themeColor.svelte';
+	import { startUpdateChecker } from '$lib/updates/updateChecker';
 	import { onMount } from 'svelte';
 
 	let { children } = $props();
@@ -50,6 +51,7 @@
 			console.error(e);
 		}
 		void loadThemeColor();
+		const stopUpdateChecker = startUpdateChecker();
 
 		window.addEventListener('error', (e) => {
 			reportClientError({
@@ -70,6 +72,8 @@
 				stack: reason instanceof Error ? reason.stack : undefined
 			});
 		});
+
+		return () => stopUpdateChecker();
 	});
 </script>
 

--- a/software/sorter/frontend/src/routes/layout.css
+++ b/software/sorter/frontend/src/routes/layout.css
@@ -15,7 +15,6 @@
 	--color-danger-hover: #B00E10;
 	--color-danger-dark: #5C0708;
 	--color-success: #00852B;
-	--color-success-hover: #006B22;
 	--color-success-dark: #003D14;
 	--color-warning: #F2A900;
 	--color-warning-dark: #4A3300;

--- a/software/sorter/frontend/src/routes/layout.css
+++ b/software/sorter/frontend/src/routes/layout.css
@@ -15,6 +15,7 @@
 	--color-danger-hover: #B00E10;
 	--color-danger-dark: #5C0708;
 	--color-success: #00852B;
+	--color-success-hover: #006B22;
 	--color-success-dark: #003D14;
 	--color-warning: #F2A900;
 	--color-warning-dark: #4A3300;


### PR DESCRIPTION
## Update-available notifications + stable/canary release channels

Builds on the Versions tab (#195) to tell a machine when its software is behind, and reworks releases into two channels.

### Update notifications
- **Background checker** (`updateChecker.ts`) polls `GET /api/system/versions?refresh=true` every 5 min (and on mount). When the ref you're on — branch or channel — is behind, it raises a green **Update available** notification in the top bar (left of the machine badge).
- Click it → Versions page. Hover → a dismiss **X**; dismissals persist and never re-show (the id encodes the target sha, so a genuinely newer version re-notifies). It also clears itself once you're up to date.
- Styled with the site's washed-out success tokens (thin border + faint tint + green icon), matching the `Alert`/"Active" pills.

### General user-config cache + notification store
- `userConfig.svelte.ts` — localStorage-backed cache (machine name, theme color, dismissed notification ids) hydrated synchronously at import; equality-guarded setters, no effect loops.
- `notifications.svelte.ts` — push/dismiss-by-id notification submodule; top-bar indicator shows one box, folding extras into a hover dropdown (closes on a short delay so moving into the menu doesn't dismiss it).
- Kills the flash of default-blue theme color on load by applying the cached color at import, then reconciling with the backend.

### Release channels (stable / canary)
- Backend models two tag namespaces: `sorter/stable/v*` and `sorter/canary/v*`. Each contributes one entry (its newest tag, by version). "On a channel" = your commit is one of its tags; updating moves you to the channel's newest tag — so an in-channel update drives the existing `is_current && !up_to_date` signal.
- `main` is dropped from the list unless you're actually on it.
- Versions page shows the current channel and a soft-green Update button in the top box; the list ("Release channels") only offers Switch.

Docs: `sorter-v2-agent-notes/.../sorter-software/releases.md` updated for the channel scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
