### PR TITLE
Piece labeling: 15-min age gate + leaderboard credit

### DIFF
--- a/software/hive/backend/app/routers/leaderboard.py
+++ b/software/hive/backend/app/routers/leaderboard.py
@@ -49,6 +49,9 @@ def list_leaderboard(
                 total_reviews=r.total_reviews,
                 accepts=r.accepts,
                 rejects=r.rejects,
+                piece_color_labels=r.piece_color_labels,
+                piece_crop_links=r.piece_crop_links,
+                total_contributions=r.total_contributions,
                 last_review_at=r.last_review_at,
             )
             for r in rows
@@ -73,6 +76,9 @@ def get_profile(
         total_reviews=profile.total_reviews,
         accepts=profile.accepts,
         rejects=profile.rejects,
+        piece_color_labels=profile.piece_color_labels,
+        piece_crop_links=profile.piece_crop_links,
+        total_contributions=profile.total_contributions,
         agreement_rate=profile.agreement_rate,
         machines_covered=profile.machines_covered,
         current_streak_days=profile.current_streak_days,

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -55,11 +55,24 @@ def _available_image_exists():
     )
 
 
+# Don't serve a piece until it's this old — the same-piece channel crops upload
+# after the piece and take a while, so a too-fresh piece would show an incomplete
+# candidate list.
+_MIN_PIECE_AGE = timedelta(minutes=15)
+
+
+def _old_enough():
+    cutoff = datetime.now(timezone.utc) - _MIN_PIECE_AGE
+    return func.coalesce(MachinePiece.seen_at, MachinePiece.recorded_at, MachinePiece.created_at) <= cutoff
+
+
 def _labelable_query(db: Session):
-    # A piece is labelable if it isn't a dead/spurious record and has a crop.
+    # A piece is labelable if it isn't a dead/spurious record, has a crop, and is
+    # old enough for its channel crops to have synced.
     return db.query(MachinePiece).filter(
         MachinePiece.dead.is_(False),
         _available_image_exists(),
+        _old_enough(),
     )
 
 
@@ -278,7 +291,7 @@ def list_pieces(
             crop_cnt_sq,
             and_(crop_cnt_sq.c.mid == MachinePiece.machine_id, crop_cnt_sq.c.puid == MachinePiece.piece_uuid),
         )
-        .filter(MachinePiece.dead.is_(False), _available_image_exists(), ~my_rejection)
+        .filter(MachinePiece.dead.is_(False), _available_image_exists(), _old_enough(), ~my_rejection)
     )
     if machine_id is not None:
         q = q.filter(MachinePiece.machine_id == machine_id)

--- a/software/hive/backend/app/schemas/leaderboard.py
+++ b/software/hive/backend/app/schemas/leaderboard.py
@@ -13,6 +13,9 @@ class LeaderboardEntry(BaseModel):
     total_reviews: int
     accepts: int
     rejects: int
+    piece_color_labels: int = 0
+    piece_crop_links: int = 0
+    total_contributions: int = 0
     last_review_at: datetime | None = None
 
 
@@ -39,6 +42,9 @@ class ReviewerProfileResponse(BaseModel):
     total_reviews: int
     accepts: int
     rejects: int
+    piece_color_labels: int = 0
+    piece_crop_links: int = 0
+    total_contributions: int = 0
     agreement_rate: float | None = None  # 0..1
     machines_covered: int
     current_streak_days: int

--- a/software/hive/backend/app/services/leaderboard.py
+++ b/software/hive/backend/app/services/leaderboard.py
@@ -21,6 +21,8 @@ from uuid import UUID
 from sqlalchemy import and_, case, func, literal, select, text
 from sqlalchemy.orm import Session
 
+from app.models.piece_color_label import PieceColorLabel
+from app.models.piece_crop_link import PieceCropLink
 from app.models.sample import Sample
 from app.models.sample_review import SampleReview
 from app.models.user import User
@@ -55,51 +57,102 @@ class LeaderboardRow:
     total_reviews: int
     accepts: int
     rejects: int
-    last_review_at: datetime | None
+    piece_color_labels: int
+    piece_crop_links: int
+    total_contributions: int  # reviews + color labels + same-piece links
+    last_review_at: datetime | None  # last activity across all sources
+
+
+def _max_dt(*values: datetime | None) -> datetime | None:
+    present = [v for v in values if v is not None]
+    return max(present) if present else None
 
 
 def get_leaderboard(db: Session, *, period: str, limit: int = 100) -> list[LeaderboardRow]:
-    """Aggregate sample_reviews into a ranked list of reviewers.
+    """Ranked contributor list across all labeling work: sample reviews plus
+    piece color labels and same-piece crop links.
 
