### PR TITLE
Brickognize corrections: submit part/color feedback

### DIFF
--- a/software/hive/backend/alembic/versions/b8c9d0e1f2a3_add_piece_corrections.py
+++ b/software/hive/backend/alembic/versions/b8c9d0e1f2a3_add_piece_corrections.py
@@ -1,0 +1,58 @@
+"""add brickognize corrections to machine_pieces
+
+Revision ID: b8c9d0e1f2a3
+Revises: d1e2f3a4b5c6
+Create Date: 2026-07-13 21:00:00.000000
+
+Adds Brickognize-correction columns to machine_pieces: the applied request's
+provenance (listing id + result ranks + item type) so a correction can be
+submitted to Brickognize's feedback API, plus the user's correction (part
+correct/wrong, corrected color) and whether it was submitted. Synced from the
+machine via the new piece_corrections stream and/or set here on Hive.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b8c9d0e1f2a3"
+down_revision: Union[str, None] = "d1e2f3a4b5c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("machine_pieces", sa.Column("brickognize_listing_id", sa.String(), nullable=True))
+    op.add_column("machine_pieces", sa.Column("brickognize_item_rank", sa.Integer(), nullable=True))
+    op.add_column("machine_pieces", sa.Column("brickognize_item_type", sa.String(), nullable=True))
+    op.add_column("machine_pieces", sa.Column("brickognize_color_rank", sa.Integer(), nullable=True))
+    op.add_column("machine_pieces", sa.Column("part_correct", sa.Boolean(), nullable=True))
+    op.add_column("machine_pieces", sa.Column("color_corrected_id", sa.String(), nullable=True))
+    op.add_column(
+        "machine_pieces",
+        sa.Column("part_feedback_submitted", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "machine_pieces",
+        sa.Column("color_feedback_submitted", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column("machine_pieces", sa.Column("correction_updated_at", sa.DateTime(timezone=True), nullable=True))
+    # Drop the server defaults now that existing rows are backfilled — new rows
+    # get their default from the app-side model.
+    op.alter_column("machine_pieces", "part_feedback_submitted", server_default=None)
+    op.alter_column("machine_pieces", "color_feedback_submitted", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("machine_pieces", "correction_updated_at")
+    op.drop_column("machine_pieces", "color_feedback_submitted")
+    op.drop_column("machine_pieces", "part_feedback_submitted")
+    op.drop_column("machine_pieces", "color_corrected_id")
+    op.drop_column("machine_pieces", "part_correct")
+    op.drop_column("machine_pieces", "brickognize_color_rank")
+    op.drop_column("machine_pieces", "brickognize_item_type")
+    op.drop_column("machine_pieces", "brickognize_item_rank")
+    op.drop_column("machine_pieces", "brickognize_listing_id")

--- a/software/hive/backend/app/models/machine_piece.py
+++ b/software/hive/backend/app/models/machine_piece.py
@@ -31,6 +31,22 @@ class MachinePiece(Base):
     bin_z = Column(Integer, nullable=True)
     dead = Column(Boolean, nullable=False, default=False)
     brickognize_preview_url = Column(String, nullable=True)
+    # Correction provenance from the applied Brickognize request, synced from the
+    # machine alongside the prediction. Needed to address a correction to
+    # Brickognize's feedback API (which keys on the listing id + result rank).
+    brickognize_listing_id = Column(String, nullable=True)
+    brickognize_item_rank = Column(Integer, nullable=True)
+    brickognize_item_type = Column(String, nullable=True)
+    brickognize_color_rank = Column(Integer, nullable=True)
+    # User correction, synced from the machine (piece_corrections stream) and/or
+    # set here on Hive. part_correct is NULL (unreviewed) / true / false;
+    # color_corrected_id is the picked true BrickLink color id; the *_submitted
+    # flags record whether the correction was sent to Brickognize.
+    part_correct = Column(Boolean, nullable=True)
+    color_corrected_id = Column(String, nullable=True)
+    part_feedback_submitted = Column(Boolean, nullable=False, default=False)
+    color_feedback_submitted = Column(Boolean, nullable=False, default=False)
+    correction_updated_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (

--- a/software/hive/backend/app/routers/machine_sync.py
+++ b/software/hive/backend/app/routers/machine_sync.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from sqlalchemy import or_, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
@@ -27,13 +28,19 @@ limiter = Limiter(key_func=get_remote_address)
 DATA_TYPE_PIECE_RECORDS = "piece_records"
 DATA_TYPE_PIECE_IMAGES = "piece_images"
 DATA_TYPE_CHANNEL_CROPS = "channel_crops"
+DATA_TYPE_PIECE_CORRECTIONS = "piece_corrections"
 
 # Columns updated on conflict — everything except the identity/immutable set
-# (id, machine_id, piece_uuid[, seq], created_at).
+# (id, machine_id, piece_uuid[, seq], created_at). The correction columns
+# (part_correct, color_corrected_id, *_feedback_submitted, correction_updated_at)
+# are intentionally NOT here: they arrive on the separate piece_corrections
+# stream, so a plain piece_records re-sync must not clobber them.
 _PIECE_UPDATE_COLS = (
     "local_id", "run_id", "seen_at", "recorded_at", "classification_status",
     "part_id", "part_name", "color_id", "color_name", "category_id", "confidence",
     "bin_x", "bin_y", "bin_z", "dead", "brickognize_preview_url",
+    "brickognize_listing_id", "brickognize_item_rank", "brickognize_item_type",
+    "brickognize_color_rank",
 )
 _IMAGE_UPDATE_COLS = (
     "local_id", "source", "channel", "ts", "captured_at", "sharpness", "bytes",
@@ -108,10 +115,28 @@ class PieceRecordIn(BaseModel):
     bin_z: int | None = None
     dead: bool = False
     brickognize_preview_url: str | None = None
+    brickognize_listing_id: str | None = None
+    brickognize_item_rank: int | None = None
+    brickognize_item_type: str | None = None
+    brickognize_color_rank: int | None = None
 
 
 class PieceRecordsBatch(BaseModel):
     records: list[PieceRecordIn]
+
+
+class PieceCorrectionIn(BaseModel):
+    piece_uuid: str
+    local_id: int
+    part_correct: bool | None = None
+    color_corrected_id: str | None = None
+    part_feedback_submitted: bool = False
+    color_feedback_submitted: bool = False
+    updated_at: float | None = None
+
+
+class PieceCorrectionsBatch(BaseModel):
+    records: list[PieceCorrectionIn]
 
 
 class PieceImageMeta(BaseModel):
@@ -154,6 +179,7 @@ def get_sync_state(
         DATA_TYPE_PIECE_RECORDS: {"max_local_id": by_type.get(DATA_TYPE_PIECE_RECORDS, 0)},
         DATA_TYPE_PIECE_IMAGES: {"max_local_id": by_type.get(DATA_TYPE_PIECE_IMAGES, 0)},
         DATA_TYPE_CHANNEL_CROPS: {"max_local_id": by_type.get(DATA_TYPE_CHANNEL_CROPS, 0)},
+        DATA_TYPE_PIECE_CORRECTIONS: {"max_local_id": by_type.get(DATA_TYPE_PIECE_CORRECTIONS, 0)},
     }
 
 
@@ -199,6 +225,10 @@ def sync_piece_records(
                 "bin_z": rec.bin_z,
                 "dead": rec.dead,
                 "brickognize_preview_url": rec.brickognize_preview_url,
+                "brickognize_listing_id": rec.brickognize_listing_id,
+                "brickognize_item_rank": rec.brickognize_item_rank,
+                "brickognize_item_type": rec.brickognize_item_type,
+                "brickognize_color_rank": rec.brickognize_color_rank,
                 "created_at": now,
             }
         )
@@ -208,6 +238,61 @@ def sync_piece_records(
     machine.last_seen_at = now
     db.commit()
     return {"max_local_id": new_max, "upserted": len(rows)}
+
+
+@router.post("/piece-corrections")
+@limiter.limit("300/minute")
+def sync_piece_corrections(
+    request: Request,
+    payload: PieceCorrectionsBatch,
+    db: Session = Depends(get_db),
+    machine: Machine = Depends(get_current_machine),
+) -> dict[str, int]:
+    if not payload.records:
+        row = (
+            db.query(MachineSyncState)
+            .filter(
+                MachineSyncState.machine_id == machine.id,
+                MachineSyncState.data_type == DATA_TYPE_PIECE_CORRECTIONS,
+            )
+            .first()
+        )
+        return {"max_local_id": row.max_local_id if row else 0, "upserted": 0}
+
+    now = _now()
+    batch_max = 0
+    upserted = 0
+    # Update-only onto the existing machine_pieces row (the correction stream
+    # carries no piece identity beyond the uuid). The piece is always classified
+    # and synced before it can be corrected, so the row exists. The submitted
+    # flags are OR'd, never overwritten, so a correction already submitted on Hive
+    # is not un-marked by a later machine re-sync (one-way sync, no flag regress).
+    for rec in payload.records:
+        batch_max = max(batch_max, rec.local_id)
+        result = db.execute(
+            update(MachinePiece)
+            .where(
+                MachinePiece.machine_id == machine.id,
+                MachinePiece.piece_uuid == rec.piece_uuid,
+            )
+            .values(
+                part_correct=rec.part_correct,
+                color_corrected_id=rec.color_corrected_id,
+                part_feedback_submitted=or_(
+                    MachinePiece.part_feedback_submitted, rec.part_feedback_submitted
+                ),
+                color_feedback_submitted=or_(
+                    MachinePiece.color_feedback_submitted, rec.color_feedback_submitted
+                ),
+                correction_updated_at=_ts(rec.updated_at) or now,
+            )
+        )
+        upserted += int(result.rowcount or 0)
+
+    new_max = _advance_watermark(db, machine.id, DATA_TYPE_PIECE_CORRECTIONS, batch_max)
+    machine.last_seen_at = now
+    db.commit()
+    return {"max_local_id": new_max, "upserted": upserted}
 
 
 @router.post("/piece-image")

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -13,6 +13,7 @@ Rebrickable `colors` external ids). Labels live in Postgres (piece_color_labels)
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
@@ -31,11 +32,14 @@ from app.models.piece_color_label import PieceColorLabel
 from app.models.piece_crop_link import PieceCropLink, PieceCropLinkMember
 from app.models.piece_rejection import PieceRejection
 from app.models.user import User
+from app.services.brickognize_feedback import submit_color_feedback, submit_part_feedback
 from app.services.channel_crop_lookup import find_possible_crops
 from app.services.channel_crop_lookup_params import DEFAULT_PARAMS
 from app.services.pixel_color import guess_piece_color
 from app.services.profile_catalog import get_profile_catalog_service
 from app.services.storage import serve_stored_file
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/labeling", tags=["labeling"])
 
@@ -427,6 +431,129 @@ def piece_detail(
         ],
         "my_label": None if label is None else {"color_id": label.color_id, "notes": label.notes},
         "my_rejection": None if rejection is None else {"reasons": list(rejection.reasons or [])},
+        # Brickognize prediction + correction state. correctable is True only
+        # when a listing id was captured (a prerequisite for submitting feedback).
+        "prediction": {
+            "color_id": piece.color_id,
+            "color_name": piece.color_name,
+        },
+        "correction": {
+            "correctable": piece.brickognize_listing_id is not None,
+            "part_correct": piece.part_correct,
+            "color_corrected_id": piece.color_corrected_id,
+            "part_feedback_submitted": bool(piece.part_feedback_submitted),
+            "color_feedback_submitted": bool(piece.color_feedback_submitted),
+        },
+    }
+
+
+class BrickognizeFeedbackPayload(BaseModel):
+    # Fields present are applied and submitted; absent fields are left alone.
+    # part_correct: True/False marks the part prediction right/wrong.
+    # color_corrected_id: the picked true BrickLink color; if omitted, this
+    # user's saved color label (piece_color_labels) is used as the true color.
+    part_correct: bool | None = None
+    color_corrected_id: int | None = None
+
+
+@router.post("/piece/{machine_id}/{piece_uuid}/brickognize-feedback")
+def submit_brickognize_feedback(
+    machine_id: UUID,
+    piece_uuid: str,
+    payload: BrickognizeFeedbackPayload,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Send a piece's part and/or color correction back to Brickognize's feedback
+    API and record that it was submitted. Gated on a captured listing id; each
+    channel is sent at most once (the *_feedback_submitted flags). The verdict is
+    written onto the piece regardless of whether the network call succeeds."""
+    piece = (
+        db.query(MachinePiece)
+        .filter(MachinePiece.machine_id == machine_id, MachinePiece.piece_uuid == piece_uuid)
+        .first()
+    )
+    if piece is None:
+        raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
+    if not piece.brickognize_listing_id:
+        raise APIError(400, "Piece has no Brickognize listing to correct", "NOT_CORRECTABLE")
+
+    part_submitted = False
+    color_submitted = False
+    submit_error: str | None = None
+
+    # Part feedback: a recorded verdict, not yet sent, with the applied item rank.
+    if payload.part_correct is not None:
+        piece.part_correct = payload.part_correct
+        if (
+            not piece.part_feedback_submitted
+            and piece.brickognize_item_rank is not None
+            and piece.part_id
+        ):
+            try:
+                submit_part_feedback(
+                    listing_id=piece.brickognize_listing_id,
+                    item_id=piece.part_id,
+                    item_rank=piece.brickognize_item_rank,
+                    item_type=piece.brickognize_item_type,
+                    is_correct=bool(piece.part_correct),
+                )
+                piece.part_feedback_submitted = True
+                part_submitted = True
+            except Exception as exc:
+                submit_error = f"part: {exc}"
+                log.warning("Brickognize part feedback failed for %s: %s", piece_uuid, exc)
+
+    # Color feedback: use the passed corrected color, else this user's saved true
+    # color. Equal to the prediction confirms it; different rejects it.
+    corrected = payload.color_corrected_id
+    if corrected is None:
+        my_label = (
+            db.query(PieceColorLabel)
+            .filter(
+                PieceColorLabel.machine_id == machine_id,
+                PieceColorLabel.piece_uuid == piece_uuid,
+                PieceColorLabel.labeler_id == current_user.id,
+            )
+            .first()
+        )
+        corrected = my_label.color_id if my_label is not None else None
+    if corrected is not None:
+        piece.color_corrected_id = str(corrected)
+        if (
+            not piece.color_feedback_submitted
+            and piece.brickognize_color_rank is not None
+            and piece.color_id
+        ):
+            try:
+                is_correct = str(corrected) == str(piece.color_id)
+                submit_color_feedback(
+                    listing_id=piece.brickognize_listing_id,
+                    color_id=piece.color_id,
+                    color_rank=piece.brickognize_color_rank,
+                    is_correct=is_correct,
+                )
+                piece.color_feedback_submitted = True
+                color_submitted = True
+            except Exception as exc:
+                prev = f"{submit_error}; " if submit_error else ""
+                submit_error = f"{prev}color: {exc}"
+                log.warning("Brickognize color feedback failed for %s: %s", piece_uuid, exc)
+
+    piece.correction_updated_at = datetime.now(timezone.utc)
+    db.commit()
+    return {
+        "ok": True,
+        "part_submitted": part_submitted,
+        "color_submitted": color_submitted,
+        "submit_error": submit_error,
+        "correction": {
+            "correctable": True,
+            "part_correct": piece.part_correct,
+            "color_corrected_id": piece.color_corrected_id,
+            "part_feedback_submitted": bool(piece.part_feedback_submitted),
+            "color_feedback_submitted": bool(piece.color_feedback_submitted),
+        },
     }
 
 

