### PR TITLE
C2/C3 channel crop capture, Hive sync/viewer, and same-piece lookup

### DIFF
--- a/software/hive/backend/alembic/versions/d4e5f6a7b8c9_add_machine_channel_crops.py
+++ b/software/hive/backend/alembic/versions/d4e5f6a7b8c9_add_machine_channel_crops.py
@@ -1,0 +1,63 @@
+"""add machine channel crops
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-07-13 12:00:00.000000
+
+Machine -> Hive sync of UNLABELED upstream-channel (C2/C3) bbox crops. Each row
+is one crop of a piece seen on a feeder channel, tagged with the metadata a
+cheap time/angle "possibly the same piece" heuristic reads: channel, frame ts,
+the COM's signed distance to the exit zone (output degrees), zone code, and the
+advisory per-pass ByteTrack id. Synced via the same watermark table
+(machine_sync_state, data_type "channel_crops"). Crops evicted from the
+machine's 512 MB local store before syncing ride up metadata-only (image_key
+NULL, evicted_locally true).
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "machine_channel_crops",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("machine_id", sa.UUID(), nullable=False),
+        sa.Column("local_id", sa.BigInteger(), nullable=False),
+        sa.Column("channel", sa.Integer(), nullable=True),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("captured_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("track_id", sa.BigInteger(), nullable=True),
+        sa.Column("com_forward_to_exit_deg", sa.Float(), nullable=True),
+        sa.Column("com_section", sa.Integer(), nullable=True),
+        sa.Column("zone_code", sa.Integer(), nullable=True),
+        sa.Column("sharpness", sa.Float(), nullable=True),
+        sa.Column("bbox_x1", sa.Integer(), nullable=True),
+        sa.Column("bbox_y1", sa.Integer(), nullable=True),
+        sa.Column("bbox_x2", sa.Integer(), nullable=True),
+        sa.Column("bbox_y2", sa.Integer(), nullable=True),
+        sa.Column("bytes", sa.Integer(), nullable=True),
+        sa.Column("image_key", sa.String(), nullable=True),
+        sa.Column("evicted_locally", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["machine_id"], ["machines.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("machine_id", "local_id", name="uq_machine_channel_crops_machine_local"),
+    )
+    op.create_index("ix_machine_channel_crops_machine_local_id", "machine_channel_crops", ["machine_id", "local_id"], unique=False)
+    op.create_index("ix_machine_channel_crops_machine_channel_ts", "machine_channel_crops", ["machine_id", "channel", "ts"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_machine_channel_crops_machine_channel_ts", table_name="machine_channel_crops")
+    op.drop_index("ix_machine_channel_crops_machine_local_id", table_name="machine_channel_crops")
+    op.drop_table("machine_channel_crops")

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -29,6 +29,7 @@ from app.models.teacher_job import TeacherJob, TeacherJobItem  # noqa: E402, F40
 from app.models.teacher_prompt import TeacherPrompt  # noqa: E402, F401
 from app.models.machine_piece import MachinePiece  # noqa: E402, F401
 from app.models.machine_piece_image import MachinePieceImage  # noqa: E402, F401
+from app.models.machine_channel_crop import MachineChannelCrop  # noqa: E402, F401
 from app.models.machine_sync_state import MachineSyncState  # noqa: E402, F401
 from app.models.machine_stats_cache import MachineStatsCache  # noqa: E402, F401
 from app.models.machine_daily_stats import MachineDailyStats  # noqa: E402, F401

--- a/software/hive/backend/app/models/machine_channel_crop.py
+++ b/software/hive/backend/app/models/machine_channel_crop.py
@@ -1,0 +1,50 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import Base
+
+
+class MachineChannelCrop(Base):
+    """An UNLABELED bbox crop of a piece seen on an upstream feeder channel
+    (C2/C3). Unlike MachinePieceImage these are not tied to a classified piece —
+    we don't yet know which piece each crop is. They carry the metadata a cheap
+    time/angle heuristic uses to later guess "possibly the same piece": the
+    channel, frame timestamp, the COM's signed distance to the exit zone in
+    output degrees, its zone, and the advisory per-pass ByteTrack id.
+    """
+
+    __tablename__ = "machine_channel_crops"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    machine_id = Column(UUID(as_uuid=True), ForeignKey("machines.id", ondelete="CASCADE"), nullable=False)
+    # The machine's sqlite autoincrement crop id — drives the per-target sync
+    # watermark and is the natural key for a (machine, crop) row.
+    local_id = Column(BigInteger, nullable=False)
+    channel = Column(Integer, nullable=True)
+    ts = Column(DateTime(timezone=True), nullable=True)
+    captured_at = Column(DateTime(timezone=True), nullable=True)
+    track_id = Column(BigInteger, nullable=True)
+    com_forward_to_exit_deg = Column(Float, nullable=True)
+    com_section = Column(Integer, nullable=True)
+    zone_code = Column(Integer, nullable=True)
+    sharpness = Column(Float, nullable=True)
+    bbox_x1 = Column(Integer, nullable=True)
+    bbox_y1 = Column(Integer, nullable=True)
+    bbox_x2 = Column(Integer, nullable=True)
+    bbox_y2 = Column(Integer, nullable=True)
+    bytes = Column(Integer, nullable=True)
+    # Object-storage key. NULL when the crop was evicted from the machine's local
+    # 512 MB store before it could be synced — the row still rides up so counts
+    # stay complete.
+    image_key = Column(String, nullable=True)
+    evicted_locally = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint("machine_id", "local_id", name="uq_machine_channel_crops_machine_local"),
+        Index("ix_machine_channel_crops_machine_local_id", "machine_id", "local_id"),
+        Index("ix_machine_channel_crops_machine_channel_ts", "machine_id", "channel", "ts"),
+    )

--- a/software/hive/backend/app/routers/machine_sync.py
+++ b/software/hive/backend/app/routers/machine_sync.py
@@ -17,14 +17,16 @@ from app.errors import APIError
 from app.models.machine import Machine
 from app.models.machine_piece import MachinePiece
 from app.models.machine_piece_image import MachinePieceImage
+from app.models.machine_channel_crop import MachineChannelCrop
 from app.models.machine_sync_state import MachineSyncState
-from app.services.storage import save_piece_image_file, validate_image
+from app.services.storage import save_channel_crop_file, save_piece_image_file, validate_image
 
 router = APIRouter(prefix="/api/machine/sync", tags=["machine-sync"])
 limiter = Limiter(key_func=get_remote_address)
 
 DATA_TYPE_PIECE_RECORDS = "piece_records"
 DATA_TYPE_PIECE_IMAGES = "piece_images"
+DATA_TYPE_CHANNEL_CROPS = "channel_crops"
 
 # Columns updated on conflict — everything except the identity/immutable set
 # (id, machine_id, piece_uuid[, seq], created_at).
@@ -36,6 +38,11 @@ _PIECE_UPDATE_COLS = (
 _IMAGE_UPDATE_COLS = (
     "local_id", "source", "channel", "ts", "captured_at", "sharpness", "bytes",
     "used", "excluded_from_result", "score", "image_key", "evicted_locally",
+)
+_CHANNEL_CROP_UPDATE_COLS = (
+    "channel", "ts", "captured_at", "track_id", "com_forward_to_exit_deg",
+    "com_section", "zone_code", "sharpness", "bbox_x1", "bbox_y1", "bbox_x2",
+    "bbox_y2", "bytes", "image_key", "evicted_locally",
 )
 
 
@@ -122,6 +129,20 @@ class PieceImageMeta(BaseModel):
     score: float | None = None
 
 
+class ChannelCropMeta(BaseModel):
+    local_id: int
+    channel: int | None = None
+    ts: float | None = None
+    captured_at: float | None = None
+    track_id: int | None = None
+    com_forward_to_exit_deg: float | None = None
+    com_section: int | None = None
+    zone_code: int | None = None
+    sharpness: float | None = None
+    bbox: list[int] | None = None
+    bytes: int | None = None
+
+
 @router.get("/state")
 def get_sync_state(
     db: Session = Depends(get_db),
@@ -132,6 +153,7 @@ def get_sync_state(
     return {
         DATA_TYPE_PIECE_RECORDS: {"max_local_id": by_type.get(DATA_TYPE_PIECE_RECORDS, 0)},
         DATA_TYPE_PIECE_IMAGES: {"max_local_id": by_type.get(DATA_TYPE_PIECE_IMAGES, 0)},
+        DATA_TYPE_CHANNEL_CROPS: {"max_local_id": by_type.get(DATA_TYPE_CHANNEL_CROPS, 0)},
     }
 
 
@@ -232,6 +254,58 @@ def sync_piece_image(
     update_cols = _IMAGE_UPDATE_COLS if image is not None else tuple(c for c in _IMAGE_UPDATE_COLS if c != "image_key")
     _upsert(db, MachinePieceImage, [row], ["machine_id", "piece_uuid", "seq"], update_cols)
     new_max = _advance_watermark(db, machine.id, DATA_TYPE_PIECE_IMAGES, meta.local_id)
+    machine.last_seen_at = now
+    db.commit()
+    return {"max_local_id": new_max, "image_stored": image is not None}
+
+
+@router.post("/channel-crop")
+@limiter.limit("1200/minute")
+def sync_channel_crop(
+    request: Request,
+    metadata: str = Form(...),
+    image: UploadFile | None = File(default=None),
+    db: Session = Depends(get_db),
+    machine: Machine = Depends(get_current_machine),
+) -> dict[str, Any]:
+    try:
+        meta = ChannelCropMeta.model_validate(json.loads(metadata))
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise APIError(400, f"Invalid metadata: {exc}", "INVALID_METADATA") from exc
+
+    image_key: str | None = None
+    evicted_locally = image is None
+    if image is not None:
+        suffix = validate_image(image)
+        image_key = save_channel_crop_file(str(machine.id), meta.local_id, meta.channel, image, suffix)
+
+    bbox = meta.bbox if (meta.bbox and len(meta.bbox) == 4) else [None, None, None, None]
+    now = _now()
+    row = {
+        "id": uuid4(),
+        "machine_id": machine.id,
+        "local_id": meta.local_id,
+        "channel": meta.channel,
+        "ts": _ts(meta.ts),
+        "captured_at": _ts(meta.captured_at),
+        "track_id": meta.track_id,
+        "com_forward_to_exit_deg": meta.com_forward_to_exit_deg,
+        "com_section": meta.com_section,
+        "zone_code": meta.zone_code,
+        "sharpness": meta.sharpness,
+        "bbox_x1": bbox[0],
+        "bbox_y1": bbox[1],
+        "bbox_x2": bbox[2],
+        "bbox_y2": bbox[3],
+        "bytes": meta.bytes,
+        "image_key": image_key,
+        "evicted_locally": evicted_locally,
+        "created_at": now,
+    }
+    # Metadata-only re-sends must not wipe a previously stored image_key.
+    update_cols = _CHANNEL_CROP_UPDATE_COLS if image is not None else tuple(c for c in _CHANNEL_CROP_UPDATE_COLS if c != "image_key")
+    _upsert(db, MachineChannelCrop, [row], ["machine_id", "local_id"], update_cols)
+    new_max = _advance_watermark(db, machine.id, DATA_TYPE_CHANNEL_CROPS, meta.local_id)
     machine.last_seen_at = now
     db.commit()
     return {"max_local_id": new_max, "image_stored": image is not None}

--- a/software/hive/backend/app/routers/machines.py
+++ b/software/hive/backend/app/routers/machines.py
@@ -14,6 +14,7 @@ from app.errors import APIError
 from app.models.machine import Machine
 from app.models.machine_piece import MachinePiece
 from app.models.machine_piece_image import MachinePieceImage
+from app.models.machine_channel_crop import MachineChannelCrop
 from app.models.user import User
 from app.schemas.machine import (
     MachineCreate,
@@ -374,6 +375,97 @@ def get_machine_piece_image(
         raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
 
     return serve_stored_file(image.image_key, headers={"Cache-Control": PIECE_IMAGE_CACHE_CONTROL})
+
+
+def _serialize_channel_crop(crop: MachineChannelCrop) -> dict[str, Any]:
+    return {
+        "local_id": crop.local_id,
+        "channel": crop.channel,
+        "ts": crop.ts.isoformat() if crop.ts else None,
+        "captured_at": crop.captured_at.isoformat() if crop.captured_at else None,
+        "track_id": crop.track_id,
+        "com_forward_to_exit_deg": crop.com_forward_to_exit_deg,
+        "com_section": crop.com_section,
+        "zone_code": crop.zone_code,
+        "sharpness": crop.sharpness,
+        "bbox": [crop.bbox_x1, crop.bbox_y1, crop.bbox_x2, crop.bbox_y2],
+        "bytes": crop.bytes,
+        # image_key is NULL once the crop was evicted from the machine's local
+        # store before syncing — the row rides up regardless.
+        "available": crop.image_key is not None,
+        "evicted_locally": crop.evicted_locally,
+    }
+
+
+@router.get("/machines/{machine_id}/channel-crops")
+def list_machine_channel_crops(
+    machine_id: UUID,
+    limit: int = Query(120, ge=1, le=500),
+    cursor: int | None = Query(None),
+    channel: int | None = Query(None),
+    zone_code: int | None = Query(None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Unlabeled C2/C3 bbox crops synced from one machine, newest first.
+    Keyset-paginated on the machine's local crop id. Optional channel / zone_code
+    filters. Accessible to the machine's owner or any admin."""
+    machine = _machine_for_viewer(db, machine_id, current_user)
+
+    query = db.query(MachineChannelCrop).filter(MachineChannelCrop.machine_id == machine_id)
+    if channel is not None:
+        query = query.filter(MachineChannelCrop.channel == channel)
+    if zone_code is not None:
+        query = query.filter(MachineChannelCrop.zone_code == zone_code)
+    if cursor is not None:
+        query = query.filter(MachineChannelCrop.local_id < cursor)
+    crops = query.order_by(MachineChannelCrop.local_id.desc()).limit(limit + 1).all()
+
+    has_more = len(crops) > limit
+    crops = crops[:limit]
+    next_cursor = crops[-1].local_id if (has_more and crops) else None
+
+    total = (
+        db.query(func.count(MachineChannelCrop.id))
+        .filter(MachineChannelCrop.machine_id == machine_id)
+        .scalar()
+        or 0
+    )
+
+    return {
+        "machine": {
+            "id": str(machine.id),
+            "name": machine.name,
+            "owner_email": machine.owner.email if machine.owner else None,
+        },
+        "items": [_serialize_channel_crop(c) for c in crops],
+        "next_cursor": next_cursor,
+        "total": total,
+    }
+
+
+@router.get("/machines/{machine_id}/channel-crops/{local_id}/image")
+def get_machine_channel_crop_image(
+    machine_id: UUID,
+    local_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Stream one synced channel crop's bytes. Cookie-session auth (owner or
+    admin) is enough for an <img> tag on a same-origin page."""
+    _machine_for_viewer(db, machine_id, current_user)
+    crop = (
+        db.query(MachineChannelCrop)
+        .filter(
+            MachineChannelCrop.machine_id == machine_id,
+            MachineChannelCrop.local_id == local_id,
+        )
+        .first()
+    )
+    if crop is None or not crop.image_key:
+        raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
+
+    return serve_stored_file(crop.image_key, headers={"Cache-Control": PIECE_IMAGE_CACHE_CONTROL})
 
 
 @router.post("/machines", response_model=MachineWithTokenResponse)

--- a/software/hive/backend/app/services/storage.py
+++ b/software/hive/backend/app/services/storage.py
@@ -60,6 +60,23 @@ def save_piece_image_file(
     return key
 
 
+def save_channel_crop_file(
+    machine_id: str, local_id: int, channel: int | None, file: UploadFile, suffix: str
+) -> str:
+    # Deterministic key keyed on the machine's crop id so a re-send overwrites
+    # in place. Unlabeled crops group under channel_crops/ch{n}/.
+    channel_part = f"ch{int(channel)}" if channel is not None else "chx"
+    key = _join_key(
+        _safe_path_component(machine_id, "machine id"),
+        "channel_crops",
+        channel_part,
+        f"{int(local_id)}{suffix}",
+    )
+    file.file.seek(0)
+    get_backend().write_stream(key, file.file, content_type=file.content_type)
+    return key
+
+
 def delete_sample_files(sample) -> None:
     backend = get_backend()
     for path in (sample.image_path, sample.full_frame_path, sample.overlay_path):

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -239,6 +239,29 @@ export interface MachinePiecesPage {
 	total: number;
 }
 
+export interface MachineChannelCropInfo {
+	local_id: number;
+	channel: number | null;
+	ts: string | null;
+	captured_at: string | null;
+	track_id: number | null;
+	com_forward_to_exit_deg: number | null;
+	com_section: number | null;
+	zone_code: number | null;
+	sharpness: number | null;
+	bbox: (number | null)[];
+	bytes: number | null;
+	available: boolean;
+	evicted_locally: boolean;
+}
+
+export interface MachineChannelCropsPage {
+	machine: { id: string; name: string; owner_email: string | null };
+	items: MachineChannelCropInfo[];
+	next_cursor: number | null;
+	total: number;
+}
+
 export interface MachineConfigBackupSummary {
 	id: string;
 	version: number;
@@ -1040,6 +1063,24 @@ export const api = {
 		return resolveApiPath(
 			`/api/machines/${machineId}/pieces/${encodeURIComponent(pieceUuid)}/images/${seq}`
 		);
+	},
+	getMachineChannelCrops(
+		machineId: string,
+		opts: { limit?: number; cursor?: number | null; channel?: number | null; zoneCode?: number | null } = {}
+	) {
+		const params = new URLSearchParams();
+		if (opts.limit) params.set('limit', String(opts.limit));
+		if (opts.cursor != null) params.set('cursor', String(opts.cursor));
+		if (opts.channel != null) params.set('channel', String(opts.channel));
+		if (opts.zoneCode != null) params.set('zone_code', String(opts.zoneCode));
+		const qs = params.toString();
+		return request<MachineChannelCropsPage>(
+			'GET',
+			`/api/machines/${machineId}/channel-crops${qs ? `?${qs}` : ''}`
+		);
+	},
+	machineChannelCropImageUrl(machineId: string, localId: number) {
+		return resolveApiPath(`/api/machines/${machineId}/channel-crops/${localId}/image`);
 	},
 
 	// Color labeling

--- a/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
@@ -212,10 +212,16 @@
 		<section class="mt-6">
 			<div class="flex items-baseline justify-between">
 				<h2 class="text-lg font-semibold text-text">Sorting</h2>
-				<a
-					href={`/machines/${machine.id}/pieces`}
-					class="text-sm text-primary hover:underline">View pieces →</a
-				>
+				<div class="flex items-baseline gap-4">
+					<a
+						href={`/machines/${machine.id}/channel-crops`}
+						class="text-sm text-primary hover:underline">Channel crops →</a
+					>
+					<a
+						href={`/machines/${machine.id}/pieces`}
+						class="text-sm text-primary hover:underline">View pieces →</a
+					>
+				</div>
 			</div>
 			<div class="mt-3 grid grid-cols-2 gap-px border border-border bg-border sm:grid-cols-4">
 				{#each [

--- a/software/hive/frontend/src/routes/machines/[machine_id]/channel-crops/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/channel-crops/+page.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { api, type MachineChannelCropInfo } from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import { Button } from '$lib/components/primitives';
+
+	const PAGE_SIZE = 120;
+
+	const machineId = $derived(page.params.machine_id ?? '');
+
+	let machineName = $state<string>('');
+	let crops = $state<MachineChannelCropInfo[]>([]);
+	let total = $state(0);
+	let nextCursor = $state<number | null>(null);
+	let loading = $state(true);
+	let loadingMore = $state(false);
+	let error = $state<string | null>(null);
+	let sentinel = $state<HTMLDivElement | null>(null);
+
+	// Filters. null = all.
+	let channel = $state<number | null>(null);
+	let zoneCode = $state<number | null>(null);
+
+	$effect(() => {
+		// Re-run the initial load whenever route id or a filter changes.
+		void machineId;
+		void channel;
+		void zoneCode;
+		void loadInitial();
+	});
+
+	$effect(() => {
+		const el = sentinel;
+		if (!el) return;
+		const observer = new IntersectionObserver((entries) => {
+			if (entries.some((e) => e.isIntersecting)) void loadMore();
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	});
+
+	async function loadInitial() {
+		if (!machineId) return;
+		loading = true;
+		error = null;
+		crops = [];
+		nextCursor = null;
+		try {
+			const res = await api.getMachineChannelCrops(machineId, {
+				limit: PAGE_SIZE,
+				channel,
+				zoneCode
+			});
+			machineName = res.machine.name;
+			crops = res.items;
+			total = res.total;
+			nextCursor = res.next_cursor;
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to load channel crops');
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadMore() {
+		if (loadingMore || loading || nextCursor == null) return;
+		loadingMore = true;
+		try {
+			const res = await api.getMachineChannelCrops(machineId, {
+				limit: PAGE_SIZE,
+				cursor: nextCursor,
+				channel,
+				zoneCode
+			});
+			crops = [...crops, ...res.items];
+			nextCursor = res.next_cursor;
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to load more crops');
+		} finally {
+			loadingMore = false;
+		}
+	}
+
+	function errMsg(e: unknown, fallback: string): string {
+		return e && typeof e === 'object' && 'error' in e
+			? String((e as { error: unknown }).error)
+			: fallback;
+	}
+
+	const ZONE_LABELS: Record<number, string> = { 0: 'mid', 1: 'drop', 2: 'exit', 3: 'precise' };
+
+	function zoneLabel(z: number | null): string {
+		return z == null ? '—' : (ZONE_LABELS[z] ?? String(z));
+	}
+
+	// Border color encodes the zone the piece's COM sat in — dense near the exit
+	// is where the same-piece heuristic cares most, so make exit/precise pop.
+	function zoneBorder(z: number | null): string {
+		switch (z) {
+			case 3:
+				return 'border-success';
+			case 2:
+				return 'border-primary';
+			case 1:
+				return 'border-info';
+			default:
+				return 'border-border';
+		}
+	}
+
+	function deg(d: number | null): string {
+		return d == null ? '—' : `${d.toFixed(1)}°`;
+	}
+
+	function when(iso: string | null): string {
+		if (!iso) return '—';
+		return new Date(iso).toLocaleTimeString();
+	}
+
+	const CHANNEL_FILTERS = [
+		{ label: 'All channels', value: null },
+		{ label: 'C2', value: 2 },
+		{ label: 'C3', value: 3 }
+	];
+	const ZONE_FILTERS = [
+		{ label: 'All zones', value: null },
+		{ label: 'Exit', value: 2 },
+		{ label: 'Precise', value: 3 },
+		{ label: 'Drop', value: 1 },
+		{ label: 'Mid', value: 0 }
+	];
+</script>
+
+<svelte:head>
+	<title>{machineName ? `${machineName} — Channel crops` : 'Channel crops'} · Hive</title>
+</svelte:head>
+
+<div class="mb-4">
+	<a href={`/machines/${machineId}`} class="text-sm text-text-muted hover:text-text">← Machine overview</a>
+</div>
+
+<div class="mb-4 flex items-end justify-between">
+	<div>
+		<h1 class="text-2xl font-bold text-text">{machineName || 'Machine'}</h1>
+		<p class="text-sm text-text-muted">
+			Unlabeled C2/C3 bbox crops synced from this machine — tagged with the piece's
+			distance to the exit zone, for same-piece lookup.
+		</p>
+	</div>
+	{#if !loading}
+		<span class="shrink-0 text-sm text-text-muted">
+			{crops.length.toLocaleString()} of {total.toLocaleString()} loaded
+		</span>
+	{/if}
+</div>
+
+<div class="mb-5 flex flex-wrap items-center gap-2">
+	<div class="flex flex-wrap gap-1">
+		{#each CHANNEL_FILTERS as f (f.label)}
+			<Button
+				variant={channel === f.value ? 'primary' : 'secondary'}
+				size="sm"
+				onclick={() => (channel = f.value)}>{f.label}</Button
+			>
+		{/each}
+	</div>
+	<div class="flex flex-wrap gap-1">
+		{#each ZONE_FILTERS as f (f.label)}
+			<Button
+				variant={zoneCode === f.value ? 'primary' : 'secondary'}
+				size="sm"
+				onclick={() => (zoneCode = f.value)}>{f.label}</Button
+			>
+		{/each}
+	</div>
+</div>
+
+{#if error}
+	<div class="mb-4 bg-primary/8 p-3 text-sm text-primary">{error}</div>
+{/if}
+
+{#if loading}
+	<div class="flex justify-center py-12">
+		<Spinner />
+	</div>
+{:else if crops.length === 0}
+	<div class="border border-border bg-surface p-8 text-center text-sm text-text-muted">
+		No channel crops synced from this machine yet.
+	</div>
+{:else}
+	<div class="flex flex-wrap gap-2">
+		{#each crops as crop (crop.local_id)}
+			<div class="flex w-24 flex-col border border-border bg-surface p-1">
+				{#if crop.available}
+					<img
+						src={api.machineChannelCropImageUrl(machineId, crop.local_id)}
+						alt={`crop ${crop.local_id}`}
+						loading="lazy"
+						title={`C${crop.channel} · ${zoneLabel(crop.zone_code)} · ${deg(
+							crop.com_forward_to_exit_deg
+						)} to exit · track ${crop.track_id ?? '—'} · ${when(crop.ts)}`}
+						class="h-20 w-full border-2 object-contain {zoneBorder(crop.zone_code)}"
+					/>
+				{:else}
+					<div
+						class="flex h-20 w-full items-center justify-center border border-dashed border-border bg-bg text-center text-[9px] text-text-muted"
+						title="evicted before sync"
+					>
+						evicted
+					</div>
+				{/if}
+				<div class="mt-1 text-center text-[10px] leading-tight text-text-muted">
+					<div class="text-text">C{crop.channel} · {zoneLabel(crop.zone_code)}</div>
+					<div class="tabular-nums">{deg(crop.com_forward_to_exit_deg)}</div>
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	<div bind:this={sentinel} class="h-px"></div>
+
+	<div class="flex justify-center py-6">
+		{#if loadingMore}
+			<Spinner />
+		{:else if nextCursor != null}
+			<Button variant="secondary" size="sm" onclick={loadMore}>Load more</Button>
+		{:else}
+			<span class="text-xs text-text-muted">End of list · {total.toLocaleString()} crops total</span>
+		{/if}
+	</div>
+{/if}

--- a/software/sorter/backend/channel_crop_lookup.py
+++ b/software/sorter/backend/channel_crop_lookup.py
@@ -1,0 +1,118 @@
+"""'Possibly the same piece' lookup over the unlabeled C2/C3 channel crops.
+
+Given a classified piece (which we saw arrive at the classification channel / C4
+at time T), find the upstream C2/C3 bbox crops that are plausibly the same
+physical piece — cheaply, by time + channel + distance-to-exit, without
+embeddings or cross-channel tracking.
+
+Model (calibrated on a real kitbash run, 19 pieces traced by eye):
+  - A piece is reliably captured in the C3 exit/precise band (small COM-to-exit
+    degrees) ~0.2..7s before its C4 arrival (median ~3s; up to ~13s if it
+    stalls). This is 'the bbox that just disappeared' — highest confidence.
+  - Its earlier C3 crops (mid/drop, larger degrees) extend back to ~T-18s,
+    progressively contaminated by the pieces queued behind it.
+  - C2 rarely contains the specific piece within the window; keep a wide,
+    low-weight net so we don't exclude it when present (superset), expect noise.
+  - Track ids are unreliable (often absent, reused across pieces) — not used.
+
+The result is a SUPERSET ranked by confidence: the true crops are (almost)
+always included; the top of the list is dominated by the correct piece.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import channel_crop_store
+
+CLASSIFICATION_CHANNEL_ID = 4
+
+ZONE_EXIT = 2
+ZONE_PRECISE = 3
+EXIT_DEG = 20.0
+C3_EXIT_LOOKBACK = 16.0
+C3_LOOKBACK = 22.0
+C2_LOOKBACK = 60.0
+FWD_SLOP = 1.5
+PEAK_DT = 3.0
+
+
+def _atExit(zone: Optional[int], deg: Optional[float]) -> bool:
+    return zone in (ZONE_EXIT, ZONE_PRECISE) or (deg is not None and abs(deg) < EXIT_DEG)
+
+
+def scoreCrop(crop: dict[str, Any], arrival_ts: float) -> Optional[float]:
+    ts = crop.get("ts")
+    if ts is None:
+        return None
+    dt = arrival_ts - ts
+    if dt < -FWD_SLOP:
+        return None
+    channel = crop.get("channel")
+    zone = crop.get("zone_code")
+    deg = crop.get("com_forward_to_exit_deg")
+    if channel == 3:
+        if _atExit(zone, deg) and dt <= C3_EXIT_LOOKBACK:
+            return max(0.5, 0.9 - abs(dt - PEAK_DT) * 0.028)
+        if dt <= C3_LOOKBACK:
+            return max(0.15, 0.5 - dt * 0.014)
+        return None
+    if channel == 2:
+        if 2.0 <= dt <= C2_LOOKBACK:
+            return max(0.05, 0.32 - dt * 0.003)
+        return None
+    return None
+
+
+def _arrivalTs(gc: Any, piece_uuid: str) -> Optional[float]:
+    # When the piece reached the classification channel: earliest C4 crop ts,
+    # else earliest crop ts of any kind, else the piece record's seen_at.
+    try:
+        import piece_image_store
+
+        images = piece_image_store.listPieceImages(piece_uuid)
+        c4 = [im["ts"] for im in images if im.get("channel") == CLASSIFICATION_CHANNEL_ID and im.get("ts")]
+        if c4:
+            return float(min(c4))
+        any_ts = [im["ts"] for im in images if im.get("ts")]
+        if any_ts:
+            return float(min(any_ts))
+    except Exception:
+        pass
+    try:
+        import piece_records
+
+        summary = piece_records.getPieceSummaryByUuid(gc, piece_uuid)
+        seen = summary.get("seen_at") if isinstance(summary, dict) else None
+        if isinstance(seen, (int, float)):
+            return float(seen)
+    except Exception:
+        pass
+    return None
+
+
+def findPossibleCrops(gc: Any, piece_uuid: str, limit: int = 40) -> dict[str, Any]:
+    arrival_ts = _arrivalTs(gc, piece_uuid)
+    if arrival_ts is None:
+        return {"arrival_ts": None, "candidates": []}
+    crops = channel_crop_store.listCropsByTimeRange(arrival_ts - C2_LOOKBACK, arrival_ts + FWD_SLOP)
+    scored: list[dict[str, Any]] = []
+    for crop in crops:
+        s = scoreCrop(crop, arrival_ts)
+        if s is None:
+            continue
+        scored.append(
+            {
+                "id": crop["id"],
+                "channel": crop["channel"],
+                "ts": crop["ts"],
+                "dt": round(arrival_ts - crop["ts"], 2),
+                "zone_code": crop["zone_code"],
+                "com_forward_to_exit_deg": crop["com_forward_to_exit_deg"],
+                "track_id": crop["track_id"],
+                "sharpness": crop["sharpness"],
+                "score": round(s, 3),
+            }
+        )
+    scored.sort(key=lambda c: c["score"], reverse=True)
+    return {"arrival_ts": arrival_ts, "candidates": scored[:limit]}

