### PR TITLE
Sorter loading UX: progressive profiles + spinner redesign

### DIFF
--- a/software/sorter/backend/server/routers/sorting_profiles.py
+++ b/software/sorter/backend/server/routers/sorting_profiles.py
@@ -86,6 +86,41 @@ def _safe_json(response: requests.Response) -> dict[str, Any]:
         return {"error": response.text}
 
 
+def _target_meta(target: dict[str, Any]) -> dict[str, Any]:
+    # Metadata only — no network. Shaped like a full library entry with empty
+    # profiles so the UI can render target cards/skeletons before the Hive
+    # fetch lands.
+    return {
+        "id": target.get("id"),
+        "name": target.get("name") or target.get("url"),
+        "url": target.get("url"),
+        "enabled": bool(target.get("enabled", False)),
+        "machine_id": target.get("machine_id"),
+        "profiles": [],
+        "assignment": None,
+        "error": None,
+    }
+
+
+def _fetch_target_library(target: dict[str, Any]) -> dict[str, Any]:
+    payload = _target_meta(target)
+    if not payload["enabled"]:
+        return payload
+    try:
+        session = _target_session(target)
+        response = session.get(f"{_target_base_url(target)}/api/machine/profiles/library", timeout=20)
+        if not response.ok:
+            body = _safe_json(response)
+            message = body.get("error") or body.get("detail") or f"HTTP {response.status_code}"
+            raise RuntimeError(str(message))
+        body = response.json()
+        payload["profiles"] = body.get("profiles", []) if isinstance(body, dict) else []
+        payload["assignment"] = body.get("assignment") if isinstance(body, dict) else None
+    except Exception as exc:
+        payload["error"] = str(exc)
+    return payload
+
+
 def _preassign_bins_from_rules(artifact: dict[str, Any]) -> int:
     """Seed bin category assignments from the artifact's rule order.
 
@@ -190,6 +225,65 @@ def _unique_local_path(base: str) -> Path:
     return candidate
 
 
+# Sorting-profile JSON files carry the full compiled part map and routinely run
+# tens of MB, so json.load costs ~1-2s (worse under CPU contention). Cache the
+# small metadata we surface, keyed by (mtime, size), so repeated reads — the 10s
+# poll, re-renders, the bundled /library — don't re-parse.
+_profile_meta_cache: dict[str, tuple[float, int, dict[str, Any]]] = {}
+
+
+def _profile_file_meta(path: Path) -> dict[str, Any]:
+    stat = path.stat()
+    key = str(path)
+    cached = _profile_meta_cache.get(key)
+    if cached is not None and cached[0] == stat.st_mtime and cached[1] == stat.st_size:
+        return cached[2]
+    with open(path, "r") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("profile file is not a JSON object")
+    meta: dict[str, Any] = {
+        "name": data.get("name"),
+        "description": data.get("description"),
+        "profile_type": data.get("profile_type"),
+        "default_category_id": data.get("default_category_id"),
+        "artifact_hash": data.get("artifact_hash"),
+        "updated_at": data.get("updated_at"),
+        "rule_count": len(data.get("rules", []) or []),
+        "category_count": len(data.get("categories", {}) or {}),
+        "part_count": len(data.get("part_to_category", {}) or {}),
+    }
+    _profile_meta_cache[key] = (stat.st_mtime, stat.st_size, meta)
+    return meta
+
+
+def _mtime_iso(path: Path) -> str | None:
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+    except OSError:
+        return None
+
+
+def _local_profile_entry_light(path: Path, active_filename: str | None) -> dict[str, Any]:
+    # No parse — filename/stem/mtime only. Counts and the real name are filled
+    # in lazily by GET /local/{filename}/meta so first paint never touches the
+    # multi-MB file.
+    return {
+        "filename": path.name,
+        "id": path.stem,
+        "name": None,
+        "description": None,
+        "profile_type": None,
+        "rule_count": None,
+        "category_count": None,
+        "part_count": None,
+        "artifact_hash": None,
+        "updated_at": _mtime_iso(path),
+        "is_active": bool(active_filename and path.name == active_filename),
+        "error": None,
+    }
+
+
 def _local_profile_entry(
     path: Path, active_hash: str | None, active_filename: str | None
 ) -> dict[str, Any]:
@@ -208,32 +302,23 @@ def _local_profile_entry(
         "error": None,
     }
     try:
-        with open(path, "r") as handle:
-            data = json.load(handle)
+        meta = _profile_file_meta(path)
     except Exception as exc:
         entry["error"] = str(exc)
         return entry
-    if not isinstance(data, dict):
-        entry["error"] = "profile file is not a JSON object"
-        return entry
-    artifact_hash = data.get("artifact_hash")
+    artifact_hash = meta["artifact_hash"]
     entry.update(
         {
-            "name": data.get("name") or path.stem,
-            "description": data.get("description"),
-            "profile_type": data.get("profile_type"),
-            "rule_count": len(data.get("rules", []) or []),
-            "category_count": len(data.get("categories", {}) or {}),
-            "part_count": len(data.get("part_to_category", {}) or {}),
+            "name": meta["name"] or path.stem,
+            "description": meta["description"],
+            "profile_type": meta["profile_type"],
+            "rule_count": meta["rule_count"],
+            "category_count": meta["category_count"],
+            "part_count": meta["part_count"],
             "artifact_hash": artifact_hash,
         }
     )
-    try:
-        entry["updated_at"] = datetime.fromtimestamp(
-            path.stat().st_mtime, tz=timezone.utc
-        ).isoformat()
-    except OSError:
-        pass
+    entry["updated_at"] = _mtime_iso(path)
     if active_filename and path.name == active_filename:
         entry["is_active"] = True
     elif artifact_hash and active_hash and artifact_hash == active_hash:
@@ -253,23 +338,26 @@ def _list_local_profiles() -> list[dict[str, Any]]:
     ]
 
 
+def _active_profile_path() -> str | None:
+    return shared_state.gc_ref.sorting_profile_path if shared_state.gc_ref is not None else None
+
+
 def _current_local_profile_status() -> dict[str, Any]:
     sync_state = getSortingProfileSyncState() or {}
-    path = shared_state.gc_ref.sorting_profile_path if shared_state.gc_ref is not None else None
+    path = _active_profile_path()
     metadata: dict[str, Any] = {}
     if path and os.path.exists(path):
         try:
-            with open(path, "r") as handle:
-                data = json.load(handle)
+            meta = _profile_file_meta(Path(path))
             metadata = {
                 "path": path,
-                "name": data.get("name"),
-                "description": data.get("description"),
-                "artifact_hash": data.get("artifact_hash"),
-                "default_category_id": data.get("default_category_id"),
-                "category_count": len(data.get("categories", {}) or {}),
-                "rule_count": len(data.get("rules", []) or []),
-                "updated_at": data.get("updated_at"),
+                "name": meta["name"],
+                "description": meta["description"],
+                "artifact_hash": meta["artifact_hash"],
+                "default_category_id": meta["default_category_id"],
+                "category_count": meta["category_count"],
+                "rule_count": meta["rule_count"],
+                "updated_at": meta["updated_at"],
             }
         except Exception as exc:
             metadata = {"path": path, "error": str(exc)}
@@ -277,6 +365,36 @@ def _current_local_profile_status() -> dict[str, Any]:
         "sync_state": sync_state,
         "local_profile": metadata,
     }
+
+
+def _current_local_profile_status_light() -> dict[str, Any]:
+    # No parse: name comes from sync_state; counts are omitted (the /profiles
+    # page only needs the active name here, and even that is a rare fallback).
+    sync_state = getSortingProfileSyncState() or {}
+    path = _active_profile_path()
+    metadata: dict[str, Any] = {}
+    if path and os.path.exists(path):
+        metadata = {
+            "path": path,
+            "name": sync_state.get("profile_name"),
+            "artifact_hash": sync_state.get("artifact_hash"),
+            "updated_at": _mtime_iso(Path(path)),
+        }
+    return {
+        "sync_state": sync_state,
+        "local_profile": metadata,
+    }
+
+
+def _list_local_profiles_light() -> list[dict[str, Any]]:
+    sync_state = getSortingProfileSyncState() or {}
+    active_filename = (
+        sync_state.get("local_filename") if sync_state.get("source") == "local" else None
+    )
+    return [
+        _local_profile_entry_light(path, active_filename)
+        for path in sorted(_local_profiles_dir().glob("*.json"))
+    ]
 
 
 def _reload_runtime_profile() -> bool:
@@ -300,40 +418,58 @@ def get_sorting_profile_status() -> dict[str, Any]:
 
 @router.get("/api/sorting-profiles/library")
 def get_sorting_profile_library() -> dict[str, Any]:
-    target_payloads: list[dict[str, Any]] = []
-    for target in _load_targets():
-        enabled = bool(target.get("enabled", False))
-        payload: dict[str, Any] = {
-            "id": target.get("id"),
-            "name": target.get("name") or target.get("url"),
-            "url": target.get("url"),
-            "enabled": enabled,
-            "machine_id": target.get("machine_id"),
-            "profiles": [],
-            "assignment": None,
-            "error": None,
-        }
-        if not enabled:
-            target_payloads.append(payload)
-            continue
-        try:
-            session = _target_session(target)
-            response = session.get(f"{_target_base_url(target)}/api/machine/profiles/library", timeout=20)
-            if not response.ok:
-                body = _safe_json(response)
-                message = body.get("error") or body.get("detail") or f"HTTP {response.status_code}"
-                raise RuntimeError(str(message))
-            body = response.json()
-            payload["profiles"] = body.get("profiles", []) if isinstance(body, dict) else []
-            payload["assignment"] = body.get("assignment") if isinstance(body, dict) else None
-        except Exception as exc:
-            payload["error"] = str(exc)
-        target_payloads.append(payload)
+    # Bundled view (local + every target's Hive fetch, sequentially). Kept for
+    # the sorting-profile dropdown. The /profiles page uses the split
+    # /local + /targets/{id}/library endpoints so fast local data renders
+    # before the slow per-target Hive calls resolve.
     return {
-        "targets": target_payloads,
+        "targets": [_fetch_target_library(target) for target in _load_targets()],
         "local_profiles": _list_local_profiles(),
         **_current_local_profile_status(),
     }
+
+
+@router.get("/api/sorting-profiles/local")
+def get_sorting_profile_local() -> dict[str, Any]:
+    # Fast tier: target metadata, active sync state, and local-profile
+    # filenames. No Hive network AND no multi-MB JSON parse — counts/names for
+    # local profiles are filled in lazily via /local/{filename}/meta so this
+    # returns in milliseconds and the page can skeleton everything at once.
+    return {
+        "targets": [_target_meta(target) for target in _load_targets()],
+        "local_profiles": _list_local_profiles_light(),
+        **_current_local_profile_status_light(),
+    }
+
+
+@router.get("/api/sorting-profiles/local/{filename}/meta")
+def get_local_profile_meta(filename: str) -> dict[str, Any]:
+    # Lazy per-card metadata (name, counts) for a local profile. Parses the file
+    # once and caches by mtime, so the 10s poll and re-renders are free.
+    path = _safe_local_path(filename)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Local profile not found.")
+    try:
+        meta = _profile_file_meta(path)
+    except Exception as exc:
+        return {"filename": path.name, "error": str(exc)}
+    return {
+        "filename": path.name,
+        "name": meta["name"] or path.stem,
+        "description": meta["description"],
+        "profile_type": meta["profile_type"],
+        "rule_count": meta["rule_count"],
+        "category_count": meta["category_count"],
+        "part_count": meta["part_count"],
+        "artifact_hash": meta["artifact_hash"],
+    }
+
+
+@router.get("/api/sorting-profiles/targets/{target_id}/library")
+def get_sorting_profile_target_library(target_id: str) -> dict[str, Any]:
+    # Single target's Hive fetch. The page calls one of these per enabled
+    # target in parallel so a slow/erroring target doesn't block the others.
+    return _fetch_target_library(_get_target_or_404(target_id))
 
 
 @router.get("/api/sorting-profiles/targets/{target_id}/profiles/{profile_id}")

--- a/software/sorter/frontend/CLAUDE.md
+++ b/software/sorter/frontend/CLAUDE.md
@@ -6,14 +6,19 @@ sharp-edged and dense. When adding or editing components, follow these rules.
 ## Sharp edges — no `rounded-*`
 
 Do not use any Tailwind `rounded-*` utility, and do not set `border-radius` in
-CSS. The only exceptions are:
+CSS. The only exception is:
 
-- `src/lib/components/Spinner.svelte` — circular spinner uses `rounded-full`.
 - `src/lib/components/MachineDropdown.svelte` — machine status dot uses
   `rounded-full`.
 
 Any other rounded corner is a bug. The style guide at `/styleguide` is the
 source of truth.
+
+The shared loading indicator is `src/lib/components/Spinner.svelte` — four
+sharp squares, one lit at a time, snapping clockwise. It is the *only* loading
+animation in the app: import it and pass a `size` rather than hand-rolling a
+`border-current` ring or spinning a lucide `Loader2`. It inherits color via
+`currentColor`.
 
 ## No left-accent borders
 

--- a/software/sorter/frontend/src/lib/components/AppHeader.svelte
+++ b/software/sorter/frontend/src/lib/components/AppHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import {
 		getBackendHttpBase,
 		getBackendWsBase,
@@ -574,10 +575,7 @@
 				<div
 					class="flex h-9 w-9 shrink-0 items-center justify-center border border-border bg-info/[0.08] text-info"
 				>
-					<div
-						class="h-4 w-4 animate-spin border-2 border-current border-t-transparent"
-						style="border-radius: 50%;"
-					></div>
+					<Spinner size={16} />
 				</div>
 				<div class="min-w-0 flex-1">
 					<div class="flex items-center justify-between gap-3">
@@ -740,10 +738,7 @@
 
 	<Modal open={restartingBackend} title="Restarting backend..." dismissible={false}>
 		<div class="flex flex-col items-center gap-4 py-4">
-			<div
-				class="h-6 w-6 animate-spin border-2 border-primary border-t-transparent"
-				style="border-radius: 50%;"
-			></div>
+			<Spinner size={24} class="text-primary" />
 			<div class="text-sm text-text-muted">Waiting for the service to come back online.</div>
 		</div>
 	</Modal>
@@ -791,10 +786,7 @@
 
 	<Modal open={poweringDown} title="Powering down..." dismissible={false}>
 		<div class="flex flex-col items-center gap-4 py-4 text-center">
-			<div
-				class="h-6 w-6 animate-spin border-2 border-primary border-t-transparent"
-				style="border-radius: 50%;"
-			></div>
+			<Spinner size={24} class="text-primary" />
 			<div class="text-sm text-text">The machine is shutting down.</div>
 			<div class="text-sm text-text-muted">
 				This page will stop responding shortly. Linux can take up to about 2 minutes to fully power
@@ -835,10 +827,7 @@
 				<div
 					class="flex h-9 w-9 shrink-0 items-center justify-center border border-border bg-info/[0.08] text-info"
 				>
-					<div
-						class="h-4 w-4 animate-spin border-2 border-current border-t-transparent"
-						style="border-radius: 50%;"
-					></div>
+					<Spinner size={16} />
 				</div>
 				<div>
 					<div class="text-xs font-semibold tracking-wider text-info uppercase">Current step</div>

--- a/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
+++ b/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import {
 		getBackendWsBase,
 		getBackendHttpBase,
@@ -187,10 +188,7 @@
 						The backend is restarting. Waiting for it to come back online...
 					</div>
 					<div class="mt-3 flex items-center gap-2 text-xs text-text-muted">
-						<div
-							class="h-3.5 w-3.5 animate-spin border-2 border-current border-t-transparent"
-							style="border-radius: 50%;"
-						></div>
+						<Spinner size={14} />
 						Reconnecting...
 					</div>
 				{:else}

--- a/software/sorter/frontend/src/lib/components/CameraFeed.svelte
+++ b/software/sorter/frontend/src/lib/components/CameraFeed.svelte
@@ -3,7 +3,8 @@
 	import { getBackendHttpBase, machineHttpBaseUrlFromWsUrl } from '$lib/backend';
 	import type { DashboardFeedCrop } from '$lib/dashboard/crops';
 	import StreamControlsOverlay from '$lib/components/StreamControlsOverlay.svelte';
-	import { WifiOff, Loader2, VideoOff } from 'lucide-svelte';
+	import { WifiOff, VideoOff } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import { onDestroy } from 'svelte';
 	import type { Snippet } from 'svelte';
 
@@ -203,7 +204,7 @@
 			<div class="absolute inset-0 flex items-center justify-center">
 				<div class="flex flex-col items-center gap-2 text-center">
 					{#if health === 'reconnecting'}
-						<Loader2 size={28} class="animate-spin text-text-muted" />
+						<Spinner size={28} class="text-text-muted" />
 						<span class="text-sm font-medium text-text-muted">Reconnecting...</span>
 					{:else if health === 'offline'}
 						<WifiOff size={28} class="text-text-muted" />

--- a/software/sorter/frontend/src/lib/components/RuntimeHomingModal.svelte
+++ b/software/sorter/frontend/src/lib/components/RuntimeHomingModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Loader2, AlertTriangle, Home } from 'lucide-svelte';
+	import { AlertTriangle, Home } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 
 	let {
@@ -38,7 +39,7 @@
 			</div>
 		{:else if homing}
 			<div class="flex items-center gap-3 border border-warning bg-warning/10 px-4 py-3 text-sm text-warning-dark">
-				<Loader2 size={18} class="animate-spin shrink-0" />
+				<Spinner size={18} class="shrink-0" />
 				<div class="flex flex-col">
 					<span class="font-medium">Homing in progress…</span>
 					<span class="text-xs text-warning-dark/80">

--- a/software/sorter/frontend/src/lib/components/Spinner.svelte
+++ b/software/sorter/frontend/src/lib/components/Spinner.svelte
@@ -1,3 +1,44 @@
+<script lang="ts">
+	let { size = 16, class: className = '' }: { size?: number; class?: string } = $props();
+</script>
+
 <div
-	class="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent opacity-50"
-></div>
+	class="sorter-spinner {className}"
+	style={`--spinner-size:${size}px`}
+	role="status"
+	aria-label="Loading"
+>
+	<i></i><i></i><i></i><i></i>
+</div>
+
+<style>
+	/* Canonical loading indicator: four squares, one lit at a time, snapping
+	   clockwise every quarter cycle. Discrete (not eased) and sharp-cornered to
+	   match the industrial style. Inherits color via currentColor and scales via
+	   the size prop. Deliberately keeps animating under prefers-reduced-motion —
+	   a frozen loading indicator reads as a hung process. */
+	.sorter-spinner {
+		position: relative;
+		display: inline-block;
+		flex: none;
+		width: var(--spinner-size);
+		height: var(--spinner-size);
+		vertical-align: middle;
+	}
+	.sorter-spinner i {
+		position: absolute;
+		width: 42%;
+		height: 42%;
+		background: currentColor;
+		opacity: 0.2;
+		animation: sorter-spinner-quarter 0.667s linear infinite;
+	}
+	.sorter-spinner i:nth-child(1) { top: 0; left: 0; animation-delay: 0s; }
+	.sorter-spinner i:nth-child(2) { top: 0; right: 0; animation-delay: 0.1667s; }
+	.sorter-spinner i:nth-child(3) { bottom: 0; right: 0; animation-delay: 0.3333s; }
+	.sorter-spinner i:nth-child(4) { bottom: 0; left: 0; animation-delay: 0.5s; }
+	@keyframes sorter-spinner-quarter {
+		0%, 24% { opacity: 1; }
+		25%, 100% { opacity: 0.2; }
+	}
+</style>

--- a/software/sorter/frontend/src/lib/components/bins/BinCard.svelte
+++ b/software/sorter/frontend/src/lib/components/bins/BinCard.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import PieceThumb from '$lib/components/PieceThumb.svelte';
 	import { Skeleton } from '$lib/components/primitives';
-	import { ArchiveX, Crosshair, FolderOutput, Loader2, Tag } from 'lucide-svelte';
+	import { ArchiveX, Crosshair, FolderOutput, Tag } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import { categoryLabel, formatLastSeen, formatRelativeTime, pieceTooltip, previewUrl } from './pieces';
 	import QuantityBadge from './QuantityBadge.svelte';
 	import type { BinContentItem, BinContents, BinInfo, SetMeta, SetProgressSummary } from './types';
@@ -77,7 +78,7 @@
 	{#if isClearing}
 		<div class="absolute inset-0 z-20 flex items-center justify-center bg-surface/82 backdrop-blur-[1px]">
 			<div class="flex items-center gap-2 border border-border bg-surface px-3 py-2 shadow-sm">
-				<Loader2 size={14} class="animate-spin text-primary" />
+				<Spinner size={14} class="text-primary" />
 				<span class="text-xs font-semibold uppercase tracking-wide text-text">{clearingLabel}</span>
 			</div>
 		</div>

--- a/software/sorter/frontend/src/lib/components/bins/BinLayoutSection.svelte
+++ b/software/sorter/frontend/src/lib/components/bins/BinLayoutSection.svelte
@@ -14,7 +14,8 @@
 		type BinLayoutRecord
 	} from '$lib/api/bin-layouts';
 	import { onMount } from 'svelte';
-	import { Check, ChevronDown, Loader2, Pencil, Trash2 } from 'lucide-svelte';
+	import { Check, ChevronDown, Pencil, Trash2 } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	let {
 		baseUrl,
@@ -180,7 +181,7 @@
 					onclick={() => (dropdownOpen = !dropdownOpen)}
 					class="flex max-w-[260px] items-center gap-2 border border-border bg-surface px-3 py-1.5 text-sm text-text transition-colors hover:bg-bg"
 				>
-					{#if restarting}<Loader2 size={14} class="shrink-0 animate-spin" />{/if}
+					{#if restarting}<Spinner size={14} class="shrink-0" />{/if}
 					<span class="truncate font-medium">{active?.name ?? 'No layout'}</span>
 					{#if isDirty}<span class="shrink-0 text-xs text-warning">unsaved</span>{/if}
 					<ChevronDown size={14} class="shrink-0 opacity-60" />

--- a/software/sorter/frontend/src/lib/components/bins/ColumnsPanel.svelte
+++ b/software/sorter/frontend/src/lib/components/bins/ColumnsPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ToggleSwitch } from '$lib/components/primitives';
-	import { Crosshair, Loader2 } from 'lucide-svelte';
+	import { Crosshair } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	let {
 		sectionCount,
@@ -59,13 +60,13 @@
 					title="Point chute at section {sectionIndex + 1}"
 				>
 					{#if pointingKey === `point-${sectionIndex}`}
-						<Loader2 size={14} class="animate-spin" />
+						<Spinner size={14} />
 					{:else}
 						<Crosshair size={14} />
 					{/if}
 				</button>
 				{#if colBusy}
-					<Loader2 size={14} class="animate-spin text-primary" />
+					<Spinner size={14} class="text-primary" />
 				{/if}
 			</div>
 		{/each}

--- a/software/sorter/frontend/src/lib/components/bins/LayerPanel.svelte
+++ b/software/sorter/frontend/src/lib/components/bins/LayerPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ToggleSwitch } from '$lib/components/primitives';
-	import { ArchiveX, FolderOutput, Loader2 } from 'lucide-svelte';
+	import { ArchiveX, FolderOutput } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import BinCard from './BinCard.svelte';
 	import SectionGroup from './SectionGroup.svelte';
 	import type { BinContents, BinInfo, LayerInfo, SetMeta, SetProgressSummary } from './types';
@@ -101,7 +102,7 @@
 	{#if layerBusy}
 		<div class="absolute inset-0 z-20 flex items-center justify-center bg-surface/78 backdrop-blur-[1px]">
 			<div class="flex items-center gap-3 border border-border bg-surface px-4 py-3 shadow-sm">
-				<Loader2 size={16} class="animate-spin text-primary" />
+				<Spinner size={16} class="text-primary" />
 				<div class="text-sm font-medium text-text">{layerClearingLabel}</div>
 			</div>
 		</div>

--- a/software/sorter/frontend/src/lib/components/bins/SectionGroup.svelte
+++ b/software/sorter/frontend/src/lib/components/bins/SectionGroup.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ToggleSwitch } from '$lib/components/primitives';
-	import { Crosshair, Loader2 } from 'lucide-svelte';
+	import { Crosshair } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import type { Snippet } from 'svelte';
 	import type { BinInfo } from './types';
 
@@ -67,7 +68,7 @@
 				title="Point chute at section {sectionIndex + 1}"
 			>
 				{#if pointing}
-					<Loader2 size={13} class="animate-spin" />
+					<Spinner size={13} />
 				{:else}
 					<Crosshair size={13} />
 				{/if}

--- a/software/sorter/frontend/src/lib/components/bins/SnapshotsModal.svelte
+++ b/software/sorter/frontend/src/lib/components/bins/SnapshotsModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Modal from '$lib/components/Modal.svelte';
-	import { ArrowLeft, Download, Loader2 } from 'lucide-svelte';
+	import { ArrowLeft, Download } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import { formatCategoryName, formatLastSeen } from './pieces';
 	import type { SnapshotDetail, SnapshotLayer, SnapshotSummary } from './types';
 
@@ -146,7 +147,7 @@
 		</div>
 	{:else if detailLoading || snapshotsLoading}
 		<div class="flex items-center justify-center gap-2 py-10 text-sm text-text-muted">
-			<Loader2 size={16} class="animate-spin" />
+			<Spinner size={16} />
 			Loading…
 		</div>
 	{:else if snapshots.length === 0}

--- a/software/sorter/frontend/src/lib/components/profiles/ProfileCardSkeleton.svelte
+++ b/software/sorter/frontend/src/lib/components/profiles/ProfileCardSkeleton.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	// Placeholder card shown while a target's Hive profiles are still loading.
+	// Mirrors ProfileCard's header + rules + footer layout so the grid doesn't
+	// jump when real cards replace it.
+	import Skeleton from '$lib/components/primitives/Skeleton.svelte';
+</script>
+
+<div class="setup-card-shell flex h-full flex-col overflow-hidden border border-border">
+	<div class="setup-card-header px-3 py-2 text-sm">
+		<div class="flex items-center justify-between gap-3">
+			<Skeleton class="h-5 w-40" />
+			<Skeleton class="h-9 w-[10.5rem]" />
+		</div>
+	</div>
+	<div class="setup-card-body border-t border-border px-4 py-3">
+		<div class="grid gap-x-4 gap-y-1.5 md:grid-cols-2">
+			{#each Array(4) as _}
+				<div class="flex items-center gap-2">
+					<Skeleton class="h-3.5 w-3.5 shrink-0" />
+					<Skeleton class="h-3.5 w-full" />
+				</div>
+			{/each}
+		</div>
+	</div>
+	<div class="setup-card-body border-t border-border px-4 py-3">
+		<Skeleton class="h-3.5 w-3/4" />
+	</div>
+</div>

--- a/software/sorter/frontend/src/lib/components/settings/HiveRuntimesSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/HiveRuntimesSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import { getBackendHttpBase, machineHttpBaseUrlFromWsUrl } from '$lib/backend';
 	import { getMachineContext } from '$lib/machines/context';
 	import { RefreshCw } from 'lucide-svelte';
@@ -486,10 +487,7 @@
 											{#each threadCountsFor(opt.id) as threadN (threadN)}
 												{#if benchmarkCurrent === resultKey(opt.id, threadN, selectedModel)}
 													<div class="flex items-center gap-1.5 text-sm text-primary">
-														<div
-															class="h-3 w-3 animate-spin border-2 border-current border-t-transparent"
-															style="border-radius: 50%;"
-														></div>
+														<Spinner size={12} />
 														<span>running {threadN} thread{threadN === 1 ? '' : 's'}…</span>
 													</div>
 												{/if}

--- a/software/sorter/frontend/src/lib/components/setup/steps/HiveStep.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/steps/HiveStep.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Check, ExternalLink, Loader2 } from 'lucide-svelte';
+	import { Check, ExternalLink } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	type HiveSetupTarget = {
 		id: string;
@@ -37,7 +38,7 @@
 <div class="flex flex-col gap-4">
 	{#if hiveLoading}
 		<div class="setup-panel flex items-center gap-2 px-4 py-3 text-sm text-text-muted">
-			<Loader2 size={14} class="animate-spin" />
+			<Spinner size={14} />
 			Checking current Hive configuration…
 		</div>
 	{:else if officialHiveTarget}
@@ -115,7 +116,7 @@
 				class="inline-flex items-center gap-2 border border-success bg-success px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-success/90 disabled:cursor-not-allowed disabled:opacity-60"
 			>
 				{#if hiveConnecting}
-					<Loader2 size={14} class="animate-spin" />
+					<Spinner size={14} />
 					Opening Hive…
 				{:else}
 					<ExternalLink size={14} />

--- a/software/sorter/frontend/src/lib/components/setup/steps/MotionStep.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/steps/MotionStep.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Check, Loader2, RotateCcw } from 'lucide-svelte';
+	import { Check, RotateCcw } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	type StepperDirectionEntry = {
 		name: string;
@@ -125,7 +126,7 @@
 		<div
 			class="flex items-center gap-3 border border-warning bg-warning/10 px-4 py-3 text-sm text-warning-dark"
 		>
-			<Loader2 size={18} class="animate-spin" />
+			<Spinner size={18} />
 			<div class="flex flex-col">
 				<span class="font-medium">Powering on steppers…</span>
 				<span class="text-xs text-warning-dark/80">

--- a/software/sorter/frontend/src/lib/sorting-profiles/api.ts
+++ b/software/sorter/frontend/src/lib/sorting-profiles/api.ts
@@ -21,6 +21,50 @@ export async function fetchLibrary(baseUrl: string): Promise<SortingProfileLibra
 	return unwrap<SortingProfileLibraryResponse>(res);
 }
 
+// Fast tier: local profiles + active sync state + target metadata (no Hive
+// network). Targets come back with empty `profiles` — fill them via
+// fetchTargetLibrary per target.
+export async function fetchLocalLibrary(baseUrl: string): Promise<SortingProfileLibraryResponse> {
+	const res = await fetch(`${baseUrl}/api/sorting-profiles/local`);
+	return unwrap<SortingProfileLibraryResponse>(res);
+}
+
+// Hive tier: one target's profile summaries + assignment. Call per target in
+// parallel so a slow target doesn't block the rest.
+export async function fetchTargetLibrary(
+	baseUrl: string,
+	targetId: string
+): Promise<HiveTargetLibrary> {
+	const res = await fetch(
+		`${baseUrl}/api/sorting-profiles/targets/${encodeURIComponent(targetId)}/library`
+	);
+	return unwrap<HiveTargetLibrary>(res);
+}
+
+// Lazy per-card metadata (name + counts) for a local profile. The fast /local
+// endpoint omits these to avoid parsing the multi-MB file; fetch them per card.
+export type LocalProfileMeta = {
+	filename: string;
+	name?: string | null;
+	description?: string | null;
+	profile_type?: string | null;
+	rule_count?: number | null;
+	category_count?: number | null;
+	part_count?: number | null;
+	artifact_hash?: string | null;
+	error?: string | null;
+};
+
+export async function fetchLocalProfileMeta(
+	baseUrl: string,
+	filename: string
+): Promise<LocalProfileMeta> {
+	const res = await fetch(
+		`${baseUrl}/api/sorting-profiles/local/${encodeURIComponent(filename)}/meta`
+	);
+	return unwrap<LocalProfileMeta>(res);
+}
+
 export async function fetchProfileDetail(
 	baseUrl: string,
 	targetId: string,
@@ -90,10 +134,9 @@ export async function uploadLocalProfile(
 }
 
 export async function deleteLocalProfile(baseUrl: string, filename: string): Promise<void> {
-	const res = await fetch(
-		`${baseUrl}/api/sorting-profiles/local/${encodeURIComponent(filename)}`,
-		{ method: 'DELETE' }
-	);
+	const res = await fetch(`${baseUrl}/api/sorting-profiles/local/${encodeURIComponent(filename)}`, {
+		method: 'DELETE'
+	});
 	if (!res.ok) {
 		const body = (await res.json().catch(() => null)) as JsonError | null;
 		throw new Error(body?.detail ?? `HTTP ${res.status}`);
@@ -116,7 +159,9 @@ export function visibleVersions(detail: SortingProfileDetail): SortingProfileVer
 	return detail.is_owner ? detail.versions : detail.versions.filter((v) => v.is_published);
 }
 
-export function displayVersion(profile: SortingProfileSummary): SortingProfileVersionSummary | null {
+export function displayVersion(
+	profile: SortingProfileSummary
+): SortingProfileVersionSummary | null {
 	return profile.latest_published_version ?? profile.latest_version;
 }
 

--- a/software/sorter/frontend/src/routes/+page.svelte
+++ b/software/sorter/frontend/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import { getMachineContext, getMachinesContext } from '$lib/machines/context';
 	import {
 		getBackendHttpBase,
@@ -1112,10 +1113,7 @@
 								</div>
 							{:else if hardwareState === 'homing'}
 								<div class="flex items-center gap-3">
-									<div
-										class="h-4 w-4 animate-spin border-2 border-primary border-t-transparent"
-										style="border-radius: 50%;"
-									></div>
+									<Spinner size={16} class="text-primary" />
 									<div>
 										<div class="text-sm font-medium text-text">Homing...</div>
 										<div class="text-xs text-text-muted">

--- a/software/sorter/frontend/src/routes/bins/+page.svelte
+++ b/software/sorter/frontend/src/routes/bins/+page.svelte
@@ -17,7 +17,7 @@
 	import { bricklinkParts } from '$lib/stores/bricklinkParts.svelte';
 	import { sortingProfileStore } from '$lib/stores/sortingProfile.svelte';
 	import { onMount } from 'svelte';
-	import { Loader2 } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	const manager = getMachinesContext();
 	// Active profile (id/name) — bin layouts are scoped to it. Local profiles carry a
@@ -733,7 +733,7 @@
 			<div class="w-full max-w-md border border-border bg-surface p-6 shadow-xl">
 				<div class="flex items-start gap-4">
 					<div class="flex h-10 w-10 items-center justify-center border border-border bg-bg">
-						<Loader2 size={18} class="animate-spin text-primary" />
+						<Spinner size={18} class="text-primary" />
 					</div>
 					<div class="space-y-2">
 						<h3 class="text-lg font-semibold text-text">{globalClearingTitle()}</h3>

--- a/software/sorter/frontend/src/routes/profiles/+page.svelte
+++ b/software/sorter/frontend/src/routes/profiles/+page.svelte
@@ -4,16 +4,19 @@
 	import ProfileApplyModal from '$lib/components/profiles/ProfileApplyModal.svelte';
 	import BsxSection from '$lib/components/profiles/BsxSection.svelte';
 	import ProfileCard from '$lib/components/profiles/ProfileCard.svelte';
+	import ProfileCardSkeleton from '$lib/components/profiles/ProfileCardSkeleton.svelte';
 	import ProfileDetailsModal from '$lib/components/profiles/ProfileDetailsModal.svelte';
 	import ProfilePagination from '$lib/components/profiles/ProfilePagination.svelte';
-	import Spinner from '$lib/components/Spinner.svelte';
+	import Skeleton from '$lib/components/primitives/Skeleton.svelte';
 	import StatusBanner from '$lib/components/StatusBanner.svelte';
 	import { getMachinesContext } from '$lib/machines/context';
 	import {
 		applyLocalProfile,
 		applyProfile,
 		deleteLocalProfile,
-		fetchLibrary,
+		fetchLocalLibrary,
+		fetchLocalProfileMeta,
+		fetchTargetLibrary,
 		fetchProfileDetail,
 		reloadRuntimeProfile as callReloadRuntime,
 		uploadLocalProfile,
@@ -36,11 +39,11 @@
 	const manager = getMachinesContext();
 	const PROFILE_PAGE_SIZE_OPTIONS = [12, 24, 48] as const;
 
-	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let success = $state<string | null>(null);
 	let warning = $state<string | null>(null);
 	let library = $state<SortingProfileLibraryResponse | null>(null);
+	let targetLoading = $state<Record<string, boolean>>({});
 	let detailCache = $state<Record<string, SortingProfileDetail>>({});
 	let detailErrors = $state<Record<string, string>>({});
 	let selectedVersionIds = $state<Record<string, string>>({});
@@ -85,16 +88,115 @@
 		return `${targetId}:${profileId}:${versionId}`;
 	}
 
-	async function loadLibrary() {
-		loading = true;
+	// Tier 1 — fast local read: target metadata, active sync state, and local
+	// profile filenames. No Hive network and no multi-MB parse, so this returns
+	// in milliseconds and the page can skeleton everything at once. Local
+	// profile counts/names arrive later via loadLocalMetas().
+	async function loadLocal() {
 		error = null;
 		try {
-			library = await fetchLibrary(baseUrl());
+			const local = await fetchLocalLibrary(baseUrl());
+			// Merge into existing state so a background refresh doesn't wipe
+			// already-loaded target profiles or local-profile metadata.
+			const prevTargets = new Map((library?.targets ?? []).map((t) => [t.id, t]));
+			const prevLocals = new Map((library?.local_profiles ?? []).map((p) => [p.filename, p]));
+			library = {
+				...local,
+				targets: local.targets.map((meta) => {
+					const existing = prevTargets.get(meta.id);
+					return existing && existing.profiles.length > 0
+						? {
+								...meta,
+								profiles: existing.profiles,
+								assignment: existing.assignment,
+								error: existing.error
+							}
+						: meta;
+				}),
+				local_profiles: local.local_profiles.map((lp) => {
+					const prev = prevLocals.get(lp.filename);
+					// Keep loaded counts/name if the file is unchanged (same mtime).
+					return prev && prev.rule_count != null && prev.updated_at === lp.updated_at
+						? {
+								...lp,
+								name: prev.name,
+								description: prev.description,
+								profile_type: prev.profile_type,
+								rule_count: prev.rule_count,
+								category_count: prev.category_count,
+								part_count: prev.part_count,
+								artifact_hash: prev.artifact_hash
+							}
+						: lp;
+				})
+			};
+			void loadLocalMetas();
 		} catch (e: unknown) {
 			error = e instanceof Error ? e.message : 'Failed to load sorting profile library';
-		} finally {
-			loading = false;
 		}
+	}
+
+	// Tier 1b — fill in local profile names/counts, one cheap (cached) request
+	// per file that still lacks them. Runs in parallel; cards show a placeholder
+	// until their meta lands.
+	async function loadLocalMetas() {
+		if (!library) return;
+		const pending = library.local_profiles.filter((p) => p.rule_count == null && !p.error);
+		await Promise.all(
+			pending.map(async (profile) => {
+				try {
+					const meta = await fetchLocalProfileMeta(baseUrl(), profile.filename);
+					if (!library) return;
+					library = {
+						...library,
+						local_profiles: library.local_profiles.map((p) =>
+							p.filename === profile.filename ? { ...p, ...meta } : p
+						)
+					};
+				} catch {
+					// Leave as-is; the card falls back to the filename.
+				}
+			})
+		);
+	}
+
+	// Tier 2 — one target's Hive profiles. Called per enabled target in
+	// parallel; updates just that target's slice as it resolves.
+	async function loadTarget(targetId: string) {
+		targetLoading = { ...targetLoading, [targetId]: true };
+		try {
+			const result = await fetchTargetLibrary(baseUrl(), targetId);
+			if (library) {
+				library = {
+					...library,
+					targets: library.targets.map((t) => (t.id === targetId ? { ...t, ...result } : t))
+				};
+			}
+		} catch (e: unknown) {
+			const message = e instanceof Error ? e.message : 'Failed to load profiles';
+			if (library) {
+				library = {
+					...library,
+					targets: library.targets.map((t) => (t.id === targetId ? { ...t, error: message } : t))
+				};
+			}
+		} finally {
+			const { [targetId]: _ignore, ...rest } = targetLoading;
+			targetLoading = rest;
+		}
+	}
+
+	function loadAllTargets() {
+		if (!library) return;
+		for (const target of library.targets) {
+			if (target.enabled) void loadTarget(target.id);
+		}
+	}
+
+	// Full refresh: fast local first, then fan out the Hive fetches.
+	async function loadLibrary() {
+		await loadLocal();
+		loadAllTargets();
 	}
 
 	async function loadProfileDetail(
@@ -342,14 +444,15 @@
 	}
 
 	function searchableProfileText(profile: SortingProfileSummary): string {
-		const ruleBits = (profile.latest_published_version ?? profile.latest_version)?.rules_summary
-			?.filter((rule) => !rule.disabled)
-			.flatMap((rule) => [
-				rule.name,
-				rule.set_num,
-				rule.set_meta?.name,
-				rule.set_meta?.year != null ? String(rule.set_meta.year) : null
-			]) ?? [];
+		const ruleBits =
+			(profile.latest_published_version ?? profile.latest_version)?.rules_summary
+				?.filter((rule) => !rule.disabled)
+				.flatMap((rule) => [
+					rule.name,
+					rule.set_num,
+					rule.set_meta?.name,
+					rule.set_meta?.year != null ? String(rule.set_meta.year) : null
+				]) ?? [];
 		const owner = profile.owner;
 		return [
 			profile.name,
@@ -431,6 +534,17 @@
 		return library.targets.filter((target) => Boolean(target.error));
 	}
 
+	// True while any enabled target's Hive fetch is still in flight — drives the
+	// skeleton cards. Suppressed during search so placeholders don't masquerade
+	// as unfiltered results.
+	function showTargetSkeletons(): boolean {
+		return Object.keys(targetLoading).length > 0 && !normalizedSearchQuery();
+	}
+
+	function skeletonCardCount(): number {
+		return filteredProfileEntries().length > 0 ? 3 : 6;
+	}
+
 	function selectedVersionIdFor(targetId: string, profileId: string): string | null {
 		return selectedVersionIds[detailKey(targetId, profileId)] ?? null;
 	}
@@ -451,7 +565,7 @@
 
 	function activeDetailsModalSummary(): SortingProfileDetail | null {
 		const key = activeDetailsModalKey();
-		return key ? detailCache[key] ?? null : null;
+		return key ? (detailCache[key] ?? null) : null;
 	}
 
 	function activeDetailsModalDetail(): SortingProfileDetail | null {
@@ -476,7 +590,7 @@
 			return versionDetailErrors[versionKey];
 		}
 		const key = activeDetailsModalKey();
-		return key ? detailErrors[key] ?? null : null;
+		return key ? (detailErrors[key] ?? null) : null;
 	}
 
 	function activeDetailsModalLoading(): boolean {
@@ -529,19 +643,17 @@
 		await handleVersionSelection(target, profile, versionId);
 	}
 
-	/** Auto-load profile detail for the currently visible cards. */
-	async function autoLoadVisibleDetails() {
+	/** Auto-load profile detail for the currently visible cards, in parallel. */
+	function autoLoadVisibleDetails() {
 		if (!library) return;
 		for (const entry of paginatedProfileEntries()) {
 			const target = entry.target;
 			const profile = entry.profile;
 			const key = detailKey(target.id, profile.id);
 			if (!detailCache[key] && !detailErrors[key] && !loadingDetailKeys[key]) {
-				try {
-					await loadProfileDetail(target.id, profile);
-				} catch {
-					// Silently ignore — user can retry manually
-				}
+				// Fire-and-forget; each card shows its own loading state until
+				// its detail lands. Errors are surfaced per-card via detailErrors.
+				void loadProfileDetail(target.id, profile);
 			}
 		}
 	}
@@ -550,6 +662,8 @@
 		const currentUrl = manager.selectedMachine?.url ?? '';
 		if (currentUrl === lastMachineUrl) return;
 		lastMachineUrl = currentUrl;
+		library = null;
+		targetLoading = {};
 		detailCache = {};
 		detailErrors = {};
 		selectedVersionIds = {};
@@ -567,14 +681,21 @@
 	// Auto-load versions whenever the visible card set changes.
 	$effect(() => {
 		if (library && library.targets.length > 0) {
-			void autoLoadVisibleDetails();
+			autoLoadVisibleDetails();
 		}
 	});
 
 	onMount(() => {
 		void loadLibrary();
-		const interval = setInterval(() => void loadLibrary(), 10000);
-		return () => clearInterval(interval);
+		// Poll the cheap local tier often (active-profile + local-profile
+		// changes); refresh the expensive Hive tier on a slower cadence to
+		// spare the CPU-bound backend.
+		const localPoll = setInterval(() => void loadLocal(), 10000);
+		const hivePoll = setInterval(() => loadAllTargets(), 60000);
+		return () => {
+			clearInterval(localPoll);
+			clearInterval(hivePoll);
+		};
 	});
 </script>
 
@@ -587,7 +708,7 @@
 	<div class="p-4 sm:p-6">
 		<div class="mb-4 flex flex-wrap items-center justify-between gap-3">
 			<h2 class="text-xl font-bold text-text">Sorting Profiles</h2>
-			<div class="flex min-w-[24rem] max-w-[36rem] flex-1 items-center justify-end gap-2">
+			<div class="flex max-w-[36rem] min-w-[24rem] flex-1 items-center justify-end gap-2">
 				<input
 					id="profile-search"
 					type="search"
@@ -622,106 +743,118 @@
 			onchange={handleUploadFile}
 		/>
 
-		{#if library}
-			<div class="mb-6">
-				<BsxSection baseUrl={baseUrl()} />
+		<div class="mb-6">
+			<BsxSection baseUrl={baseUrl()} />
+		</div>
+		<div class="mb-6">
+			<div class="mb-3 flex items-center justify-between gap-3">
+				<h3 class="text-sm font-semibold tracking-wider text-text-muted uppercase">
+					Local profiles
+				</h3>
+				<button
+					type="button"
+					onclick={() => fileInput?.click()}
+					disabled={uploading}
+					class="flex items-center gap-2 border border-border bg-surface px-3 py-1.5 text-sm text-text transition-colors hover:bg-bg disabled:opacity-50"
+				>
+					<Upload size={14} />
+					{uploading ? 'Uploading…' : 'Upload JSON'}
+				</button>
 			</div>
-			<div class="mb-6">
-				<div class="mb-3 flex items-center justify-between gap-3">
-					<h3 class="text-sm font-semibold uppercase tracking-wider text-text-muted">
-						Local profiles
-					</h3>
-					<button
-						type="button"
-						onclick={() => fileInput?.click()}
-						disabled={uploading}
-						class="flex items-center gap-2 border border-border bg-surface px-3 py-1.5 text-sm text-text transition-colors hover:bg-bg disabled:opacity-50"
-					>
-						<Upload size={14} />
-						{uploading ? 'Uploading…' : 'Upload JSON'}
-					</button>
-				</div>
 
-				{#if localProfiles().length === 0}
-					<div class="border border-border bg-surface px-4 py-6 text-center text-sm text-text-muted">
-						No local profiles saved yet. Upload a profile JSON to keep it on this machine.
-					</div>
-				{:else}
-					<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-						{#each localProfiles() as profile}
-							<div
-								class="setup-card-shell flex h-full flex-col overflow-hidden border transition-colors {profile.is_active
-									? 'border-success ring-1 ring-success/20'
-									: 'border-border hover:border-text-muted'}"
-							>
-								<div class="setup-card-header px-3 py-2 text-sm">
-									<div class="flex items-start justify-between gap-3">
-										<div class="min-w-0 flex-1">
-											<div class="truncate text-sm font-semibold text-text">
-												{profile.name || profile.filename}
-											</div>
-											<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
-												<span class="font-mono">local:{profile.filename}</span>
-												{#if profile.is_active}
-													<span
-														class="border border-success/30 bg-success/10 px-1.5 py-0.5 font-medium uppercase tracking-wide text-success"
-														>Active</span
-													>
-												{/if}
-											</div>
+			{#if library == null}
+				<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+					{#each Array(2) as _}
+						<ProfileCardSkeleton />
+					{/each}
+				</div>
+			{:else if localProfiles().length === 0}
+				<div class="border border-border bg-surface px-4 py-6 text-center text-sm text-text-muted">
+					No local profiles saved yet. Upload a profile JSON to keep it on this machine.
+				</div>
+			{:else}
+				<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+					{#each localProfiles() as profile}
+						<div
+							class="setup-card-shell flex h-full flex-col overflow-hidden border transition-colors {profile.is_active
+								? 'border-success ring-1 ring-success/20'
+								: 'border-border hover:border-text-muted'}"
+						>
+							<div class="setup-card-header px-3 py-2 text-sm">
+								<div class="flex items-start justify-between gap-3">
+									<div class="min-w-0 flex-1">
+										<div class="truncate text-sm font-semibold text-text">
+											{profile.name || profile.filename}
 										</div>
-										<div class="flex shrink-0 items-center gap-2">
-											<button
-												type="button"
-												onclick={() => requestApplyLocal(profile)}
-												disabled={localApplyingFilename === profile.filename || Boolean(profile.error)}
-												class="border border-border bg-white px-3 py-2 text-sm text-text transition-colors hover:bg-bg disabled:opacity-50"
-											>
-												{localApplyingFilename === profile.filename ? 'Activating…' : 'activate'}
-											</button>
-											<button
-												type="button"
-												onclick={() => {
-													pendingDelete = profile;
-													localDeleteOpen = true;
-												}}
-												disabled={deletingFilename === profile.filename}
-												title="Delete local profile"
-												class="border border-border bg-white p-2 text-text-muted transition-colors hover:bg-bg hover:text-danger disabled:opacity-50"
-											>
-												<Trash2 size={16} />
-											</button>
+										<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-muted">
+											<span class="font-mono">local:{profile.filename}</span>
+											{#if profile.is_active}
+												<span
+													class="border border-success/30 bg-success/10 px-1.5 py-0.5 font-medium tracking-wide text-success uppercase"
+													>Active</span
+												>
+											{/if}
 										</div>
 									</div>
-								</div>
-								<div class="setup-card-body border-t border-border px-4 py-3 text-xs text-text-muted">
-									{#if profile.error}
-										<span class="text-amber-700 dark:text-amber-300">Unreadable: {profile.error}</span>
-									{:else}
-										<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-											{#if profile.rule_count != null}<span>{profile.rule_count} rules</span>{/if}
-											{#if profile.category_count != null}
-												<span aria-hidden="true">·</span>
-												<span>{profile.category_count} categories</span>
-											{/if}
-											{#if profile.profile_type}
-												<span aria-hidden="true">·</span>
-												<span>{profile.profile_type}</span>
-											{/if}
-										</div>
-									{/if}
+									<div class="flex shrink-0 items-center gap-2">
+										<button
+											type="button"
+											onclick={() => requestApplyLocal(profile)}
+											disabled={localApplyingFilename === profile.filename ||
+												Boolean(profile.error)}
+											class="border border-border bg-white px-3 py-2 text-sm text-text transition-colors hover:bg-bg disabled:opacity-50"
+										>
+											{localApplyingFilename === profile.filename ? 'Activating…' : 'activate'}
+										</button>
+										<button
+											type="button"
+											onclick={() => {
+												pendingDelete = profile;
+												localDeleteOpen = true;
+											}}
+											disabled={deletingFilename === profile.filename}
+											title="Delete local profile"
+											class="border border-border bg-white p-2 text-text-muted transition-colors hover:bg-bg hover:text-danger disabled:opacity-50"
+										>
+											<Trash2 size={16} />
+										</button>
+									</div>
 								</div>
 							</div>
-						{/each}
-					</div>
-				{/if}
-			</div>
-		{/if}
+							<div class="setup-card-body border-t border-border px-4 py-3 text-xs text-text-muted">
+								{#if profile.error}
+									<span class="text-amber-700 dark:text-amber-300">Unreadable: {profile.error}</span
+									>
+								{:else if profile.rule_count == null}
+									<Skeleton class="h-3.5 w-32" />
+								{:else}
+									<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+										{#if profile.rule_count != null}<span>{profile.rule_count} rules</span>{/if}
+										{#if profile.category_count != null}
+											<span aria-hidden="true">·</span>
+											<span>{profile.category_count} categories</span>
+										{/if}
+										{#if profile.profile_type}
+											<span aria-hidden="true">·</span>
+											<span>{profile.profile_type}</span>
+										{/if}
+									</div>
+								{/if}
+							</div>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
 
-		{#if loading && !library}
-			<Spinner />
-		{:else if !library}
-			<p class="text-text-muted">No sorting profile data available.</p>
+		{#if library == null}
+			{#if !error}
+				<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+					{#each Array(6) as _}
+						<ProfileCardSkeleton />
+					{/each}
+				</div>
+			{/if}
 		{:else if library.targets.length === 0}
 			<p class="text-sm text-text-muted">
 				No Hive targets are configured on this machine right now.
@@ -749,7 +882,7 @@
 				</div>
 			{/if}
 
-			{#if filteredProfileEntries().length > 0}
+			{#if filteredProfileEntries().length > 0 || showTargetSkeletons()}
 				<div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
 					{#each paginatedProfileEntries() as entry}
 						{@const key = detailKey(entry.target.id, entry.profile.id)}
@@ -760,9 +893,9 @@
 							detailError={detailErrors[key]}
 							syncState={library.sync_state}
 							selectedVersionId={selectedVersionIds[key] ?? null}
-							applyingKey={applyingKey}
+							{applyingKey}
 							cardKey={key}
-							openVersionMenuKey={openVersionMenuKey}
+							{openVersionMenuKey}
 							onOpenDetails={() => void openProfileDetails(entry.target, entry.profile)}
 							onApply={() => void requestApplyProfile(entry.target, entry.profile)}
 							onApplyVersion={(versionId) =>
@@ -770,23 +903,30 @@
 							onToggleVersionMenu={() => toggleVersionMenu(key)}
 						/>
 					{/each}
+					{#if showTargetSkeletons()}
+						{#each Array(skeletonCardCount()) as _}
+							<ProfileCardSkeleton />
+						{/each}
+					{/if}
 				</div>
 
-				<ProfilePagination
-					pageSize={pageSize}
-					pageSizeOptions={PROFILE_PAGE_SIZE_OPTIONS}
-					currentPage={currentListPage()}
-					totalPages={totalPages()}
-					summary={paginationSummary()}
-					visiblePageNumbers={visiblePageNumbers()}
-					onPageSizeChange={(size) => {
-						pageSize = size;
-						currentPage = 1;
-					}}
-					onPageChange={(page) => {
-						currentPage = Math.min(Math.max(page, 1), totalPages());
-					}}
-				/>
+				{#if filteredProfileEntries().length > 0}
+					<ProfilePagination
+						{pageSize}
+						pageSizeOptions={PROFILE_PAGE_SIZE_OPTIONS}
+						currentPage={currentListPage()}
+						totalPages={totalPages()}
+						summary={paginationSummary()}
+						visiblePageNumbers={visiblePageNumbers()}
+						onPageSizeChange={(size) => {
+							pageSize = size;
+							currentPage = 1;
+						}}
+						onPageChange={(page) => {
+							currentPage = Math.min(Math.max(page, 1), totalPages());
+						}}
+					/>
+				{/if}
 			{/if}
 		{/if}
 	</div>
@@ -823,12 +963,12 @@
 				<p class="text-sm text-text-muted">Choose how bins should be initialized.</p>
 				<div class="flex flex-col gap-2 border border-border bg-bg p-3 text-sm text-text-muted">
 					<div>
-						<span class="font-medium text-text">Reset (dynamic)</span> — clear every bin;
-						categories are assigned as pieces arrive.
+						<span class="font-medium text-text">Reset (dynamic)</span> — clear every bin; categories are
+						assigned as pieces arrive.
 					</div>
 					<div>
-						<span class="font-medium text-text">Pre-assign (rule order)</span> — seed bins in the
-						order of the profile's rules.
+						<span class="font-medium text-text">Pre-assign (rule order)</span> — seed bins in the order
+						of the profile's rules.
 					</div>
 				</div>
 				<div class="flex flex-wrap items-center justify-end gap-2 border-t border-border pt-3">
@@ -863,8 +1003,8 @@
 			{@const profile = pendingDelete}
 			<div class="flex flex-col gap-4">
 				<p class="text-sm text-text">
-					Delete <span class="font-semibold">{profile.name || profile.filename}</span> from this
-					machine? This removes the saved JSON file.
+					Delete <span class="font-semibold">{profile.name || profile.filename}</span> from this machine?
+					This removes the saved JSON file.
 				</p>
 				<div class="flex items-center justify-end gap-2 border-t border-border pt-3">
 					<button

--- a/software/sorter/frontend/src/routes/styleguide/+page.svelte
+++ b/software/sorter/frontend/src/routes/styleguide/+page.svelte
@@ -3,7 +3,8 @@
 	import SectionCard from '$lib/components/settings/SectionCard.svelte';
 	import StatusBanner from '$lib/components/StatusBanner.svelte';
 	import { Alert, Button, Input, Tooltip } from '$lib/components/primitives';
-	import { Check, CheckCircle2, ChevronRight, HelpCircle, Loader2, RefreshCcw } from 'lucide-svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import { Check, CheckCircle2, ChevronRight, HelpCircle, RefreshCcw } from 'lucide-svelte';
 
 	let primitiveInputText = $state('');
 	let primitiveInputNumber = $state(0);
@@ -566,21 +567,57 @@
 
 		<SectionCard
 			title="Loading states"
-			description="Spinner row used when fetching async data inside a step or panel."
+			description="One canonical loading indicator: the Spinner component. Four squares, one lit at a time, snapping clockwise — discrete and sharp-cornered to match the industrial style."
 		>
-			<div class="flex flex-col gap-3">
-				<div
-					class="setup-panel flex items-center gap-2 px-4 py-3 text-sm text-text-muted"
-				>
-					<Loader2 size={14} class="animate-spin" />
+			<div class="flex flex-col gap-4">
+				<Alert variant="info">
+					<div class="text-[11px] font-semibold tracking-wider text-primary-dark uppercase dark:text-sky-200">
+						Use the Spinner component — nothing else
+					</div>
+					<div class="mt-1 text-xs leading-relaxed text-text">
+						This is the single loading animation for the whole app. Do not hand-roll a
+						<code>border-current</code> ring or spin a lucide <code>Loader2</code> — import
+						<code>Spinner</code> and pass a <code>size</code>. It inherits color via
+						<code>currentColor</code>, so a wrapping <code>text-*</code> class tints it. When
+						building another surface on this design scheme, copy this component and its CSS
+						verbatim.
+					</div>
+				</Alert>
+
+				<div class="flex flex-wrap items-center gap-6">
+					<div class="flex flex-col items-center gap-2">
+						<Spinner size={14} />
+						<span class="font-mono text-xs text-text-muted">size 14 — inline / buttons</span>
+					</div>
+					<div class="flex flex-col items-center gap-2">
+						<Spinner size={24} />
+						<span class="font-mono text-xs text-text-muted">size 24 — panels</span>
+					</div>
+					<div class="flex flex-col items-center gap-2">
+						<Spinner size={40} />
+						<span class="font-mono text-xs text-text-muted">size 40 — full-panel</span>
+					</div>
+					<div class="flex flex-col items-center gap-2">
+						<span class="text-primary"><Spinner size={24} /></span>
+						<span class="font-mono text-xs text-text-muted">tinted via text-primary</span>
+					</div>
+				</div>
+
+				<div class="setup-panel flex items-center gap-2 px-4 py-3 text-sm text-text-muted">
+					<Spinner size={14} />
 					Checking current Hive configuration…
 				</div>
 				<pre
-					class="setup-panel overflow-x-auto px-3 py-2 text-[11px] font-mono leading-relaxed text-text">{`<div class="setup-panel flex items-center gap-2
+					class="setup-panel overflow-x-auto px-3 py-2 text-[11px] font-mono leading-relaxed text-text">{`import Spinner from '$lib/components/Spinner.svelte';
+
+<div class="setup-panel flex items-center gap-2
             px-4 py-3 text-sm text-text-muted">
-  <Loader2 size={14} class="animate-spin" />
+  <Spinner size={14} />
   Checking current Hive configuration…
-</div>`}</pre>
+</div>
+
+<!-- tint by wrapping in a text-* color -->
+<span class="text-primary"><Spinner size={24} /></span>`}</pre>
 			</div>
 		</SectionCard>
 


### PR DESCRIPTION
Two related loading-UX changes for the sorter frontend.

## 1. Profiles page — progressive loading with instant skeletons

The `/profiles` page showed a full-page spinner for ~4s on open. Two causes:
- The `/library` endpoint bundled fast local disk reads **behind** slow per-target Hive network calls.
- It parsed two ~57MB active-profile JSON files inline just to surface a name and a few counts.

**Backend** (`sorting_profiles.py`)
- Split `/library` into a fast `/local` (target metadata, sync state, local-profile filenames — no Hive network, no multi-MB parse) and per-target `/targets/{id}/library`.
- Added `/local/{filename}/meta` for lazy per-card counts, plus an mtime-keyed cache so repeated reads (10s poll, re-renders) don't re-parse the giant files.
- `/local` measured **~2.4s → ~55ms** on the dev machine.

**Frontend** (`profiles/+page.svelte`, `sorting-profiles/api.ts`, new `ProfileCardSkeleton`)
- Render skeletons immediately; fetch local, each Hive target, and each card's version detail **in parallel** (was serial).
- Lazily fill local-profile names/counts; poll only the cheap local tier at 10s, refresh Hive targets on a slower 60s cadence.

Result: page chrome + skeletons in ~50ms → real Hive cards stream in at ~0.3–0.5s → counts/activate buttons fill in as they resolve.

## 2. Loading spinner redesign

Replace ad-hoc spinners (border-current rings, spun lucide `Loader2`) across the sorter UI with the shared `Spinner` — four sharp squares, one lit at a time, snapping clockwise — matching the app's sharp-edged style. Routes every loading indicator (bins, camera feed, setup steps, homing modal, connection guard, styleguide) through it and documents it as the single loading animation in the frontend `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)