--- a/software/hive/backend/app/services/brickognize_feedback.py
+++ b/software/hive/backend/app/services/brickognize_feedback.py
@@ -1,0 +1,58 @@
+"""Submit part/color corrections to Brickognize's feedback API.
+
+These are confirm/reject signals against a prior /predict/ call (identified by
+its listing_id): we tell Brickognize whether a specific ranked result was
+correct, keyed by the rank it came back at. Brickognize can't be handed an
+arbitrary "right" answer that wasn't in its results, so a color correction to a
+different color reduces to rejecting the prediction.
+
+Mirrors the sorter-side client (sorter/backend/classification/brickognize_feedback.py);
+kept separate because the two backends don't share code.
+"""
+
+from __future__ import annotations
+
+import requests
+
+PART_FEEDBACK_URL = "https://api.brickognize.com/feedback/"
+COLOR_FEEDBACK_URL = "https://api.brickognize.com/feedback/color/"
+FEEDBACK_SOURCE = "external-app"
+FEEDBACK_TIMEOUT_S = (30.0, 30.0)
+
+
+def submit_part_feedback(
+    *,
+    listing_id: str,
+    item_id: str,
+    item_rank: int,
+    is_correct: bool,
+    item_type: str | None = None,
+) -> None:
+    payload = {
+        "listing_id": listing_id,
+        "item_id": str(item_id),
+        "item_type": item_type or "part",
+        "is_prediction_correct": bool(is_correct),
+        "source": FEEDBACK_SOURCE,
+        "item_rank": int(item_rank),
+    }
+    response = requests.post(PART_FEEDBACK_URL, json=payload, timeout=FEEDBACK_TIMEOUT_S)
+    response.raise_for_status()
+
+
+def submit_color_feedback(
+    *,
+    listing_id: str,
+    color_id: str,
+    color_rank: int,
+    is_correct: bool,
+) -> None:
+    payload = {
+        "listing_id": listing_id,
+        "is_prediction_correct": bool(is_correct),
+        "source": FEEDBACK_SOURCE,
+        "color_id": str(color_id),
+        "color_rank": int(color_rank),
+    }
+    response = requests.post(COLOR_FEEDBACK_URL, json=payload, timeout=FEEDBACK_TIMEOUT_S)
+    response.raise_for_status()

--- a/software/hive/backend/tests/test_machine_sync.py
+++ b/software/hive/backend/tests/test_machine_sync.py
@@ -20,6 +20,8 @@ def test_sync_state_starts_empty(client, machine_token):
     assert resp.json() == {
         "piece_records": {"max_local_id": 0},
         "piece_images": {"max_local_id": 0},
+        "channel_crops": {"max_local_id": 0},
+        "piece_corrections": {"max_local_id": 0},
     }
 
 
@@ -43,6 +45,65 @@ def test_piece_records_upsert_is_idempotent(client, machine_token):
 
     state = client.get("/api/machine/sync/state", headers=_bearer(machine_token)).json()
     assert state["piece_records"]["max_local_id"] == 11