--- a/software/sorter/backend/channel_crop_store.py
+++ b/software/sorter/backend/channel_crop_store.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import queue
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from local_state import local_state_db_path
+
+# Durable store for UNLABELED channel bbox crops. Unlike piece_image_store
+# (which keys every crop to a known piece_uuid gathered during classification),
+# this store holds crops of pieces seen on the upstream feeder channels (C2/C3)
+# where we do NOT yet know which piece it is. Each crop is tagged with the
+# metadata a cheap time/angle heuristic can later use to guess "possibly the
+# same piece": the channel, the frame timestamp, the piece's signed
+# center-of-mass distance to the exit zone in output degrees
+# (com_forward_to_exit_deg), the zone the COM sits in, and the advisory
+# per-pass ByteTrack id (crops sharing one (channel, track_id) over a short
+# window are the same physical piece).
+#
+# Rows carry an autoincrement id (the sync cursor) plus hive sync markers
+# (synced_at / hive_crop_id) mirroring piece_image_store, so the shared
+# HiveSyncWorker can drain them to the Hive and retention prefers evicting
+# already-synced files. The cap bounds disk at ~512 MB even if sync is absent.
+#
+# Writes never happen on the perception hot path: the capture collector
+# enqueues already-encoded JPEG bytes + metadata (bounded, drop-on-full) and a
+# single daemon worker does the file write, insert, and retention sweep.
+
+_INIT_LOCK = threading.Lock()
+_initialized = False
+
+_QUEUE_MAX_ITEMS = 512
+_RETENTION_SWEEP_INTERVAL_S = 60.0
+# Retention: over the cap, oldest files are deleted first, already-synced files
+# before unsynced ones. 512 MB is the budget Spencer set for these crops.
+_MAX_TOTAL_BYTES = 512 * 1024 * 1024
+
+_queue: "queue.Queue[tuple[bytes, dict[str, Any]]]" = queue.Queue(maxsize=_QUEUE_MAX_ITEMS)
+_worker_started = threading.Event()
+_logger: Any = None
+
+_stats_lock = threading.Lock()
+_stats = {
+    "enqueued": 0,
+    "dropped_queue_full": 0,
+    "written": 0,
+    "write_errors": 0,
+    "evicted_files": 0,
+}
+
+
+def configure(logger: Any) -> None:
+    global _logger
+    _logger = logger
+
+
+def _log(level: str, message: str) -> None:
+    logger = _logger
+    if logger is None:
+        return
+    try:
+        getattr(logger, level)(message)
+    except Exception:
+        pass
+
+
+def channel_crops_dir() -> Path:
+    return local_state_db_path().parent / "channel_crops"
+
+
+def _connect() -> sqlite3.Connection:
+    db_path = local_state_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path, timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA synchronous = NORMAL")
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
+@contextmanager
+def _connection() -> Iterator[sqlite3.Connection]:
+    _ensureInitialized()
+    conn = _connect()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _ensureInitialized() -> None:
+    global _initialized
+    if _initialized:
+        return
+    with _INIT_LOCK:
+        if _initialized:
+            return
+        conn = _connect()
+        try:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS channel_crops ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "channel INTEGER, "
+                # Frame capture time (epoch seconds) and row insert time.
+                "ts REAL, "
+                "created_at REAL NOT NULL, "
+                # Advisory per-pass ByteTrack id — same physical piece keeps one
+                # id across frames on a channel. NULL when tracking unavailable.
+                "track_id INTEGER, "
+                # Signed COM distance to the exit zone in output degrees; the key
+                # field the time/angle same-piece heuristic reads. NULL if unknown.
+                "com_forward_to_exit_deg REAL, "
+                "com_section INTEGER, "
+                # 0=none, 1=drop, 2=exit_only, 3=precise (perception.arcs LUT).
+                "zone_code INTEGER, "
+                "sharpness REAL, "
+                "bbox_x1 INTEGER, bbox_y1 INTEGER, bbox_x2 INTEGER, bbox_y2 INTEGER, "
+                "bytes INTEGER NOT NULL, "
+                # Path relative to channel_crops_dir().
+                "file_path TEXT NOT NULL, "
+                # Set when retention removed the local file; the row (and any hive
+                # pointer) survives so the crop stays addressable.
+                "deleted_at REAL, "
+                # Hive sync markers, written by the shared HiveSyncWorker.
+                "synced_at REAL, "
+                "hive_crop_id TEXT"
+                ")"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_channel_crops_live "
+                "ON channel_crops(created_at) WHERE deleted_at IS NULL"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_channel_crops_channel_ts "
+                "ON channel_crops(channel, ts)"
+            )
+            conn.commit()
+            _initialized = True
+        finally:
+            conn.close()
+
+
+def enqueue(jpeg: bytes, meta: dict[str, Any]) -> None:
+    """Persist one already-encoded JPEG crop with its metadata. Called off the
+    perception hot path by the capture collector; bounded + drop-on-full so a
+    slow disk never stalls capture."""
+    if not jpeg:
+        return
+    _ensureWorker()
+    try:
+        _queue.put_nowait((jpeg, dict(meta)))
+        with _stats_lock:
+            _stats["enqueued"] += 1
+    except queue.Full:
+        with _stats_lock:
+            _stats["dropped_queue_full"] += 1
+
+
+def _ensureWorker() -> None:
+    if _worker_started.is_set():
+        return
+    with _INIT_LOCK:
+        if _worker_started.is_set():
+            return
+        thread = threading.Thread(target=_workerLoop, daemon=True, name="channel-crop-store")
+        thread.start()
+        _worker_started.set()
+
+
+def _workerLoop() -> None:
+    last_sweep = 0.0
+    while True:
+        item: tuple[bytes, dict[str, Any]] | None
+        try:
+            item = _queue.get(timeout=_RETENTION_SWEEP_INTERVAL_S)
+        except queue.Empty:
+            item = None
+        if item is not None:
+            jpeg, meta = item
+            try:
+                _writeCrop(jpeg, meta)
+                with _stats_lock:
+                    _stats["written"] += 1
+            except Exception as exc:
+                with _stats_lock:
+                    _stats["write_errors"] += 1
+                _log("warning", f"channel_crop_store: failed to persist crop: {exc}")
+        now = time.monotonic()
+        if now - last_sweep >= _RETENTION_SWEEP_INTERVAL_S:
+            last_sweep = now
+            try:
+                _retentionSweep()
+            except Exception as exc:
+                _log("warning", f"channel_crop_store: retention sweep failed: {exc}")
+
+
+def _asInt(value: Any) -> Optional[int]:
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def _asFloat(value: Any) -> Optional[float]:
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _writeCrop(jpeg: bytes, meta: dict[str, Any]) -> None:
+    created_at = meta.get("created_at")
+    if not isinstance(created_at, (int, float)):
+        created_at = time.time()
+    channel = _asInt(meta.get("channel"))
+    bbox = meta.get("bbox") or (None, None, None, None)
+    # Insert first (file_path filled with a placeholder), then name the file by
+    # the assigned rowid so the on-disk name matches the sync cursor.
+    with _connection() as conn:
+        cur = conn.execute(
+            "INSERT INTO channel_crops "
+            "(channel, ts, created_at, track_id, com_forward_to_exit_deg, com_section, "
+            "zone_code, sharpness, bbox_x1, bbox_y1, bbox_x2, bbox_y2, bytes, file_path) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '')",
+            (
+                channel,
+                _asFloat(meta.get("ts")),
+                float(created_at),
+                _asInt(meta.get("track_id")),
+                _asFloat(meta.get("com_forward_to_exit_deg")),
+                _asInt(meta.get("com_section")),
+                _asInt(meta.get("zone_code")),
+                _asFloat(meta.get("sharpness")),
+                _asInt(bbox[0]),
+                _asInt(bbox[1]),
+                _asInt(bbox[2]),
+                _asInt(bbox[3]),
+                len(jpeg),
+            ),
+        )
+        crop_id = int(cur.lastrowid or 0)
+        rel_path = f"ch{channel if channel is not None else 'x'}/{crop_id}.jpg"
+        abs_path = channel_crops_dir() / rel_path
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_path.write_bytes(jpeg)
+        conn.execute(
+            "UPDATE channel_crops SET file_path = ? WHERE id = ?", (rel_path, crop_id)
+        )
+        conn.commit()
+
+
+def _retentionSweep() -> None:
+    with _connection() as conn:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(bytes), 0) AS total FROM channel_crops WHERE deleted_at IS NULL"
+        ).fetchone()
+        total = int(row["total"]) if row is not None else 0
+        if total <= _MAX_TOTAL_BYTES:
+            return
+        overage = total - _MAX_TOTAL_BYTES
+        # Synced files go first ((synced_at IS NULL)=0 sorts before 1), oldest
+        # first within each group.
+        rows = conn.execute(
+            "SELECT id, file_path, bytes FROM channel_crops WHERE deleted_at IS NULL "
+            "ORDER BY (synced_at IS NULL) ASC, created_at ASC LIMIT 1000"
+        ).fetchall()
+        now = time.time()
+        freed = 0
+        evicted = 0
+        for r in rows:
+            if freed >= overage:
+                break
+            abs_path = channel_crops_dir() / str(r["file_path"])
+            try:
+                abs_path.unlink(missing_ok=True)
+                parent = abs_path.parent
+                if parent != channel_crops_dir() and not any(parent.iterdir()):
+                    parent.rmdir()
+            except OSError:
+                pass
+            conn.execute(
+                "UPDATE channel_crops SET deleted_at = ? WHERE id = ?",
+                (now, int(r["id"])),
+            )
+            freed += int(r["bytes"] or 0)
+            evicted += 1
+        conn.commit()
+    if evicted:
+        with _stats_lock:
+            _stats["evicted_files"] += evicted
+        _log(
+            "info",
+            f"channel_crop_store: retention evicted {evicted} files ({freed / 1024 / 1024:.1f} MB)",
+        )
+
+
+def _rowToDict(r: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": int(r["id"]),
+        "channel": r["channel"],
+        "ts": r["ts"],
+        "created_at": r["created_at"],
+        "track_id": r["track_id"],
+        "com_forward_to_exit_deg": r["com_forward_to_exit_deg"],
+        "com_section": r["com_section"],
+        "zone_code": r["zone_code"],
+        "sharpness": r["sharpness"],
+        "bbox": [r["bbox_x1"], r["bbox_y1"], r["bbox_x2"], r["bbox_y2"]],
+        "bytes": int(r["bytes"] or 0),
+    }
+
+
+def listCropsAfter(after_id: int, limit: int) -> list[dict[str, Any]]:
+    # Rows ASC by id for the Hive sync worker; the cursor is id > after_id.
+    # Includes deleted_at so the worker knows file-present vs evicted.
+    with _connection() as conn:
+        rows = conn.execute(
+            "SELECT id, channel, ts, created_at, track_id, com_forward_to_exit_deg, "
+            "com_section, zone_code, sharpness, bbox_x1, bbox_y1, bbox_x2, bbox_y2, "
+            "bytes, deleted_at FROM channel_crops WHERE id > ? ORDER BY id ASC LIMIT ?",
+            (int(after_id), int(limit)),
+        ).fetchall()
+    out = []
+    for r in rows:
+        d = _rowToDict(r)
+        d["evicted_locally"] = r["deleted_at"] is not None
+        out.append(d)
+    return out
+
+
+def listCropsByTimeRange(t_start: float, t_end: float) -> list[dict[str, Any]]:
+    # Live (non-evicted) crops whose frame ts falls in [t_start, t_end], newest
+    # first. Backs the 'possibly the same piece' time/angle lookup.
+    with _connection() as conn:
+        rows = conn.execute(
+            "SELECT id, channel, ts, created_at, track_id, com_forward_to_exit_deg, "
+            "com_section, zone_code, sharpness, bbox_x1, bbox_y1, bbox_x2, bbox_y2, bytes "
+            "FROM channel_crops WHERE deleted_at IS NULL AND ts >= ? AND ts <= ? "
+            "ORDER BY ts DESC",
+            (float(t_start), float(t_end)),
+        ).fetchall()
+    return [_rowToDict(r) for r in rows]
+
+
+def getCropFileById(crop_id: int) -> Optional[Path]:
+    with _connection() as conn:
+        row = conn.execute(
+            "SELECT file_path, deleted_at FROM channel_crops WHERE id = ?",
+            (int(crop_id),),
+        ).fetchone()
+    if row is None or row["deleted_at"] is not None:
+        return None
+    abs_path = channel_crops_dir() / str(row["file_path"])
+    return abs_path if abs_path.is_file() else None
+
+
+def getMaxCropId() -> int:
+    with _connection() as conn:
+        row = conn.execute("SELECT COALESCE(MAX(id), 0) AS m FROM channel_crops").fetchone()
+    return int(row["m"] or 0)
+
+
+def markSyncedUpTo(max_id: int, synced_at: float) -> None:
+    # Retention hint only (mirrors piece_image_store.markImagesSyncedUpTo): stamp
+    # synced_at on rows at/below the min watermark across all enabled hive
+    # targets so retention only evicts a crop once every hive has it.
+    if max_id <= 0:
+        return
+    with _connection() as conn:
+        conn.execute(
+            "UPDATE channel_crops SET synced_at = ? WHERE id <= ? AND synced_at IS NULL",
+            (float(synced_at), int(max_id)),
+        )
+        conn.commit()
+
+
+def getStats() -> dict[str, Any]:
+    with _stats_lock:
+        stats = dict(_stats)
+    stats["queue_depth"] = _queue.qsize()
+    with _connection() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n, COALESCE(SUM(bytes), 0) AS total FROM channel_crops "
+            "WHERE deleted_at IS NULL"
+        ).fetchone()
+        stats["live_files"] = int(row["n"]) if row is not None else 0
+        stats["live_bytes"] = int(row["total"]) if row is not None else 0
+        row = conn.execute("SELECT COUNT(*) AS n FROM channel_crops").fetchone()
+        stats["total_rows"] = int(row["n"]) if row is not None else 0
+    return stats

