### PR TITLE
Hive: analytics dashboards over any set of machines

### DIFF
--- a/software/hive/backend/alembic/versions/b2c3d4e5f6a7_add_machine_daily_stats.py
+++ b/software/hive/backend/alembic/versions/b2c3d4e5f6a7_add_machine_daily_stats.py
@@ -1,0 +1,39 @@
+"""add machine daily stats
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f7
+Create Date: 2026-07-11 22:30:00.000000
+
+Per-machine per-day pieces/distributed/active-seconds, the substrate for the
+analytics time-series (pieces / PPM / sorting-capacity over time) across any set
+of machines. Refreshed hourly by the machine-stats worker.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "machine_daily_stats",
+        sa.Column("machine_id", sa.UUID(), nullable=False),
+        sa.Column("day", sa.Date(), nullable=False),
+        sa.Column("pieces_seen", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("distributed", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("active_seconds", sa.Float(), nullable=False, server_default="0"),
+        sa.ForeignKeyConstraint(["machine_id"], ["machines.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("machine_id", "day"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("machine_daily_stats")

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -11,6 +11,7 @@ from app.errors import APIError, api_error_handler, http_exception_handler, unha
 from app.routers import (
     admin,
     admin_parts,
+    analytics,
     api_keys,
     auth,
     leaderboard,
@@ -74,6 +75,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.include_router(auth.router)
 app.include_router(admin.router)
 app.include_router(admin_parts.router)
+app.include_router(analytics.router)
 app.include_router(machines.router)
 app.include_router(machine_config_backups.router)
 app.include_router(machine_lookup.router)

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -31,3 +31,4 @@ from app.models.machine_piece import MachinePiece  # noqa: E402, F401
 from app.models.machine_piece_image import MachinePieceImage  # noqa: E402, F401
 from app.models.machine_sync_state import MachineSyncState  # noqa: E402, F401
 from app.models.machine_stats_cache import MachineStatsCache  # noqa: E402, F401
+from app.models.machine_daily_stats import MachineDailyStats  # noqa: E402, F401

--- a/software/hive/backend/app/models/machine_daily_stats.py
+++ b/software/hive/backend/app/models/machine_daily_stats.py
@@ -1,0 +1,28 @@
+from sqlalchemy import BigInteger, Column, Date, Float, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import Base
+
+
+class MachineDailyStats(Base):
+    """Per-machine, per-day sorting metrics — the substrate for the analytics
+    time-series (pieces/PPM/capacity over time) across any set of machines.
+
+    One row per (machine, calendar day of seen_at). active_seconds is the summed
+    gap between consecutive pieces on that day, ignoring idle gaps (same rule as
+    machine_stats). PPM is derived (distributed * 60 / active_seconds). A
+    background pass (app.services.analytics) upserts these hourly; rows are only
+    ever added/updated since pieces aren't deleted.
+    """
+
+    __tablename__ = "machine_daily_stats"
+
+    machine_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("machines.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    day = Column(Date, primary_key=True)
+    pieces_seen = Column(BigInteger, nullable=False, default=0)
+    distributed = Column(BigInteger, nullable=False, default=0)
+    active_seconds = Column(Float, nullable=False, default=0.0)

--- a/software/hive/backend/app/routers/analytics.py
+++ b/software/hive/backend/app/routers/analytics.py
@@ -1,0 +1,43 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.deps import get_current_user, get_db
+from app.models.machine_daily_stats import MachineDailyStats
+from app.models.user import User
+from app.services import analytics
+
+router = APIRouter(prefix="/api", tags=["analytics"])
+
+
+@router.get("/analytics")
+def get_analytics(
+    machine_id: UUID | None = Query(None),
+    owner_id: UUID | None = Query(None),
+    scope: str | None = Query(None, pattern="^(mine|all)$"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Analytics over a set of machines, chosen by (in precedence order)
+    machine_id, owner_id, or scope=mine|all. Authorization is enforced by
+    resolve_machine_set; served from machine_daily_stats + live group-bys."""
+    resolved = analytics.resolve_machine_set(
+        db, current_user, machine_id=machine_id, owner_id=owner_id, scope=scope
+    )
+    # Cold-start: populate the daily table on the first request if the worker
+    # hasn't run yet, so analytics isn't blank on a fresh deploy.
+    if db.query(MachineDailyStats.machine_id).first() is None:
+        try:
+            analytics.refresh_daily_stats(db)
+        except Exception:
+            db.rollback()
+    data = analytics.get_analytics(db, resolved["ids"])
+    return {
+        "scope": {
+            "kind": resolved["kind"],
+            "label": resolved["label"],
+            "machine_count": len(resolved["ids"]),
+        },
+        **data,
+    }

