### PR TITLE
Add piece color labeling to Hive

### DIFF
--- a/software/hive/backend/alembic/versions/c3d4e5f6a7b8_add_piece_color_labels.py
+++ b/software/hive/backend/alembic/versions/c3d4e5f6a7b8_add_piece_color_labels.py
@@ -1,0 +1,49 @@
+"""add piece color labels
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-07-13 12:20:00.000000
+
+Human ground-truth BrickLink color for a synced machine piece. Distinct from
+sample_reviews: here a labeler corrects the machine's Brickognize color
+prediction by picking the true color from the crop. One label per
+(machine, piece, labeler).
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "piece_color_labels",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("machine_id", sa.UUID(), nullable=False),
+        sa.Column("piece_uuid", sa.String(), nullable=False),
+        sa.Column("labeler_id", sa.UUID(), nullable=False),
+        sa.Column("color_id", sa.Integer(), nullable=False),
+        sa.Column("notes", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["machine_id"], ["machines.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["labeler_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("machine_id", "piece_uuid", "labeler_id", name="uq_piece_color_labels_piece_labeler"),
+    )
+    op.create_index("ix_piece_color_labels_machine_piece", "piece_color_labels", ["machine_id", "piece_uuid"])
+    op.create_index("ix_piece_color_labels_labeler_id", "piece_color_labels", ["labeler_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_piece_color_labels_labeler_id", table_name="piece_color_labels")
+    op.drop_index("ix_piece_color_labels_machine_piece", table_name="piece_color_labels")
+    op.drop_table("piece_color_labels")

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -22,6 +22,7 @@ from app.routers import (
     machine_sync,
     machines,
     models as models_router,
+    piece_color_labels,
     profiles,
     review,
     samples,
@@ -89,6 +90,7 @@ app.include_router(stats.router)
 app.include_router(models_router.router)
 app.include_router(machine_models.router)
 app.include_router(machine_parts.router)
+app.include_router(piece_color_labels.router)
 app.include_router(api_keys.router)
 app.include_router(teacher.router)
 app.include_router(leaderboard.router)

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -32,3 +32,4 @@ from app.models.machine_piece_image import MachinePieceImage  # noqa: E402, F401
 from app.models.machine_sync_state import MachineSyncState  # noqa: E402, F401
 from app.models.machine_stats_cache import MachineStatsCache  # noqa: E402, F401
 from app.models.machine_daily_stats import MachineDailyStats  # noqa: E402, F401
+from app.models.piece_color_label import PieceColorLabel  # noqa: E402, F401

--- a/software/hive/backend/app/models/piece_color_label.py
+++ b/software/hive/backend/app/models/piece_color_label.py
@@ -1,0 +1,47 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import Base
+
+
+class PieceColorLabel(Base):
+    """A human-provided ground-truth color for one synced machine piece.
+
+    Distinct from sample_reviews (which accept/reject part-classification
+    training crops). Here a labeler looks at a piece's synced crop(s) and records
+    the TRUE Lego color from the BrickLink palette. The piece's own
+    color_id/color_name is only the machine's Brickognize prediction (also in
+    BrickLink color space), shown for reference — this table is the correction.
+
+    color_id is a BrickLink color id (parts.db is a separate sqlite catalog with
+    no BrickLink-colors table of its own; the palette is derived from the
+    Rebrickable `colors.extra` external ids — see
+    ProfileCatalogService.list_bricklink_colors). No FK, since it's a
+    cross-catalog id. One label per (machine, piece, labeler) — mirrors
+    sample_reviews so multiple labelers can be aggregated later.
+    """
+
+    __tablename__ = "piece_color_labels"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    machine_id = Column(UUID(as_uuid=True), ForeignKey("machines.id", ondelete="CASCADE"), nullable=False)
+    piece_uuid = Column(String, nullable=False)
+    labeler_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    color_id = Column(Integer, nullable=False)
+    notes = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("machine_id", "piece_uuid", "labeler_id", name="uq_piece_color_labels_piece_labeler"),
+        Index("ix_piece_color_labels_machine_piece", "machine_id", "piece_uuid"),
+        Index("ix_piece_color_labels_labeler_id", "labeler_id"),
+    )

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -1,0 +1,308 @@
+"""Human color-labeling of synced machine pieces.
+
+A labeler views a piece's synced crop(s) and records the TRUE BrickLink color.
+To speed labeling we suggest a pixel-average guess computed on the fly from the
+crop pixels (see services.pixel_color) — a plain traditional estimate, not a
+learned prediction — matched to the nearest BrickLink color. Nothing about the
+suggestion is stored; a row is written only when a user provides a color, and
+each user gets their own row (multiple independent labels per piece).
+
+The palette comes from the parts.db catalog (BrickLink colors derived from the
+Rebrickable `colors` external ids). Labels live in Postgres (piece_color_labels).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import and_, exists, func
+from sqlalchemy.orm import Session
+
+from app.deps import get_current_user, get_db
+from app.errors import APIError
+from app.models.machine import Machine
+from app.models.machine_piece import MachinePiece
+from app.models.machine_piece_image import MachinePieceImage
+from app.models.piece_color_label import PieceColorLabel
+from app.models.user import User
+from app.services.pixel_color import guess_piece_color
+from app.services.profile_catalog import get_profile_catalog_service
+from app.services.storage import serve_stored_file
+
+router = APIRouter(prefix="/api/color-labels", tags=["color-labels"])
+
+PIECE_IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+def _available_image_exists():
+    """Correlated EXISTS: the piece has at least one synced crop still in
+    storage (image_key set). Pieces whose crops were evicted before sync can't
+    be color-labeled, so they're excluded from the queue."""
+    return exists().where(
+        and_(
+            MachinePieceImage.machine_id == MachinePiece.machine_id,
+            MachinePieceImage.piece_uuid == MachinePiece.piece_uuid,
+            MachinePieceImage.image_key.isnot(None),
+        )
+    )
+
+
+def _labelable_query(db: Session):
+    # A piece is labelable if it isn't a dead/spurious record and has a crop.
+    return db.query(MachinePiece).filter(
+        MachinePiece.dead.is_(False),
+        _available_image_exists(),
+    )
+
+
+class ColorOut(BaseModel):
+    id: int
+    name: str
+    rgb: str | None = None
+    is_trans: bool = False
+
+
+class ColorsResponse(BaseModel):
+    results: list[ColorOut]
+
+
+@router.get("/colors", response_model=ColorsResponse)
+def list_colors(
+    _user: User = Depends(get_current_user),
+) -> ColorsResponse:
+    """The BrickLink color palette to label from."""
+    colors = get_profile_catalog_service().list_bricklink_colors()
+    return ColorsResponse(results=[ColorOut(**c) for c in colors])
+
+
+@router.get("/stats")
+def label_stats(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, int]:
+    total_labelable = _labelable_query(db).count()
+    labeled_by_me = (
+        db.query(func.count(PieceColorLabel.id))
+        .filter(PieceColorLabel.labeler_id == current_user.id)
+        .scalar()
+        or 0
+    )
+    total_labels = db.query(func.count(PieceColorLabel.id)).scalar() or 0
+    return {
+        "total_labelable": total_labelable,
+        "labeled_by_me": int(labeled_by_me),
+        "total_labels": int(total_labels),
+    }
+
+
+@router.get("/queue")
+def label_queue(
+    only_unlabeled: bool = Query(True),
+    limit: int = Query(40, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Pieces to color-label, newest first.
+
+    With only_unlabeled=true (default) the labeler's already-labeled pieces drop
+    out, so the client just re-fetches from the top as it works — no cursor. Set
+    only_unlabeled=false to browse the full set (use offset to page)."""
+    query = _labelable_query(db)
+
+    if only_unlabeled:
+        my_label = exists().where(
+            and_(
+                PieceColorLabel.machine_id == MachinePiece.machine_id,
+                PieceColorLabel.piece_uuid == MachinePiece.piece_uuid,
+                PieceColorLabel.labeler_id == current_user.id,
+            )
+        )
+        query = query.filter(~my_label)
+
+    query = query.order_by(
+        MachinePiece.recorded_at.desc().nullslast(),
+        MachinePiece.created_at.desc(),
+    )
+    pieces = query.offset(offset).limit(limit + 1).all()
+    has_more = len(pieces) > limit
+    pieces = pieces[:limit]
+
+    machine_ids = {p.machine_id for p in pieces}
+    machine_names = {
+        mid: name
+        for mid, name in db.query(Machine.id, Machine.name).filter(Machine.id.in_(machine_ids)).all()
+    } if machine_ids else {}
+
+    # Available crops for the returned pieces, keyed by piece_uuid.
+    images_by_piece: dict[str, list[MachinePieceImage]] = {}
+    piece_uuids = [p.piece_uuid for p in pieces]
+    if piece_uuids:
+        rows = (
+            db.query(MachinePieceImage)
+            .filter(
+                MachinePieceImage.piece_uuid.in_(piece_uuids),
+                MachinePieceImage.image_key.isnot(None),
+            )
+            .order_by(MachinePieceImage.seq.asc())
+            .all()
+        )
+        for im in rows:
+            if im.machine_id in machine_ids:
+                images_by_piece.setdefault(im.piece_uuid, []).append(im)
+
+    # This user's existing labels for the returned pieces (present when
+    # only_unlabeled=false, so the UI can show/edit them).
+    my_labels: dict[tuple, PieceColorLabel] = {}
+    if piece_uuids:
+        label_rows = (
+            db.query(PieceColorLabel)
+            .filter(
+                PieceColorLabel.labeler_id == current_user.id,
+                PieceColorLabel.piece_uuid.in_(piece_uuids),
+            )
+            .all()
+        )
+        for lb in label_rows:
+            my_labels[(lb.machine_id, lb.piece_uuid)] = lb
+
+    items = []
+    for p in pieces:
+        lb = my_labels.get((p.machine_id, p.piece_uuid))
+        piece_images = images_by_piece.get(p.piece_uuid, [])
+        items.append(
+            {
+                "machine_id": str(p.machine_id),
+                "machine_name": machine_names.get(p.machine_id),
+                "piece_uuid": p.piece_uuid,
+                "recorded_at": p.recorded_at.isoformat() if p.recorded_at else None,
+                "seen_at": p.seen_at.isoformat() if p.seen_at else None,
+                "part": {"part_id": p.part_id, "part_name": p.part_name},
+                # Suggested color from a plain pixel average of the crops —
+                # recomputed each request, never stored.
+                "pixel_guess": guess_piece_color(piece_images),
+                "images": [
+                    {"seq": im.seq, "source": im.source, "used": im.used, "score": im.score}
+                    for im in piece_images
+                ],
+                "my_label": None if lb is None else {"color_id": lb.color_id, "notes": lb.notes},
+            }
+        )
+
+    return {"items": items, "has_more": has_more}
+
+
+class ColorLabelPayload(BaseModel):
+    machine_id: UUID
+    piece_uuid: str = Field(min_length=1)
+    color_id: int
+    notes: str | None = None
+
+
+@router.post("")
+def submit_label(
+    payload: ColorLabelPayload,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Create or update the current user's color label for a piece."""
+    valid_ids = {c["id"] for c in get_profile_catalog_service().list_bricklink_colors()}
+    if payload.color_id not in valid_ids:
+        raise APIError(400, f"Unknown BrickLink color id {payload.color_id}", "COLOR_ID_INVALID")
+
+    piece = (
+        db.query(MachinePiece.id)
+        .filter(
+            MachinePiece.machine_id == payload.machine_id,
+            MachinePiece.piece_uuid == payload.piece_uuid,
+        )
+        .first()
+    )
+    if piece is None:
+        raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
+
+    now = datetime.now(timezone.utc)
+    label = (
+        db.query(PieceColorLabel)
+        .filter(
+            PieceColorLabel.machine_id == payload.machine_id,
+            PieceColorLabel.piece_uuid == payload.piece_uuid,
+            PieceColorLabel.labeler_id == current_user.id,
+        )
+        .first()
+    )
+    if label is None:
+        label = PieceColorLabel(
+            machine_id=payload.machine_id,
+            piece_uuid=payload.piece_uuid,
+            labeler_id=current_user.id,
+            color_id=payload.color_id,
+            notes=payload.notes,
+        )
+        db.add(label)
+        created = True
+    else:
+        label.color_id = payload.color_id
+        label.notes = payload.notes
+        label.updated_at = now
+        created = False
+    db.commit()
+
+    labeled_by_me = (
+        db.query(func.count(PieceColorLabel.id))
+        .filter(PieceColorLabel.labeler_id == current_user.id)
+        .scalar()
+        or 0
+    )
+    return {"ok": True, "created": created, "labeled_by_me": int(labeled_by_me)}
+
+
+@router.delete("/{machine_id}/{piece_uuid}")
+def delete_label(
+    machine_id: UUID,
+    piece_uuid: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    label = (
+        db.query(PieceColorLabel)
+        .filter(
+            PieceColorLabel.machine_id == machine_id,
+            PieceColorLabel.piece_uuid == piece_uuid,
+            PieceColorLabel.labeler_id == current_user.id,
+        )
+        .first()
+    )
+    if label is None:
+        raise APIError(404, "Label not found", "LABEL_NOT_FOUND")
+    db.delete(label)
+    db.commit()
+    return {"ok": True}
+
+
+@router.get("/pieces/{machine_id}/{piece_uuid}/images/{seq}")
+def get_piece_image(
+    machine_id: UUID,
+    piece_uuid: str,
+    seq: int,
+    db: Session = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> object:
+    """Stream one synced crop. Any authenticated user may view it — color
+    labeling is a community task over the whole synced fleet, not just the
+    machine's owner (unlike the owner-gated /machines/... image route)."""
+    image = (
+        db.query(MachinePieceImage)
+        .filter(
+            MachinePieceImage.machine_id == machine_id,
+            MachinePieceImage.piece_uuid == piece_uuid,
+            MachinePieceImage.seq == seq,
+        )
+        .first()
+    )
+    if image is None or not image.image_key:
+        raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
+    return serve_stored_file(image.image_key, headers={"Cache-Control": PIECE_IMAGE_CACHE_CONTROL})

--- a/software/hive/backend/app/services/pixel_color.py
+++ b/software/hive/backend/app/services/pixel_color.py
@@ -1,0 +1,121 @@
+"""Traditional pixel-average color guess for a synced piece.
+
+Independent of any external model: it averages the actual crop pixels the machine
+already stored and matches that to the nearest BrickLink catalog color. Nothing is
+persisted — the guess is recomputed on demand (cheap, and cached per crop).
+
+Algorithm ("pixel average"): for up to N crops of a piece (preferring the ones the
+machine marked `used`), take the mean RGB of each crop's central region (trims the
+channel background), average those, then pick the nearest BrickLink color by CIE-Lab
+(deltaE76).
+"""
+
+from __future__ import annotations
+
+import io
+from functools import lru_cache
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+from app.services.profile_catalog import get_profile_catalog_service
+from app.services.storage_backend import get_backend
+
+METHOD = "pixel_average"
+MAX_SAMPLES = 5
+CENTER_FRACTION = 0.6  # keep the middle 60% box to de-weight background
+THUMB = 48
+
+
+def _srgb_to_lab(rgb: np.ndarray) -> np.ndarray:
+    """rgb: (...,3) in 0-255 -> Lab (...,3). Vectorized (D65)."""
+    c = rgb.astype(np.float64) / 255.0
+    lin = np.where(c <= 0.04045, c / 12.92, ((c + 0.055) / 1.055) ** 2.4)
+    r, g, b = lin[..., 0], lin[..., 1], lin[..., 2]
+    x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047
+    y = r * 0.2126 + g * 0.7152 + b * 0.0722
+    z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883
+    xyz = np.stack([x, y, z], axis=-1)
+    f = np.where(xyz > 0.008856, np.cbrt(xyz), 7.787 * xyz + 16.0 / 116.0)
+    fx, fy, fz = f[..., 0], f[..., 1], f[..., 2]
+    return np.stack([116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz)], axis=-1)
+
+
+@lru_cache(maxsize=1)
+def _palette() -> tuple[np.ndarray, tuple[dict[str, Any], ...]]:
+    colors = get_profile_catalog_service().list_bricklink_colors()
+    rgbs = []
+    meta = []
+    for c in colors:
+        # Keep non-answers out of the auto-match (they still exist in the full
+        # palette for manual selection): id<=0 is "(Not Applicable)"/[Unknown],
+        # and Modulex ("Mx ...") is a separate non-Lego brick system.
+        if not isinstance(c.get("id"), int) or c["id"] <= 0:
+            continue
+        if str(c.get("name", "")).startswith("Mx "):
+            continue
+        hex_rgb = c.get("rgb")
+        if not isinstance(hex_rgb, str) or len(hex_rgb.replace("#", "")) < 6:
+            continue
+        h = hex_rgb.replace("#", "")
+        try:
+            rgbs.append([int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)])
+        except ValueError:
+            continue
+        meta.append(c)
+    if not rgbs:
+        return np.empty((0, 3)), tuple()
+    return _srgb_to_lab(np.array(rgbs, dtype=np.float64)), tuple(meta)
+
+
+def _nearest_color(avg_rgb: tuple[float, float, float]) -> dict[str, Any] | None:
+    labs, meta = _palette()
+    if len(meta) == 0:
+        return None
+    target = _srgb_to_lab(np.array(avg_rgb, dtype=np.float64))
+    idx = int(np.argmin(np.linalg.norm(labs - target, axis=1)))
+    c = meta[idx]
+    return {"color_id": c["id"], "color_name": c["name"], "match_rgb": c.get("rgb")}
+
+
+@lru_cache(maxsize=8192)
+def _crop_average(image_key: str) -> tuple[float, float, float] | None:
+    try:
+        data = get_backend().read_bytes(image_key)
+        with Image.open(io.BytesIO(data)) as im:
+            im = im.convert("RGB")
+            w, h = im.size
+            bx = int(w * (1 - CENTER_FRACTION) / 2)
+            by = int(h * (1 - CENTER_FRACTION) / 2)
+            if w - 2 * bx >= 2 and h - 2 * by >= 2:
+                im = im.crop((bx, by, w - bx, h - by))
+            im.thumbnail((THUMB, THUMB))
+            arr = np.asarray(im, dtype=np.float64).reshape(-1, 3)
+    except Exception:
+        return None
+    r, g, b = arr.mean(axis=0)
+    return (float(r), float(g), float(b))
+
+
+def guess_piece_color(images: list) -> dict[str, Any] | None:
+    """images: MachinePieceImage rows for one piece. Returns the pixel-average
+    guess, or None if no crop was readable."""
+    with_key = [im for im in images if im.image_key]
+    used = [im for im in with_key if im.used]
+    chosen = (used or with_key)[:MAX_SAMPLES]
+    samples = [avg for im in chosen if (avg := _crop_average(im.image_key)) is not None]
+    if not samples:
+        return None
+    r = sum(s[0] for s in samples) / len(samples)
+    g = sum(s[1] for s in samples) / len(samples)
+    b = sum(s[2] for s in samples) / len(samples)
+    nearest = _nearest_color((r, g, b))
+    if nearest is None:
+        return None
+    return {
+        "method": METHOD,
+        "rgb": "%02X%02X%02X" % (round(r), round(g), round(b)),
+        "sample_count": len(samples),
+        **nearest,
+    }

--- a/software/hive/backend/app/services/profile_catalog.py
+++ b/software/hive/backend/app/services/profile_catalog.py
@@ -355,6 +355,42 @@ class ProfileCatalogService:
             )
         return colors
 
+    def list_bricklink_colors(self) -> list[dict[str, Any]]:
+        """The BrickLink color palette, derived from the Rebrickable `colors`
+        catalog's external ids (parts.db has no BrickLink-colors table).
+
+        brickognize predictions and machine piece color_ids are in BrickLink
+        color space, so this is the palette the color-labeling UI picks from.
+        Each Rebrickable color carries a BrickLink ext_ids/ext_descrs pair; we
+        flatten those to BL id + BL name and borrow the Rebrickable rgb/is_trans
+        as the swatch. First Rebrickable mapping wins on a BL-id collision."""
+        by_bl_id: dict[int, dict[str, Any]] = {}
+        for rb_color_id, color in sorted(self._parts_data.colors.items()):
+            bricklink = color.get("external_ids", {}).get("BrickLink", {})
+            if not isinstance(bricklink, dict):
+                continue
+            ext_ids = bricklink.get("ext_ids", [])
+            ext_descrs = bricklink.get("ext_descrs", [])
+            if not isinstance(ext_ids, list):
+                continue
+            for index, raw_bl_id in enumerate(ext_ids):
+                try:
+                    bl_id = int(raw_bl_id)
+                except (TypeError, ValueError):
+                    continue
+                if bl_id in by_bl_id:
+                    continue
+                descr = ext_descrs[index] if isinstance(ext_descrs, list) and index < len(ext_descrs) else None
+                bl_name = descr[0] if isinstance(descr, list) and descr else color.get("name") or str(bl_id)
+                by_bl_id[bl_id] = {
+                    "id": bl_id,
+                    "name": bl_name,
+                    "rgb": color.get("rgb"),
+                    "is_trans": bool(color.get("is_trans", False)),
+                    "rb_color_id": rb_color_id,
+                }
+        return [by_bl_id[bl_id] for bl_id in sorted(by_bl_id)]
+
     def import_bricklink_csv(self, csv_content: str, filename: str | None = None) -> dict[str, Any]:
         if not isinstance(csv_content, str) or not csv_content.strip():
             raise APIError(400, "CSV content is required", "PROFILE_CATALOG_CSV_EMPTY")

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -923,6 +923,52 @@ export interface PartsDbCategory {
 	actual_part_count: number;
 }
 
+export interface BrickLinkColor {
+	id: number;
+	name: string;
+	rgb: string | null;
+	is_trans: boolean;
+}
+
+export interface ColorLabelStats {
+	total_labelable: number;
+	labeled_by_me: number;
+	total_labels: number;
+}
+
+export interface ColorLabelPixelGuess {
+	method: string;
+	rgb: string;
+	sample_count: number;
+	color_id: number;
+	color_name: string;
+	match_rgb: string | null;
+}
+
+export interface ColorLabelQueueImage {
+	seq: number;
+	source: string | null;
+	used: boolean;
+	score: number | null;
+}
+
+export interface ColorLabelQueueItem {
+	machine_id: string;
+	machine_name: string | null;
+	piece_uuid: string;
+	recorded_at: string | null;
+	seen_at: string | null;
+	part: { part_id: string | null; part_name: string | null };
+	pixel_guess: ColorLabelPixelGuess | null;
+	images: ColorLabelQueueImage[];
+	my_label: { color_id: number; notes: string | null } | null;
+}
+
+export interface ColorLabelQueue {
+	items: ColorLabelQueueItem[];
+	has_more: boolean;
+}
+
 export const api = {
 	// Auth
 	register(email: string, password: string, display_name: string) {
@@ -993,6 +1039,40 @@ export const api = {
 	machinePieceImageUrl(machineId: string, pieceUuid: string, seq: number) {
 		return resolveApiPath(
 			`/api/machines/${machineId}/pieces/${encodeURIComponent(pieceUuid)}/images/${seq}`
+		);
+	},
+
+	// Color labeling
+	colorLabelColors() {
+		return request<{ results: BrickLinkColor[] }>('GET', '/api/color-labels/colors');
+	},
+	colorLabelStats() {
+		return request<ColorLabelStats>('GET', '/api/color-labels/stats');
+	},
+	colorLabelQueue(opts: { onlyUnlabeled?: boolean; limit?: number; offset?: number } = {}) {
+		const params = new URLSearchParams();
+		if (opts.onlyUnlabeled === false) params.set('only_unlabeled', 'false');
+		if (opts.limit) params.set('limit', String(opts.limit));
+		if (opts.offset) params.set('offset', String(opts.offset));
+		const qs = params.toString();
+		return request<ColorLabelQueue>('GET', `/api/color-labels/queue${qs ? `?${qs}` : ''}`);
+	},
+	submitColorLabel(body: { machine_id: string; piece_uuid: string; color_id: number; notes?: string | null }) {
+		return request<{ ok: boolean; created: boolean; labeled_by_me: number }>(
+			'POST',
+			'/api/color-labels',
+			body
+		);
+	},
+	deleteColorLabel(machineId: string, pieceUuid: string) {
+		return request<{ ok: boolean }>(
+			'DELETE',
+			`/api/color-labels/${machineId}/${encodeURIComponent(pieceUuid)}`
+		);
+	},
+	colorLabelImageUrl(machineId: string, pieceUuid: string, seq: number) {
+		return resolveApiPath(
+			`/api/color-labels/pieces/${machineId}/${encodeURIComponent(pieceUuid)}/images/${seq}`
 		);
 	},
 	createMachine(name: string, description?: string) {

--- a/software/hive/frontend/src/routes/color-labels/+page.svelte
+++ b/software/hive/frontend/src/routes/color-labels/+page.svelte
@@ -1,0 +1,385 @@
+<script lang="ts">
+	import {
+		api,
+		type BrickLinkColor,
+		type ColorLabelQueueItem,
+		type ColorLabelStats
+	} from '$lib/api';
+	import Badge from '$lib/components/Badge.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import { Button } from '$lib/components/primitives';
+
+	const BATCH = 30;
+	const PREFETCH_WITHIN = 5;
+	const SIMILAR_COUNT = 10;
+
+	let colors = $state<BrickLinkColor[]>([]);
+	let colorsById = $derived(new Map(colors.map((c) => [c.id, c])));
+	let stats = $state<ColorLabelStats | null>(null);
+
+	let items = $state<ColorLabelQueueItem[]>([]);
+	let shownKeys = new Set<string>();
+	let fetchOffset = 0;
+	let hasMore = $state(true);
+	let index = $state(0);
+
+	let search = $state('');
+	let loading = $state(true);
+	let fetchingMore = $state(false);
+	let submitting = $state(false);
+	let error = $state<string | null>(null);
+
+	const current = $derived(items[index] ?? null);
+
+	// The pixel-average guess's nearest catalog color (used to highlight it and
+	// for the one-click accept). Always a valid palette id when present.
+	const guessColorId = $derived.by(() => {
+		const id = current?.pixel_guess?.color_id;
+		return id != null && colorsById.has(id) ? id : null;
+	});
+
+	const filteredColors = $derived.by(() => {
+		const q = search.trim().toLowerCase();
+		if (!q) return colors;
+		return colors.filter(
+			(c) => c.name.toLowerCase().includes(q) || String(c.id) === q
+		);
+	});
+
+	// Perceptual color distance (CIE Lab / deltaE76) so the "closest to guess"
+	// shortcut surfaces colors a human would actually confuse with the pixel
+	// average (e.g. Tan vs Dark Tan) rather than RGB-nearest.
+	function hexToLab(hex: string | null): [number, number, number] | null {
+		if (!hex) return null;
+		const m = hex.replace('#', '');
+		if (m.length < 6) return null;
+		const r = parseInt(m.slice(0, 2), 16);
+		const g = parseInt(m.slice(2, 4), 16);
+		const b = parseInt(m.slice(4, 6), 16);
+		if ([r, g, b].some(Number.isNaN)) return null;
+		const lin = (c: number) => {
+			c /= 255;
+			return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+		};
+		const R = lin(r);
+		const G = lin(g);
+		const B = lin(b);
+		const X = (R * 0.4124 + G * 0.3576 + B * 0.1805) / 0.95047;
+		const Y = R * 0.2126 + G * 0.7152 + B * 0.0722;
+		const Z = (R * 0.0193 + G * 0.1192 + B * 0.9505) / 1.08883;
+		const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
+		const fx = f(X);
+		const fy = f(Y);
+		const fz = f(Z);
+		return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
+	}
+
+	const labById = $derived(
+		new Map(colors.map((c) => [c.id, hexToLab(c.rgb)] as const))
+	);
+
+	// Rank the palette against the raw pixel-average RGB (more precise than the
+	// already-rounded nearest color), excluding that nearest color since it's the
+	// prominent one-click option.
+	const similarColors = $derived.by(() => {
+		const target = hexToLab(current?.pixel_guess?.rgb ?? null);
+		if (!target) return [] as BrickLinkColor[];
+		return colors
+			.filter((c) => c.id !== guessColorId && labById.get(c.id) != null)
+			.map((c) => {
+				const lab = labById.get(c.id)!;
+				const d = Math.hypot(lab[0] - target[0], lab[1] - target[1], lab[2] - target[2]);
+				return { color: c, d };
+			})
+			.sort((a, b) => a.d - b.d)
+			.slice(0, SIMILAR_COUNT)
+			.map((x) => x.color);
+	});
+
+	function key(it: ColorLabelQueueItem): string {
+		return `${it.machine_id}|${it.piece_uuid}`;
+	}
+
+	function errMsg(e: unknown, fallback: string): string {
+		return e && typeof e === 'object' && 'error' in e
+			? String((e as { error: unknown }).error)
+			: fallback;
+	}
+
+	async function loadAll() {
+		loading = true;
+		error = null;
+		items = [];
+		shownKeys = new Set();
+		fetchOffset = 0;
+		hasMore = true;
+		index = 0;
+		try {
+			const [colorsRes, statsRes] = await Promise.all([
+				api.colorLabelColors(),
+				api.colorLabelStats()
+			]);
+			// Drop non-answers: id<=0 is "(Not Applicable)"/[Unknown]; "Mx …" is
+			// Modulex, a separate non-Lego system. (Speckle/Pearl/Chrome/Trans are
+			// real Lego finishes and stay.)
+			colors = colorsRes.results.filter((c) => c.id > 0 && !c.name.startsWith('Mx '));
+			stats = statsRes;
+			await fetchMore();
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to load labeling queue');
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function fetchMore() {
+		if (fetchingMore || !hasMore) return;
+		fetchingMore = true;
+		try {
+			const res = await api.colorLabelQueue({ onlyUnlabeled: true, limit: BATCH, offset: fetchOffset });
+			fetchOffset += BATCH;
+			hasMore = res.has_more;
+			for (const it of res.items) {
+				const k = key(it);
+				if (!shownKeys.has(k)) {
+					shownKeys.add(k);
+					items.push(it);
+				}
+			}
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to load more pieces');
+		} finally {
+			fetchingMore = false;
+		}
+	}
+
+	function maybePrefetch() {
+		if (hasMore && items.length - index <= PREFETCH_WITHIN) void fetchMore();
+	}
+
+	function advance() {
+		if (index < items.length - 1) index += 1;
+		else index = items.length; // past the end → "all done" state
+		maybePrefetch();
+	}
+
+	async function label(colorId: number) {
+		if (!current || submitting) return;
+		submitting = true;
+		error = null;
+		const it = current;
+		try {
+			const res = await api.submitColorLabel({
+				machine_id: it.machine_id,
+				piece_uuid: it.piece_uuid,
+				color_id: colorId
+			});
+			if (stats) stats.labeled_by_me = res.labeled_by_me;
+			search = '';
+			advance();
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to save label');
+		} finally {
+			submitting = false;
+		}
+	}
+
+	function skip() {
+		if (!current) return;
+		search = '';
+		advance();
+	}
+
+	function back() {
+		if (index > 0) index -= 1;
+	}
+
+	function onKey(e: KeyboardEvent) {
+		if (e.target instanceof HTMLInputElement) return;
+		if (e.key === 'Enter' && guessColorId != null) {
+			e.preventDefault();
+			void label(guessColorId);
+		} else if (e.key === 'ArrowRight' || e.key === ' ') {
+			e.preventDefault();
+			skip();
+		} else if (e.key === 'ArrowLeft') {
+			e.preventDefault();
+			back();
+		}
+	}
+
+	$effect(() => {
+		void loadAll();
+	});
+</script>
+
+<svelte:head>
+	<title>Color Labeling · Hive</title>
+</svelte:head>
+
+<svelte:window on:keydown={onKey} />
+
+<div class="mb-6 flex items-end justify-between">
+	<div>
+		<h1 class="text-2xl font-bold text-text">Color Labeling</h1>
+		<p class="text-sm text-text-muted">
+			Pick the true BrickLink color of each synced piece. A
+			<span class="font-medium">pixel-average guess</span> from the crops is offered as a starting point.
+		</p>
+	</div>
+	{#if stats}
+		<div class="text-right text-sm text-text-muted">
+			<div><span class="text-text tabular-nums">{stats.labeled_by_me.toLocaleString()}</span> labeled by you</div>
+			<div><span class="text-text tabular-nums">{stats.total_labelable.toLocaleString()}</span> labelable · {stats.total_labels.toLocaleString()} total</div>
+		</div>
+	{/if}
+</div>
+
+{#if error}
+	<div class="mb-4 bg-primary/8 p-3 text-sm text-primary">{error}</div>
+{/if}
+
+{#if loading}
+	<div class="flex justify-center py-16"><Spinner /></div>
+{:else if !current}
+	<div class="border border-border bg-surface p-10 text-center">
+		<p class="text-sm text-text-muted">
+			{items.length === 0
+				? 'No pieces with crops available to label yet.'
+				: 'All caught up — no more unlabeled pieces.'}
+		</p>
+		<div class="mt-4 flex justify-center">
+			<Button variant="secondary" size="sm" onclick={loadAll}>Reload</Button>
+		</div>
+	</div>
+{:else}
+	<div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem]">
+		<!-- Piece under review -->
+		<div class="border border-border bg-surface p-4">
+			<div class="mb-3 flex flex-wrap items-center gap-2">
+				<span class="text-sm font-medium text-text">
+					{current.part.part_name || current.part.part_id || 'Unidentified'}
+				</span>
+				{#if current.part.part_id}
+					<span class="text-xs text-text-muted">#{current.part.part_id}</span>
+				{/if}
+				<span class="text-xs text-text-muted">· {current.machine_name ?? 'machine'}</span>
+			</div>
+
+			<!-- Crops -->
+			<div class="flex flex-wrap gap-2">
+				{#each current.images as img (img.seq)}
+					<img
+						src={api.colorLabelImageUrl(current.machine_id, current.piece_uuid, img.seq)}
+						alt={`crop ${img.seq}`}
+						loading="lazy"
+						title={`seq ${img.seq}${img.source ? ` · ${img.source}` : ''}`}
+						class="h-28 w-28 border-2 bg-transparent object-contain {img.used ? 'border-success' : 'border-border'}"
+					/>
+				{/each}
+			</div>
+
+			<!-- Pixel-average guess computed from the crops above -->
+			<div class="mt-4 flex items-center gap-3 border-t border-border pt-3">
+				{#if current.pixel_guess}
+					<span
+						class="h-10 w-10 shrink-0 border border-border"
+						style={`background:#${current.pixel_guess.rgb}`}
+						title={`average pixel color #${current.pixel_guess.rgb}`}
+					></span>
+					<div class="min-w-0 text-xs text-text-muted">
+						<div class="uppercase tracking-wide text-[10px]">Pixel-average guess</div>
+						<div class="mt-0.5 flex items-center gap-1.5">
+							{#if guessColorId != null}
+								{@const gc = colorsById.get(guessColorId)}
+								<span class="inline-block h-3.5 w-3.5 border border-border" style={`background:#${gc?.rgb ?? '000'}`}></span>
+							{/if}
+							<span class="text-text">{current.pixel_guess.color_name}</span>
+							<span>({current.pixel_guess.color_id})</span>
+							<span class="ml-2">nearest of {current.pixel_guess.sample_count} crop{current.pixel_guess.sample_count === 1 ? '' : 's'}</span>
+						</div>
+					</div>
+				{:else}
+					<span class="text-xs text-text-muted">No pixel guess — crops unavailable.</span>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Palette picker -->
+		<div class="flex flex-col border border-border bg-surface p-4">
+			<div class="mb-3 flex items-center justify-between">
+				<span class="text-sm font-medium text-text">True color</span>
+				<div class="flex gap-1.5">
+					<Button variant="ghost" size="sm" onclick={back} disabled={index === 0}>← Back</Button>
+					<Button variant="secondary" size="sm" onclick={skip} disabled={submitting}>Skip →</Button>
+				</div>
+			</div>
+
+			{#if guessColorId != null}
+				{@const gc = colorsById.get(guessColorId)}
+				<button
+					class="mb-3 flex items-center gap-2 border border-success/60 bg-success/8 px-3 py-2 text-sm text-text hover:bg-success/15 disabled:opacity-50"
+					onclick={() => label(guessColorId!)}
+					disabled={submitting}
+				>
+					<span class="inline-block h-4 w-4 border border-border" style={`background:#${gc?.rgb ?? '000'}`}></span>
+					<span>Use guess — <span class="font-medium">{gc?.name}</span></span>
+					<span class="ml-auto text-xs text-text-muted">Enter</span>
+				</button>
+			{/if}
+
+			{#snippet swatch(color: BrickLinkColor)}
+				<button
+					class="group flex flex-col items-center gap-1 border p-1 hover:border-primary disabled:opacity-50 {color.id ===
+					guessColorId
+						? 'border-success'
+						: 'border-border'}"
+					title={`${color.name} (${color.id})`}
+					onclick={() => label(color.id)}
+					disabled={submitting}
+				>
+					<span
+						class="h-9 w-full border border-border {color.is_trans ? 'opacity-70' : ''}"
+						style={`background:#${color.rgb ?? '000'}`}
+					></span>
+					<span class="w-full truncate text-center text-[10px] leading-tight text-text-muted group-hover:text-text">
+						{color.name}
+					</span>
+				</button>
+			{/snippet}
+
+			{#if !search.trim() && similarColors.length > 0}
+				<div class="mb-3">
+					<div class="mb-1.5 text-xs font-medium text-text-muted">Closest to guess</div>
+					<div class="grid grid-cols-4 gap-1.5">
+						{#each similarColors as color (color.id)}
+							{@render swatch(color)}
+						{/each}
+					</div>
+				</div>
+				<div class="mb-2 text-xs font-medium text-text-muted">All colors</div>
+			{/if}
+
+			<input
+				type="text"
+				bind:value={search}
+				placeholder="Search colors…"
+				class="mb-3 w-full border border-border bg-bg px-3 py-1.5 text-sm text-text placeholder:text-text-muted focus:border-primary focus:outline-none"
+			/>
+
+			<div class="grid max-h-[60vh] grid-cols-4 gap-1.5 overflow-y-auto pr-1">
+				{#each filteredColors as color (color.id)}
+					{@render swatch(color)}
+				{/each}
+			</div>
+			{#if filteredColors.length === 0}
+				<p class="py-4 text-center text-xs text-text-muted">No colors match “{search}”.</p>
+			{/if}
+		</div>
+	</div>
+
+	<div class="mt-3 flex items-center gap-3 text-xs text-text-muted">
+		{#if submitting}<Spinner />{/if}
+		<span>Keys: <span class="text-text">Enter</span> accept prediction · <span class="text-text">→</span>/<span class="text-text">Space</span> skip · <span class="text-text">←</span> back</span>
+	</div>
+{/if}


### PR DESCRIPTION
Adds a color-labeling page to Hive. You can browse the pieces synced from your machines, look at each piece's crop images, and label its true BrickLink color — or skip it.

To speed things up, a pixel-average color guess is computed from the piece's crop images and offered as a one-click starting point, with the most similar colors surfaced first. Nothing about the guess is stored; it's recomputed on demand.

Each label is stored per piece per user, so multiple people can label the same piece independently.

**Backend**
- `piece_color_labels` table + migration
- `/api/color-labels` endpoints: color palette, labeling queue, submit/update, per-crop image serving, and stats
- `pixel_color` service: averages the piece's crops and matches to the nearest BrickLink catalog color

**Frontend**
- New `/color-labels` page: crop viewer, pixel-average guess, searchable color palette with a "closest to guess" shortcut, and keyboard shortcuts (Enter to accept the guess, → to skip, ← to go back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)