--- a/software/sorter/backend/hive_telemetry.py
+++ b/software/sorter/backend/hive_telemetry.py
@@ -39,6 +39,12 @@ TELEMETRY_FIELDS: tuple[dict[str, Any], ...] = (
         "description": "Classification results per piece (part, color, confidence, bin, timestamps) and set sorting progress.",
         "default": True,
     },
+    {
+        "key": "channel_crops",
+        "label": "Channel crops (C2/C3)",
+        "description": "Unlabeled bbox crops of pieces on the upstream feeder channels, tagged with position for same-piece lookup. Off by default — experimental, high volume.",
+        "default": False,
+    },
 )
 
 _TELEMETRY_FIELD_KEYS = tuple(field["key"] for field in TELEMETRY_FIELDS)
@@ -166,6 +172,21 @@ class HiveTelemetryClient:
             "POST",
             "/api/machine/sync/piece-image",
             fields=("detection_images",),
+            data={"metadata": json.dumps(meta)},
+            files=files,
+            timeout=60,
+        )
+        return int(response.json()["max_local_id"])
+
+    def pushChannelCrop(self, meta: dict[str, Any], file_path: Path | None) -> int:
+        files = None
+        if file_path is not None and file_path.is_file():
+            with open(file_path, "rb") as handle:
+                files = {"image": (file_path.name, handle.read(), "image/jpeg")}
+        response = self._request(
+            "POST",
+            "/api/machine/sync/channel-crop",
+            fields=("channel_crops",),
             data={"metadata": json.dumps(meta)},
             files=files,
             timeout=60,

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -188,6 +188,18 @@ def _maybeStartPerception(gc: GlobalConfig, irl_config, camera_service) -> None:
     except Exception as exc:
         gc.logger.warning(f"Failed to start upstream-crop store: {exc}")
 
+    try:
+        import channel_crop_store
+        from perception.channel_crop_capture import ChannelCropCollector
+
+        channel_crop_store.configure(gc.logger)
+        collector = ChannelCropCollector(perception_service=service, logger=gc.logger)
+        collector.start()
+        service.channel_crop_collector = collector
+        gc.logger.info("Channel-crop capture collector started.")
+    except Exception as exc:
+        gc.logger.warning(f"Failed to start channel-crop collector: {exc}")
+
 
 def runServer(gc: GlobalConfig) -> None:
     # Bind to loopback by default. Setting SORTER_API_HOST=0.0.0.0 (or a

--- a/software/sorter/backend/perception/channel_crop_capture.py
+++ b/software/sorter/backend/perception/channel_crop_capture.py
@@ -1,0 +1,279 @@
+"""Capture collector for unlabeled C2/C3 channel bbox crops.
+
+Polls each upstream channel's latest ``(pieces, frame)`` from the perception
+service, decides per piece whether to grab a crop (a cheap cadence gate keyed
+on the piece's advisory ByteTrack id + how far its center-of-mass has travelled
+toward the exit since its last capture), crops + JPEG-encodes off the hot path,
+and hands the bytes to ``channel_crop_store`` for durable, size-capped storage.
+
+The cadence is deliberately zone-aware so the crops we keep are dense exactly
+where the same-piece heuristic needs them — many right at the C3 exit (a piece
+about to fall onto C4), fewer in the drop zone, and just a couple per pass on
+C2. All thresholds are plain constants so they can be tuned against a real run.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import cv2
+import numpy as np
+
+import channel_crop_store
+
+
+# Region codes from perception.arcs._region_lookup / PieceObservation.zone_code.
+_ZONE_NONE = 0
+_ZONE_DROP = 1
+_ZONE_EXIT_ONLY = 2
+_ZONE_PRECISE = 3
+
+
+@dataclass(frozen=True)
+class _ZoneCadence:
+    # Capture again once the piece's COM has advanced this many output degrees
+    # toward the exit since its last capture for this track.
+    advance_deg: float
+    # Hard cap on crops kept per track while it sits in this zone band.
+    max_captures: int
+
+
+@dataclass
+class ChannelCropCaptureConfig:
+    enabled: bool = True
+    channels: tuple[int, ...] = (2, 3)
+    # Poll faster than the ~30 Hz camera; the per-frame-ts dedup + cadence gate
+    # do the real rate limiting.
+    poll_interval_s: float = 0.03
+    crop_pad_px: int = 6
+    jpeg_quality: int = 80
+    # Never take two crops of one track closer together in time than this, even
+    # if it jumped zones — guards against duplicate near-identical frames.
+    min_capture_interval_s: float = 0.05
+    # Forget a track this long after we last saw it (a new pass reuses the id).
+    track_ttl_s: float = 4.0
+    # Zone-aware cadence for C3 (the interesting channel). Exit/precise get dense
+    # coverage; drop and between-zone get sparse.
+    c3_cadence: dict[int, _ZoneCadence] = field(
+        default_factory=lambda: {
+            _ZONE_PRECISE: _ZoneCadence(advance_deg=3.0, max_captures=4),
+            _ZONE_EXIT_ONLY: _ZoneCadence(advance_deg=3.0, max_captures=4),
+            _ZONE_DROP: _ZoneCadence(advance_deg=12.0, max_captures=2),
+            _ZONE_NONE: _ZoneCadence(advance_deg=18.0, max_captures=2),
+        }
+    )
+    # C2 is far upstream — Spencer wants roughly two crops per pass, no more.
+    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=25.0, max_captures=2)
+
+
+@dataclass
+class _TrackState:
+    last_capture_ts: float
+    last_capture_deg: Optional[float]
+    count: int
+    last_seen_ts: float
+
+
+class ChannelCropCollector:
+    def __init__(self, *, perception_service: Any, logger: Any = None,
+                 config: Optional[ChannelCropCaptureConfig] = None) -> None:
+        self._service = perception_service
+        self._logger = logger
+        self._cfg = config or ChannelCropCaptureConfig()
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        # (channel_id, track_key) -> _TrackState
+        self._tracks: dict[tuple[int, Any], _TrackState] = {}
+        self._last_frame_ts: dict[int, float] = {}
+        self._last_prune = 0.0
+        self._captured_total = 0
+
+    # --- lifecycle ------------------------------------------------------
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._loop, daemon=True, name="channel-crop-collector"
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+        self._thread = None
+
+    def stats(self) -> dict[str, Any]:
+        return {"captured_total": self._captured_total, "tracked": len(self._tracks)}
+
+    # --- gating ---------------------------------------------------------
+
+    def _isSorting(self) -> bool:
+        # Only collect while actively sorting (RUNNING) — pieces aren't flowing
+        # otherwise. Mirrors UpstreamCropStore._isSorting.
+        try:
+            from server import shared_state
+            from defs.sorter_controller import SorterLifecycle
+
+            controller = shared_state.controller_ref
+            if controller is None:
+                return False
+            return controller.state == SorterLifecycle.RUNNING
+        except Exception:
+            return False
+
+    # --- loop -----------------------------------------------------------
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            cfg = self._cfg
+            if not cfg.enabled or not self._isSorting():
+                self._stop.wait(0.5)
+                continue
+            for channel_id in cfg.channels:
+                try:
+                    self._collectChannel(channel_id, cfg)
+                except Exception as exc:
+                    _log(self._logger, "warning",
+                         f"[channel-crop] collect ch{channel_id} failed: {exc}")
+            self._maybePrune()
+            self._stop.wait(cfg.poll_interval_s)
+
+    def _collectChannel(self, channel_id: int, cfg: ChannelCropCaptureConfig) -> None:
+        res = self._service.read_pieces_and_frame(channel_id)
+        if res is None:
+            return
+        pieces, frame = res
+        if not pieces:
+            return
+        ts = float(frame.timestamp)
+        if self._last_frame_ts.get(channel_id) == ts:
+            return
+        self._last_frame_ts[channel_id] = ts
+        bgr = frame.bgr
+        if bgr is None or bgr.size == 0:
+            return
+        h, w = bgr.shape[:2]
+        now = time.time()
+        for piece in pieces:
+            self._considerPiece(channel_id, piece, bgr, w, h, ts, now, cfg)
+
+    def _cadenceFor(self, channel_id: int, zone_code: int,
+                    cfg: ChannelCropCaptureConfig) -> _ZoneCadence:
+        if channel_id == 2:
+            return cfg.c2_cadence
+        return cfg.c3_cadence.get(zone_code, cfg.c3_cadence[_ZONE_NONE])
+
+    def _considerPiece(self, channel_id: int, piece: Any, bgr: np.ndarray,
+                       w: int, h: int, ts: float, now: float,
+                       cfg: ChannelCropCaptureConfig) -> None:
+        zone_code = int(getattr(piece, "zone_code", 0) or 0)
+        deg = getattr(piece, "com_forward_to_exit_deg", None)
+        deg_f = float(deg) if isinstance(deg, (int, float)) else None
+        cadence = self._cadenceFor(channel_id, zone_code, cfg)
+
+        track_id = getattr(piece, "sv_bt_track_id", None)
+        # Without a stable id we can't associate a piece across frames, so bucket
+        # by coarse COM section (~4 deg) as a stand-in identity for the gate.
+        if track_id is not None:
+            track_key: Any = ("t", int(track_id))
+        else:
+            section = int(getattr(piece, "com_section", 0) or 0)
+            track_key = ("p", section // 4)
+        key = (channel_id, track_key)
+
+        state = self._tracks.get(key)
+        if state is not None:
+            state.last_seen_ts = now
+            if now - state.last_capture_ts < cfg.min_capture_interval_s:
+                return
+            if state.count >= cadence.max_captures:
+                return
+            # Advance gate: only re-capture once the piece has travelled far
+            # enough toward the exit (smaller deg = more forward). If either deg
+            # is unknown, fall through and capture (time gate already passed).
+            if deg_f is not None and state.last_capture_deg is not None:
+                if state.last_capture_deg - deg_f < cadence.advance_deg:
+                    return
+
+        bbox = getattr(piece, "bbox", None)
+        crop = _cropBbox(bgr, bbox, cfg.crop_pad_px, w, h)
+        if crop is None or crop.size == 0:
+            return
+        ok, buf = cv2.imencode(
+            ".jpg", crop, [int(cv2.IMWRITE_JPEG_QUALITY), int(cfg.jpeg_quality)]
+        )
+        if not ok:
+            return
+        jpeg = buf.tobytes()
+        meta = {
+            "channel": channel_id,
+            "ts": ts,
+            "created_at": now,
+            "track_id": int(track_id) if track_id is not None else None,
+            "com_forward_to_exit_deg": deg_f,
+            "com_section": int(getattr(piece, "com_section", 0) or 0),
+            "zone_code": zone_code,
+            "sharpness": _sharpness(crop),
+            "bbox": tuple(int(v) for v in bbox) if bbox else None,
+        }
+        channel_crop_store.enqueue(jpeg, meta)
+        self._captured_total += 1
+
+        if state is None:
+            self._tracks[key] = _TrackState(
+                last_capture_ts=now, last_capture_deg=deg_f, count=1, last_seen_ts=now
+            )
+        else:
+            state.last_capture_ts = now
+            state.last_capture_deg = deg_f
+            state.count += 1
+
+    def _maybePrune(self) -> None:
+        now = time.time()
+        if now - self._last_prune < 1.0:
+            return
+        self._last_prune = now
+        ttl = self._cfg.track_ttl_s
+        stale = [k for k, s in self._tracks.items() if now - s.last_seen_ts > ttl]
+        for k in stale:
+            self._tracks.pop(k, None)
+
+
+def _cropBbox(bgr: np.ndarray, bbox: Any, pad: int, w: int, h: int) -> Optional[np.ndarray]:
+    if not bbox:
+        return None
+    try:
+        x1, y1, x2, y2 = float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3])
+    except (TypeError, ValueError, IndexError):
+        return None
+    xa = max(0, int(round(min(x1, x2))) - pad)
+    ya = max(0, int(round(min(y1, y2))) - pad)
+    xb = min(w, int(round(max(x1, x2))) + pad)
+    yb = min(h, int(round(max(y1, y2))) + pad)
+    if xb <= xa or yb <= ya:
+        return None
+    # Copy — the capture thread reuses the frame buffer once we return.
+    return bgr[ya:yb, xa:xb].copy()
+
+
+def _sharpness(crop: np.ndarray) -> Optional[float]:
+    try:
+        gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY)
+        return float(cv2.Laplacian(gray, cv2.CV_64F).var())
+    except Exception:
+        return None
+
+
+def _log(logger: Any, level: str, message: str) -> None:
+    if logger is None:
+        return
+    try:
+        getattr(logger, level)(message)
+    except Exception:
+        pass

--- a/software/sorter/backend/perception/inference.py
+++ b/software/sorter/backend/perception/inference.py
@@ -202,6 +202,13 @@ class InferenceWorker:
         # frame they were computed against without triggering a new inference.
         self._latest_raw: Optional[tuple] = None
 
+        # Latest ``(pieces, PerceptionFrame)`` written together in the hot loop so
+        # a consumer (the channel-crop capture collector) gets a per-piece
+        # PieceObservation list — bbox + angle + zone + track id — consistent with
+        # the exact frame it was computed against. GIL-atomic tuple ref, same
+        # pattern as ``latest_raw``; off the state-machine read path.
+        self._latest_pieces_frame: Optional[tuple] = None
+
         # Richer record for the perception-debug overlay only: raw (pre-filter)
         # bboxes, the on-channel subset, the crop rect, the frame, and timing.
         # GIL-atomic dict ref; never read on the hot path.
@@ -257,6 +264,13 @@ class InferenceWorker:
         """Latest ``(bboxes, PerceptionFrame)`` pair from the last successful
         inference. GIL-atomic read — no lock required."""
         return self._latest_raw
+
+    @property
+    def latest_pieces_frame(self) -> Optional[tuple]:
+        """Latest ``(pieces, PerceptionFrame)`` from the last successful
+        inference — per-piece PieceObservations (bbox + angle + zone + track id)
+        with the frame they were computed against. GIL-atomic read."""
+        return self._latest_pieces_frame
 
     @property
     def latest_debug(self) -> Optional[dict]:
@@ -674,6 +688,7 @@ class InferenceWorker:
                 )
                 self._slot.write(state)
                 self._latest_raw = (list(bboxes), frame)
+                self._latest_pieces_frame = (pieces, frame)
                 # Tag ALL in-crop detections (not just on-channel) with zone
                 # provenance so the overlay can show foreign-zone hits and future
                 # consumers can ask which zone a piece is in. Off the hot read

--- a/software/sorter/backend/perception/service.py
+++ b/software/sorter/backend/perception/service.py
@@ -362,6 +362,17 @@ class PerceptionService:
         on_channel = [b for b in bboxes if bboxInsideChannelMask(b, channel)]
         return on_channel, frame
 
+    def read_pieces_and_frame(self, channel_id: int):
+        """Latest ``(pieces, PerceptionFrame)`` for this channel — the per-piece
+        PieceObservation tuple (bbox + com_forward_to_exit_deg + zone_code +
+        sv_bt_track_id) with the exact frame it was computed against, written
+        together in the worker's hot loop. Returns ``None`` if the worker hasn't
+        completed a cycle yet. GIL-atomic read; callers must not mutate."""
+        worker = self._workers.get(channel_id)
+        if worker is None:
+            return None
+        return worker.latest_pieces_frame
+
     def read_detections(self, channel_id: int):
         """Latest in-crop ``Detection`` list for this channel, each tagged with
         ``in_primary`` and the secondary-zone ids it falls in. Display/tag only —

--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -566,6 +566,33 @@ def get_piece_image(uuid: str, image_id: int) -> Any:
     )
 
 
