### PR TITLE
Hive: AI same-piece predictions on the labeling page

### DIFF
--- a/software/hive/backend/alembic/versions/d5e6f7a8b9c0_add_piece_crop_ai_predictions.py
+++ b/software/hive/backend/alembic/versions/d5e6f7a8b9c0_add_piece_crop_ai_predictions.py
@@ -1,0 +1,56 @@
+"""add piece crop ai predictions
+
+Revision ID: d5e6f7a8b9c0
+Revises: e7c1a2b3d4f5
+Create Date: 2026-07-13 22:30:00.000000
+
+A vision model's "which upstream C2/C3 crops are the same physical piece" guess
+for a classified piece — the AI analog of the time/angle heuristic. Populated
+out-of-band; the labeling page pre-selects the AI's picks instead of the
+heuristic's when a row exists. One row per (machine, piece); a re-run overwrites.
+Stored separately from piece_crop_links (human ground truth).
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: Union[str, None] = "e7c1a2b3d4f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    json_type = sa.JSON().with_variant(JSONB, "postgresql")
+    op.create_table(
+        "piece_crop_ai_predictions",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("machine_id", sa.UUID(), nullable=False),
+        sa.Column("piece_uuid", sa.String(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("reasoning", sa.String(), nullable=True),
+        sa.Column("candidate_local_ids", json_type, nullable=False),
+        sa.Column("same_local_ids", json_type, nullable=False),
+        sa.Column("cost_usd", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["machine_id"], ["machines.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("machine_id", "piece_uuid", name="uq_piece_crop_ai_predictions_machine_piece"),
+    )
+    op.create_index(
+        "ix_piece_crop_ai_predictions_machine_piece",
+        "piece_crop_ai_predictions",
+        ["machine_id", "piece_uuid"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_piece_crop_ai_predictions_machine_piece", table_name="piece_crop_ai_predictions")
+    op.drop_table("piece_crop_ai_predictions")

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -35,6 +35,7 @@ from app.models.machine_stats_cache import MachineStatsCache  # noqa: E402, F401
 from app.models.machine_daily_stats import MachineDailyStats  # noqa: E402, F401
 from app.models.piece_color_label import PieceColorLabel  # noqa: E402, F401
 from app.models.piece_crop_link import PieceCropLink, PieceCropLinkMember  # noqa: E402, F401
+from app.models.piece_crop_ai_prediction import PieceCropAiPrediction  # noqa: E402, F401
 from app.models.piece_rejection import PieceRejection  # noqa: E402, F401
 from app.models.install import Install  # noqa: E402, F401
 from app.models.color_model import ColorModel  # noqa: E402, F401

--- a/software/hive/backend/app/models/piece_crop_ai_prediction.py
+++ b/software/hive/backend/app/models/piece_crop_ai_prediction.py
@@ -1,0 +1,48 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import JSON_VARIANT, Base
+
+
+class PieceCropAiPrediction(Base):
+    """A vision model's "which upstream crops are the same physical piece" guess
+    for one classified piece — the AI analog of the time/angle heuristic.
+
+    Populated out-of-band (scripts/run_piece_crop_ai_match.py): the model is shown
+    the piece's C4 anchor image plus a numbered contact-sheet grid of the
+    heuristic's candidate C2/C3 crops and returns which cells match. We store the
+    candidate set it was shown (candidate_local_ids) and the ones it picked
+    (same_local_ids) so the labeling page can pre-select the AI's picks instead of
+    the heuristic's when a prediction exists. One row per (machine, piece); a
+    re-run overwrites it. Kept separate from piece_crop_links (human labels) — this
+    is a machine suggestion, not ground truth, and must not be confused with the
+    was_predicted heuristic-accuracy signal stored on human links.
+    """
+
+    __tablename__ = "piece_crop_ai_predictions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    machine_id = Column(UUID(as_uuid=True), ForeignKey("machines.id", ondelete="CASCADE"), nullable=False)
+    piece_uuid = Column(String, nullable=False)
+    model = Column(String, nullable=False)
+    reasoning = Column(String, nullable=True)
+    # Crop local_ids (machine_channel_crops.local_id) the model was shown, and the
+    # subset it judged to be the same piece. JSONB lists of ints.
+    candidate_local_ids = Column(JSON_VARIANT, nullable=False)
+    same_local_ids = Column(JSON_VARIANT, nullable=False)
+    cost_usd = Column(Float, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("machine_id", "piece_uuid", name="uq_piece_crop_ai_predictions_machine_piece"),
+        Index("ix_piece_crop_ai_predictions_machine_piece", "machine_id", "piece_uuid"),
+    )

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -22,13 +22,14 @@ from pydantic import BaseModel, Field
 from sqlalchemy import and_, exists, func
 from sqlalchemy.orm import Session
 
-from app.deps import get_current_user, get_db
+from app.deps import get_current_user, get_db, verify_csrf
 from app.errors import APIError
 from app.models.machine import Machine
 from app.models.machine_channel_crop import MachineChannelCrop
 from app.models.machine_piece import MachinePiece
 from app.models.machine_piece_image import MachinePieceImage
 from app.models.piece_color_label import PieceColorLabel
+from app.models.piece_crop_ai_prediction import PieceCropAiPrediction
 from app.models.piece_crop_link import PieceCropLink, PieceCropLinkMember
 from app.models.piece_rejection import PieceRejection
 from app.models.user import User
@@ -36,8 +37,15 @@ from app.services.brickognize_feedback import submit_color_feedback, submit_part
 from app.services.channel_crop_lookup import find_possible_crops
 from app.services.channel_crop_lookup_params import DEFAULT_PARAMS
 from app.services.color_predictor import predict as predict_piece_color
+from app.services.piece_crop_ai_matcher import (
+    DEFAULT_MATCH_MODEL,
+    AiMatchError,
+    match_piece_crops,
+    store_prediction,
+)
 from app.services.pixel_color import guess_piece_color
 from app.services.profile_catalog import get_profile_catalog_service
+from app.services.secrets import decrypt_secret
 from app.services.storage import serve_stored_file
 
 log = logging.getLogger(__name__)
@@ -801,6 +809,47 @@ def _my_link_members(db: Session, machine_id: UUID, piece_uuid: str, labeler_id:
     ]
 
 
+def _ai_prediction(db: Session, machine_id: UUID, piece_uuid: str) -> PieceCropAiPrediction | None:
+    return (
+        db.query(PieceCropAiPrediction)
+        .filter(
+            PieceCropAiPrediction.machine_id == machine_id,
+            PieceCropAiPrediction.piece_uuid == piece_uuid,
+        )
+        .first()
+    )
+
+
+def _possible_crops_result(db: Session, machine_id: UUID, piece_uuid: str, labeler_id: UUID) -> dict:
+    """Heuristic candidate set for a piece, annotated with this labeler's saved
+    selection and the stored AI prediction (if any).
+
+    Each candidate keeps the heuristic's `predicted` flag (untouched — it feeds
+    the was_predicted training signal). When an AI prediction exists we add
+    `ai_same` per candidate (True/False for crops the model was shown, None for
+    any it didn't see) and set `prediction_source='ai'`; the UI pre-selects
+    `ai_same` over `predicted` when present, falling back to the heuristic."""
+    result = find_possible_crops(db, machine_id, piece_uuid)
+    result["my_link"] = _my_link_members(db, machine_id, piece_uuid, labeler_id)
+
+    ai = _ai_prediction(db, machine_id, piece_uuid)
+    if ai is not None:
+        same_ids = set(ai.same_local_ids or [])
+        shown_ids = set(ai.candidate_local_ids or [])
+        for c in result.get("candidates", []):
+            c["ai_same"] = (c["local_id"] in same_ids) if c["local_id"] in shown_ids else None
+        result["prediction_source"] = "ai"
+        result["ai_model"] = ai.model
+        result["ai_reasoning"] = ai.reasoning
+    else:
+        for c in result.get("candidates", []):
+            c["ai_same"] = None
+        result["prediction_source"] = "heuristic"
+        result["ai_model"] = None
+        result["ai_reasoning"] = None
+    return result
+
+
 @router.get("/possible-crops/{machine_id}/{piece_uuid}")
 def possible_crops(
     machine_id: UUID,
@@ -809,10 +858,57 @@ def possible_crops(
     current_user: User = Depends(get_current_user),
 ) -> dict:
     """Ranked "possibly the same piece" C2/C3 candidates for a classified piece,
-    plus this labeler's saved selection (if any) so the UI can restore it."""
-    result = find_possible_crops(db, machine_id, piece_uuid)
-    result["my_link"] = _my_link_members(db, machine_id, piece_uuid, current_user.id)
-    return result
+    plus this labeler's saved selection (if any) and any stored AI prediction."""
+    return _possible_crops_result(db, machine_id, piece_uuid, current_user.id)
+
+
+class AiPredictRequest(BaseModel):
+    model: str | None = None
+
+
+@router.post("/possible-crops/{machine_id}/{piece_uuid}/ai-predict")
+def run_ai_predict(
+    machine_id: UUID,
+    piece_uuid: str,
+    payload: AiPredictRequest | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _csrf: None = Depends(verify_csrf),
+) -> dict:
+    """Run the vision model NOW to guess which candidate crops are the same piece,
+    store it, and return the refreshed candidate set with the AI's picks applied.
+
+    Open to admins and to any labeler who has added their own OpenRouter key
+    (which pays for the call) — mirroring the sample teacher's key gating."""
+    if current_user.role != "admin" and not current_user.openrouter_configured:
+        raise APIError(
+            403,
+            "Add your OpenRouter API key on your profile to run AI predictions.",
+            "OPENROUTER_KEY_MISSING",
+        )
+    api_key = decrypt_secret(current_user.openrouter_api_key_encrypted)
+    if not api_key:
+        raise APIError(
+            400,
+            "Set your OpenRouter API key on your profile to run AI predictions.",
+            "OPENROUTER_KEY_MISSING",
+        )
+
+    model = (payload.model if payload else None) or DEFAULT_MATCH_MODEL
+    try:
+        result = match_piece_crops(db, machine_id, piece_uuid, api_key, model=model)
+    except AiMatchError as exc:
+        raise APIError(422, f"AI prediction could not run: {exc}", "AI_PREDICT_FAILED") from exc
+    except Exception as exc:  # noqa: BLE001
+        raise APIError(502, f"AI prediction failed: {exc}", "AI_PREDICT_ERROR") from exc
+
+    store_prediction(db, machine_id, piece_uuid, result)
+    db.commit()
+
+    refreshed = _possible_crops_result(db, machine_id, piece_uuid, current_user.id)
+    refreshed["ai_cost_usd"] = result.get("cost_usd")
+    refreshed["ai_elapsed_ms"] = result.get("elapsed_ms")
+    return refreshed
 
 
 @router.get("/channel-crops/{machine_id}/{local_id}/image")

--- a/software/hive/backend/app/services/piece_crop_ai_matcher.py
+++ b/software/hive/backend/app/services/piece_crop_ai_matcher.py
@@ -1,0 +1,272 @@
+"""Vision-model "which upstream crops are the same piece" matcher.
+
+Given a classified piece, this builds the piece's C4 anchor image plus ONE
+numbered contact-sheet grid of the heuristic's candidate C2/C3 crops, asks a
+vision model (via OpenRouter) which numbered cells show the same physical piece,
+and returns the picked crop local_ids. Populates piece_crop_ai_predictions.
+
+The grid format (all candidates in a single image, numbered) was chosen over one
+image per crop after an offline experiment: it matched human labels with ~perfect
+precision at ~20x lower cost, and — crucially — it respects the "piece must be
+100% inside the crop" convention the human labels follow. See the labeling page
+for how a stored prediction pre-selects the AI's picks instead of the heuristic's.
+
+Runs off-thread of the request path (a script / background task), so it reads
+crop bytes straight from the storage backend rather than the HTTP image routes.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+import math
+import re
+import time
+import urllib.request
+from typing import Any, Optional
+from uuid import UUID
+
+from datetime import datetime, timezone
+
+from PIL import Image, ImageDraw
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.machine_channel_crop import MachineChannelCrop
+from app.models.machine_piece_image import MachinePieceImage
+from app.models.piece_crop_ai_prediction import PieceCropAiPrediction
+from app.services.channel_crop_lookup import find_possible_crops
+from app.services.channel_crop_lookup_params import DEFAULT_PARAMS
+from app.services.storage_backend import get_backend
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MATCH_MODEL = "google/gemini-3.5-flash"
+OPENROUTER_TIMEOUT_S = 180.0
+
+CELL = 96
+LABEL_H = 14
+ANCHOR_MAX = 512
+MAX_ANCHOR_VIEWS = 3
+
+GRID_PROMPT = (
+    "Image 1 shows one LEGO piece photographed in the classification chamber of a "
+    "sorting machine (possibly several views of it side by side).\n"
+    "Image 2 is a numbered grid of small crops from cameras EARLIER in the machine. "
+    "Some crops may show the same physical piece moments before it reached the "
+    "chamber; most show other pieces.\n\n"
+    "Find every numbered cell that shows the SAME physical piece as Image 1 — same "
+    "shape/mold AND same color. Judge by appearance only.\n"
+    "Only count a cell if the piece is COMPLETELY inside the crop (not cut off at an "
+    "edge). If the same piece appears but is partially cut off, do not count that cell.\n"
+    "If no cell qualifies, return an empty list.\n\n"
+    'Respond with valid JSON only, no markdown: {"matches": [cell numbers], '
+    '"reasoning": "one short sentence"}'
+)
+
+
+class AiMatchError(RuntimeError):
+    pass
+
+
+def _load_image(key: str) -> Optional[Image.Image]:
+    try:
+        raw = get_backend().read_bytes(key)
+    except FileNotFoundError:
+        return None
+    except Exception as exc:  # noqa: BLE001 — storage errors shouldn't kill a batch
+        log.warning("ai-match: failed to read %s: %s", key, exc)
+        return None
+    try:
+        return Image.open(io.BytesIO(raw)).convert("RGB")
+    except Exception as exc:  # noqa: BLE001
+        log.warning("ai-match: undecodable image %s: %s", key, exc)
+        return None
+
+
+def _anchor_keys(db: Session, machine_id: UUID, piece_uuid: str) -> list[str]:
+    # The piece's classification-channel (C4) burst, preferred; fall back to any
+    # of its images. Ordered by seq so the first views (usually sharpest) win.
+    rows = (
+        db.query(MachinePieceImage.channel, MachinePieceImage.seq, MachinePieceImage.image_key)
+        .filter(
+            MachinePieceImage.machine_id == machine_id,
+            MachinePieceImage.piece_uuid == piece_uuid,
+            MachinePieceImage.image_key.isnot(None),
+        )
+        .order_by(MachinePieceImage.seq.asc())
+        .all()
+    )
+    c4 = [r.image_key for r in rows if r.channel == DEFAULT_PARAMS.classification_channel_id]
+    keys = c4 if c4 else [r.image_key for r in rows]
+    return keys[:MAX_ANCHOR_VIEWS]
+
+
+def _crop_key(db: Session, machine_id: UUID, local_id: int) -> Optional[str]:
+    row = (
+        db.query(MachineChannelCrop.image_key)
+        .filter(MachineChannelCrop.machine_id == machine_id, MachineChannelCrop.local_id == local_id)
+        .first()
+    )
+    return row.image_key if row and row.image_key else None
+
+
+def _build_anchor_image(images: list[Image.Image]) -> Image.Image:
+    h = min(min(v.height for v in images), ANCHOR_MAX)
+    images = [v.resize((max(1, int(v.width * h / v.height)), h), Image.BILINEAR) for v in images]
+    out = Image.new("RGB", (sum(v.width for v in images), max(v.height for v in images)), (255, 255, 255))
+    x = 0
+    for v in images:
+        out.paste(v, (x, 0))
+        x += v.width
+    return out
+
+
+def _build_grid(cells: list[tuple[int, Image.Image]]) -> Image.Image:
+    n = len(cells)
+    cols = math.ceil(math.sqrt(n))
+    rows = math.ceil(n / cols)
+    grid = Image.new("RGB", (cols * (CELL + 2), rows * (CELL + LABEL_H + 2)), (255, 255, 255))
+    draw = ImageDraw.Draw(grid)
+    for i, (_local_id, img) in enumerate(cells):
+        scale = min(CELL / img.width, CELL / img.height)
+        thumb = img.resize((max(1, int(img.width * scale)), max(1, int(img.height * scale))), Image.BILINEAR)
+        r, c = divmod(i, cols)
+        x = c * (CELL + 2)
+        y = r * (CELL + LABEL_H + 2)
+        panel = Image.new("RGB", (CELL, CELL + LABEL_H), (30, 30, 30))
+        panel.paste(thumb, ((CELL - thumb.width) // 2, LABEL_H + (CELL - thumb.height) // 2))
+        grid.paste(panel, (x, y))
+        draw.text((x + 3, y + 1), str(i + 1), fill=(255, 255, 0))
+    return grid
+
+
+def _image_part(img: Image.Image) -> dict[str, Any]:
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=90)
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}}
+
+
+def _call_openrouter(model: str, content: list[dict[str, Any]], api_key: str) -> tuple[dict[str, Any], Optional[float]]:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": content}],
+        "temperature": 0.1,
+        "max_tokens": 2048,
+        "usage": {"include": True},
+    }
+    req = urllib.request.Request(
+        f"{settings.OPENROUTER_BASE_URL.rstrip('/')}/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": settings.public_app_url,
+            "X-Title": "Hive Piece-Crop AI Matcher",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=OPENROUTER_TIMEOUT_S) as resp:  # noqa: S310
+            data = json.loads(resp.read().decode())
+    except Exception as exc:  # noqa: BLE001
+        raise AiMatchError(f"OpenRouter request failed: {exc}") from exc
+    try:
+        text = data["choices"][0]["message"]["content"] or ""
+    except (KeyError, IndexError, TypeError) as exc:
+        raise AiMatchError("OpenRouter returned an unexpected response shape") from exc
+    match = re.search(r"\{[\s\S]*\}", text)
+    if not match:
+        raise AiMatchError(f"Model response contained no JSON: {text[:200]!r}")
+    parsed = json.loads(match.group())
+    usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+    cost = usage.get("cost") if isinstance(usage.get("cost"), (int, float)) and not isinstance(usage.get("cost"), bool) else None
+    return parsed, cost
+
+
+def match_piece_crops(
+    db: Session,
+    machine_id: UUID,
+    piece_uuid: str,
+    api_key: str,
+    model: str = DEFAULT_MATCH_MODEL,
+    limit: int = 60,
+) -> dict[str, Any]:
+    """Ask the vision model which candidate crops are the same piece.
+
+    Returns {candidate_local_ids, same_local_ids, reasoning, cost_usd, model,
+    elapsed_ms, arrival_ts}. Raises AiMatchError if the piece has no usable
+    candidates/anchor or the model call fails.
+    """
+    lookup = find_possible_crops(db, machine_id, piece_uuid, limit=limit)
+    candidates = lookup.get("candidates", [])
+    candidates = [c for c in candidates if c.get("available")]
+    if not candidates:
+        raise AiMatchError("Piece has no available candidate crops")
+
+    anchor_keys = _anchor_keys(db, machine_id, piece_uuid)
+    anchor_imgs = [img for img in (_load_image(k) for k in anchor_keys) if img is not None]
+    if not anchor_imgs:
+        raise AiMatchError("Piece has no readable anchor image")
+
+    cells: list[tuple[int, Image.Image]] = []
+    for c in candidates:
+        key = _crop_key(db, machine_id, c["local_id"])
+        img = _load_image(key) if key else None
+        if img is not None:
+            cells.append((c["local_id"], img))
+    if not cells:
+        raise AiMatchError("None of the candidate crop images could be read")
+
+    anchor = _build_anchor_image(anchor_imgs)
+    grid = _build_grid(cells)
+    content = [{"type": "text", "text": GRID_PROMPT}, _image_part(anchor), _image_part(grid)]
+
+    start = time.monotonic()
+    parsed, cost = _call_openrouter(model, content, api_key)
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+
+    raw_matches = parsed.get("matches") or []
+    picked_positions = {
+        int(p) for p in raw_matches if isinstance(p, (int, float)) or (isinstance(p, str) and p.strip().isdigit())
+    }
+    candidate_local_ids = [local_id for local_id, _ in cells]
+    same_local_ids = [
+        local_id for pos, (local_id, _) in enumerate(cells, start=1) if pos in picked_positions
+    ]
+
+    return {
+        "model": model,
+        "reasoning": str(parsed.get("reasoning") or "")[:1000] or None,
+        "candidate_local_ids": candidate_local_ids,
+        "same_local_ids": same_local_ids,
+        "cost_usd": cost,
+        "elapsed_ms": elapsed_ms,
+        "arrival_ts": lookup.get("arrival_ts"),
+    }
+
+
+def store_prediction(db: Session, machine_id: UUID, piece_uuid: str, result: dict[str, Any]) -> PieceCropAiPrediction:
+    """Upsert the AI prediction for a piece (one row per machine+piece; re-run
+    overwrites). Caller commits."""
+    row = (
+        db.query(PieceCropAiPrediction)
+        .filter(
+            PieceCropAiPrediction.machine_id == machine_id,
+            PieceCropAiPrediction.piece_uuid == piece_uuid,
+        )
+        .first()
+    )
+    if row is None:
+        row = PieceCropAiPrediction(machine_id=machine_id, piece_uuid=piece_uuid)
+        db.add(row)
+    row.model = result["model"]
+    row.reasoning = result.get("reasoning")
+    row.candidate_local_ids = result["candidate_local_ids"]
+    row.same_local_ids = result["same_local_ids"]
+    row.cost_usd = result.get("cost_usd")
+    row.updated_at = datetime.now(timezone.utc)
+    return row

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -1099,7 +1099,10 @@ export interface ColorModelsResponse {
 }
 
 // A "possibly the same piece" upstream C2/C3 crop candidate, ranked by the
-// shared time/angle heuristic. `predicted` = the machine's default selection.
+// shared time/angle heuristic. `predicted` = the heuristic's default selection.
+// `ai_same` = a stored vision-model verdict (true/false for crops it was shown,
+// null when it wasn't shown this crop or no AI prediction has been run). The UI
+// pre-selects `ai_same` over `predicted` when a prediction exists.
 export interface PossibleCropCandidate {
 	local_id: number;
 	channel: number | null;
@@ -1110,6 +1113,7 @@ export interface PossibleCropCandidate {
 	sharpness: number | null;
 	score: number;
 	predicted: boolean;
+	ai_same: boolean | null;
 	available: boolean;
 }
 
@@ -1123,6 +1127,12 @@ export interface PossibleCropsResult {
 	arrival_ts: string | null;
 	candidates: PossibleCropCandidate[];
 	my_link: PieceCropLinkMember[];
+	prediction_source: 'ai' | 'heuristic';
+	ai_model: string | null;
+	ai_reasoning: string | null;
+	// Present only on the ai-predict POST response.
+	ai_cost_usd?: number | null;
+	ai_elapsed_ms?: number | null;
 }
 
 export const api = {
@@ -1291,6 +1301,13 @@ export const api = {
 		return request<PossibleCropsResult>(
 			'GET',
 			`/api/labeling/possible-crops/${machineId}/${encodeURIComponent(pieceUuid)}`
+		);
+	},
+	runAiPredict(machineId: string, pieceUuid: string, model?: string) {
+		return request<PossibleCropsResult>(
+			'POST',
+			`/api/labeling/possible-crops/${machineId}/${encodeURIComponent(pieceUuid)}/ai-predict`,
+			model ? { model } : {}
 		);
 	},
 	channelCropLabelImageUrl(machineId: string, localId: number) {

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -8,6 +8,7 @@
 		type ColorLabelPieceDetail,
 		type PossibleCropCandidate
 	} from '$lib/api';
+	import { auth } from '$lib/auth.svelte';
 	import * as nav from '$lib/colorLabelNav';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import { Alert, Button } from '$lib/components/primitives';
@@ -59,6 +60,13 @@
 	let cropSaved = $state(false); // a selection is committed to the db
 	let cropDirty = $state(false); // toggled since last save/load
 	let cropError = $state<string | null>(null);
+	// Which model drove the pre-selection: the time/angle heuristic or a stored
+	// vision-model prediction. The AI "Run" action is open to admins or anyone
+	// with their own OpenRouter key on file.
+	let predictionSource = $state<'ai' | 'heuristic'>('heuristic');
+	let aiReasoning = $state<string | null>(null);
+	let aiRunning = $state(false);
+	const canRunAi = $derived(auth.isAdmin || auth.user?.openrouter_configured === true);
 
 	// Reject-this-bbox-sample
 	let rejectOpen = $state(false);
@@ -193,23 +201,52 @@
 			correction = d.correction;
 			partVerdict = d.correction.part_correct;
 			feedback = null;
-			cropCandidates = crops.candidates;
-			cropArrivalTs = crops.arrival_ts;
-			cropDirty = false;
-			const savedPos = crops.my_link.filter((m) => m.is_same).map((m) => m.local_id);
-			if (crops.my_link.length > 0) {
-				const present = new Set(crops.candidates.map((c) => c.local_id));
-				cropSelected = new Set(savedPos.filter((id) => present.has(id)));
-				cropSaved = true;
-			} else {
-				cropSelected = new Set(crops.candidates.filter((c) => c.predicted).map((c) => c.local_id));
-				cropSaved = false;
-			}
+			applyCrops(crops);
 			pos = nav.position({ machine_id: mid, piece_uuid: puid });
 		} catch (e: unknown) {
 			if (pieceKey === k) error = errMsg(e, 'Failed to load piece');
 		} finally {
 			if (pieceKey === k) loading = false;
+		}
+	}
+
+	// Load a possible-crops result into state. If the user already saved a
+	// selection, restore it; otherwise pre-select the AI's picks when a stored
+	// prediction exists, else the time/angle heuristic's picks.
+	function applyCrops(crops: import('$lib/api').PossibleCropsResult, preferAi = false) {
+		cropCandidates = crops.candidates;
+		cropArrivalTs = crops.arrival_ts;
+		cropDirty = false;
+		predictionSource = crops.prediction_source;
+		aiReasoning = crops.ai_reasoning;
+		const savedPos = crops.my_link.filter((m) => m.is_same).map((m) => m.local_id);
+		// A just-run AI prediction overrides the saved selection in the UI so the
+		// labeler can review the fresh picks; on plain load, a saved selection wins.
+		if (crops.my_link.length > 0 && !preferAi) {
+			const present = new Set(crops.candidates.map((c) => c.local_id));
+			cropSelected = new Set(savedPos.filter((id) => present.has(id)));
+			cropSaved = true;
+		} else {
+			const useAi = preferAi || crops.prediction_source === 'ai';
+			cropSelected = new Set(
+				crops.candidates.filter((c) => (useAi ? c.ai_same === true : c.predicted)).map((c) => c.local_id)
+			);
+			cropSaved = crops.my_link.length > 0;
+		}
+	}
+
+	async function runAiPredict() {
+		if (aiRunning || cropCandidates.length === 0) return;
+		aiRunning = true;
+		cropError = null;
+		try {
+			const crops = await api.runAiPredict(machineId, pieceUuid);
+			applyCrops(crops, true);
+			cropDirty = true; // AI picks are a fresh suggestion; prompt a save
+		} catch (e: unknown) {
+			cropError = errMsg(e, 'AI prediction failed');
+		} finally {
+			aiRunning = false;
 		}
 	}
 
@@ -559,6 +596,17 @@
 					<span class="text-xs text-text-muted tabular-nums">
 						{cropSelected.size} of {cropCandidates.length} selected
 					</span>
+					{#if canRunAi}
+						<Button
+							variant="secondary"
+							size="sm"
+							loading={aiRunning}
+							disabled={cropCandidates.length === 0 || cropLoading}
+							onclick={runAiPredict}
+						>
+							<span class="flex items-center gap-1"><Sparkles size={13} /> Run AI</span>
+						</Button>
+					{/if}
 					<Button
 						variant={cropDirty ? 'primary' : 'secondary'}
 						size="sm"
@@ -570,10 +618,21 @@
 					</Button>
 				</div>
 			</div>
-			<p class="mb-3 text-sm text-text-muted">
-				Our guess of which upstream C2/C3 crops are this same physical piece, ranked by a
-				time-and-angle heuristic. Keep or drop our picks and add any we missed, then
-				<span class="font-medium">Accept</span>.
+			<p class="mb-2 text-sm text-text-muted">
+				Our guess of which upstream C2/C3 crops are this same physical piece. Keep or drop
+				the picks and add any we missed, then <span class="font-medium">Accept</span>.
+			</p>
+			<p class="mb-3 flex items-center gap-1.5 text-xs">
+				{#if predictionSource === 'ai'}
+					<Sparkles size={12} class="shrink-0 text-info" />
+					<span class="text-text-muted">
+						Picks from a vision model{aiReasoning ? `: ${aiReasoning}` : '.'}
+					</span>
+				{:else}
+					<span class="text-text-muted">
+						Picks from the time-and-angle heuristic.{canRunAi ? ' Run AI for a vision-model guess.' : ''}
+					</span>
+				{/if}
 			</p>
 
 			{#if cropLoading}
@@ -586,10 +645,11 @@
 				<div class="flex max-h-[42vh] flex-wrap gap-2 overflow-y-auto pr-1">
 					{#each cropCandidates as c (c.local_id)}
 						{@const selected = cropSelected.has(c.local_id)}
+						{@const isPick = predictionSource === 'ai' ? c.ai_same === true : c.predicted}
 						<button
 							type="button"
 							onclick={() => toggleCrop(c.local_id)}
-							title={`C${c.channel} · ${ZONE_LABEL[c.zone_code ?? 0] ?? '?'} · ${c.dt != null ? c.dt + 's before arrival' : 'unknown dt'} · ${c.com_forward_to_exit_deg != null ? Math.round(c.com_forward_to_exit_deg) + '° to exit' : ''} · score ${c.score}${c.predicted ? ' · our pick' : ''}`}
+							title={`C${c.channel} · ${ZONE_LABEL[c.zone_code ?? 0] ?? '?'} · ${c.dt != null ? c.dt + 's before arrival' : 'unknown dt'} · ${c.com_forward_to_exit_deg != null ? Math.round(c.com_forward_to_exit_deg) + '° to exit' : ''} · score ${c.score}${isPick ? (predictionSource === 'ai' ? ' · AI pick' : ' · heuristic pick') : ''}`}
 							class="relative flex flex-col items-center gap-1 border-2 p-1 hover:border-primary {selected
 								? 'border-success bg-success/10'
 								: 'border-border opacity-70 hover:opacity-100'}"
@@ -610,8 +670,13 @@
 								{#if selected}<Check size={12} class="text-success" />{/if}
 								C{c.channel}·{c.dt}s
 							</span>
-							{#if c.predicted}
-								<span class="absolute right-0.5 top-0.5 flex items-center bg-info/80 p-0.5 text-white" title="our prediction"><Sparkles size={11} /></span>
+							{#if isPick}
+								<span
+									class="absolute right-0.5 top-0.5 flex items-center bg-info/80 p-0.5 text-white"
+									title={predictionSource === 'ai' ? 'AI prediction' : 'heuristic prediction'}
+								>
+									<Sparkles size={11} />
+								</span>
 							{/if}
 						</button>
 					{/each}


### PR DESCRIPTION
## What

On the piece color-labeling page, the "same piece across channels" section pre-selects candidate C2/C3 crops using a trivial time/angle heuristic. This adds a **vision-model prediction** that replaces those pre-selections when one exists for a piece.

## How it works

- **New table `piece_crop_ai_predictions`** — one row per (machine, piece): the model, its reasoning, the candidate crop `local_id`s it was shown, and the subset it judged to be the same physical piece. A re-run overwrites the row.
- **`piece_crop_ai_matcher` service** — builds the piece's C4 anchor image plus a single numbered contact-sheet **grid** of the heuristic's candidate crops (reading bytes from the storage backend), and asks an OpenRouter vision model which numbered cells match. The grid format was chosen from an offline experiment: ~perfect precision at ~20× lower cost than one-image-per-crop, and it respects the "piece must be 100% inside the bbox" convention the human labels follow.
- **Serving** — `GET .../possible-crops` now returns `ai_same` per candidate (`true`/`false` for crops the model saw, `null` otherwise) plus `prediction_source`/`ai_model`/`ai_reasoning`. The heuristic's `predicted`/`was_predicted` fields are **left untouched**, so the existing training signal (heuristic precision/recall from human links) is unaffected.
- **`POST .../ai-predict`** — runs the model synchronously and stores the result. Open to **admins or any labeler who has added their own OpenRouter key** (which pays for the call), mirroring the sample teacher's key gating.
- **UI** — a **Run AI** button, a source line showing the model's reasoning, and per-crop pick badges that reflect whichever source is active. When an AI prediction exists (or is just run), the UI pre-selects the AI's picks instead of the heuristic's.

## Testing

Verified end-to-end on **local hive** with a real OpenRouter call, seeded with real labeled pieces/crops:

- Migration applies and reverses cleanly (single head).
- Before: `prediction_source=heuristic`, 2 pre-selected picks.
- Clicked **Run AI** in the UI → gemini-3.5-flash picked 5/22 (all the green-axle crops, incl. 3 the heuristic missed), source line updated to the model's reasoning, selection went 2 → 5, prediction row persisted.
- `predicted` flag preserved across the flip.
- `svelte-check` clean (0 errors). Full backend suite: the 11 failures are pre-existing (unrelated raw-SQL SQLite incompatibility; fail identically without this branch).

The default model is `google/gemini-3.5-flash` (`DEFAULT_MATCH_MODEL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)