--- a/software/hive/backend/app/services/analytics.py
+++ b/software/hive/backend/app/services/analytics.py
@@ -1,0 +1,363 @@
+"""Analytics over an arbitrary set of machines.
+
+The same primitives serve every context — one machine, a user's whole fleet, one
+user's fleet (admin), or the entire fleet (admin) — by resolving the request to a
+list of machine ids and aggregating over it:
+
+  * time-series  — machines / pieces / distributed / avg-PPM / sorting-capacity
+    per day, from the pre-computed machine_daily_stats table.
+  * distributions — pieces by machine / classification status / top parts / top
+    colors (live group-bys, cheap at current scale).
+  * totals        — headline numbers for the set.
+
+"Sorting capacity" on day D = for each machine active that day, its PPM that day
+projected over a full day (× 1440 min), summed across machines — i.e. how many
+pieces the fleet could theoretically sort in a day at that day's throughput.
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_mod
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.errors import APIError
+from app.models.machine import Machine
+from app.models.machine_daily_stats import MachineDailyStats
+from app.models.machine_piece import MachinePiece
+from app.models.user import User
+
+# Idle-gap threshold — must match app.services.machine_stats so the derived
+# active time is consistent between the summary cache and the daily table.
+ACTIVE_GAP_IDLE_S = 60.0
+MINUTES_PER_DAY = 1440.0
+
+
+# --------------------------------------------------------------------------- refresh
+
+def refresh_daily_stats(db: Session) -> int:
+    """Recompute per-(machine, day) pieces/distributed/active_seconds and upsert.
+
+    Full recompute each pass — pieces are only ever appended, so upsert-in-place
+    keeps every day correct without deleting anything. Returns rows written.
+    """
+    if db.bind.dialect.name == "postgresql":
+        from sqlalchemy import text
+
+        result = db.execute(
+            text(
+                """
+                INSERT INTO machine_daily_stats (machine_id, day, pieces_seen, distributed, active_seconds)
+                SELECT machine_id, day,
+                       count(*) AS pieces_seen,
+                       count(*) FILTER (WHERE bin_x IS NOT NULL) AS distributed,
+                       COALESCE(SUM(CASE WHEN gap > 0 AND gap <= :idle THEN gap ELSE 0 END), 0) AS active_seconds
+                FROM (
+                    SELECT machine_id, bin_x,
+                           (seen_at AT TIME ZONE 'UTC')::date AS day,
+                           EXTRACT(EPOCH FROM (
+                               seen_at - LAG(seen_at) OVER (
+                                   PARTITION BY machine_id ORDER BY seen_at, local_id))) AS gap
+                    FROM machine_pieces
+                    WHERE seen_at IS NOT NULL
+                ) g
+                GROUP BY machine_id, day
+                ON CONFLICT (machine_id, day) DO UPDATE SET
+                    pieces_seen = EXCLUDED.pieces_seen,
+                    distributed = EXCLUDED.distributed,
+                    active_seconds = EXCLUDED.active_seconds
+                """
+            ),
+            {"idle": ACTIVE_GAP_IDLE_S},
+        )
+        db.commit()
+        return result.rowcount or 0
+
+    return _refresh_daily_stats_python(db)
+
+
+def _refresh_daily_stats_python(db: Session) -> int:
+    """SQLite / non-Postgres fallback — compute in Python, upsert via ORM."""
+    rows = (
+        db.query(
+            MachinePiece.machine_id,
+            MachinePiece.seen_at,
+            MachinePiece.bin_x,
+        )
+        .filter(MachinePiece.seen_at.isnot(None))
+        .order_by(MachinePiece.machine_id, MachinePiece.seen_at, MachinePiece.local_id)
+        .all()
+    )
+    agg: dict[tuple[Any, Any], dict[str, float]] = {}
+    prev_mid = None
+    prev_seen = None
+    for mid, seen_at, bin_x in rows:
+        day = seen_at.date()
+        key = (str(mid), day)
+        cell = agg.setdefault(key, {"pieces": 0, "distributed": 0, "active": 0.0})
+        cell["pieces"] += 1
+        if bin_x is not None:
+            cell["distributed"] += 1
+        if prev_mid == str(mid) and prev_seen is not None:
+            gap = (seen_at - prev_seen).total_seconds()
+            if 0 < gap <= ACTIVE_GAP_IDLE_S:
+                cell["active"] += gap
+        prev_mid = str(mid)
+        prev_seen = seen_at
+
+    existing = {(str(r.machine_id), r.day): r for r in db.query(MachineDailyStats).all()}
+    for (mid, day), cell in agg.items():
+        row = existing.get((mid, day))
+        if row is None:
+            row = MachineDailyStats(machine_id=uuid_mod.UUID(mid), day=day)
+            db.add(row)
+        row.pieces_seen = int(cell["pieces"])
+        row.distributed = int(cell["distributed"])
+        row.active_seconds = float(cell["active"])
+    db.commit()
+    return len(agg)
+
+
+# --------------------------------------------------------------------------- scope
+
+def resolve_machine_set(
+    db: Session,
+    current_user: User,
+    *,
+    machine_id: Any | None = None,
+    owner_id: Any | None = None,
+    scope: str | None = None,
+) -> dict[str, Any]:
+    """Resolve + authorize a machine set. Returns {ids, kind, label}.
+
+    Precedence: machine_id > owner_id > scope. Default is the caller's own fleet.
+    Non-owner/non-admin access to another's machine yields 404 (existence hidden).
+    """
+    is_admin = current_user.role == "admin"
+
+    if machine_id is not None:
+        machine = db.query(Machine).filter(Machine.id == machine_id).first()
+        if machine is None or (str(machine.owner_id) != str(current_user.id) and not is_admin):
+            raise APIError(404, "Machine not found", "MACHINE_NOT_FOUND")
+        return {"ids": [machine.id], "kind": "machine", "label": machine.name}
+
+    if owner_id is not None:
+        if str(owner_id) != str(current_user.id) and not is_admin:
+            raise APIError(403, "Forbidden", "FORBIDDEN")
+        ids = _owner_ids(db, owner_id)
+        owner = db.query(User).filter(User.id == owner_id).first()
+        label = (owner.display_name or owner.email) if owner else "fleet"
+        return {"ids": ids, "kind": "owner_fleet", "label": label}
+
+    if scope == "all":
+        if not is_admin:
+            raise APIError(403, "Admin only", "FORBIDDEN")
+        ids = [mid for (mid,) in db.query(Machine.id).filter(Machine.archived_at.is_(None)).all()]
+        return {"ids": ids, "kind": "all", "label": "All machines"}
+
+    return {"ids": _owner_ids(db, current_user.id), "kind": "my_fleet", "label": "My machines"}
+
+
+def _owner_ids(db: Session, owner_id: Any) -> list[Any]:
+    return [
+        mid
+        for (mid,) in db.query(Machine.id)
+        .filter(Machine.owner_id == owner_id, Machine.archived_at.is_(None))
+        .all()
+    ]
+
+
+# --------------------------------------------------------------------------- reads
+
+def get_timeseries(db: Session, machine_ids: list[Any]) -> list[dict[str, Any]]:
+    if not machine_ids:
+        return []
+    rows = (
+        db.query(MachineDailyStats)
+        .filter(MachineDailyStats.machine_id.in_(machine_ids))
+        .order_by(MachineDailyStats.day)
+        .all()
+    )
+    if not rows:
+        return []
+
+    day_agg: dict[Any, dict[str, Any]] = {}
+    machine_first_day: dict[str, Any] = {}
+    for r in rows:
+        d = r.day
+        cell = day_agg.setdefault(d, {"pieces": 0, "distributed": 0, "active": 0.0, "cap": 0.0, "ppms": []})
+        cell["pieces"] += r.pieces_seen
+        cell["distributed"] += r.distributed
+        cell["active"] += r.active_seconds
+        if r.active_seconds and r.active_seconds > 0:
+            ppm = r.distributed * 60.0 / r.active_seconds
+            cell["cap"] += ppm * MINUTES_PER_DAY
+            cell["ppms"].append(ppm)
+        mid = str(r.machine_id)
+        if mid not in machine_first_day or d < machine_first_day[mid]:
+            machine_first_day[mid] = d
+
+    first_days = sorted(machine_first_day.values())
+    days = sorted(day_agg.keys())
+
+    series: list[dict[str, Any]] = []
+    cum_pieces = 0
+    cum_distributed = 0
+    fd_idx = 0
+    for d in days:
+        cell = day_agg[d]
+        cum_pieces += cell["pieces"]
+        cum_distributed += cell["distributed"]
+        while fd_idx < len(first_days) and first_days[fd_idx] <= d:
+            fd_idx += 1
+        throughput = (cell["distributed"] * 60.0 / cell["active"]) if cell["active"] > 0 else 0.0
+        avg_ppm = (sum(cell["ppms"]) / len(cell["ppms"])) if cell["ppms"] else 0.0
+        series.append(
+            {
+                "day": d.isoformat(),
+                "pieces_seen": cell["pieces"],
+                "distributed": cell["distributed"],
+                "active_seconds": round(cell["active"], 1),
+                "avg_ppm": round(avg_ppm, 3),
+                "throughput_ppm": round(throughput, 3),
+                "capacity_per_day": round(cell["cap"], 1),
+                "cumulative_pieces": cum_pieces,
+                "cumulative_distributed": cum_distributed,
+                "cumulative_machines": fd_idx,
+            }
+        )
+    return series
+
+
+def get_distributions(db: Session, machine_ids: list[Any]) -> dict[str, Any]:
+    if not machine_ids:
+        return {"by_machine": [], "by_status": [], "top_parts": [], "top_colors": []}
+
+    base = db.query(MachinePiece).filter(MachinePiece.machine_id.in_(machine_ids))
+
+    by_status = [
+        {"label": status or "unknown", "value": count}
+        for status, count in (
+            base.with_entities(MachinePiece.classification_status, func.count())
+            .group_by(MachinePiece.classification_status)
+            .all()
+        )
+    ]
+
+    top_parts = [
+        {"part_id": pid, "part_name": pname, "value": count}
+        for pid, pname, count in (
+            base.with_entities(MachinePiece.part_id, func.max(MachinePiece.part_name), func.count())
+            .filter(MachinePiece.part_id.isnot(None))
+            .group_by(MachinePiece.part_id)
+            .order_by(func.count().desc())
+            .limit(15)
+            .all()
+        )
+    ]
+
+    top_colors = [
+        {"color_id": cid, "color_name": cname, "value": count}
+        for cid, cname, count in (
+            base.with_entities(MachinePiece.color_id, func.max(MachinePiece.color_name), func.count())
+            .filter(MachinePiece.color_id.isnot(None))
+            .group_by(MachinePiece.color_id)
+            .order_by(func.count().desc())
+            .limit(15)
+            .all()
+        )
+    ]
+
+    by_machine: list[dict[str, Any]] = []
+    if len(machine_ids) > 1:
+        name_by_id = {
+            str(mid): name
+            for mid, name in db.query(Machine.id, Machine.name).filter(Machine.id.in_(machine_ids)).all()
+        }
+        rows = (
+            base.with_entities(MachinePiece.machine_id, func.count())
+            .group_by(MachinePiece.machine_id)
+            .order_by(func.count().desc())
+            .all()
+        )
+        by_machine = [
+            {"machine_id": str(mid), "label": name_by_id.get(str(mid), "?"), "value": count}
+            for mid, count in rows
+        ]
+
+    return {
+        "by_machine": by_machine,
+        "by_status": by_status,
+        "top_parts": top_parts,
+        "top_colors": top_colors,
+    }
+
+
+def get_totals(db: Session, machine_ids: list[Any], series: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    empty = {
+        "machines": 0, "pieces_seen": 0, "distributed": 0, "classified": 0,
+        "unique_parts": 0, "unique_colors": 0, "active_seconds": 0.0,
+        "overall_ppm": 0.0, "capacity_recent": 0.0, "first_day": None, "last_day": None,
+    }
+    if not machine_ids:
+        return empty
+
+    agg = (
+        db.query(
+            func.count().label("pieces_seen"),
+            func.count().filter(MachinePiece.bin_x.isnot(None)).label("distributed"),
+            func.count().filter(MachinePiece.classification_status == "classified").label("classified"),
+            func.count(func.distinct(MachinePiece.part_id)).label("unique_parts"),
+            func.count(func.distinct(MachinePiece.color_id)).label("unique_colors"),
+        )
+        .filter(MachinePiece.machine_id.in_(machine_ids))
+        .one()
+    )
+    active_seconds = (
+        db.query(func.coalesce(func.sum(MachineDailyStats.active_seconds), 0.0))
+        .filter(MachineDailyStats.machine_id.in_(machine_ids))
+        .scalar()
+    ) or 0.0
+    day_bounds = (
+        db.query(func.min(MachineDailyStats.day), func.max(MachineDailyStats.day))
+        .filter(MachineDailyStats.machine_id.in_(machine_ids))
+        .one()
+    )
+    machines_with_pieces = (
+        db.query(func.count(func.distinct(MachinePiece.machine_id)))
+        .filter(MachinePiece.machine_id.in_(machine_ids))
+        .scalar()
+    ) or 0
+
+    distributed = agg.distributed or 0
+    overall_ppm = (distributed * 60.0 / active_seconds) if active_seconds > 0 else 0.0
+
+    # Recent capacity = the most recent day's theoretical daily throughput.
+    if series is None:
+        series = get_timeseries(db, machine_ids)
+    capacity_recent = series[-1]["capacity_per_day"] if series else 0.0
+
+    return {
+        "machines": machines_with_pieces,
+        "pieces_seen": agg.pieces_seen or 0,
+        "distributed": distributed,
+        "classified": agg.classified or 0,
+        "unique_parts": agg.unique_parts or 0,
+        "unique_colors": agg.unique_colors or 0,
+        "active_seconds": round(active_seconds, 1),
+        "overall_ppm": round(overall_ppm, 3),
+        "capacity_recent": capacity_recent,
+        "first_day": day_bounds[0].isoformat() if day_bounds[0] else None,
+        "last_day": day_bounds[1].isoformat() if day_bounds[1] else None,
+    }
+
+
+def get_analytics(db: Session, machine_ids: list[Any]) -> dict[str, Any]:
+    series = get_timeseries(db, machine_ids)
+    return {
+        "totals": get_totals(db, machine_ids, series=series),
+        "timeseries": series,
+        "distributions": get_distributions(db, machine_ids),
+    }

--- a/software/hive/backend/app/services/machine_stats.py
+++ b/software/hive/backend/app/services/machine_stats.py
@@ -379,6 +379,10 @@ class MachineStatsWorker:
         db = SessionLocal()
         try:
             count = refresh_cache(db)
+            # Same pass also maintains the per-day analytics substrate.
+            from app.services import analytics
+
+            analytics.refresh_daily_stats(db)
             self._update_state(
                 last_run_at=datetime.now(timezone.utc).isoformat(),
                 last_run_machines=count,

--- a/software/hive/backend/tests/test_analytics.py
+++ b/software/hive/backend/tests/test_analytics.py
@@ -1,0 +1,96 @@
+"""Analytics over a machine set: daily aggregation, timeseries, auth scopes."""
+
+from __future__ import annotations
+
+from app.models.user import User
+from tests.conftest import _login_user, _register_user
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _sync_two_days(client, machine_token) -> None:
+    # Day 1: 1_760_000_000 = 2025-10-09 UTC; +86400 -> day 2. Two distributed
+    # pieces 5s apart each day (active gap counts), one far-apart piece (idle).
+    d1 = 1_760_000_000.0
+    d2 = d1 + 86400.0
+    records = [
+        {"piece_uuid": "a", "local_id": 1, "seen_at": d1, "classification_status": "classified",
+         "part_id": "3001", "color_id": "5", "bin_x": 1, "bin_y": 0, "bin_z": 0},
+        {"piece_uuid": "b", "local_id": 2, "seen_at": d1 + 5, "classification_status": "classified",
+         "part_id": "3002", "color_id": "5", "bin_x": 1, "bin_y": 0, "bin_z": 0},
+        {"piece_uuid": "c", "local_id": 3, "seen_at": d2, "classification_status": "classified",
+         "part_id": "3001", "color_id": "4", "bin_x": 1, "bin_y": 0, "bin_z": 0},
+        {"piece_uuid": "d", "local_id": 4, "seen_at": d2 + 5, "classification_status": "unknown",
+         "part_id": None, "color_id": None},
+    ]
+    r = client.post("/api/machine/sync/piece-records", headers=_bearer(machine_token), json={"records": records})
+    assert r.status_code == 200, r.text
+
+
+def test_single_machine_analytics(client, machine_token, test_machine):
+    _sync_two_days(client, machine_token)
+    r = client.get(f"/api/analytics?machine_id={test_machine['id']}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["scope"]["kind"] == "machine"
+    assert body["scope"]["machine_count"] == 1
+
+    ts = body["timeseries"]
+    assert len(ts) == 2  # two distinct days
+    assert ts[0]["pieces_seen"] == 2 and ts[1]["pieces_seen"] == 2
+    # Cumulative pieces monotonically increase; one machine seen from day 1.
+    assert ts[0]["cumulative_pieces"] == 2 and ts[1]["cumulative_pieces"] == 4
+    assert ts[0]["cumulative_machines"] == 1 and ts[1]["cumulative_machines"] == 1
+    # Day 1: 2 distributed over 5s active -> ppm = 2*60/5 = 24; capacity = 24*1440.
+    assert abs(ts[0]["throughput_ppm"] - 24.0) < 0.01
+    assert abs(ts[0]["capacity_per_day"] - 24.0 * 1440.0) < 1.0
+
+    totals = body["totals"]
+    assert totals["pieces_seen"] == 4
+    assert totals["distributed"] == 3
+    assert totals["classified"] == 3
+    assert totals["unique_parts"] == 2  # 3001, 3002 (piece d has null part)
+    assert totals["machines"] == 1
+
+    dist = body["distributions"]
+    statuses = {d["label"]: d["value"] for d in dist["by_status"]}
+    assert statuses.get("classified") == 3 and statuses.get("unknown") == 1
+    assert dist["by_machine"] == []  # single machine -> omitted
+    parts = {d["part_id"]: d["value"] for d in dist["top_parts"]}
+    assert parts.get("3001") == 2 and parts.get("3002") == 1
+
+
+def test_my_fleet_scope_default(client, machine_token, test_machine):
+    _sync_two_days(client, machine_token)
+    r = client.get("/api/analytics")  # default scope = my fleet
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["scope"]["kind"] == "my_fleet"
+    assert body["totals"]["pieces_seen"] == 4
+
+
+def test_scope_all_requires_admin(client, db, machine_token, test_machine):
+    _sync_two_days(client, machine_token)
+    # member -> forbidden
+    assert client.get("/api/analytics?scope=all").status_code == 403
+    # promote -> allowed
+    user = db.query(User).filter(User.email == "member@test.com").first()
+    user.role = "admin"
+    db.commit()
+    r = client.get("/api/analytics?scope=all")
+    assert r.status_code == 200, r.text
+    assert r.json()["scope"]["kind"] == "all"
+    assert r.json()["totals"]["pieces_seen"] == 4
+
+
+def test_other_users_machine_is_404(client, db, machine_token, test_machine):
+    _sync_two_days(client, machine_token)
+    _register_user(client, "other@test.com", "Password123!", "Other")
+    _login_user(client, "other@test.com", "Password123!")
+    assert client.get(f"/api/analytics?machine_id={test_machine['id']}").status_code == 404
+    # their own (empty) fleet is fine, just empty
+    r = client.get("/api/analytics")
+    assert r.status_code == 200
+    assert r.json()["timeseries"] == []

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -153,6 +153,53 @@ export interface ServerHealth {
 	};
 }
 
+export interface AnalyticsScope {
+	kind: 'machine' | 'my_fleet' | 'owner_fleet' | 'all' | string;
+	label: string;
+	machine_count: number;
+}
+
+export interface AnalyticsDayPoint {
+	day: string;
+	pieces_seen: number;
+	distributed: number;
+	active_seconds: number;
+	avg_ppm: number;
+	throughput_ppm: number;
+	capacity_per_day: number;
+	cumulative_pieces: number;
+	cumulative_distributed: number;
+	cumulative_machines: number;
+}
+
+export interface AnalyticsTotals {
+	machines: number;
+	pieces_seen: number;
+	distributed: number;
+	classified: number;
+	unique_parts: number;
+	unique_colors: number;
+	active_seconds: number;
+	overall_ppm: number;
+	capacity_recent: number;
+	first_day: string | null;
+	last_day: string | null;
+}
+
+export interface AnalyticsDistributions {
+	by_machine: { machine_id: string; label: string; value: number }[];
+	by_status: { label: string; value: number }[];
+	top_parts: { part_id: string | null; part_name: string | null; value: number }[];
+	top_colors: { color_id: string | null; color_name: string | null; value: number }[];
+}
+
+export interface Analytics {
+	scope: AnalyticsScope;
+	totals: AnalyticsTotals;
+	timeseries: AnalyticsDayPoint[];
+	distributions: AnalyticsDistributions;
+}
+
 export interface MachinePieceImageInfo {
 	seq: number;
 	source: string | null;
@@ -911,6 +958,14 @@ export const api = {
 	},
 	getMachineOverview(machineId: string) {
 		return request<MachineOverview>('GET', `/api/machines/${machineId}/overview`);
+	},
+	getAnalytics(params: { machineId?: string; ownerId?: string; scope?: 'mine' | 'all' } = {}) {
+		const sp = new URLSearchParams();
+		if (params.machineId) sp.set('machine_id', params.machineId);
+		if (params.ownerId) sp.set('owner_id', params.ownerId);
+		if (params.scope) sp.set('scope', params.scope);
+		const qs = sp.toString();
+		return request<Analytics>('GET', `/api/analytics${qs ? `?${qs}` : ''}`);
 	},
 	refreshAllMachineStats() {
 		return request<{ ok: boolean; refreshed: number }>('POST', '/api/admin/machines/stats/refresh');

--- a/software/hive/frontend/src/lib/components/charts/AnalyticsDashboard.svelte
+++ b/software/hive/frontend/src/lib/components/charts/AnalyticsDashboard.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import { api, type Analytics } from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import SeriesChart, { type SeriesPoint } from './SeriesChart.svelte';
+	import DonutChart, { type DonutSegment } from './DonutChart.svelte';
+	import BarList, { type BarItem } from './BarList.svelte';
+	import ChartCard from './ChartCard.svelte';
+
+	let {
+		machineId,
+		ownerId,
+		scope,
+		showTotals = true
+	}: {
+		machineId?: string;
+		ownerId?: string;
+		scope?: 'mine' | 'all';
+		showTotals?: boolean;
+	} = $props();
+
+	let data = $state<Analytics | null>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	$effect(() => {
+		// Re-fetch whenever the selected machine set changes.
+		const params = { machineId, ownerId, scope };
+		void params.machineId;
+		void params.ownerId;
+		void params.scope;
+		loading = true;
+		error = null;
+		api
+			.getAnalytics(params)
+			.then((d) => {
+				data = d;
+			})
+			.catch((e: unknown) => {
+				error = e && typeof e === 'object' && 'error' in e ? String((e as { error: unknown }).error) : 'Failed to load analytics';
+			})
+			.finally(() => {
+				loading = false;
+			});
+	});
+
+	const isMulti = $derived((data?.scope.machine_count ?? 0) > 1);
+
+	// Time-series projections.
+	const piecesPerDay = $derived<SeriesPoint[]>((data?.timeseries ?? []).map((p) => ({ date: p.day, value: p.pieces_seen })));
+	const cumulativePieces = $derived<SeriesPoint[]>((data?.timeseries ?? []).map((p) => ({ date: p.day, value: p.cumulative_pieces })));
+	const avgPpm = $derived<SeriesPoint[]>((data?.timeseries ?? []).map((p) => ({ date: p.day, value: p.avg_ppm })));
+	const capacity = $derived<SeriesPoint[]>((data?.timeseries ?? []).map((p) => ({ date: p.day, value: p.capacity_per_day })));
+	const machinesOverTime = $derived<SeriesPoint[]>((data?.timeseries ?? []).map((p) => ({ date: p.day, value: p.cumulative_machines })));
+
+	const PALETTE = [
+		'var(--color-primary)',
+		'var(--color-info)',
+		'var(--color-success)',
+		'var(--color-warning-strong)',
+		'var(--color-danger)',
+		'color-mix(in srgb, var(--color-primary) 55%, var(--color-bg))',
+		'color-mix(in srgb, var(--color-info) 55%, var(--color-bg))',
+		'color-mix(in srgb, var(--color-success) 55%, var(--color-bg))'
+	];
+
+	function statusColor(label: string): string {
+		switch (label) {
+			case 'classified':
+				return 'var(--color-success)';
+			case 'failed':
+			case 'multi_drop_fail':
+				return 'var(--color-danger)';
+			case 'not_found':
+				return 'var(--color-primary)';
+			case 'unknown':
+				return 'var(--color-warning-strong)';
+			case 'pending':
+			case 'classifying':
+				return 'var(--color-info)';
+			default:
+				return 'var(--color-text-muted)';
+		}
+	}
+
+	const statusSegments = $derived<DonutSegment[]>(
+		(data?.distributions.by_status ?? []).map((s) => ({ label: s.label, value: s.value, color: statusColor(s.label) }))
+	);
+	const machineSegments = $derived<DonutSegment[]>(
+		(data?.distributions.by_machine ?? []).map((m, i) => ({ label: m.label, value: m.value, color: PALETTE[i % PALETTE.length] }))
+	);
+	const topParts = $derived<BarItem[]>(
+		(data?.distributions.top_parts ?? []).map((p) => ({ label: p.part_name || p.part_id || '—', sublabel: p.part_id, value: p.value }))
+	);
+	const topColors = $derived<BarItem[]>(
+		(data?.distributions.top_colors ?? []).map((c) => ({ label: c.color_name || c.color_id || '—', value: c.value }))
+	);
+
+	function num(n: number | null | undefined): string {
+		return n != null ? Math.round(n).toLocaleString() : '—';
+	}
+	function ppm(n: number | null | undefined): string {
+		return n && n > 0 ? n.toFixed(1) : '—';
+	}
+	function duration(seconds: number | null | undefined): string {
+		if (!seconds || seconds <= 0) return '—';
+		const h = seconds / 3600;
+		return h >= 1 ? `${h.toFixed(1)}h` : `${Math.round(seconds / 60)}m`;
+	}
+
+	const totalsCards = $derived(
+		data
+			? [
+					{ label: 'Pieces counted', value: num(data.totals.pieces_seen) },
+					{ label: 'Distributed', value: num(data.totals.distributed) },
+					{ label: 'Overall PPM', value: ppm(data.totals.overall_ppm) },
+					{ label: 'Capacity / day', value: num(data.totals.capacity_recent) },
+					{ label: 'Unique parts', value: num(data.totals.unique_parts) },
+					{ label: 'Unique colors', value: num(data.totals.unique_colors) },
+					{ label: 'Active time', value: duration(data.totals.active_seconds) },
+					{ label: isMulti ? 'Machines' : 'Classified', value: isMulti ? num(data.totals.machines) : num(data.totals.classified) }
+				]
+			: []
+	);
+</script>
+
+{#if loading}
+	<div class="flex justify-center py-10"><Spinner /></div>
+{:else if error}
+	<div class="bg-primary/8 p-3 text-sm text-primary">{error}</div>
+{:else if data}
+	{#if showTotals}
+		<div class="grid grid-cols-2 gap-px border border-border bg-border sm:grid-cols-4">
+			{#each totalsCards as cell (cell.label)}
+				<div class="flex flex-col items-center bg-surface py-4">
+					<span class="text-xl font-bold text-text tabular-nums">{cell.value}</span>
+					<span class="mt-0.5 text-center text-[10px] uppercase tracking-wider text-text-muted">{cell.label}</span>
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	{#if data.timeseries.length === 0}
+		<div class="mt-4 border border-border bg-surface p-8 text-center text-sm text-text-muted">
+			No sorting activity recorded yet — charts appear once pieces are synced.
+		</div>
+	{:else}
+		<!-- Time-series -->
+		<div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+			<ChartCard title="Pieces per day" subtitle="Pieces seen each day">
+				<SeriesChart points={piecesPerDay} kind="bar" />
+			</ChartCard>
+			<ChartCard title="Total pieces" subtitle="Cumulative pieces seen">
+				<SeriesChart points={cumulativePieces} color="var(--color-info)" />
+			</ChartCard>
+			<ChartCard title="Average PPM" subtitle="Mean per-machine pieces/min per day">
+				<SeriesChart points={avgPpm} color="var(--color-success)" formatValue={(v) => v.toFixed(1)} />
+			</ChartCard>
+			<ChartCard title="Sorting capacity" subtitle="Theoretical pieces/day at that day’s PPM (24h)">
+				<SeriesChart points={capacity} color="var(--color-warning-strong)" />
+			</ChartCard>
+			{#if isMulti}
+				<ChartCard title="Machines over time" subtitle="Cumulative machines seen">
+					<SeriesChart points={machinesOverTime} color="var(--color-primary)" />
+				</ChartCard>
+			{/if}
+		</div>
+
+		<!-- Distributions -->
+		<div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+			<div class="border border-border bg-surface">
+				<div class="border-b border-border bg-bg px-4 py-2">
+					<h3 class="text-sm font-semibold text-text">Classification outcomes</h3>
+				</div>
+				<div class="p-4"><DonutChart segments={statusSegments} centerLabel="pieces" /></div>
+			</div>
+
+			{#if isMulti && machineSegments.length > 0}
+				<div class="border border-border bg-surface">
+					<div class="border-b border-border bg-bg px-4 py-2">
+						<h3 class="text-sm font-semibold text-text">Pieces by machine</h3>
+					</div>
+					<div class="p-4"><DonutChart segments={machineSegments} centerLabel="pieces" /></div>
+				</div>
+			{/if}
+
+			<div class="border border-border bg-surface">
+				<div class="border-b border-border bg-bg px-4 py-2">
+					<h3 class="text-sm font-semibold text-text">Top parts</h3>
+				</div>
+				<div class="p-4"><BarList items={topParts} /></div>
+			</div>
+
+			<div class="border border-border bg-surface">
+				<div class="border-b border-border bg-bg px-4 py-2">
+					<h3 class="text-sm font-semibold text-text">Top colors</h3>
+				</div>
+				<div class="p-4"><BarList items={topColors} color="color-mix(in srgb, var(--color-info) 70%, transparent)" /></div>
+			</div>
+		</div>
+	{/if}
+{/if}

--- a/software/hive/frontend/src/lib/components/charts/BarList.svelte
+++ b/software/hive/frontend/src/lib/components/charts/BarList.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	// Horizontal bar list for ranked categorical data (top parts, top colors).
+	export type BarItem = { label: string; sublabel?: string | null; value: number; swatch?: string | null };
+
+	let {
+		items,
+		color = 'color-mix(in srgb, var(--color-primary) 70%, transparent)'
+	}: {
+		items: BarItem[];
+		color?: string;
+	} = $props();
+
+	const max = $derived(Math.max(1, ...items.map((i) => i.value)));
+</script>
+
+{#if items.length === 0}
+	<div class="flex h-24 items-center justify-center text-sm text-text-muted">No data yet.</div>
+{:else}
+	<div class="flex flex-col gap-1.5">
+		{#each items as item (item.label + (item.sublabel ?? ''))}
+			<div class="flex items-center gap-2 text-sm">
+				{#if item.swatch}
+					<span class="h-3 w-3 flex-shrink-0 border border-border" style:background-color={item.swatch}></span>
+				{/if}
+				{#if item.sublabel}
+					<span class="w-14 flex-shrink-0 truncate font-mono text-xs text-text-muted">{item.sublabel}</span>
+				{/if}
+				<span class="w-28 flex-shrink-0 truncate text-text" title={item.label}>{item.label}</span>
+				<div class="h-4 flex-1 bg-bg">
+					<div class="h-full" style="width: {(item.value / max) * 100}%; background: {color}"></div>
+				</div>
+				<span class="w-16 flex-shrink-0 text-right tabular-nums text-text-muted">{item.value.toLocaleString()}</span>
+			</div>
+		{/each}
+	</div>
+{/if}

--- a/software/hive/frontend/src/lib/components/charts/ChartCard.svelte
+++ b/software/hive/frontend/src/lib/components/charts/ChartCard.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		title,
+		subtitle = '',
+		children
+	}: {
+		title: string;
+		subtitle?: string;
+		children: Snippet;
+	} = $props();
+</script>
+
+<div class="border border-border bg-surface">
+	<div class="border-b border-border bg-bg px-4 py-2">
+		<h3 class="text-sm font-semibold text-text">{title}</h3>
+		{#if subtitle}<p class="text-xs text-text-muted">{subtitle}</p>{/if}
+	</div>
+	<div class="p-3">{@render children()}</div>
+</div>

--- a/software/hive/frontend/src/lib/components/charts/DonutChart.svelte
+++ b/software/hive/frontend/src/lib/components/charts/DonutChart.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	// Hand-rolled SVG donut. Segments drawn with stroke-dasharray on a circle so
+	// there's no arc math; the legend carries the exact numbers.
+	export type DonutSegment = { label: string; value: number; color: string };
+
+	let {
+		segments,
+		centerLabel = ''
+	}: {
+		segments: DonutSegment[];
+		centerLabel?: string;
+	} = $props();
+
+	const R = 42;
+	const STROKE = 20;
+	const C = 2 * Math.PI * R;
+
+	const total = $derived(segments.reduce((sum, s) => sum + s.value, 0));
+	const arcs = $derived.by(() => {
+		let offset = 0;
+		return segments
+			.filter((s) => s.value > 0)
+			.map((s) => {
+				const frac = total > 0 ? s.value / total : 0;
+				const arc = { ...s, frac, dash: frac * C, offset };
+				offset += frac * C;
+				return arc;
+			});
+	});
+
+	function pct(frac: number): string {
+		return `${(frac * 100).toFixed(frac >= 0.1 ? 0 : 1)}%`;
+	}
+</script>
+
+{#if total === 0}
+	<div class="flex h-32 items-center justify-center text-sm text-text-muted">No data yet.</div>
+{:else}
+	<div class="flex flex-wrap items-center gap-4">
+		<svg viewBox="0 0 120 120" class="h-36 w-36 flex-shrink-0" role="img">
+			<circle cx="60" cy="60" r={R} fill="none" stroke="var(--color-border)" stroke-width={STROKE} />
+			{#each arcs as a (a.label)}
+				<circle
+					cx="60"
+					cy="60"
+					r={R}
+					fill="none"
+					stroke={a.color}
+					stroke-width={STROKE}
+					stroke-dasharray="{a.dash} {C - a.dash}"
+					stroke-dashoffset={-a.offset}
+					transform="rotate(-90 60 60)"
+				>
+					<title>{a.label}: {a.value.toLocaleString()} ({pct(a.frac)})</title>
+				</circle>
+			{/each}
+			<text x="60" y="58" text-anchor="middle" font-size="14" font-weight="700" fill="var(--color-text)">
+				{total.toLocaleString()}
+			</text>
+			{#if centerLabel}
+				<text x="60" y="72" text-anchor="middle" font-size="9" fill="var(--color-text-muted)">
+					{centerLabel}
+				</text>
+			{/if}
+		</svg>
+		<div class="flex min-w-0 flex-1 flex-col gap-1">
+			{#each arcs as a (a.label)}
+				<div class="flex items-center gap-2 text-sm">
+					<span class="h-3 w-3 flex-shrink-0 border border-border" style:background-color={a.color}></span>
+					<span class="truncate text-text">{a.label}</span>
+					<span class="ml-auto tabular-nums text-text-muted">
+						{a.value.toLocaleString()} · {pct(a.frac)}
+					</span>
+				</div>
+			{/each}
+		</div>
+	</div>
+{/if}

--- a/software/hive/frontend/src/lib/components/charts/SeriesChart.svelte
+++ b/software/hive/frontend/src/lib/components/charts/SeriesChart.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	// Hand-rolled SVG time-series chart (line/area or bar). No charting dep —
+	// matches the flat, token-driven design system.
+	export type SeriesPoint = { date: string; value: number };
+
+	let {
+		points,
+		kind = 'line',
+		color = 'var(--color-primary)',
+		formatValue = (v: number) => v.toLocaleString()
+	}: {
+		points: SeriesPoint[];
+		kind?: 'line' | 'bar';
+		color?: string;
+		formatValue?: (v: number) => string;
+	} = $props();
+
+	const W = 560;
+	const H = 170;
+	const M = { top: 10, right: 10, bottom: 22, left: 44 };
+	const innerW = W - M.left - M.right;
+	const innerH = H - M.top - M.bottom;
+
+	function parseDay(day: string): number {
+		const t = Date.parse(`${day}T00:00:00`);
+		return Number.isNaN(t) ? 0 : t;
+	}
+
+	// Round the axis max up to 1/2/5 × 10^n so gridline labels read clean.
+	function niceMax(v: number): number {
+		if (v <= 0) return 1;
+		const pow = Math.pow(10, Math.floor(Math.log10(v)));
+		for (const step of [1, 2, 5, 10]) {
+			if (v <= step * pow) return step * pow;
+		}
+		return 10 * pow;
+	}
+
+	const sorted = $derived([...points].sort((a, b) => parseDay(a.date) - parseDay(b.date)));
+	const yMax = $derived(niceMax(Math.max(0, ...sorted.map((p) => p.value))));
+	const t0 = $derived(sorted.length > 0 ? parseDay(sorted[0].date) : 0);
+	const t1 = $derived(sorted.length > 0 ? parseDay(sorted[sorted.length - 1].date) : 1);
+	const span = $derived(Math.max(1, t1 - t0));
+
+	function xOf(day: string): number {
+		if (sorted.length <= 1) return M.left + innerW / 2;
+		return M.left + ((parseDay(day) - t0) / span) * innerW;
+	}
+
+	function yOf(value: number): number {
+		return M.top + innerH - (Math.min(value, yMax) / yMax) * innerH;
+	}
+
+	const linePath = $derived(
+		sorted.map((p, i) => `${i === 0 ? 'M' : 'L'}${xOf(p.date).toFixed(1)},${yOf(p.value).toFixed(1)}`).join(' ')
+	);
+	const areaPath = $derived(
+		sorted.length > 1
+			? `${linePath} L${xOf(sorted[sorted.length - 1].date).toFixed(1)},${(M.top + innerH).toFixed(1)} L${xOf(sorted[0].date).toFixed(1)},${(M.top + innerH).toFixed(1)} Z`
+			: ''
+	);
+
+	const dayCount = $derived(Math.max(1, Math.round(span / 86400000) + 1));
+	const barW = $derived(Math.max(1, Math.min(16, (innerW / dayCount) * 0.85)));
+
+	function formatDayLabel(day: string): string {
+		const d = new Date(`${day}T00:00:00`);
+		if (Number.isNaN(d.getTime())) return day;
+		return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	}
+
+	const xTicks = $derived.by(() => {
+		if (sorted.length === 0) return [] as { x: number; label: string; anchor: string }[];
+		const ticks = [{ x: xOf(sorted[0].date), label: formatDayLabel(sorted[0].date), anchor: 'start' }];
+		if (sorted.length > 2) {
+			const mid = sorted[Math.floor(sorted.length / 2)];
+			ticks.push({ x: xOf(mid.date), label: formatDayLabel(mid.date), anchor: 'middle' });
+		}
+		if (sorted.length > 1) {
+			const last = sorted[sorted.length - 1];
+			ticks.push({ x: xOf(last.date), label: formatDayLabel(last.date), anchor: 'end' });
+		}
+		return ticks;
+	});
+</script>
+
+{#if sorted.length === 0}
+	<div class="flex h-32 items-center justify-center text-sm text-text-muted">No data yet.</div>
+{:else}
+	<svg viewBox="0 0 {W} {H}" class="h-auto w-full" role="img">
+		{#each [0, 0.5, 1] as f (f)}
+			{@const y = M.top + innerH - f * innerH}
+			<line x1={M.left} y1={y} x2={M.left + innerW} y2={y} stroke="var(--color-border)" stroke-width="1" />
+			<text x={M.left - 6} y={y + 3.5} text-anchor="end" font-size="10" fill="var(--color-text-muted)">
+				{formatValue(yMax * f)}
+			</text>
+		{/each}
+
+		{#if kind === 'bar'}
+			{#each sorted as p (p.date)}
+				<rect
+					x={xOf(p.date) - barW / 2}
+					y={yOf(p.value)}
+					width={barW}
+					height={Math.max(0, M.top + innerH - yOf(p.value))}
+					fill={color}
+				>
+					<title>{formatDayLabel(p.date)}: {formatValue(p.value)}</title>
+				</rect>
+			{/each}
+		{:else}
+			{#if areaPath}
+				<path d={areaPath} fill={color} fill-opacity="0.08" />
+			{/if}
+			<path d={linePath} fill="none" stroke={color} stroke-width="1.5" />
+			{#each sorted as p (p.date)}
+				<circle cx={xOf(p.date)} cy={yOf(p.value)} r="2" fill={color}>
+					<title>{formatDayLabel(p.date)}: {formatValue(p.value)}</title>
+				</circle>
+			{/each}
+		{/if}
+
+		{#each xTicks as t (t.x + t.label)}
+			<text x={t.x} y={H - 6} text-anchor={t.anchor} font-size="10" fill="var(--color-text-muted)">
+				{t.label}
+			</text>
+		{/each}
+	</svg>
+{/if}

--- a/software/hive/frontend/src/routes/admin/machines/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/machines/+page.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import Badge from '$lib/components/Badge.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
+	import AnalyticsDashboard from '$lib/components/charts/AnalyticsDashboard.svelte';
 
 	let machines = $state<FleetMachine[]>([]);
 	let stats = $state<Record<string, FleetMachineStats>>({});
@@ -73,6 +74,11 @@
 		{machines.length} machines · {num(fleetPieces)} pieces sorted
 	</span>
 </div>
+
+<section class="mb-8">
+	<h2 class="mb-3 text-lg font-semibold text-text">Fleet analytics</h2>
+	<AnalyticsDashboard scope="all" />
+</section>
 
 {#if error}
 	<div class="mb-4 bg-primary/8 p-3 text-sm text-primary">{error}</div>

--- a/software/hive/frontend/src/routes/machines/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/+page.svelte
@@ -4,6 +4,7 @@
 	import Badge from '$lib/components/Badge.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
+	import AnalyticsDashboard from '$lib/components/charts/AnalyticsDashboard.svelte';
 
 	let machines = $state<Machine[]>([]);
 	let loading = $state(true);
@@ -520,6 +521,13 @@ async function loadAssignmentProfile(profileId: string) {
 			</div>
 		{/each}
 	</div>
+{/if}
+
+{#if !loading && machines.length > 0}
+	<section class="mt-10">
+		<h2 class="mb-3 text-lg font-semibold text-text">Fleet analytics</h2>
+		<AnalyticsDashboard scope="mine" />
+	</section>
 {/if}
 
 <Modal open={showAddModal} title="Add Machine" onclose={() => { showAddModal = false; }}>

--- a/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
@@ -9,6 +9,7 @@
 	import Badge from '$lib/components/Badge.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import { Alert } from '$lib/components/primitives';
+	import AnalyticsDashboard from '$lib/components/charts/AnalyticsDashboard.svelte';
 
 	const machineId = $derived(page.params.machine_id ?? '');
 
@@ -284,6 +285,12 @@
 		{#if stats?.computed_at}
 			<p class="mt-4 text-xs text-text-muted">Stats as of {formatDate(stats.computed_at)} (refreshed hourly).</p>
 		{/if}
+
+		<!-- Analytics (charts) -->
+		<section class="mt-8">
+			<h2 class="mb-3 text-lg font-semibold text-text">Analytics</h2>
+			<AnalyticsDashboard machineId={machine.id} showTotals={false} />
+		</section>
 
 		<!-- Config backups (owner only) -->
 		{#if isOwner}


### PR DESCRIPTION
## What
Time-series + distribution analytics that work over **any set of machines** — the same components serve a single machine, a user's own fleet, one user's fleet (admin), or the entire fleet (admin). Driven by a machine-set selector, per your framing.

### Backend
- **`machine_daily_stats`** table (per-machine per-day pieces/distributed/active_seconds) + migration. Refreshed hourly by the existing `MachineStatsWorker` (Postgres window-function upsert; Python fallback for SQLite) — reuses the background service.
- **`app/services/analytics.py`**: `resolve_machine_set` (auth per `machine_id` / `owner_id` / `scope=mine|all`), `get_timeseries` (machines / pieces / avg-PPM / **sorting-capacity** over time), `get_distributions` (by machine / status / top parts / top colors), `get_totals`.
- **`GET /api/analytics?machine_id|owner_id|scope`** — authorized per set; cold-start self-heals the daily table on first hit. New `test_analytics.py`.

**Sorting capacity** for a day = Σ over machines of (that machine's PPM that day × 1440 min) — the fleet's theoretical daily throughput at that day's rate.

### Frontend
- Reusable hand-rolled **SVG charts** (no new dep, matches design system): `SeriesChart` (line/bar), `DonutChart`, `BarList`, `ChartCard`, and `AnalyticsDashboard` (self-fetching, machine-set aware).
- Wired into: **machine overview** (single), **My Machines** (own fleet), **admin All Machines** (entire fleet).

## Verified on staging (staging01-hive)
- Migration applied; worker populated `machine_daily_stats` (5 days).
- `/api/analytics?scope=all` → 200, 5-day series, 1424 pieces, capacity ≈ 6,110/day, status + top-parts distributions.
- `pnpm check` 0 errors, `pnpm build` green; backend suite: no new failures (same pre-existing SQLite/JSONB ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)