+@app.get("/api/pieces/{uuid}/possible-crops")
+def get_possible_crops(uuid: str) -> Dict[str, Any]:
+    # 'Possibly the same piece': upstream C2/C3 crops that are plausibly this
+    # classified piece, found by time + channel + distance-to-exit (no
+    # embeddings). Returns a confidence-ranked superset.
+    import channel_crop_lookup
+
+    gc = shared_state.gc_ref
+    return {"piece_uuid": uuid, **channel_crop_lookup.findPossibleCrops(gc, uuid)}
+
+
+@app.get("/api/channel-crops/{crop_id}/image")
+def get_channel_crop_image(crop_id: int) -> Any:
+    from fastapi.responses import FileResponse
+
+    import channel_crop_store
+
+    path = channel_crop_store.getCropFileById(crop_id)
+    if path is None:
+        raise HTTPException(status_code=404, detail="crop not available locally")
+    return FileResponse(
+        path,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )
+
+
 @app.get("/api/piece-images/stats")
 def get_piece_image_stats() -> Dict[str, Any]:
     import piece_image_store

--- a/software/sorter/backend/server/hive_sync.py
+++ b/software/sorter/backend/server/hive_sync.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import requests
 
+import channel_crop_store
 import piece_image_store
 import piece_records
 from blob_manager import getHiveConfig