-    Includes anyone who has at least one review in the period; ordered by
-    total review count desc, then by display_name asc for ties.
+    Includes anyone with at least one contribution in the period; ordered by
+    total contributions desc, then display_name asc for ties.
     """
 
     cutoff = _cutoff(period)
-    q = db.query(
-        User.id.label("user_id"),
-        User.display_name,
-        User.avatar_url,
-        User.role,
+
+    review_q = db.query(
+        SampleReview.reviewer_id.label("uid"),
         func.count(SampleReview.id).label("total"),
         func.sum(case((SampleReview.decision == "accept", 1), else_=0)).label("accepts"),
         func.sum(case((SampleReview.decision == "reject", 1), else_=0)).label("rejects"),
         func.max(SampleReview.created_at).label("last_at"),
-    ).join(SampleReview, SampleReview.reviewer_id == User.id)
-    # WHERE-clause must be applied before group/order/limit — SQLAlchemy
-    # raises InvalidRequestError if you call .filter() after .limit().
-    if cutoff is not None:
-        q = q.filter(SampleReview.created_at >= cutoff)
-    q = (
-        q.group_by(User.id, User.display_name, User.avatar_url, User.role)
-        .order_by(func.count(SampleReview.id).desc(), User.display_name.asc())
-        .limit(limit)
     )
+    color_q = db.query(
+        PieceColorLabel.labeler_id.label("uid"),
+        func.count(PieceColorLabel.id).label("cnt"),
+        func.max(PieceColorLabel.created_at).label("last_at"),
+    )
+    crop_q = db.query(
+        PieceCropLink.labeler_id.label("uid"),
+        func.count(PieceCropLink.id).label("cnt"),
+        func.max(PieceCropLink.created_at).label("last_at"),
+    )
+    if cutoff is not None:
+        review_q = review_q.filter(SampleReview.created_at >= cutoff)
+        color_q = color_q.filter(PieceColorLabel.created_at >= cutoff)
+        crop_q = crop_q.filter(PieceCropLink.created_at >= cutoff)
+    review_rows = review_q.group_by(SampleReview.reviewer_id).all()
+    color_rows = color_q.group_by(PieceColorLabel.labeler_id).all()
+    crop_rows = crop_q.group_by(PieceCropLink.labeler_id).all()
 
-    rows = q.all()
-    return [
-        LeaderboardRow(
-            user_id=r.user_id,
-            display_name=r.display_name,
-            avatar_url=r.avatar_url,
-            role=r.role,
-            total_reviews=int(r.total or 0),
-            accepts=int(r.accepts or 0),
-            rejects=int(r.rejects or 0),
-            last_review_at=r.last_at,
+    agg: dict[UUID, dict[str, Any]] = {}
+
+    def _slot(uid: UUID) -> dict[str, Any]:
+        return agg.setdefault(
+            uid,
+            {"total": 0, "accepts": 0, "rejects": 0, "color": 0, "crop": 0, "last_at": None},
         )
-        for r in rows
+
+    for r in review_rows:
+        s = _slot(r.uid)
+        s["total"] = int(r.total or 0)
+        s["accepts"] = int(r.accepts or 0)
+        s["rejects"] = int(r.rejects or 0)
+        s["last_at"] = _max_dt(s["last_at"], r.last_at)
+    for r in color_rows:
+        s = _slot(r.uid)
+        s["color"] = int(r.cnt or 0)
+        s["last_at"] = _max_dt(s["last_at"], r.last_at)
+    for r in crop_rows:
+        s = _slot(r.uid)
+        s["crop"] = int(r.cnt or 0)
+        s["last_at"] = _max_dt(s["last_at"], r.last_at)
+
+    if not agg:
+        return []
+
+    users = {
+        u.id: u
+        for u in db.query(User.id, User.display_name, User.avatar_url, User.role).filter(User.id.in_(agg.keys())).all()
+    }
+
+    rows = [
+        LeaderboardRow(
+            user_id=uid,
+            display_name=users[uid].display_name if uid in users else None,
+            avatar_url=users[uid].avatar_url if uid in users else None,
+            role=users[uid].role if uid in users else "member",
+            total_reviews=s["total"],
+            accepts=s["accepts"],
+            rejects=s["rejects"],
+            piece_color_labels=s["color"],
+            piece_crop_links=s["crop"],
+            total_contributions=s["total"] + s["color"] + s["crop"],
+            last_review_at=s["last_at"],
+        )
+        for uid, s in agg.items()
+        if uid in users
     ]
+    rows.sort(key=lambda r: (-r.total_contributions, (r.display_name or "").lower()))
+    return rows[:limit]
 
 
 # ----------------------------------------------------------------------- profile
@@ -114,6 +167,9 @@ class ReviewerProfile:
     total_reviews: int
     accepts: int
     rejects: int
+    piece_color_labels: int
+    piece_crop_links: int
+    total_contributions: int  # reviews + color labels + same-piece links
     agreement_rate: float | None  # 0..1 (None if no conclusive samples reviewed)
     machines_covered: int
     current_streak_days: int
@@ -384,6 +440,11 @@ def get_reviewer_profile(db: Session, user_id: UUID) -> ReviewerProfile | None:
     accepts = int(totals.accepts or 0) if totals else 0
     rejects = int(totals.rejects or 0) if totals else 0
 
+    color_labels = (
+        db.query(func.count(PieceColorLabel.id)).filter(PieceColorLabel.labeler_id == user_id).scalar() or 0
+    )
+    crop_links = db.query(func.count(PieceCropLink.id)).filter(PieceCropLink.labeler_id == user_id).scalar() or 0
+
     agreement = _agreement_rate(db, user_id)
     machines = _machines_covered(db, user_id)
     current_streak, longest_streak = _streak_days(db, user_id)
@@ -409,6 +470,9 @@ def get_reviewer_profile(db: Session, user_id: UUID) -> ReviewerProfile | None:
         total_reviews=total,
         accepts=accepts,
         rejects=rejects,
+        piece_color_labels=int(color_labels),
+        piece_crop_links=int(crop_links),
+        total_contributions=total + int(color_labels) + int(crop_links),
         agreement_rate=agreement,
         machines_covered=machines,
         current_streak_days=current_streak,

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -1815,6 +1815,9 @@ export interface LeaderboardEntry {
 	total_reviews: number;
 	accepts: number;
 	rejects: number;
+	piece_color_labels: number;
+	piece_crop_links: number;
+	total_contributions: number;
 	last_review_at: string | null;
 }
 
@@ -1841,6 +1844,9 @@ export interface ReviewerProfile {
 	total_reviews: number;
 	accepts: number;
 	rejects: number;
+	piece_color_labels: number;
+	piece_crop_links: number;
+	total_contributions: number;
 	agreement_rate: number | null;
 	machines_covered: number;
 	current_streak_days: number;

--- a/software/hive/frontend/src/routes/leaderboard/+page.svelte
+++ b/software/hive/frontend/src/routes/leaderboard/+page.svelte
@@ -95,9 +95,9 @@
 <div class="space-y-5">
 	<div class="flex flex-wrap items-center justify-between gap-3">
 		<div>
-			<h1 class="text-2xl font-bold text-text">Reviewer leaderboard</h1>
+			<h1 class="text-2xl font-bold text-text">Contributor leaderboard</h1>
 			<p class="mt-1 text-sm text-text-muted">
-				Who's keeping the queue flowing. Period switches the ranking; clicks open a reviewer's full stats + achievements.
+				Ranked by total contributions — sample reviews plus piece labels (color + same-piece). Period switches the ranking; clicks open full stats + achievements.
 			</p>
 		</div>
 		<div class="flex border border-border bg-surface text-xs">
@@ -119,15 +119,15 @@
 		<div class="border border-danger bg-danger/10 px-3 py-2 text-sm text-danger">{error}</div>
 	{:else if !data || data.entries.length === 0}
 		<div class="border border-border bg-surface px-3 py-10 text-center text-sm text-text-muted">
-			No reviews in this period yet. Be the first.
+			No contributions in this period yet. Be the first.
 		</div>
 	{:else}
 		<div class="border border-border bg-surface">
-			<div class="grid grid-cols-[40px_1fr_120px_150px_140px] items-center gap-3 border-b border-border bg-bg px-4 py-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+			<div class="grid grid-cols-[40px_1fr_90px_150px_120px] items-center gap-3 border-b border-border bg-bg px-4 py-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
 				<span>Rank</span>
-				<span>Reviewer</span>
-				<span class="text-right">Reviews</span>
-				<span class="text-right">✓ Accept · ✗ Reject</span>
+				<span>Contributor</span>
+				<span class="text-right">Total</span>
+				<span class="text-right">Samples · Pieces</span>
 				<span class="text-right">Last activity</span>
 			</div>
 			{#each data.entries as entry, idx (entry.user_id)}
@@ -135,7 +135,7 @@
 				{@const medal = medalFor(idx)}
 				<a
 					href={profileHref(entry)}
-					class="grid grid-cols-[40px_1fr_120px_150px_140px] items-center gap-3 border-b border-border px-4 py-2.5 text-sm transition-colors hover:bg-bg {isMe ? 'bg-primary-light/30' : ''} last:border-b-0"
+					class="grid grid-cols-[40px_1fr_90px_150px_120px] items-center gap-3 border-b border-border px-4 py-2.5 text-sm transition-colors hover:bg-bg {isMe ? 'bg-primary-light/30' : ''} last:border-b-0"
 				>
 					<span class="text-center text-base font-semibold tabular-nums text-text">
 						{medal ?? idx + 1}
@@ -157,10 +157,13 @@
 						</span>
 					</span>
 					<span class="text-right text-base font-bold tabular-nums text-text">
-						{entry.total_reviews.toLocaleString()}
+						{entry.total_contributions.toLocaleString()}
 					</span>
 					<span class="text-right text-xs tabular-nums text-text-muted">
-						<span class="text-success">{entry.accepts}</span> · <span class="text-primary">{entry.rejects}</span>
+						<span title="sample reviews">{entry.total_reviews.toLocaleString()}</span>
+						· <span class="text-primary" title="piece color labels + same-piece links">
+							{(entry.piece_color_labels + entry.piece_crop_links).toLocaleString()}
+						</span>
 					</span>
 					<span class="text-right text-xs text-text-muted">{relativeTime(entry.last_review_at)}</span>
 				</a>

--- a/software/hive/frontend/src/routes/leaderboard/[user_id]/+page.svelte
+++ b/software/hive/frontend/src/routes/leaderboard/[user_id]/+page.svelte
@@ -95,16 +95,30 @@
 				</div>
 			</div>
 
-			<!-- Metric pills -->
-			<div class="grid grid-cols-2 gap-px border-t border-border bg-border sm:grid-cols-4">
+			<!-- Contributions breakdown: samples vs pieces (kept separate) -->
+			<div class="grid grid-cols-2 gap-px border-t border-border bg-border sm:grid-cols-3">
 				<div class="bg-surface px-4 py-3">
-					<div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Total reviews</div>
+					<div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Total contributions</div>
+					<div class="text-2xl font-bold text-text">{profile.total_contributions.toLocaleString()}</div>
+					<div class="text-[11px] text-text-muted">reviews + piece labels</div>
+				</div>
+				<div class="bg-surface px-4 py-3">
+					<div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Sample reviews</div>
 					<div class="text-2xl font-bold text-text">{profile.total_reviews.toLocaleString()}</div>
 					<div class="text-[11px] text-text-muted">
 						<span class="text-success">{profile.accepts}</span> ✓ ·
 						<span class="text-primary">{profile.rejects}</span> ✗
 					</div>
 				</div>
+				<div class="bg-surface px-4 py-3">
+					<div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Piece labels</div>
+					<div class="text-2xl font-bold text-text">{(profile.piece_color_labels + profile.piece_crop_links).toLocaleString()}</div>
+					<div class="text-[11px] text-text-muted">{profile.piece_color_labels} color · {profile.piece_crop_links} same-piece</div>
+				</div>
+			</div>
+
+			<!-- Review quality metrics -->
+			<div class="grid grid-cols-2 gap-px border-t border-border bg-border sm:grid-cols-3">
 				<div class="bg-surface px-4 py-3">
 					<div class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Agreement</div>
 					<div class="text-2xl font-bold text-text">{pct(profile.agreement_rate)}</div>


### PR DESCRIPTION
Two related changes to the piece-labeling feature.

### Only serve pieces ≥ 15 minutes old
The same-piece channel crops upload after the piece and take a while, so a too-fresh piece would show an incomplete "Same piece across channels" list. The labeling queue + stats now gate on `coalesce(seen_at, recorded_at, created_at)` being at least 15 minutes ago.

### Leaderboard counts piece labeling (kept separate)
You can now get on the leaderboard by labeling pieces, not just reviewing samples. Ranking is by **total contributions = sample reviews + piece color labels + same-piece links**, so labeling alone (even with zero reviews) puts you on the board.

The sources stay **separate** so a profile shows where a rank comes from:
- List: a **Samples · Pieces** split column next to the Total.
- Profile (`/leaderboard/<id>`): **Total contributions / Sample reviews / Piece labels** (with color vs same-piece), alongside the existing review-quality stats.

Backend: `get_leaderboard` now aggregates across `sample_reviews`, `piece_color_labels`, and `piece_crop_links` (period-filtered) and ranks by the sum; `get_reviewer_profile` adds the piece counts. Schemas + api.ts interfaces extended with `piece_color_labels`, `piece_crop_links`, `total_contributions`.

Verified on the local hive: `pnpm check` + `pnpm build` green; the admin (0 reviews, 80 color + 16 same-piece) now ranks with total 96 and the profile shows the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)