+
+
+def test_piece_corrections_update_machine_piece(client, machine_token):
+    base = 1_760_000_000.0
+    # A classified piece with Brickognize provenance must exist first.
+    client.post(
+        "/api/machine/sync/piece-records",
+        headers=_bearer(machine_token),
+        json={"records": [{
+            "piece_uuid": "pc1", "local_id": 20, "classification_status": "classified",
+            "part_id": "3001", "color_id": "5", "brickognize_listing_id": "res-abc",
+            "brickognize_item_rank": 0, "brickognize_item_type": "part",
+            "brickognize_color_rank": 1,
+        }]},
+    )
+    r = client.post(
+        "/api/machine/sync/piece-corrections",
+        headers=_bearer(machine_token),
+        json={"records": [{
+            "piece_uuid": "pc1", "local_id": 1, "part_correct": False,
+            "color_corrected_id": "7", "part_feedback_submitted": True,
+            "color_feedback_submitted": False, "updated_at": base,
+        }]},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json() == {"max_local_id": 1, "upserted": 1}
+
+    from app.models.machine_piece import MachinePiece
+    from tests.conftest import TestingSessionLocal
+    s: Session = TestingSessionLocal()
+    try:
+        piece = s.query(MachinePiece).filter_by(piece_uuid="pc1").first()
+        assert piece.part_correct is False
+        assert piece.color_corrected_id == "7"
+        assert piece.part_feedback_submitted is True
+        assert piece.color_feedback_submitted is False
+        assert piece.brickognize_listing_id == "res-abc"
+    finally:
+        s.close()
+
+    # A later re-sync carrying submitted=False must NOT un-mark the flag (OR'd).
+    client.post(
+        "/api/machine/sync/piece-corrections",
+        headers=_bearer(machine_token),
+        json={"records": [{
+            "piece_uuid": "pc1", "local_id": 2, "part_correct": False,
+            "color_corrected_id": "7", "part_feedback_submitted": False,
+            "color_feedback_submitted": False, "updated_at": base + 1,
+        }]},
+    )
+    s = TestingSessionLocal()
+    try:
+        piece = s.query(MachinePiece).filter_by(piece_uuid="pc1").first()
+        assert piece.part_feedback_submitted is True
+    finally:
+        s.close()
+
+    state = client.get("/api/machine/sync/state", headers=_bearer(machine_token)).json()
+    assert state["piece_corrections"]["max_local_id"] == 2
 
 
 def test_piece_records_update_on_conflict(client, machine_token):

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -997,6 +997,27 @@ export interface ColorLabelPiecesPage {
 	sort: ColorLabelSort;
 }
 
+export interface ColorLabelPrediction {
+	color_id: string | null;
+	color_name: string | null;
+}
+
+export interface ColorLabelCorrection {
+	correctable: boolean;
+	part_correct: boolean | null;
+	color_corrected_id: string | null;
+	part_feedback_submitted: boolean;
+	color_feedback_submitted: boolean;
+}
+
+export interface BrickognizeFeedbackResponse {
+	ok: boolean;
+	part_submitted: boolean;
+	color_submitted: boolean;
+	submit_error: string | null;
+	correction: ColorLabelCorrection;
+}
+
 export interface ColorLabelPieceDetail {
 	machine_id: string;
 	machine_name: string | null;
@@ -1008,6 +1029,8 @@ export interface ColorLabelPieceDetail {
 	images: ColorLabelQueueImage[];
 	my_label: { color_id: number; notes: string | null } | null;
 	my_rejection: { reasons: string[] } | null;
+	prediction: ColorLabelPrediction;
+	correction: ColorLabelCorrection;
 }
 
 export type RejectReason = 'no_piece' | 'multiple_pieces';
@@ -1214,6 +1237,17 @@ export const api = {
 		return request<{ ok: boolean }>(
 			'DELETE',
 			`/api/labeling/${machineId}/${encodeURIComponent(pieceUuid)}`
+		);
+	},
+	submitBrickognizeFeedback(
+		machineId: string,
+		pieceUuid: string,
+		body: { part_correct?: boolean | null; color_corrected_id?: number | null }
+	) {
+		return request<BrickognizeFeedbackResponse>(
+			'POST',
+			`/api/labeling/piece/${machineId}/${encodeURIComponent(pieceUuid)}/brickognize-feedback`,
+			body
 		);
 	},
 	colorLabelImageUrl(machineId: string, pieceUuid: string, seq: number) {

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -4,12 +4,13 @@
 	import {
 		api,
 		type BrickLinkColor,
+		type ColorLabelCorrection,
 		type ColorLabelPieceDetail,
 		type PossibleCropCandidate
 	} from '$lib/api';
 	import * as nav from '$lib/colorLabelNav';
 	import Spinner from '$lib/components/Spinner.svelte';
-	import { Button } from '$lib/components/primitives';
+	import { Alert, Button } from '$lib/components/primitives';
 	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
 	import ArrowRight from 'lucide-svelte/icons/arrow-right';
 	import Ban from 'lucide-svelte/icons/ban';
@@ -64,6 +65,14 @@
 	let rejecting = $state(false);
 	let rejectReasons = $state<Set<string>>(new Set());
 	let rejected = $state(false); // this user already rejected the piece
+
+	// Brickognize part/color correction feedback
+	let correction = $state<ColorLabelCorrection | null>(null);
+	let partVerdict = $state<boolean | null>(null); // pending part right/wrong choice
+	let sendingFeedback = $state(false);
+	// Result banner after a send: success (reached Brickognize), warning (saved
+	// but Brickognize didn't accept it), or danger (the request itself failed).
+	let feedback = $state<{ variant: 'success' | 'warning' | 'danger'; text: string } | null>(null);
 
 	const guessColorId = $derived.by(() => {
 		const id = detail?.pixel_guess?.color_id;
@@ -170,6 +179,9 @@
 			rejectOpen = false;
 			rejected = d.my_rejection != null;
 			rejectReasons = new Set(d.my_rejection?.reasons ?? []);
+			correction = d.correction;
+			partVerdict = d.correction.part_correct;
+			feedback = null;
 			cropCandidates = crops.candidates;
 			cropArrivalTs = crops.arrival_ts;
 			cropDirty = false;
@@ -288,6 +300,41 @@
 			error = errMsg(e, 'Failed to reject piece');
 		} finally {
 			rejecting = false;
+		}
+	}
+
+	// Send the part verdict (and, unless already sent, the corrected color) to
+	// Brickognize. Passes the user's selected true color explicitly so a save
+	// isn't required first; the server falls back to the saved label if omitted.
+	async function sendBrickognizeFeedback() {
+		if (sendingFeedback || !correction) return;
+		sendingFeedback = true;
+		feedback = null;
+		try {
+			const body: { part_correct?: boolean | null; color_corrected_id?: number | null } = {};
+			if (!correction.part_feedback_submitted && partVerdict != null) {
+				body.part_correct = partVerdict;
+			}
+			if (!correction.color_feedback_submitted && myColorId != null) {
+				body.color_corrected_id = myColorId;
+			}
+			const res = await api.submitBrickognizeFeedback(machineId, pieceUuid, body);
+			correction = res.correction;
+			partVerdict = res.correction.part_correct;
+			if (res.submit_error) {
+				feedback = {
+					variant: 'warning',
+					text: `Saved, but Brickognize didn't accept it: ${res.submit_error}`
+				};
+			} else if (res.part_submitted || res.color_submitted) {
+				feedback = { variant: 'success', text: 'Correction sent to Brickognize.' };
+			} else {
+				feedback = { variant: 'success', text: 'Correction saved.' };
+			}
+		} catch (e: unknown) {
+			feedback = { variant: 'danger', text: errMsg(e, 'Failed to send correction') };
+		} finally {
+			sendingFeedback = false;
 		}
 	}
 
@@ -534,8 +581,10 @@
 			</div>
 		</div>
 
+		<!-- Sidebar: color picker + Brickognize correction -->
+		<div class="flex flex-col gap-6 lg:w-96">
 		<!-- Color picker -->
-		<div class="flex flex-col border bg-surface p-4 lg:w-96 {stateBorder(colorState)}">
+		<div class="flex flex-col border bg-surface p-4 {stateBorder(colorState)}">
 			<div class="mb-3 flex items-center justify-between gap-2">
 				<span class="text-sm font-medium text-text">True color</span>
 				{@render statusBadge(colorState)}
@@ -598,6 +647,103 @@
 			{#if filteredColors.length === 0}
 				<p class="py-4 text-center text-sm text-text-muted">No colors match “{search}”.</p>
 			{/if}
+		</div>
+
+		<!-- Brickognize correction — only when the piece has a Brickognize listing -->
+		{#if correction?.correctable}
+			{@const partSent = correction.part_feedback_submitted}
+			{@const colorSent = correction.color_feedback_submitted}
+			{@const canSendPart = !partSent && partVerdict != null}
+			{@const canSendColor = !colorSent && myColorId != null}
+			<div class="flex flex-col border border-border bg-surface p-4">
+				<div class="mb-3 flex items-center justify-between gap-2">
+					<span class="text-sm font-medium text-text">Correct Brickognize</span>
+					{#if partSent && colorSent}
+						<span class="flex items-center gap-1 text-xs text-success"><CircleCheck size={13} /> Sent</span>
+					{/if}
+				</div>
+
+				<!-- Predicted part + verdict -->
+				<div class="mb-1 text-xs font-semibold uppercase tracking-wider text-text-muted">Predicted part</div>
+				<div class="mb-2 flex items-center gap-2 text-sm text-text">
+					<span class="truncate">{detail.part.part_name || detail.part.part_id || 'Unidentified'}</span>
+					{#if detail.part.part_id}
+						<span class="text-xs text-text-muted">#{detail.part.part_id}</span>
+					{/if}
+				</div>
+
+				<div class="mb-3 flex items-center gap-2">
+					<Button
+						variant={partVerdict === true ? 'primary' : 'secondary'}
+						size="sm"
+						disabled={partSent}
+						onclick={() => (partVerdict = true)}
+					>
+						<Check size={14} /> Correct
+					</Button>
+					<Button
+						variant={partVerdict === false ? 'danger' : 'secondary'}
+						size="sm"
+						disabled={partSent}
+						onclick={() => (partVerdict = false)}
+					>
+						<Ban size={14} /> Wrong
+					</Button>
+					{#if partSent}
+						<span class="ml-auto flex items-center gap-1 text-xs text-success" title="already sent to Brickognize">
+							<CircleCheck size={13} /> sent
+						</span>
+					{/if}
+				</div>
+
+				<!-- Predicted color + corrected color -->
+				<div class="mb-1 text-xs font-semibold uppercase tracking-wider text-text-muted">Color</div>
+				<div class="mb-3 flex flex-col gap-1 text-sm">
+					<div class="flex items-center gap-2 text-text-muted">
+						<span>Predicted:</span>
+						<span class="text-text">{detail.prediction.color_name ?? '—'}</span>
+						{#if detail.prediction.color_id}<span class="text-xs">({detail.prediction.color_id})</span>{/if}
+					</div>
+					<div class="flex items-center gap-2 text-text-muted">
+						<span>Corrected to:</span>
+						{#if myColorId != null}
+							{@const cc = colorsById.get(myColorId)}
+							<span class="inline-block h-3.5 w-3.5 border border-border" style={`background:#${cc?.rgb ?? '000'}`}></span>
+							<span class="text-text">{cc?.name ?? myColorId}</span>
+						{:else if colorSent && correction.color_corrected_id}
+							<span class="text-text">{correction.color_corrected_id}</span>
+						{:else}
+							<span class="text-text-muted">pick a true color above</span>
+						{/if}
+						{#if colorSent}
+							<span class="ml-auto flex items-center gap-1 text-xs text-success" title="already sent to Brickognize">
+								<CircleCheck size={13} /> sent
+							</span>
+						{/if}
+					</div>
+				</div>
+
+				{#if feedback}
+					<div class="mb-2">
+						<Alert variant={feedback.variant}>{feedback.text}</Alert>
+					</div>
+				{/if}
+
+				<Button
+					variant="primary"
+					size="sm"
+					loading={sendingFeedback}
+					disabled={!canSendPart && !canSendColor}
+					onclick={sendBrickognizeFeedback}
+				>
+					{#if partSent && colorSent}
+						Sent to Brickognize
+					{:else}
+						Send correction to Brickognize
+					{/if}
+				</Button>
+			</div>
+		{/if}
 		</div>
 	</div>
 

--- a/software/sorter/backend/classification/brickognize.py
+++ b/software/sorter/backend/classification/brickognize.py
@@ -176,6 +176,15 @@ def _classifyImages(
     response.raise_for_status()
     result = cast(BrickognizeResponse, response.json())
 
+    # Stamp each item/color with its position in the UNFILTERED response before
+    # we drop primo/duplo items. Brickognize's feedback API keys on these ranks
+    # (item_rank / color_rank), so they must survive category filtering — the
+    # applied item carries its original rank even if items ahead of it are cut.
+    for rank, item in enumerate(result.get("items", []) or []):
+        item["rank"] = rank
+    for rank, color in enumerate(result.get("colors", []) or []):
+        color["rank"] = rank
+
     result["items"] = [
         item
         for item in result["items"]

--- a/software/sorter/backend/classification/brickognize_feedback.py
+++ b/software/sorter/backend/classification/brickognize_feedback.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+import requests
+
+# Brickognize's feedback endpoints. These are confirm/reject signals against a
+# prior /predict/ call (identified by its listing_id): you tell Brickognize
+# whether a specific ranked result was correct, keyed by the rank it came back
+# at. You cannot hand it an arbitrary "right" answer that wasn't in the results —
+# so a color correction to a different color reduces to rejecting the prediction.
+PART_FEEDBACK_URL = "https://api.brickognize.com/feedback/"
+COLOR_FEEDBACK_URL = "https://api.brickognize.com/feedback/color/"
+# The "source" enum value Brickognize records for feedback originating from an
+# external integration (as opposed to their own site / discord / etc.).
+FEEDBACK_SOURCE = "external-app"
+FEEDBACK_TIMEOUT_S = (30.0, 30.0)
+
+
+def submitPartFeedback(
+    *,
+    listing_id: str,
+    item_id: str,
+    item_rank: int,
+    is_correct: bool,
+    item_type: Optional[str] = None,
+) -> None:
+    payload = {
+        "listing_id": listing_id,
+        "item_id": str(item_id),
+        "item_type": item_type or "part",
+        "is_prediction_correct": bool(is_correct),
+        "source": FEEDBACK_SOURCE,
+        "item_rank": int(item_rank),
+    }
+    response = requests.post(PART_FEEDBACK_URL, json=payload, timeout=FEEDBACK_TIMEOUT_S)
+    response.raise_for_status()
+
+
+def submitColorFeedback(
+    *,
+    listing_id: str,
+    color_id: str,
+    color_rank: int,
+    is_correct: bool,
+) -> None:
+    payload = {
+        "listing_id": listing_id,
+        "is_prediction_correct": bool(is_correct),
+        "source": FEEDBACK_SOURCE,
+        "color_id": str(color_id),
+        "color_rank": int(color_rank),
+    }
+    response = requests.post(COLOR_FEEDBACK_URL, json=payload, timeout=FEEDBACK_TIMEOUT_S)
+    response.raise_for_status()

--- a/software/sorter/backend/classification/brickognize_types.py
+++ b/software/sorter/backend/classification/brickognize_types.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, List
+from typing import TypedDict, List, NotRequired
 
 
 class BrickognizeExternalSite(TypedDict):
@@ -24,12 +24,20 @@ class BrickognizeItem(TypedDict):
     category: str
     type: str
     score: float
+    # Zero-based position of this item in Brickognize's UNFILTERED response,
+    # injected by _classifyImages before category filtering. This is the
+    # ``item_rank`` the Brickognize feedback API expects, so it must reflect the
+    # original ordering even after we drop primo/duplo items.
+    rank: NotRequired[int]
 
 
 class BrickognizeColor(TypedDict):
     id: str
     name: str
     score: float
+    # Zero-based position of this color in the response, injected by
+    # _classifyImages. This is the ``color_rank`` the color-feedback API expects.
+    rank: NotRequired[int]
 
 
 class BrickognizeResponse(TypedDict):

--- a/software/sorter/backend/defs/events.py
+++ b/software/sorter/backend/defs/events.py
@@ -164,6 +164,14 @@ class KnownObjectData(BaseModel):
     drop_snapshot: Optional[str] = None
     brickognize_preview_url: Optional[str] = None
     brickognize_source_view: Optional[str] = None
+    # Correction provenance from the applied request. brickognize_listing_id being
+    # set is what makes a piece "correctable" in the UI (the client can only submit
+    # a correction when we captured the listing). Carried on the live payload so a
+    # freshly classified piece is correctable immediately, before it's recorded.
+    brickognize_listing_id: Optional[str] = None
+    brickognize_item_rank: Optional[int] = None
+    brickognize_item_type: Optional[str] = None
+    brickognize_color_rank: Optional[int] = None
     # C4 burst captures + any upstream (C2/C3) match crops, each flagged with
     # whether it was actually submitted to Brickognize.
     recognition_image_set: List["RecognitionImage"] = Field(default_factory=list)

--- a/software/sorter/backend/defs/known_object.py
+++ b/software/sorter/backend/defs/known_object.py
@@ -100,6 +100,15 @@ class ClassificationAttempt:
     # resolves these against the recognition image set to show which crops went
     # into each parallel call when a request row is expanded.
     image_ts: List[float] = field(default_factory=list)
+    # Brickognize's per-request search id, needed to submit a correction for this
+    # request's result (the feedback API keys on it). None on error/older records.
+    listing_id: Optional[str] = None
+    # Zero-based rank of this request's top item/color in Brickognize's original
+    # response (the item_rank/color_rank the feedback API expects). ``item_type``
+    # is Brickognize's type for the top item ("part"/"set"/"fig"/"sticker").
+    item_rank: Optional[int] = None
+    item_type: Optional[str] = None
+    color_rank: Optional[int] = None
 
 
 @dataclass
@@ -177,6 +186,18 @@ class KnownObject:
     drop_snapshot: Optional[str] = None
     brickognize_preview_url: Optional[str] = None
     brickognize_source_view: Optional[str] = None
+    # Correction-submission provenance, copied from the APPLIED Brickognize
+    # request so a user correction can be sent back to Brickognize's feedback API
+    # without re-querying. ``brickognize_listing_id`` is the applied request's
+    # search id; ``brickognize_item_rank``/``brickognize_item_type`` describe the
+    # applied top item's position/type in that response; ``brickognize_color_rank``
+    # is the applied top color's position. Brickognize's feedback API only
+    # accepts/rejects a specific ranked result, so these scalars are all a
+    # part-or-color correction needs. None until a request is applied / on error.
+    brickognize_listing_id: Optional[str] = None
+    brickognize_item_rank: Optional[int] = None
+    brickognize_item_type: Optional[str] = None
+    brickognize_color_rank: Optional[int] = None
     # Every image gathered for recognition — C4 burst captures plus any upstream
     # (C2/C3) match crops fused in by the embedding search — each flagged with
     # whether it was actually submitted to Brickognize. The burst keeps all its

--- a/software/sorter/backend/hive_telemetry.py
+++ b/software/sorter/backend/hive_telemetry.py
@@ -163,6 +163,16 @@ class HiveTelemetryClient:
         )
         return int(response.json()["max_local_id"])
 
+    def pushPieceCorrections(self, records: list[dict[str, Any]]) -> int:
+        response = self._request(
+            "POST",
+            "/api/machine/sync/piece-corrections",
+            fields=("piece_metadata",),
+            json={"records": records},
+            timeout=60,
+        )
+        return int(response.json()["max_local_id"])
+
     def pushPieceImage(self, meta: dict[str, Any], file_path: Path | None) -> int:
         files = None
         if file_path is not None and file_path.is_file():

--- a/software/sorter/backend/piece_metadata_db.py
+++ b/software/sorter/backend/piece_metadata_db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import sqlite3
@@ -116,6 +117,64 @@ def _movingAvg(price: dict[str, dict[str, Any]]) -> Optional[float]:
         if isinstance(value, (int, float)) and value > 0:
             return round(float(value), 4)
     return None
+
+
+_bricklink_colors_cache: Optional[list[dict[str, Any]]] = None
+_bricklink_colors_lock = threading.Lock()
+
+
+def listBrickLinkColors(gc: GlobalConfig) -> list[dict[str, Any]]:
+    # BrickLink color palette derived from the Rebrickable `colors` catalog's
+    # external ids (same derivation as Hive's profile_catalog.list_bricklink_colors).
+    # Brickognize predictions and piece color_ids live in BrickLink color space,
+    # so this is the palette the correction dropdown picks from. First Rebrickable
+    # mapping wins on a BL-id collision. Cached for the process lifetime (the DB is
+    # a static read-only snapshot).
+    global _bricklink_colors_cache
+    with _bricklink_colors_lock:
+        if _bricklink_colors_cache is not None:
+            return _bricklink_colors_cache
+    conn = _getConn(gc)
+    if conn is None:
+        return []
+    with _query_lock:
+        rows = conn.execute(
+            "SELECT id, name, rgb, is_trans, extra FROM colors ORDER BY id"
+        ).fetchall()
+    by_bl_id: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        extra: Any = {}
+        if row["extra"]:
+            try:
+                extra = json.loads(row["extra"])
+            except (ValueError, TypeError):
+                extra = {}
+        bricklink = extra.get("external_ids", {}).get("BrickLink", {}) if isinstance(extra, dict) else {}
+        if not isinstance(bricklink, dict):
+            continue
+        ext_ids = bricklink.get("ext_ids", [])
+        ext_descrs = bricklink.get("ext_descrs", [])
+        if not isinstance(ext_ids, list):
+            continue
+        for index, raw_bl_id in enumerate(ext_ids):
+            try:
+                bl_id = int(raw_bl_id)
+            except (TypeError, ValueError):
+                continue
+            if bl_id in by_bl_id:
+                continue
+            descr = ext_descrs[index] if isinstance(ext_descrs, list) and index < len(ext_descrs) else None
+            bl_name = descr[0] if isinstance(descr, list) and descr else (row["name"] or str(bl_id))
+            by_bl_id[bl_id] = {
+                "id": bl_id,
+                "name": bl_name,
+                "rgb": row["rgb"],
+                "is_trans": bool(row["is_trans"]),
+            }
+    result = [by_bl_id[bl_id] for bl_id in sorted(by_bl_id)]
+    with _bricklink_colors_lock:
+        _bricklink_colors_cache = result
+    return result
 
 
 def _selectPriceRow(

--- a/software/sorter/backend/piece_records.py
+++ b/software/sorter/backend/piece_records.py
@@ -87,6 +87,47 @@ def _ensureInitialized() -> None:
                 conn.execute(
                     "ALTER TABLE piece_records ADD COLUMN brickognize_preview_url TEXT"
                 )
+            # Brickognize-correction columns. The first four are provenance copied
+            # from the applied classification request (needed to address a
+            # correction to Brickognize's feedback API). The rest hold the user's
+            # correction: part_correct is NULL (unreviewed) / 1 (right) / 0
+            # (wrong); color_corrected_id is the user-picked true BrickLink color;
+            # the *_feedback_submitted flags record whether we sent it to
+            # Brickognize; correction_updated_at is the last correction edit time.
+            for _col, _ddl in (
+                ("brickognize_listing_id", "TEXT"),
+                ("brickognize_item_rank", "INTEGER"),
+                ("brickognize_item_type", "TEXT"),
+                ("brickognize_color_rank", "INTEGER"),
+                ("part_correct", "INTEGER"),
+                ("color_corrected_id", "TEXT"),
+                ("part_feedback_submitted", "INTEGER NOT NULL DEFAULT 0"),
+                ("color_feedback_submitted", "INTEGER NOT NULL DEFAULT 0"),
+                ("correction_updated_at", "REAL"),
+            ):
+                if _col not in existing_columns:
+                    conn.execute(
+                        f"ALTER TABLE piece_records ADD COLUMN {_col} {_ddl}"
+                    )
+            # Append-only log of correction edits, drained to Hive by the sync
+            # worker on its own watermark (id). Each edit appends a fresh row so
+            # the monotonic id advances even when the same piece is corrected
+            # twice (e.g. mark, then submit); Hive upserts the latest per piece.
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS piece_corrections ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "piece_uuid TEXT NOT NULL, "
+                "part_correct INTEGER, "
+                "color_corrected_id TEXT, "
+                "part_feedback_submitted INTEGER NOT NULL DEFAULT 0, "
+                "color_feedback_submitted INTEGER NOT NULL DEFAULT 0, "
+                "updated_at REAL NOT NULL"
+                ")"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_piece_corrections_uuid "
+                "ON piece_corrections(piece_uuid)"
+            )
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_piece_records_seen "
                 "ON piece_records(seen_at)"
@@ -126,8 +167,10 @@ def recordPiece(
             "INSERT OR IGNORE INTO piece_records "
             "(uuid, run_id, machine_id, seen_at, recorded_at, classification_status, "
             "part_id, part_name, color_id, color_name, category_id, confidence, "
-            "bin_x, bin_y, bin_z, dead, brickognize_preview_url) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "bin_x, bin_y, bin_z, dead, brickognize_preview_url, "
+            "brickognize_listing_id, brickognize_item_rank, brickognize_item_type, "
+            "brickognize_color_rank) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 uuid_val,
                 run_id,
@@ -146,6 +189,10 @@ def recordPiece(
                 bin_z,
                 dead,
                 piece.get("brickognize_preview_url"),
+                piece.get("brickognize_listing_id"),
+                piece.get("brickognize_item_rank"),
+                piece.get("brickognize_item_type"),
+                piece.get("brickognize_color_rank"),
             ),
         )
         conn.commit()
@@ -304,7 +351,9 @@ def _hasPieceImagesTable(conn: sqlite3.Connection) -> bool:
 _SUMMARY_COLUMNS = (
     "id, uuid, run_id, seen_at, recorded_at, classification_status, "
     "part_id, part_name, color_id, color_name, category_id, confidence, "
-    "bin_x, bin_y, bin_z, dead, brickognize_preview_url"
+    "bin_x, bin_y, bin_z, dead, brickognize_preview_url, "
+    "brickognize_listing_id, part_correct, color_corrected_id, "
+    "part_feedback_submitted, color_feedback_submitted"
 )
 
 
@@ -349,6 +398,18 @@ def _rowToSummary(gc: Any, row: sqlite3.Row) -> dict[str, Any]:
         "has_images": bool(row["has_images"]),
         "preview_url": row["brickognize_preview_url"],
         "est_value": _estValue(gc, row["part_id"], row["color_id"]),
+        # Brickognize-correction state. correctable is True when we captured a
+        # listing id for this piece (only then can a correction be submitted).
+        # part_correct is None (unreviewed) / True / False; color_corrected_id is
+        # the user-picked true color; the submitted flags say whether we sent the
+        # correction to Brickognize.
+        "correctable": row["brickognize_listing_id"] is not None,
+        "part_correct": (
+            None if row["part_correct"] is None else bool(row["part_correct"])
+        ),
+        "color_corrected_id": row["color_corrected_id"],
+        "part_feedback_submitted": bool(row["part_feedback_submitted"]),
+        "color_feedback_submitted": bool(row["color_feedback_submitted"]),
     }
 
 
@@ -499,7 +560,9 @@ def iterPieceSummaries(
 _SYNC_COLUMNS = (
     "id, uuid, run_id, machine_id, seen_at, recorded_at, classification_status, "
     "part_id, part_name, color_id, color_name, category_id, confidence, "
-    "bin_x, bin_y, bin_z, dead, brickognize_preview_url"
+    "bin_x, bin_y, bin_z, dead, brickognize_preview_url, "
+    "brickognize_listing_id, brickognize_item_rank, brickognize_item_type, "
+    "brickognize_color_rank"
 )
 
 
@@ -517,6 +580,140 @@ def listRecordsAfter(id_cursor: int, limit: int) -> list[dict[str, Any]]:
 def getMaxRecordId() -> int:
     with _connection() as conn:
         row = conn.execute("SELECT COALESCE(MAX(id), 0) AS m FROM piece_records").fetchone()
+    return int(row["m"] or 0)
+
+
+# --- Brickognize corrections -------------------------------------------------
+
+# Fields the correction API needs to build a Brickognize feedback call and to
+# render current state, resolved by uuid.
+_CORRECTION_CONTEXT_COLUMNS = (
+    "uuid, part_id, color_id, color_name, "
+    "brickognize_listing_id, brickognize_item_rank, brickognize_item_type, "
+    "brickognize_color_rank, part_correct, color_corrected_id, "
+    "part_feedback_submitted, color_feedback_submitted"
+)
+
+
+def _appendCorrectionLog(conn: sqlite3.Connection, uuid_val: str) -> None:
+    # Snapshot the current correction state into the append-only sync log so the
+    # Hive sync worker's watermark advances and picks up this edit.
+    row = conn.execute(
+        "SELECT part_correct, color_corrected_id, part_feedback_submitted, "
+        "color_feedback_submitted, correction_updated_at "
+        "FROM piece_records WHERE uuid = ?",
+        (uuid_val,),
+    ).fetchone()
+    if row is None:
+        return
+    conn.execute(
+        "INSERT INTO piece_corrections "
+        "(piece_uuid, part_correct, color_corrected_id, part_feedback_submitted, "
+        "color_feedback_submitted, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            uuid_val,
+            row["part_correct"],
+            row["color_corrected_id"],
+            row["part_feedback_submitted"],
+            row["color_feedback_submitted"],
+            row["correction_updated_at"] if row["correction_updated_at"] is not None else time.time(),
+        ),
+    )
+
+
+def getCorrectionContext(uuid_val: str) -> Optional[dict[str, Any]]:
+    with _connection() as conn:
+        row = conn.execute(
+            f"SELECT {_CORRECTION_CONTEXT_COLUMNS} FROM piece_records WHERE uuid = ?",
+            (uuid_val,),
+        ).fetchone()
+    if row is None:
+        return None
+    d = dict(row)
+    d["part_correct"] = None if d["part_correct"] is None else bool(d["part_correct"])
+    d["part_feedback_submitted"] = bool(d["part_feedback_submitted"])
+    d["color_feedback_submitted"] = bool(d["color_feedback_submitted"])
+    return d
+
+
+def setPieceCorrection(
+    uuid_val: str,
+    *,
+    set_part: bool = False,
+    part_correct: Optional[bool] = None,
+    set_color: bool = False,
+    color_corrected_id: Optional[str] = None,
+) -> bool:
+    # Update the user's correction verdict on a piece. ``set_part``/``set_color``
+    # gate which fields change so the part check/x and the color dropdown can be
+    # edited independently. Appends to the sync log. Returns False if no such
+    # piece exists.
+    now = time.time()
+    sets = ["correction_updated_at = ?"]
+    params: list[Any] = [now]
+    if set_part:
+        sets.append("part_correct = ?")
+        params.append(None if part_correct is None else (1 if part_correct else 0))
+    if set_color:
+        sets.append("color_corrected_id = ?")
+        params.append(str(color_corrected_id) if color_corrected_id is not None else None)
+    params.append(uuid_val)
+    with _connection() as conn:
+        cur = conn.execute(
+            f"UPDATE piece_records SET {', '.join(sets)} WHERE uuid = ?", params
+        )
+        if cur.rowcount == 0:
+            conn.commit()
+            return False
+        _appendCorrectionLog(conn, uuid_val)
+        conn.commit()
+    return True
+
+
+def markFeedbackSubmitted(
+    uuid_val: str, *, part: bool = False, color: bool = False
+) -> bool:
+    # Flag that a part and/or color correction was sent to Brickognize. Only ever
+    # turns the flags on. Appends to the sync log. Returns False if unknown piece.
+    if not part and not color:
+        return False
+    now = time.time()
+    sets = ["correction_updated_at = ?"]
+    params: list[Any] = [now]
+    if part:
+        sets.append("part_feedback_submitted = 1")
+    if color:
+        sets.append("color_feedback_submitted = 1")
+    params.append(uuid_val)
+    with _connection() as conn:
+        cur = conn.execute(
+            f"UPDATE piece_records SET {', '.join(sets)} WHERE uuid = ?", params
+        )
+        if cur.rowcount == 0:
+            conn.commit()
+            return False
+        _appendCorrectionLog(conn, uuid_val)
+        conn.commit()
+    return True
+
+
+def listCorrectionsAfter(id_cursor: int, limit: int) -> list[dict[str, Any]]:
+    # Append-only correction log rows ASC by id for the Hive sync watermark.
+    with _connection() as conn:
+        rows = conn.execute(
+            "SELECT id, piece_uuid, part_correct, color_corrected_id, "
+            "part_feedback_submitted, color_feedback_submitted, updated_at "
+            "FROM piece_corrections WHERE id > ? ORDER BY id ASC LIMIT ?",
+            (int(id_cursor), int(limit)),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def getMaxCorrectionId() -> int:
+    with _connection() as conn:
+        row = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) AS m FROM piece_corrections"
+        ).fetchone()
     return int(row["m"] or 0)
 
 

--- a/software/sorter/backend/run_recorder.py
+++ b/software/sorter/backend/run_recorder.py
@@ -28,6 +28,11 @@ def _serializePiece(p: KnownObject) -> dict:
         "confidence": p.confidence,
         "destination_bin": list(p.destination_bin) if p.destination_bin else None,
         "brickognize_preview_url": p.brickognize_preview_url,
+        # Correction-submission provenance from the applied Brickognize request.
+        "brickognize_listing_id": p.brickognize_listing_id,
+        "brickognize_item_rank": p.brickognize_item_rank,
+        "brickognize_item_type": p.brickognize_item_type,
+        "brickognize_color_rank": p.brickognize_color_rank,
     }
 
 

--- a/software/sorter/backend/server/hive_sync.py
+++ b/software/sorter/backend/server/hive_sync.py
@@ -31,8 +31,11 @@ log = logging.getLogger(__name__)
 DATA_TYPE_RECORDS = "piece_records"
 DATA_TYPE_IMAGES = "piece_images"
 DATA_TYPE_CROPS = "channel_crops"
+DATA_TYPE_CORRECTIONS = "piece_corrections"
 
 RECORDS_BATCH = 500
+CORRECTIONS_BATCH = 500
+CORRECTIONS_THROTTLE_S = 0.15
 # Images push one file per request (multipart), so a small chunk per cycle keeps
 # each pass short and interleaves fairly across targets.
 IMAGES_CHUNK = 10
@@ -76,6 +79,26 @@ def _recordToPayload(row: dict[str, Any]) -> dict[str, Any]:
         "bin_z": row["bin_z"],
         "dead": bool(row["dead"]),
         "brickognize_preview_url": row["brickognize_preview_url"],
+        # Correction provenance from the applied Brickognize request, so a
+        # correction entered on Hive can be submitted to Brickognize there.
+        "brickognize_listing_id": row["brickognize_listing_id"],
+        "brickognize_item_rank": row["brickognize_item_rank"],
+        "brickognize_item_type": row["brickognize_item_type"],
+        "brickognize_color_rank": row["brickognize_color_rank"],
+    }
+
+
+def _correctionToPayload(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "piece_uuid": row["piece_uuid"],
+        "local_id": row["id"],
+        "part_correct": (
+            None if row["part_correct"] is None else bool(row["part_correct"])
+        ),
+        "color_corrected_id": row["color_corrected_id"],
+        "part_feedback_submitted": bool(row["part_feedback_submitted"]),
+        "color_feedback_submitted": bool(row["color_feedback_submitted"]),
+        "updated_at": row["updated_at"],
     }
 
 
@@ -163,7 +186,7 @@ class HiveSyncWorker:
                 "enabled": enabled,
                 "client": None,
                 "state_ok": False,
-                "wm": dict(prev.get("wm", {DATA_TYPE_RECORDS: None, DATA_TYPE_IMAGES: None, DATA_TYPE_CROPS: None})),
+                "wm": dict(prev.get("wm", {DATA_TYPE_RECORDS: None, DATA_TYPE_IMAGES: None, DATA_TYPE_CROPS: None, DATA_TYPE_CORRECTIONS: None})),
                 "backoff_s": float(prev.get("backoff_s", SERVER_DOWN_BACKOFF_S)),
                 "retry_after": float(prev.get("retry_after", 0.0)),
                 "last_error": prev.get("last_error"),
@@ -205,7 +228,8 @@ class HiveSyncWorker:
                 # a run, so an `or` chain would starve crops behind that backlog.
                 records_or_images = self._drainRecords(target) or self._drainImages(target)
                 crops = self._drainChannelCrops(target)
-                progressed = records_or_images or crops
+                corrections = self._drainCorrections(target)
+                progressed = records_or_images or crops or corrections
                 target["state_ok"] = True
                 target["backoff_s"] = SERVER_DOWN_BACKOFF_S
                 target["last_error"] = None
@@ -220,7 +244,12 @@ class HiveSyncWorker:
         if target["state_ok"] and target["wm"][DATA_TYPE_RECORDS] is not None:
             return
         state = target["client"].getSyncState()
-        for data_type in (DATA_TYPE_RECORDS, DATA_TYPE_IMAGES, DATA_TYPE_CROPS):
+        for data_type in (
+            DATA_TYPE_RECORDS,
+            DATA_TYPE_IMAGES,
+            DATA_TYPE_CROPS,
+            DATA_TYPE_CORRECTIONS,
+        ):
             raw = state.get(data_type) if isinstance(state, dict) else None
             value = raw.get("max_local_id") if isinstance(raw, dict) else 0
             target["wm"][data_type] = int(value or 0)
@@ -274,6 +303,25 @@ class HiveSyncWorker:
             new_max = target["client"].pushChannelCrop(_cropToMeta(row), file_path)
             target["wm"][DATA_TYPE_CROPS] = max(int(target["wm"][DATA_TYPE_CROPS] or 0), int(new_max), int(row["id"]))
             time.sleep(CROPS_THROTTLE_S)
+        return True
+
+    def _drainCorrections(self, target: dict[str, Any]) -> bool:
+        # Correction edits are piece metadata, so they follow the same gate as
+        # piece_records. The append-only piece_corrections log gives a clean
+        # monotonic cursor; Hive upserts the latest edit per piece.
+        if not telemetryAllows(target["id"], "piece_metadata"):
+            return False
+        wm = int(target["wm"][DATA_TYPE_CORRECTIONS] or 0)
+        if piece_records.getMaxCorrectionId() <= wm:
+            return False
+        rows = piece_records.listCorrectionsAfter(wm, CORRECTIONS_BATCH)
+        if not rows:
+            return False
+        new_max = target["client"].pushPieceCorrections(
+            [_correctionToPayload(r) for r in rows]
+        )
+        target["wm"][DATA_TYPE_CORRECTIONS] = max(wm, int(new_max), int(rows[-1]["id"]))
+        time.sleep(CORRECTIONS_THROTTLE_S)
         return True
 
     def _markImageRetention(self, targets: list[dict[str, Any]]) -> None:

--- a/software/sorter/backend/server/routers/pieces.py
+++ b/software/sorter/backend/server/routers/pieces.py
@@ -71,6 +71,13 @@ class PieceSummary(BaseModel):
     has_images: bool = False
     preview_url: Optional[str] = None
     est_value: Optional[float] = None
+    # Brickognize-correction state. correctable is True only when a listing id
+    # was captured for this piece (a prerequisite for submitting any correction).
+    correctable: bool = False
+    part_correct: Optional[bool] = None
+    color_corrected_id: Optional[str] = None
+    part_feedback_submitted: bool = False
+    color_feedback_submitted: bool = False
 
 
 class PiecesListResponse(BaseModel):
@@ -219,6 +226,30 @@ def getPiecesAggregates(days: int = 365) -> Dict[str, Any]:
     return piece_records.getAggregates(shared_state.gc_ref, days=days)
 
 
+class ColorOption(BaseModel):
+    id: int
+    name: str
+    rgb: Optional[str] = None
+    is_trans: bool = False
+
+
+class ColorsResponse(BaseModel):
+    results: List[ColorOption]
+
+
+@router.get("/api/pieces/colors", response_model=ColorsResponse)
+def getPieceColors() -> ColorsResponse:
+    # BrickLink color palette for the correction dropdown (searchable list of all
+    # LEGO colors). Sourced from the local parts.db; empty when it's unavailable.
+    import piece_metadata_db
+
+    gc = shared_state.gc_ref
+    if gc is None:
+        return ColorsResponse(results=[])
+    colors = piece_metadata_db.listBrickLinkColors(gc)
+    return ColorsResponse(results=[ColorOption(**c) for c in colors])
+
+
 _CSV_COLUMNS = [
     "uuid",
     "run_id",
@@ -352,6 +383,116 @@ def listPieces(
     )
 
 
+class CorrectionRequest(BaseModel):
+    # Fields present in the request body are applied; absent fields are left
+    # unchanged (so the part check/x and the color dropdown can be saved
+    # independently). part_correct null clears the piece back to unreviewed.
+    part_correct: Optional[bool] = None
+    color_corrected_id: Optional[str] = None
+    # When true (default), any pending (verdict recorded, not yet submitted)
+    # correction is sent to Brickognize now. The verdict is always recorded.
+    submit: bool = True
+
+
+class CorrectionResponse(BaseModel):
+    summary: PieceSummary
+    part_submitted: bool = False
+    color_submitted: bool = False
+    submit_error: Optional[str] = None
+
+
+@router.post("/api/pieces/{uuid}/correction", response_model=CorrectionResponse)
+def submitPieceCorrection(uuid: str, body: CorrectionRequest) -> CorrectionResponse:
+    import piece_records
+    from classification.brickognize_feedback import (
+        submitColorFeedback,
+        submitPartFeedback,
+    )
+
+    gc = shared_state.gc_ref
+    ctx = piece_records.getCorrectionContext(uuid)
+    if ctx is None:
+        raise HTTPException(status_code=404, detail="not found")
+
+    fields = body.model_fields_set
+    set_part = "part_correct" in fields
+    set_color = "color_corrected_id" in fields
+    if set_part or set_color:
+        piece_records.setPieceCorrection(
+            uuid,
+            set_part=set_part,
+            part_correct=body.part_correct,
+            set_color=set_color,
+            color_corrected_id=body.color_corrected_id,
+        )
+        ctx = piece_records.getCorrectionContext(uuid) or ctx
+
+    part_submitted = False
+    color_submitted = False
+    submit_error: Optional[str] = None
+
+    if body.submit:
+        listing_id = ctx.get("brickognize_listing_id")
+        # Part feedback: needs a listing, the applied item's rank, a part id, and
+        # a recorded verdict that hasn't already been sent.
+        if (
+            listing_id
+            and ctx.get("part_correct") is not None
+            and not ctx.get("part_feedback_submitted")
+            and ctx.get("brickognize_item_rank") is not None
+            and ctx.get("part_id")
+        ):
+            try:
+                submitPartFeedback(
+                    listing_id=str(listing_id),
+                    item_id=str(ctx["part_id"]),
+                    item_rank=int(ctx["brickognize_item_rank"]),
+                    item_type=ctx.get("brickognize_item_type"),
+                    is_correct=bool(ctx["part_correct"]),
+                )
+                piece_records.markFeedbackSubmitted(uuid, part=True)
+                part_submitted = True
+            except Exception as e:
+                submit_error = f"part: {e}"
+                if gc is not None:
+                    gc.logger.warning(f"Brickognize part feedback failed for {uuid}: {e}")
+        # Color feedback: a corrected color equal to the prediction confirms it; a
+        # different one rejects the prediction (Brickognize only accepts/rejects
+        # its own ranked color, so it can't be told the actual true color).
+        if (
+            listing_id
+            and ctx.get("color_corrected_id") is not None
+            and not ctx.get("color_feedback_submitted")
+            and ctx.get("brickognize_color_rank") is not None
+            and ctx.get("color_id")
+        ):
+            try:
+                is_correct = str(ctx["color_corrected_id"]) == str(ctx["color_id"])
+                submitColorFeedback(
+                    listing_id=str(listing_id),
+                    color_id=str(ctx["color_id"]),
+                    color_rank=int(ctx["brickognize_color_rank"]),
+                    is_correct=is_correct,
+                )
+                piece_records.markFeedbackSubmitted(uuid, color=True)
+                color_submitted = True
+            except Exception as e:
+                prev = submit_error + "; " if submit_error else ""
+                submit_error = f"{prev}color: {e}"
+                if gc is not None:
+                    gc.logger.warning(f"Brickognize color feedback failed for {uuid}: {e}")
+
+    summary = piece_records.getPieceSummaryByUuid(gc, uuid)
+    if summary is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return CorrectionResponse(
+        summary=PieceSummary(**summary),
+        part_submitted=part_submitted,
+        color_submitted=color_submitted,
+        submit_error=submit_error,
+    )
+
+
 def _summaryFromMemory(gc: Any, payload: Dict[str, Any]) -> PieceSummary:
     # HOT PATH: RecentObjects polls this per active piece every 600ms during
     # sorting. Everything here must come from the in-memory payload / process
@@ -387,6 +528,10 @@ def _summaryFromMemory(gc: Any, payload: Dict[str, Any]) -> PieceSummary:
         has_images=bool(payload.get("recognition_image_set")),
         preview_url=payload.get("brickognize_preview_url"),
         est_value=est_value,
+        # A freshly classified piece can be corrected the moment it appears in
+        # the recent list — the correction state itself lives only in the DB, so
+        # it defaults to unreviewed here.
+        correctable=payload.get("brickognize_listing_id") is not None,
     )
 
 

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/base.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/base.py
@@ -506,6 +506,18 @@ class Rev01BaseState(BaseState):
                     image_ts=[
                         s.rec.ts for s in req.images if s.rec.ts is not None
                     ],
+                    listing_id=(
+                        result.get("listing_id") if isinstance(result, dict) else None
+                    ),
+                    item_rank=(
+                        top.get("rank") if isinstance(top, dict) else None
+                    ),
+                    item_type=(
+                        top.get("type") if isinstance(top, dict) else None
+                    ),
+                    color_rank=(
+                        top_color.get("rank") if isinstance(top_color, dict) else None
+                    ),
                 )
             )
             attempt_reqs.append(req)
@@ -690,6 +702,11 @@ class Rev01BaseState(BaseState):
         elif isinstance(result, dict):
             items = result.get("items", [])
             colors = result.get("colors", [])
+            # Correction provenance from the applied request: the search id, so a
+            # later user correction can be submitted to Brickognize's feedback API
+            # without re-querying. Per-result ranks are set alongside the applied
+            # item/color below.
+            obj.brickognize_listing_id = result.get("listing_id")
             if items:
                 best = items[0]
                 obj.part_id = best.get("id")
@@ -697,6 +714,8 @@ class Rev01BaseState(BaseState):
                 obj.part_category = best.get("category")
                 obj.confidence = best.get("score")
                 obj.brickognize_preview_url = best.get("img_url")
+                obj.brickognize_item_rank = best.get("rank")
+                obj.brickognize_item_type = best.get("type")
                 obj.classification_status = ClassificationStatus.classified
             else:
                 obj.classification_status = ClassificationStatus.not_found
@@ -704,6 +723,7 @@ class Rev01BaseState(BaseState):
                 best_color = max(colors, key=lambda c: c.get("score", 0))
                 obj.color_id = str(best_color.get("id", "any_color"))
                 obj.color_name = str(best_color.get("name", "Any Color"))
+                obj.brickognize_color_rank = best_color.get("rank")
         else:
             obj.classification_status = ClassificationStatus.unknown
 

--- a/software/sorter/backend/utils/event.py
+++ b/software/sorter/backend/utils/event.py
@@ -79,6 +79,10 @@ def knownObjectToEvent(obj: KnownObject) -> KnownObjectEvent:
             drop_snapshot=obj.drop_snapshot,
             brickognize_preview_url=obj.brickognize_preview_url,
             brickognize_source_view=obj.brickognize_source_view,
+            brickognize_listing_id=obj.brickognize_listing_id,
+            brickognize_item_rank=obj.brickognize_item_rank,
+            brickognize_item_type=obj.brickognize_item_type,
+            brickognize_color_rank=obj.brickognize_color_rank,
             recognition_used_crop_ts=list(obj.recognition_used_crop_ts or []),
             recognition_image_set=[
                 RecognitionImage(

--- a/software/sorter/frontend/src/lib/api/events.ts
+++ b/software/sorter/frontend/src/lib/api/events.ts
@@ -131,6 +131,8 @@ export interface KnownObjectData {
   drop_snapshot?: string | null;
   brickognize_preview_url?: string | null;
   brickognize_source_view?: string | null;
+  // Set when a Brickognize listing was captured — makes the piece correctable.
+  brickognize_listing_id?: string | null;
   recognition_image_set?: RecognitionImage[];
   classification_attempts?: ClassificationAttempt[];
   classification_strategy?: ClassificationAttemptStrategy | null;

--- a/software/sorter/frontend/src/lib/components/PieceCorrection.svelte
+++ b/software/sorter/frontend/src/lib/components/PieceCorrection.svelte
@@ -1,0 +1,363 @@
+<script lang="ts">
+	import { Check, X, Search, Sparkles } from 'lucide-svelte';
+	import { Button, Alert } from '$lib/components/primitives';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import {
+		fetchLegoColors,
+		swatchHex,
+		swatchTextColor,
+		type BrickLinkColor,
+		type PieceSummary
+	} from '$lib/pieces';
+
+	// Reusable Brickognize correction controls. Render only when
+	// `piece.correctable === true` — the parent is responsible for that gate, but
+	// the component also no-ops defensively if handed a non-correctable piece.
+	//
+	// Two independent verdicts:
+	//   • PART — a check/X marking whether the predicted PART TYPE was right. This
+	//     is ONLY about the part, never the color.
+	//   • COLOR — a searchable dropdown of the whole BrickLink palette. The
+	//     predicted color is pre-selected and flagged; the user can pick another
+	//     and Confirm to lock it in.
+	//
+	// Every mutation POSTs to /api/pieces/{uuid}/correction (submit:true) and the
+	// parent is handed the fresh summary via `onUpdated` so it can update in place.
+	let {
+		piece,
+		endpointBase,
+		onUpdated,
+		compact = false
+	}: {
+		piece: PieceSummary;
+		endpointBase: string;
+		onUpdated?: (summary: PieceSummary) => void;
+		// Slightly tighter layout for the modal/popover surface.
+		compact?: boolean;
+	} = $props();
+
+	type CorrectionResponse = {
+		summary: PieceSummary;
+		part_submitted: boolean;
+		color_submitted: boolean;
+		submit_error: string | null;
+	};
+
+	let colors = $state<BrickLinkColor[]>([]);
+	let colorsLoading = $state(false);
+	let colorsError = $state<string | null>(null);
+
+	let partBusy = $state(false);
+	let colorBusy = $state(false);
+	// Result banner after a correction call: success (reached Brickognize),
+	// warning (recorded locally but Brickognize didn't accept it), or danger
+	// (the request itself failed, nothing saved).
+	let feedback = $state<{ variant: 'success' | 'warning' | 'danger'; text: string } | null>(null);
+
+	// Color dropdown state.
+	let pickerOpen = $state(false);
+	let query = $state('');
+	// The staged selection (BrickLink id as string) before Confirm. Initialized
+	// to the already-corrected color if present, else the prediction.
+	let selectedId = $state<string | null>(null);
+
+	const predictedColorId = $derived(piece.color_id ?? null);
+	const committedColorId = $derived(piece.color_corrected_id ?? null);
+
+	async function loadColors() {
+		if (colors.length > 0 || colorsLoading) return;
+		colorsLoading = true;
+		colorsError = null;
+		try {
+			colors = await fetchLegoColors(endpointBase);
+		} catch {
+			colorsError = 'Could not load the color list.';
+		} finally {
+			colorsLoading = false;
+		}
+	}
+
+	function openPicker() {
+		selectedId = committedColorId ?? predictedColorId ?? null;
+		query = '';
+		pickerOpen = true;
+		void loadColors();
+	}
+
+	function closePicker() {
+		pickerOpen = false;
+	}
+
+	const filteredColors = $derived.by(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) return colors;
+		return colors.filter((c) => c.name.toLowerCase().includes(q));
+	});
+
+	function colorNameFor(id: string | null): string | null {
+		if (!id) return null;
+		const match = colors.find((c) => String(c.id) === id);
+		return match?.name ?? null;
+	}
+
+	function colorRgbFor(id: string | null): string | null {
+		if (!id) return null;
+		return colors.find((c) => String(c.id) === id)?.rgb ?? null;
+	}
+
+	async function postCorrection(body: {
+		part_correct?: boolean | null;
+		color_corrected_id?: string | null;
+		submit?: boolean;
+	}): Promise<CorrectionResponse | null> {
+		const res = await fetch(
+			`${endpointBase}/api/pieces/${encodeURIComponent(piece.uuid)}/correction`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body)
+			}
+		);
+		if (!res.ok) throw new Error(`correction ${res.status}`);
+		return (await res.json()) as CorrectionResponse;
+	}
+
+	// Turn a correction response into a result banner. `sent` is the channel's
+	// submitted flag (part_submitted / color_submitted) for the "reached
+	// Brickognize" success message.
+	function applyResponse(resp: CorrectionResponse, noun: string, sent: boolean) {
+		onUpdated?.(resp.summary);
+		if (resp.submit_error) {
+			feedback = {
+				variant: 'warning',
+				text: `${noun} saved, but Brickognize didn't accept it: ${resp.submit_error}`
+			};
+		} else if (sent) {
+			feedback = { variant: 'success', text: `${noun} sent to Brickognize.` };
+		} else {
+			feedback = { variant: 'success', text: `${noun} saved.` };
+		}
+	}
+
+	async function setPartVerdict(verdict: boolean) {
+		if (partBusy) return;
+		partBusy = true;
+		feedback = null;
+		try {
+			const resp = await postCorrection({ part_correct: verdict, submit: true });
+			if (resp) applyResponse(resp, 'Part verdict', resp.part_submitted);
+		} catch {
+			feedback = { variant: 'danger', text: 'Failed to reach the machine — nothing was saved.' };
+		} finally {
+			partBusy = false;
+		}
+	}
+
+	async function confirmColor() {
+		if (colorBusy || !selectedId) return;
+		colorBusy = true;
+		feedback = null;
+		try {
+			const resp = await postCorrection({ color_corrected_id: selectedId, submit: true });
+			if (resp) {
+				applyResponse(resp, 'Color correction', resp.color_submitted);
+				pickerOpen = false;
+			}
+		} catch {
+			feedback = { variant: 'danger', text: 'Failed to reach the machine — nothing was saved.' };
+		} finally {
+			colorBusy = false;
+		}
+	}
+
+	function chooseColor(id: string) {
+		selectedId = id;
+	}
+
+	// Load colors eagerly so the committed/predicted swatch renders with a name
+	// even before the picker is opened.
+	$effect(() => {
+		if (piece.correctable) void loadColors();
+	});
+
+	const partVerdict = $derived(piece.part_correct ?? null);
+	const partSent = $derived(Boolean(piece.part_feedback_submitted));
+	const colorSent = $derived(Boolean(piece.color_feedback_submitted));
+
+	// The color currently shown on the trigger button: the committed correction
+	// if any, otherwise the Brickognize prediction.
+	const shownColorId = $derived(committedColorId ?? predictedColorId);
+	const shownColorName = $derived(colorNameFor(shownColorId) ?? piece.color_name ?? null);
+	const shownColorHex = $derived(swatchHex(colorRgbFor(shownColorId)));
+
+	const gap = $derived(compact ? 'gap-2' : 'gap-3');
+</script>
+
+{#if piece.correctable}
+	<div class="flex flex-col {gap}">
+		<!-- PART verdict -->
+		<div class="flex flex-wrap items-center gap-2">
+			<span class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+				Part correct?
+			</span>
+			<div class="flex border border-border">
+				<button
+					type="button"
+					onclick={() => setPartVerdict(true)}
+					disabled={partBusy}
+					title="The predicted PART TYPE is correct (this does NOT judge the color)"
+					aria-label="Mark part prediction correct"
+					class="inline-flex items-center gap-1 border-r border-border px-2 py-1 text-sm transition-colors disabled:opacity-50 {partVerdict ===
+					true
+						? 'bg-success/15 text-success'
+						: 'text-text-muted hover:text-success'}"
+				>
+					<Check size={14} />
+					Yes
+				</button>
+				<button
+					type="button"
+					onclick={() => setPartVerdict(false)}
+					disabled={partBusy}
+					title="The predicted PART TYPE is wrong (this does NOT judge the color)"
+					aria-label="Mark part prediction wrong"
+					class="inline-flex items-center gap-1 px-2 py-1 text-sm transition-colors disabled:opacity-50 {partVerdict ===
+					false
+						? 'bg-danger/15 text-danger'
+						: 'text-text-muted hover:text-danger'}"
+				>
+					<X size={14} />
+					No
+				</button>
+			</div>
+			{#if partBusy}
+				<Spinner size={12} />
+			{:else if partSent}
+				<span
+					class="inline-flex items-center border border-success/50 bg-success/[0.12] px-1.5 py-0.5 text-xs font-semibold tracking-wider text-success uppercase"
+					title="This part verdict has been sent to Brickognize"
+				>
+					Sent
+				</span>
+			{/if}
+			<span class="text-xs text-text-muted">Part type only — not the color.</span>
+		</div>
+
+		<!-- COLOR verdict -->
+		<div class="flex flex-col gap-1.5">
+			<div class="flex flex-wrap items-center gap-2">
+				<span class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+					True color
+				</span>
+				<button
+					type="button"
+					onclick={() => (pickerOpen ? closePicker() : openPicker())}
+					class="inline-flex items-center gap-1.5 border border-border bg-surface px-2 py-1 text-sm text-text transition-colors hover:bg-bg"
+				>
+					{#if shownColorHex}
+						<span
+							class="inline-block h-3.5 w-3.5 border border-border"
+							style:background-color={shownColorHex}
+						></span>
+					{/if}
+					<span>{shownColorName ?? 'Pick a color'}</span>
+				</button>
+				{#if committedColorId}
+					{#if colorSent}
+						<span
+							class="inline-flex items-center border border-success/50 bg-success/[0.12] px-1.5 py-0.5 text-xs font-semibold tracking-wider text-success uppercase"
+							title="This color correction has been sent to Brickognize"
+						>
+							Sent
+						</span>
+					{:else}
+						<span
+							class="inline-flex items-center border border-border bg-surface px-1.5 py-0.5 text-xs font-semibold tracking-wider text-text-muted uppercase"
+						>
+							Locked in
+						</span>
+					{/if}
+				{/if}
+			</div>
+
+			{#if pickerOpen}
+				<div class="flex flex-col gap-2 border border-border bg-surface p-2">
+					<div class="flex items-center gap-2 border border-border bg-bg px-2">
+						<Search size={14} class="text-text-muted" />
+						<input
+							type="search"
+							bind:value={query}
+							placeholder="Search colors…"
+							aria-label="Search colors"
+							class="w-full bg-transparent py-1.5 text-sm text-text outline-none"
+						/>
+					</div>
+
+					{#if colorsLoading && colors.length === 0}
+						<div class="flex items-center gap-2 px-1 py-2 text-sm text-text-muted">
+							<Spinner size={12} /> Loading colors…
+						</div>
+					{:else if colorsError}
+						<Alert variant="danger">{colorsError}</Alert>
+					{:else}
+						<div class="max-h-56 overflow-y-auto">
+							{#each filteredColors as c (c.id)}
+								{@const idStr = String(c.id)}
+								{@const hex = swatchHex(c.rgb)}
+								{@const isPrediction = idStr === predictedColorId}
+								{@const isSelected = idStr === selectedId}
+								<button
+									type="button"
+									onclick={() => chooseColor(idStr)}
+									class="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm transition-colors {isSelected
+										? 'bg-primary/15 text-text'
+										: 'text-text hover:bg-bg'}"
+								>
+									<span
+										class="inline-block h-4 w-4 flex-shrink-0 border border-border"
+										style:background-color={hex ?? 'transparent'}
+									></span>
+									<span class="flex-1 truncate">{c.name}</span>
+									{#if c.is_trans}
+										<span class="text-xs text-text-muted">trans</span>
+									{/if}
+									{#if isPrediction}
+										<span
+											class="inline-flex items-center gap-1 border border-info/60 bg-info/[0.12] px-1.5 py-0.5 text-xs font-semibold tracking-wider text-info uppercase"
+											title="Brickognize predicted this color"
+										>
+											<Sparkles size={11} />
+											Prediction
+										</span>
+									{/if}
+									{#if isSelected}
+										<Check size={14} class="flex-shrink-0 text-primary" />
+									{/if}
+								</button>
+							{:else}
+								<div class="px-2 py-2 text-sm text-text-muted">No colors match.</div>
+							{/each}
+						</div>
+					{/if}
+
+					<div class="flex items-center justify-end gap-2">
+						<Button variant="ghost" size="sm" onclick={closePicker}>Cancel</Button>
+						<Button
+							variant="primary"
+							size="sm"
+							loading={colorBusy}
+							disabled={!selectedId}
+							onclick={confirmColor}
+						>
+							Confirm color
+						</Button>
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		{#if feedback}
+			<Alert variant={feedback.variant}>{feedback.text}</Alert>
+		{/if}
+	</div>
+{/if}

--- a/software/sorter/frontend/src/lib/components/RecentObjects.svelte
+++ b/software/sorter/frontend/src/lib/components/RecentObjects.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { getMachineContext } from '$lib/machines/context';
+	import { Wand2 } from 'lucide-svelte';
 	import type { KnownObjectData } from '$lib/api/events';
 	import Spinner from './Spinner.svelte';
+	import Modal from './Modal.svelte';
+	import PieceCorrection from './PieceCorrection.svelte';
 	import PieceStatusBadge from './PieceStatusBadge.svelte';
 	import { sortingProfileStore } from '$lib/stores/sortingProfile.svelte';
 	import { getBackendHttpBase, machineHttpBaseUrlFromWsUrl } from '$lib/backend';
@@ -9,8 +12,10 @@
 	import {
 		pieceStore,
 		pieceToKnownObjectView,
+		pieceToSummary,
 		isTerminalPiece,
 		type Piece,
+		type PieceSummary,
 		type PiecesListResponse
 	} from '$lib/pieces';
 
@@ -51,6 +56,29 @@
 
 	const machineId = $derived(ctx.machine?.identity?.machine_id ?? null);
 	const storePieces = $derived(pieceStore.entriesFor(machineId));
+
+	// --- Brickognize correction modal -------------------------------------
+	// The recent-piece cards are links to the detail page; opening the correction
+	// UI must not navigate. A small wand button on correctable cards opens the
+	// shared PieceCorrection component in a modal. The summary is derived live
+	// from the store so a correction updates in place.
+	let correctingUuid = $state<string | null>(null);
+	const correctingSummary = $derived.by<PieceSummary | null>(() => {
+		if (!correctingUuid) return null;
+		const p = storePieces.find((x) => x.uuid === correctingUuid);
+		return p ? pieceToSummary(p) : null;
+	});
+	const correctionOpen = $derived(correctingSummary !== null);
+
+	function openCorrection(uuid: string, event: MouseEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+		correctingUuid = uuid;
+	}
+
+	function onCorrectionUpdated(summary: PieceSummary) {
+		if (machineId) pieceStore.upsertFromRest(machineId, [summary]);
+	}
 
 	// Initial fill: the backend no longer replays recent pieces on WS connect —
 	// the durable records API is the source for "what happened before this
@@ -610,11 +638,24 @@
 					<span class="truncate text-sm font-semibold {primary_class}">
 						{primary_text}
 					</span>
-					{#if typeof obj.confidence === 'number' && !is_unknown && !is_multi_drop}
-						<span class="flex-shrink-0 text-sm font-semibold tabular-nums {confidenceClass(obj.confidence)}">
-							{(obj.confidence * 100).toFixed(0)}%
-						</span>
-					{/if}
+					<div class="flex flex-shrink-0 items-center gap-2">
+						{#if typeof obj.confidence === 'number' && !is_unknown && !is_multi_drop}
+							<span class="text-sm font-semibold tabular-nums {confidenceClass(obj.confidence)}">
+								{(obj.confidence * 100).toFixed(0)}%
+							</span>
+						{/if}
+						{#if p.correctable}
+							<button
+								type="button"
+								onclick={(e) => openCorrection(obj.uuid, e)}
+								class="inline-flex items-center text-text-muted transition-colors hover:text-primary"
+								title="Correct this Brickognize prediction"
+								aria-label="Correct prediction"
+							>
+								<Wand2 size={14} />
+							</button>
+						{/if}
+					</div>
 				</div>
 
 				{#if has_name && obj.part_id}
@@ -768,3 +809,13 @@
 		{/if}
 	</div>
 </div>
+
+<Modal open={correctionOpen} title="Correct prediction" on:close={() => (correctingUuid = null)}>
+	{#if correctingSummary}
+		<PieceCorrection
+			piece={correctingSummary}
+			endpointBase={effectiveBase()}
+			onUpdated={onCorrectionUpdated}
+		/>
+	{/if}
+</Modal>

--- a/software/sorter/frontend/src/lib/components/records/PieceCard.svelte
+++ b/software/sorter/frontend/src/lib/components/records/PieceCard.svelte
@@ -3,6 +3,7 @@
 	import ImageInfoBadge from '$lib/components/ImageInfoBadge.svelte';
 	import PieceStatusBadge from '$lib/components/PieceStatusBadge.svelte';
 	import ReclassifyPanel from '$lib/components/ReclassifyPanel.svelte';
+	import PieceCorrection from '$lib/components/PieceCorrection.svelte';
 	import { Skeleton } from '$lib/components/primitives';
 	import { LEGO_COLORS, type LegoColor } from '$lib/lego-colors';
 	import type { ClassificationAttempt, ClassificationAttemptStrategy } from '$lib/api/events';
@@ -15,6 +16,7 @@
 		endpointBase,
 		reclassifyOpen = false,
 		onToggleReclassify,
+		onPieceCorrected,
 		liveCrop = null
 	}: {
 		piece: PieceSummary;
@@ -22,6 +24,9 @@
 		endpointBase: string;
 		reclassifyOpen?: boolean;
 		onToggleReclassify?: () => void;
+		// Called with the fresh summary after a correction so the parent can
+		// update its list in place without a refetch.
+		onPieceCorrected?: (summary: PieceSummary) => void;
 		// Newest captured crop off the live socket — shown for in-flight pieces
 		// that haven't been hydrated from the detail endpoint yet.
 		liveCrop?: string | null;
@@ -381,6 +386,12 @@
 			</div>
 		{/if}
 	</div>
+
+	{#if piece.correctable}
+		<div class="border-t border-border bg-bg p-3">
+			<PieceCorrection {piece} {endpointBase} onUpdated={onPieceCorrected} />
+		</div>
+	{/if}
 
 	{#if reclassifyOpen && imgState?.status === 'ok' && imgState.origin === 'memory'}
 		<div class="border-t border-border p-3">

--- a/software/sorter/frontend/src/lib/pieces/colors.ts
+++ b/software/sorter/frontend/src/lib/pieces/colors.ts
@@ -1,0 +1,58 @@
+// The full BrickLink LEGO color palette, served by GET /api/pieces/colors and
+// used to populate the correction color picker. Cached per backend base so the
+// palette is fetched once per machine per session rather than on every open.
+
+export type BrickLinkColor = {
+	id: number;
+	name: string;
+	rgb: string | null; // hex WITHOUT a leading '#', e.g. "05131D"
+	is_trans: boolean;
+};
+
+type ColorsResponse = { results: BrickLinkColor[] };
+
+const cache = new Map<string, BrickLinkColor[]>();
+const inflight = new Map<string, Promise<BrickLinkColor[]>>();
+
+export async function fetchLegoColors(base: string): Promise<BrickLinkColor[]> {
+	const cached = cache.get(base);
+	if (cached) return cached;
+	const pending = inflight.get(base);
+	if (pending) return pending;
+
+	const p = (async () => {
+		const res = await fetch(`${base}/api/pieces/colors`);
+		if (!res.ok) throw new Error(`colors ${res.status}`);
+		const json = (await res.json()) as ColorsResponse;
+		const results = Array.isArray(json?.results) ? json.results : [];
+		cache.set(base, results);
+		return results;
+	})();
+	inflight.set(base, p);
+	try {
+		return await p;
+	} finally {
+		inflight.delete(base);
+	}
+}
+
+// A '#'-prefixed CSS color for a swatch, or null when the palette entry has no
+// rgb (some BrickLink colors carry no canonical hex).
+export function swatchHex(rgb: string | null | undefined): string | null {
+	if (!rgb) return null;
+	const trimmed = rgb.replace(/^#/, '');
+	return /^[0-9a-fA-F]{6}$/.test(trimmed) ? `#${trimmed}` : null;
+}
+
+// Readable text-on-swatch: white for dark colors, black for light. Mirrors the
+// luminance threshold used by lego-colors.ts.
+export function swatchTextColor(rgb: string | null | undefined): string {
+	const hex = swatchHex(rgb);
+	if (!hex) return '#000000';
+	const r = parseInt(hex.slice(1, 3), 16) / 255;
+	const g = parseInt(hex.slice(3, 5), 16) / 255;
+	const b = parseInt(hex.slice(5, 7), 16) / 255;
+	const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+	const luminance = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+	return luminance > 0.3 ? '#000000' : '#ffffff';
+}

--- a/software/sorter/frontend/src/lib/pieces/index.ts
+++ b/software/sorter/frontend/src/lib/pieces/index.ts
@@ -10,3 +10,10 @@ export {
 	type PieceDetailEnvelope,
 	type PiecesListResponse
 } from './store.svelte';
+
+export {
+	fetchLegoColors,
+	swatchHex,
+	swatchTextColor,
+	type BrickLinkColor
+} from './colors';

--- a/software/sorter/frontend/src/lib/pieces/store.svelte.ts
+++ b/software/sorter/frontend/src/lib/pieces/store.svelte.ts
@@ -23,6 +23,13 @@ export type PieceSummary = {
 	has_images?: boolean;
 	preview_url?: string | null;
 	est_value?: number | null;
+	// Brickognize correction fields. `correctable` is only true when a listing
+	// was captured for this piece — the correction UI is gated on it.
+	correctable?: boolean;
+	part_correct?: boolean | null;
+	color_corrected_id?: string | null;
+	part_feedback_submitted?: boolean;
+	color_feedback_submitted?: boolean;
 };
 
 // GET /api/pieces/{uuid} — tiered envelope. `detail` is the full KnownObject
@@ -61,6 +68,13 @@ export type Piece = {
 	has_images: boolean;
 	preview_url: string | null;
 	est_value: number | null;
+	// Brickognize correction state — only meaningful for rest-origin summaries;
+	// live WS events don't carry it, so it's backfilled from REST.
+	correctable: boolean;
+	part_correct: boolean | null;
+	color_corrected_id: string | null;
+	part_feedback_submitted: boolean;
+	color_feedback_submitted: boolean;
 	ws: KnownObjectData | null;
 };
 
@@ -109,6 +123,11 @@ function pieceFromSummary(s: PieceSummary): Piece {
 		has_images: Boolean(s.has_images),
 		preview_url: s.preview_url ?? null,
 		est_value: s.est_value ?? null,
+		correctable: Boolean(s.correctable),
+		part_correct: s.part_correct ?? null,
+		color_corrected_id: s.color_corrected_id ?? null,
+		part_feedback_submitted: Boolean(s.part_feedback_submitted),
+		color_feedback_submitted: Boolean(s.color_feedback_submitted),
 		ws: null
 	};
 }
@@ -134,6 +153,12 @@ function pieceFromKnownObject(obj: KnownObjectData): Piece {
 		),
 		preview_url: obj.brickognize_preview_url ?? null,
 		est_value: obj.moving_avg_price ?? null,
+		// WS events don't carry correction state; it's backfilled from REST.
+		correctable: false,
+		part_correct: null,
+		color_corrected_id: null,
+		part_feedback_submitted: false,
+		color_feedback_submitted: false,
 		ws: obj
 	};
 }
@@ -155,7 +180,12 @@ export function pieceToSummary(p: Piece): PieceSummary {
 		dead: p.dead,
 		has_images: p.has_images,
 		preview_url: p.preview_url,
-		est_value: p.est_value
+		est_value: p.est_value,
+		correctable: p.correctable,
+		part_correct: p.part_correct,
+		color_corrected_id: p.color_corrected_id,
+		part_feedback_submitted: p.part_feedback_submitted,
+		color_feedback_submitted: p.color_feedback_submitted
 	};
 }
 
@@ -303,6 +333,12 @@ class PieceStore {
 			merged.est_value = merged.est_value ?? existing.est_value;
 			merged.preview_url = merged.preview_url ?? existing.preview_url;
 			merged.has_images = merged.has_images || existing.has_images;
+			// Correction state only comes from REST; a live event mustn't wipe it.
+			merged.correctable = merged.correctable || existing.correctable;
+			merged.part_correct = existing.part_correct;
+			merged.color_corrected_id = existing.color_corrected_id;
+			merged.part_feedback_submitted = existing.part_feedback_submitted;
+			merged.color_feedback_submitted = existing.color_feedback_submitted;
 		}
 		let next: Piece[];
 		if (idx >= 0) {
@@ -335,7 +371,14 @@ class PieceStore {
 					recorded_at: existing.recorded_at ?? s.recorded_at ?? null,
 					est_value: existing.est_value ?? s.est_value ?? null,
 					preview_url: existing.preview_url ?? s.preview_url ?? null,
-					has_images: existing.has_images || Boolean(s.has_images)
+					has_images: existing.has_images || Boolean(s.has_images),
+					correctable: existing.correctable || Boolean(s.correctable),
+					part_correct: s.part_correct ?? existing.part_correct,
+					color_corrected_id: s.color_corrected_id ?? existing.color_corrected_id,
+					part_feedback_submitted:
+						existing.part_feedback_submitted || Boolean(s.part_feedback_submitted),
+					color_feedback_submitted:
+						existing.color_feedback_submitted || Boolean(s.color_feedback_submitted)
 				};
 			} else {
 				next[idx] = pieceFromSummary(s);

--- a/software/sorter/frontend/src/lib/pieces/store.svelte.ts
+++ b/software/sorter/frontend/src/lib/pieces/store.svelte.ts
@@ -153,8 +153,9 @@ function pieceFromKnownObject(obj: KnownObjectData): Piece {
 		),
 		preview_url: obj.brickognize_preview_url ?? null,
 		est_value: obj.moving_avg_price ?? null,
-		// WS events don't carry correction state; it's backfilled from REST.
-		correctable: false,
+		// A live piece is correctable the moment a Brickognize listing is captured.
+		// The verdict/submitted state is DB-only and backfilled from REST.
+		correctable: Boolean(obj.brickognize_listing_id),
 		part_correct: null,
 		color_corrected_id: null,
 		part_feedback_submitted: false,

--- a/software/sorter/frontend/src/routes/records/+page.svelte
+++ b/software/sorter/frontend/src/routes/records/+page.svelte
@@ -51,6 +51,14 @@
 		expandedReclassify = next;
 	}
 
+	// A correction returns the fresh summary. Update the rest-loaded page list in
+	// place and feed the store so live rows (and RecentObjects) reflect it too.
+	function onPieceCorrected(summary: PieceSummary) {
+		items = items.map((it) => (it.uuid === summary.uuid ? { ...it, ...summary } : it));
+		const mid = ctx.machine?.identity?.machine_id ?? null;
+		if (mid) pieceStore.upsertFromRest(mid, [summary]);
+	}
+
 	let pageNum = $derived(pageIndex + 1);
 	let pageCount = $derived(Math.max(1, Math.ceil(total / PAGE_SIZE)));
 	let rangeStart = $derived(pageIndex * PAGE_SIZE + 1);
@@ -347,6 +355,7 @@
 						liveCrop={row.liveCrop}
 						reclassifyOpen={expandedReclassify.has(row.piece.uuid)}
 						onToggleReclassify={() => toggleReclassify(row.piece.uuid)}
+						{onPieceCorrected}
 					/>
 				{/each}
 			</div>

--- a/software/sorter/frontend/src/routes/records/+page.svelte
+++ b/software/sorter/frontend/src/routes/records/+page.svelte
@@ -181,8 +181,20 @@
 		}
 		for (const item of items) {
 			const s = storeByUuid.get(item.uuid);
+			// A live-seen piece keeps its store view (fresh crop/status), but the
+			// correction state is DB-authoritative — take it from the REST item so a
+			// live WS event (which carries no verdict) can't blank it out.
 			rows.push({
-				piece: s?.ws ? pieceToSummary(s) : item,
+				piece: s?.ws
+					? {
+							...pieceToSummary(s),
+							correctable: item.correctable,
+							part_correct: item.part_correct,
+							color_corrected_id: item.color_corrected_id,
+							part_feedback_submitted: item.part_feedback_submitted,
+							color_feedback_submitted: item.color_feedback_submitted
+						}
+					: item,
 				live: false,
 				liveCrop: null
 			});


### PR DESCRIPTION
Let a user confirm or correct a Brickognize prediction and send that back to Brickognize's feedback API.

- Capture each prediction's listing so a correction can be addressed to it.
- Sorter: a part correct/wrong toggle and a searchable true-color picker (prediction pre-selected) on the records page and the dashboard's recent pieces; submits accept/reject to Brickognize.
- Hive: the same correction control on the per-piece label page.
- Corrections sync with Hive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