@@ -29,14 +30,19 @@ log = logging.getLogger(__name__)
 
 DATA_TYPE_RECORDS = "piece_records"
 DATA_TYPE_IMAGES = "piece_images"
+DATA_TYPE_CROPS = "channel_crops"
 
 RECORDS_BATCH = 500
 # Images push one file per request (multipart), so a small chunk per cycle keeps
 # each pass short and interleaves fairly across targets.
 IMAGES_CHUNK = 10
+CROPS_CHUNK = 10
 
 RECORDS_THROTTLE_S = 0.15
 IMAGES_THROTTLE_S = 0.8
+# Channel crops are high-volume but small; push them a touch faster than piece
+# images so the backlog keeps up with capture during a run.
+CROPS_THROTTLE_S = 0.3
 IDLE_POLL_S = 10.0
 
 SERVER_DOWN_BACKOFF_S = 10.0
@@ -87,6 +93,22 @@ def _imageToMeta(row: dict[str, Any]) -> dict[str, Any]:
         "used": row["used"],
         "excluded_from_result": row["excluded_from_result"],
         "score": row["score"],
+    }
+
+
+def _cropToMeta(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "local_id": row["id"],
+        "channel": row["channel"],
+        "ts": row["ts"],
+        "captured_at": row["created_at"],
+        "track_id": row["track_id"],
+        "com_forward_to_exit_deg": row["com_forward_to_exit_deg"],
+        "com_section": row["com_section"],
+        "zone_code": row["zone_code"],
+        "sharpness": row["sharpness"],
+        "bbox": row["bbox"],
+        "bytes": row["bytes"],
     }
 
 
