### PR TITLE
versions: prune stale release tags on fetch

### DIFF
--- a/software/sorter/backend/server/routers/versions.py
+++ b/software/sorter/backend/server/routers/versions.py
@@ -194,7 +194,7 @@ def get_versions(refresh: bool = False) -> Dict[str, Any]:
     fetch_error: Optional[str] = None
     if refresh:
         result = _git(
-            "fetch", "--tags", "--prune", "--force", "origin",
+            "fetch", "--tags", "--prune", "--prune-tags", "--force", "origin",
             timeout=GIT_FETCH_TIMEOUT_S,
         )
         if result.returncode != 0:
@@ -231,7 +231,7 @@ def update_version(req: UpdateRequest) -> Dict[str, Any]:
         _update_target = f"{req.kind}:{req.name}"
 
         fetch = _git(
-            "fetch", "--tags", "--prune", "--force", "origin",
+            "fetch", "--tags", "--prune", "--prune-tags", "--force", "origin",
             timeout=GIT_FETCH_TIMEOUT_S,
         )
         if fetch.returncode != 0:


### PR DESCRIPTION
Adds `--prune-tags` to the `git fetch` calls in `versions.py` (version list refresh + update). `--prune` alone only prunes branches, so a release tag deleted on origin stayed on the machine and kept appearing as a channel/version. With `--prune-tags`, deleted release tags are removed on the next refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)