@@ -141,7 +163,7 @@ class HiveSyncWorker:
                 "enabled": enabled,
                 "client": None,
                 "state_ok": False,
-                "wm": dict(prev.get("wm", {DATA_TYPE_RECORDS: None, DATA_TYPE_IMAGES: None})),
+                "wm": dict(prev.get("wm", {DATA_TYPE_RECORDS: None, DATA_TYPE_IMAGES: None, DATA_TYPE_CROPS: None})),
                 "backoff_s": float(prev.get("backoff_s", SERVER_DOWN_BACKOFF_S)),
                 "retry_after": float(prev.get("retry_after", 0.0)),
                 "last_error": prev.get("last_error"),
@@ -178,7 +200,12 @@ class HiveSyncWorker:
                 continue
             try:
                 self._ensureState(target)
-                progressed = self._drainRecords(target) or self._drainImages(target)
+                # Drain channel crops on its own leg rather than short-circuited
+                # behind records/images: piece-image capture is continuous during
+                # a run, so an `or` chain would starve crops behind that backlog.
+                records_or_images = self._drainRecords(target) or self._drainImages(target)
+                crops = self._drainChannelCrops(target)
+                progressed = records_or_images or crops
                 target["state_ok"] = True
                 target["backoff_s"] = SERVER_DOWN_BACKOFF_S
                 target["last_error"] = None
@@ -193,7 +220,7 @@ class HiveSyncWorker:
         if target["state_ok"] and target["wm"][DATA_TYPE_RECORDS] is not None:
             return
         state = target["client"].getSyncState()
-        for data_type in (DATA_TYPE_RECORDS, DATA_TYPE_IMAGES):
+        for data_type in (DATA_TYPE_RECORDS, DATA_TYPE_IMAGES, DATA_TYPE_CROPS):
             raw = state.get(data_type) if isinstance(state, dict) else None
             value = raw.get("max_local_id") if isinstance(raw, dict) else 0
             target["wm"][data_type] = int(value or 0)
@@ -230,16 +257,45 @@ class HiveSyncWorker:
             time.sleep(IMAGES_THROTTLE_S)
         return True
 
+    def _drainChannelCrops(self, target: dict[str, Any]) -> bool:
+        # Gated on its own channel_crops field (default off) so experimental
+        # crops never leak to production — enable it per-target. With it off the
+        # watermark freezes here and the backlog drains if enabled later.
+        if not telemetryAllows(target["id"], "channel_crops"):
+            return False
+        wm = int(target["wm"][DATA_TYPE_CROPS] or 0)
+        if channel_crop_store.getMaxCropId() <= wm:
+            return False
+        rows = channel_crop_store.listCropsAfter(wm, CROPS_CHUNK)
+        if not rows:
+            return False
+        for row in rows:
+            file_path = None if row["evicted_locally"] else channel_crop_store.getCropFileById(row["id"])
+            new_max = target["client"].pushChannelCrop(_cropToMeta(row), file_path)
+            target["wm"][DATA_TYPE_CROPS] = max(int(target["wm"][DATA_TYPE_CROPS] or 0), int(new_max), int(row["id"]))
+            time.sleep(CROPS_THROTTLE_S)
+        return True
+
     def _markImageRetention(self, targets: list[dict[str, Any]]) -> None:
-        # Stamp synced_at up to the MIN image watermark across enabled targets so
-        # retention only evicts a crop once EVERY hive has it.
-        watermarks = [
-            int(t["wm"][DATA_TYPE_IMAGES])
-            for t in targets
-            if t["state_ok"] and t["wm"][DATA_TYPE_IMAGES] is not None
-        ]
-        if watermarks and len(watermarks) == len(targets):
-            piece_image_store.markImagesSyncedUpTo(min(watermarks), time.time())
+        # Stamp synced_at up to the MIN watermark across enabled targets so
+        # retention only evicts a crop once EVERY hive has it — per store.
+        def _min_wm(data_type: str) -> int | None:
+            watermarks = [
+                int(t["wm"][data_type])
+                for t in targets
+                if t["state_ok"] and t["wm"][data_type] is not None
+            ]
+            if watermarks and len(watermarks) == len(targets):
+                return min(watermarks)
+            return None
+
+        now = time.time()
+        images_wm = _min_wm(DATA_TYPE_IMAGES)
+        if images_wm is not None:
+            piece_image_store.markImagesSyncedUpTo(images_wm, now)
+        crops_wm = _min_wm(DATA_TYPE_CROPS)
+        if crops_wm is not None:
+            channel_crop_store.markSyncedUpTo(crops_wm, now)
 
     def _backoff(self, target: dict[str, Any], exc: Exception) -> None:
         target["state_ok"] = False  # re-fetch watermark on recovery (handles a hive DB reset)

--- a/software/sorter/frontend/src/routes/tracked/[uuid]/+page.svelte
+++ b/software/sorter/frontend/src/routes/tracked/[uuid]/+page.svelte
@@ -58,6 +58,22 @@
 	let _diskSummary = $state<PieceSummary | null>(null);
 	let _diskImages = $state<DisplayImage[]>([]);
 
+	// 'Possibly the same piece': cheap time/angle lookup over the unlabeled
+	// C2/C3 channel crops (no embeddings). Confidence-ranked superset.
+	type PossibleCrop = {
+		id: number;
+		channel: number | null;
+		ts: number | null;
+		dt: number;
+		zone_code: number | null;
+		com_forward_to_exit_deg: number | null;
+		track_id: number | null;
+		sharpness: number | null;
+		score: number;
+	};
+	let _possibleCrops = $state<PossibleCrop[]>([]);
+	let _possibleStatus = $state<'idle' | 'loading' | 'ok' | 'error'>('idle');
+
 	$effect(() => {
 		// Reset whenever the route UUID changes. Reading `uuid` registers the
 		// dependency; the body clears the sticky cache so a different route
@@ -68,7 +84,35 @@
 		_diskSummary = null;
 		_diskImages = [];
 		_fetchStatus = 'idle';
+		_possibleCrops = [];
+		_possibleStatus = 'idle';
 	});
+
+	$effect(() => {
+		if (_possibleStatus !== 'idle') return;
+		const targetUuid = uuid;
+		_possibleStatus = 'loading';
+		void fetch(`${effectiveBase()}/api/pieces/${encodeURIComponent(targetUuid)}/possible-crops`)
+			.then(async (res) => {
+				if (targetUuid !== uuid) return;
+				if (!res.ok) {
+					_possibleStatus = 'error';
+					return;
+				}
+				const data = (await res.json()) as { candidates?: PossibleCrop[] };
+				if (targetUuid !== uuid) return;
+				_possibleCrops = data.candidates ?? [];
+				_possibleStatus = 'ok';
+			})
+			.catch(() => {
+				if (targetUuid === uuid) _possibleStatus = 'error';
+			});
+	});
+
+	const ZONE_LABEL: Record<number, string> = { 0: 'mid', 1: 'drop', 2: 'exit', 3: 'precise' };
+	function possibleCropSrc(id: number): string {
+		return `${effectiveBase()}/api/channel-crops/${id}/image`;
+	}
 
 	$effect(() => {
 		const entries = pieceStore.entriesFor(ctx.machine?.identity?.machine_id ?? null);
@@ -1456,6 +1500,74 @@
 				{/if}
 			</section>
 		{/if}
+
+		<!-- Possibly the same piece: cheap time/angle lookup over C2/C3 crops.
+		     Rendered for any UUID (live or disk-fallback) — it only needs the
+		     piece's arrival time, not the live detail payload. -->
+		<section class="border border-border bg-surface">
+			<div class="flex items-center justify-between border-b border-border bg-bg px-3 py-2 text-sm">
+				<div class="font-medium text-text">
+					Possibly the same piece
+					<span class="ml-2 text-text-muted">{_possibleCrops.length}</span>
+				</div>
+				<span class="text-sm text-text-muted">upstream C2/C3 · ranked by confidence</span>
+			</div>
+			<div class="p-3">
+				{#if _possibleStatus === 'loading'}
+					<div class="text-sm text-text-muted">Searching…</div>
+				{:else if _possibleStatus === 'error'}
+					<div class="text-sm text-text-muted">Lookup unavailable.</div>
+				{:else if _possibleCrops.length === 0}
+					<div class="text-sm text-text-muted">
+						No upstream crops found near this piece's arrival time.
+					</div>
+				{:else}
+					<div class="grid gap-2" style="grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));">
+						{#each _possibleCrops as crop (crop.id)}
+							<button
+								type="button"
+								class="flex flex-col border border-border bg-bg text-left hover:border-primary/70"
+								title={`C${crop.channel} · ${crop.zone_code != null ? ZONE_LABEL[crop.zone_code] : '?'} · ${crop.com_forward_to_exit_deg != null ? crop.com_forward_to_exit_deg.toFixed(0) + '° to exit' : ''} · ${crop.dt >= 0 ? crop.dt.toFixed(1) + 's before arrival' : Math.abs(crop.dt).toFixed(1) + 's after'} · score ${crop.score.toFixed(2)}`}
+								onclick={() =>
+									(zoomImage = {
+										src: possibleCropSrc(crop.id),
+										label: `C${crop.channel} ${crop.zone_code != null ? ZONE_LABEL[crop.zone_code] : ''} · ${crop.dt.toFixed(1)}s · score ${crop.score.toFixed(2)}`
+									})}
+							>
+								<div class="relative aspect-square w-full bg-white">
+									<img
+										src={possibleCropSrc(crop.id)}
+										alt={`crop ${crop.id}`}
+										class="h-full w-full object-contain"
+										loading="lazy"
+									/>
+									<span
+										class="absolute right-1 top-1 bg-primary px-1.5 py-0.5 text-xs font-semibold text-white tabular-nums"
+										title="Same-piece confidence (higher = more likely this piece)"
+									>
+										{crop.score.toFixed(2)}
+									</span>
+									<span
+										class="absolute bottom-1 left-1 bg-text/80 px-1 py-0.5 text-xs font-semibold text-bg"
+										title="Channel and zone the crop came from"
+									>
+										C{crop.channel}{crop.zone_code != null ? ` ${ZONE_LABEL[crop.zone_code]}` : ''}
+									</span>
+								</div>
+								<div class="flex items-center justify-between gap-2 px-2 py-1.5 text-xs text-text-muted">
+									<span class="tabular-nums">{crop.dt >= 0 ? `−${crop.dt.toFixed(1)}s` : `+${Math.abs(crop.dt).toFixed(1)}s`}</span>
+									<span class="tabular-nums"
+										>{crop.com_forward_to_exit_deg != null
+											? `${crop.com_forward_to_exit_deg.toFixed(0)}°`
+											: ''}</span
+									>
+								</div>
+							</button>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</section>
 	</div>
 </div>
 


### PR DESCRIPTION
## What

Record **unlabeled bbox crops of pieces on the upstream feeder channels (C2/C3)**, tagged with what a cheap time/angle heuristic needs to later find "possibly the same piece" — channel, frame ts, the COM's signed **distance to the exit zone in output degrees**, zone, and track id — no embeddings (the existing embedding path is dead on the Pi anyway; `sqlite_vec` missing).

## Sorter backend
- **`channel_crop_store.py`** — durable SQLite + disk store, 512 MB cap with oldest-first retention, hive sync cursor.
- **`perception/channel_crop_capture.py`** — a collector that samples C2/C3 crops **off the perception hot path** with a zone-aware cadence (dense right at the C3 exit, ~2× on C2). `InferenceWorker` now exposes `(pieces, frame)` atomically for it.
- **`channel_crop_lookup.py`** — given a piece's C4 arrival time, returns a confidence-ranked **superset** of C2/C3 crops plausibly the same piece. Windows + scoring calibrated against a real kitbash run (19 pieces traced by eye): C3 exit/precise crops ~0.2–7s before arrival are the strongest signal (median ~3s, up to ~13s for stalled pieces); earlier C3 back to ~18s; C2 wide but low-weight. On the traced pieces, recall was 100% and the top of the list was ~60–80% the correct piece.
- Endpoints: `GET /api/pieces/{uuid}/possible-crops`, `GET /api/channel-crops/{id}/image`.
- **`hive_sync`** — drains `channel_crops` on its own leg (won't starve behind the continuous piece-image backlog), gated on a **new `channel_crops` telemetry field defaulting OFF** so experimental crops never reach production.

## Sorter frontend
- **"Possibly the same piece"** section on the tracked page (`/tracked/{uuid}`), rendered for any piece — live or durable disk-fallback.

## Hive
- `MachineChannelCrop` model + Alembic migration, `POST /api/machine/sync/channel-crop`, and a per-machine viewer at `/machines/{id}/channel-crops` (admin any machine, owner their own). Verified end-to-end against the local Hive.

## Notes
- Deployed and exercised on kitbash; the lookup endpoint returns the expected rankings on real captured data.
- Scoring constants live at the top of `channel_crop_lookup.py` for easy tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)