### PR TITLE
Hive: optional color-model predictions for piece labeling

### DIFF
--- a/software/hive/backend/alembic/versions/e7c1a2b3d4f5_add_color_models.py
+++ b/software/hive/backend/alembic/versions/e7c1a2b3d4f5_add_color_models.py
@@ -1,0 +1,54 @@
+"""add color models registry (and merge divergent heads)
+
+Revision ID: e7c1a2b3d4f5
+Revises: a9c4d2b3e5f7, b8c9d0e1f2a3, d2e3f4a5b6c7
+Create Date: 2026-07-13 22:30:00.000000
+
+Registry of uploaded color-classifier models. Rows are reconciled from a dir
+scan of COLOR_MODEL_DIR; one row per `.onnx`. At most one is active and serves
+piece-color predictions.
+
+This also merges the three Alembic heads that had accumulated from parallel PRs
+(a9c4d2b3e5f7 / b8c9d0e1f2a3 / d2e3f4a5b6c7) back into a single head, so
+`alembic upgrade head` is unambiguous again.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "e7c1a2b3d4f5"
+down_revision: Union[str, Sequence[str], None] = ("a9c4d2b3e5f7", "b8c9d0e1f2a3", "d2e3f4a5b6c7")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "color_models",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("filename", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("sha256", sa.String(length=64), nullable=False),
+        sa.Column("class_count", sa.Integer(), nullable=False),
+        sa.Column("input_size", sa.Integer(), nullable=False),
+        sa.Column("file_size", sa.BigInteger(), nullable=False),
+        sa.Column("meta", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("filename", name="uq_color_models_filename"),
+    )
+    op.create_index("ix_color_models_is_active", "color_models", ["is_active"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_color_models_is_active", table_name="color_models")
+    op.drop_table("color_models")

--- a/software/hive/backend/app/config.py
+++ b/software/hive/backend/app/config.py
@@ -14,6 +14,10 @@ class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql://hive:hive_dev@localhost:5432/hive"
     JWT_SECRET: str | None = None
     UPLOAD_DIR: str = "data/uploads"
+    # Local dir scanned for color-classifier models (`.onnx`). One row per file is
+    # reconciled into the color_models table; the active one serves piece-color
+    # predictions. Model bytes are uploaded here out of band (not through the API).
+    COLOR_MODEL_DIR: str = "data/color_models"
     STORAGE_BACKEND: str = "local"
     S3_BUCKET: str = ""
     S3_ENDPOINT_URL: str = ""

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -14,6 +14,7 @@ from app.routers import (
     analytics,
     api_keys,
     auth,
+    color_models,
     installs,
     leaderboard,
     machine_config_backups,
@@ -93,6 +94,7 @@ app.include_router(models_router.router)
 app.include_router(machine_models.router)
 app.include_router(machine_parts.router)
 app.include_router(piece_color_labels.router)
+app.include_router(color_models.router)
 app.include_router(api_keys.router)
 app.include_router(teacher.router)
 app.include_router(leaderboard.router)

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -37,3 +37,4 @@ from app.models.piece_color_label import PieceColorLabel  # noqa: E402, F401
 from app.models.piece_crop_link import PieceCropLink, PieceCropLinkMember  # noqa: E402, F401
 from app.models.piece_rejection import PieceRejection  # noqa: E402, F401
 from app.models.install import Install  # noqa: E402, F401
+from app.models.color_model import ColorModel  # noqa: E402, F401

--- a/software/hive/backend/app/models/color_model.py
+++ b/software/hive/backend/app/models/color_model.py
@@ -1,0 +1,43 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import JSON_VARIANT, Base
+
+
+class ColorModel(Base):
+    """Registry of color-classifier models available to serve piece-color
+    predictions. Rows are reconciled from a dir scan of COLOR_MODEL_DIR — one row
+    per ``.onnx`` file found there — so the DB holds the metadata (display name,
+    class count, input size, sha) while the model bytes live on disk and are
+    uploaded out of band. At most one row has ``is_active`` true; that model's
+    prediction is shown alongside the pixel-average suggestion in the labeling
+    view.
+
+    ``sha256`` lets a scan notice a file was replaced in place (same name, new
+    bytes) and refresh the cached session. ``meta`` keeps the full embedded
+    metadata block for reference/debugging.
+    """
+
+    __tablename__ = "color_models"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    filename = Column(String, nullable=False, unique=True)
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    kind = Column(String, nullable=False, default="color_classifier")
+    sha256 = Column(String(64), nullable=False)
+    class_count = Column(Integer, nullable=False, default=0)
+    input_size = Column(Integer, nullable=False, default=0)
+    file_size = Column(BigInteger, nullable=False, default=0)
+    meta = Column(JSON_VARIANT, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/software/hive/backend/app/routers/color_models.py
+++ b/software/hive/backend/app/routers/color_models.py
@@ -1,0 +1,80 @@
+"""Admin management of color-classifier models.
+
+Models are uploaded to COLOR_MODEL_DIR out of band (scp/manual). This router
+reconciles the DB registry to what's on disk and lets an admin pick the single
+globally-active model whose prediction the piece-labeling view serves.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.deps import get_db, require_role, verify_csrf
+from app.errors import APIError
+from app.models.color_model import ColorModel
+from app.models.user import User
+from app.services import color_predictor
+
+router = APIRouter(prefix="/api/color-models", tags=["color-models"])
+
+
+def _serialize(row: ColorModel) -> dict:
+    return {
+        "id": str(row.id),
+        "filename": row.filename,
+        "name": row.name,
+        "description": row.description,
+        "kind": row.kind,
+        "sha256": row.sha256,
+        "class_count": row.class_count,
+        "input_size": row.input_size,
+        "file_size": row.file_size,
+        "is_active": bool(row.is_active),
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+@router.get("")
+def list_color_models(
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+) -> dict:
+    """Reconcile the registry to the models on disk, then list them. The scan
+    picks up newly-uploaded files and drops rows whose files were removed."""
+    rows = color_predictor.reconcile(db)
+    return {
+        "models": [_serialize(r) for r in rows],
+        "model_dir": str(color_predictor.model_dir()),
+    }
+
+
+@router.post("/{model_id}/activate")
+def activate_color_model(
+    model_id: UUID,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+    _csrf: None = Depends(verify_csrf),
+) -> dict:
+    """Make this the single globally-active model. Clears any prior active one."""
+    row = color_predictor.set_active(db, model_id, True)
+    if row is None:
+        raise APIError(404, "Color model not found", "COLOR_MODEL_NOT_FOUND")
+    return {"ok": True, "model": _serialize(row)}
+
+
+@router.post("/{model_id}/deactivate")
+def deactivate_color_model(
+    model_id: UUID,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+    _csrf: None = Depends(verify_csrf),
+) -> dict:
+    """Turn this model off. With none active, the labeling view falls back to the
+    pixel-average suggestion."""
+    row = color_predictor.set_active(db, model_id, False)
+    if row is None:
+        raise APIError(404, "Color model not found", "COLOR_MODEL_NOT_FOUND")
+    return {"ok": True, "model": _serialize(row)}

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -35,6 +35,7 @@ from app.models.user import User
 from app.services.brickognize_feedback import submit_color_feedback, submit_part_feedback
 from app.services.channel_crop_lookup import find_possible_crops
 from app.services.channel_crop_lookup_params import DEFAULT_PARAMS
+from app.services.color_predictor import predict as predict_piece_color
 from app.services.pixel_color import guess_piece_color
 from app.services.profile_catalog import get_profile_catalog_service
 from app.services.storage import serve_stored_file
@@ -426,6 +427,9 @@ def piece_detail(
         "recorded_at": piece.recorded_at.isoformat() if piece.recorded_at else None,
         "seen_at": piece.seen_at.isoformat() if piece.seen_at else None,
         "pixel_guess": guess_piece_color(images),
+        # Learned prediction from the globally-active color model, if one is set.
+        # None → the UI falls back to the pixel-average guess alone.
+        "model_prediction": predict_piece_color(db, images),
         "images": [
             {"seq": im.seq, "source": im.source, "used": im.used, "score": im.score} for im in images
         ],

--- a/software/hive/backend/app/services/color_predictor.py
+++ b/software/hive/backend/app/services/color_predictor.py
@@ -1,0 +1,292 @@
+"""Serve piece-color predictions from an uploaded ONNX color classifier.
+
+The active model (one global row in ``color_models``) replaces nothing on disk —
+its bytes live in ``COLOR_MODEL_DIR`` and are uploaded out of band. Each ``.onnx``
+is self-describing: a ``hive.*`` metadata block (baked in at export time) carries
+the display name, input size, preprocess recipe, and the class-index → BrickLink
+color-id map, so a dir scan needs no sidecar files.
+
+Prediction path (per piece): read up to N crops from storage, resize to the model's
+input size, scale to [0,1] (mean/std normalization is baked into the graph), run the
+session, average the per-crop softmax, and map argmax → BrickLink color. Cheap: one
+indexed DB lookup for the active row plus a cached session; no dir scan.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import onnxruntime as ort
+from PIL import Image
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.color_model import ColorModel
+from app.services.profile_catalog import get_profile_catalog_service
+from app.services.storage_backend import get_backend
+
+log = logging.getLogger(__name__)
+
+MAX_SAMPLES = 5
+_HIVE_KIND = "color_classifier"
+
+
+def model_dir() -> Path:
+    return Path(settings.COLOR_MODEL_DIR)
+
+
+@dataclass
+class _Loaded:
+    session: ort.InferenceSession
+    input_name: str
+    output_name: str
+    input_size: int
+    class_ids: list[int]
+
+
+_lock = threading.Lock()
+_session_cache: dict[tuple[str, str], _Loaded] = {}
+
+
+def _sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _read_metadata(path: Path) -> dict[str, str] | None:
+    """Read the model's ``hive.*`` metadata via a throwaway ort session. Returns
+    None when the file isn't a readable color classifier."""
+    try:
+        so = ort.SessionOptions()
+        so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+        sess = ort.InferenceSession(str(path), sess_options=so, providers=["CPUExecutionProvider"])
+    except Exception as exc:
+        log.warning("color model %s failed to load: %s", path.name, exc)
+        return None
+    meta = sess.get_modelmeta().custom_metadata_map or {}
+    if meta.get("hive.kind") != _HIVE_KIND:
+        log.warning("color model %s is not a %s (kind=%r)", path.name, _HIVE_KIND, meta.get("hive.kind"))
+        return None
+    return dict(meta)
+
+
+def _parse_class_ids(meta: dict[str, str]) -> list[int]:
+    try:
+        return [int(x) for x in json.loads(meta.get("hive.classes", "[]"))]
+    except (ValueError, TypeError):
+        return []
+
+
+def scan_models() -> list[dict[str, Any]]:
+    """Every readable color classifier in COLOR_MODEL_DIR, with its metadata."""
+    directory = model_dir()
+    if not directory.exists():
+        return []
+    found: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.onnx")):
+        meta = _read_metadata(path)
+        if meta is None:
+            continue
+        class_ids = _parse_class_ids(meta)
+        try:
+            input_size = int(meta.get("hive.input_size", "0"))
+        except ValueError:
+            input_size = 0
+        found.append(
+            {
+                "filename": path.name,
+                "name": meta.get("hive.name") or path.stem,
+                "description": meta.get("hive.description"),
+                "kind": meta.get("hive.kind", _HIVE_KIND),
+                "sha256": _sha256_of(path),
+                "class_count": len(class_ids),
+                "input_size": input_size,
+                "file_size": path.stat().st_size,
+                "meta": meta,
+            }
+        )
+    return found
+
+
+def reconcile(db: Session) -> list[ColorModel]:
+    """Sync color_models rows to the files on disk: insert new, refresh changed
+    (sha differs), drop vanished. Returns all rows after reconciliation."""
+    scanned = {m["filename"]: m for m in scan_models()}
+    existing = {row.filename: row for row in db.query(ColorModel).all()}
+
+    for filename, m in scanned.items():
+        row = existing.get(filename)
+        if row is None:
+            db.add(
+                ColorModel(
+                    filename=filename,
+                    name=m["name"],
+                    description=m["description"],
+                    kind=m["kind"],
+                    sha256=m["sha256"],
+                    class_count=m["class_count"],
+                    input_size=m["input_size"],
+                    file_size=m["file_size"],
+                    meta=m["meta"],
+                )
+            )
+        elif row.sha256 != m["sha256"]:
+            row.name = m["name"]
+            row.description = m["description"]
+            row.kind = m["kind"]
+            row.sha256 = m["sha256"]
+            row.class_count = m["class_count"]
+            row.input_size = m["input_size"]
+            row.file_size = m["file_size"]
+            row.meta = m["meta"]
+
+    for filename, row in existing.items():
+        if filename not in scanned:
+            db.delete(row)
+
+    db.commit()
+    return db.query(ColorModel).order_by(ColorModel.name.asc()).all()
+
+
+def get_active(db: Session) -> ColorModel | None:
+    return db.query(ColorModel).filter(ColorModel.is_active.is_(True)).first()
+
+
+def set_active(db: Session, model_id, active: bool) -> ColorModel | None:
+    row = db.query(ColorModel).filter(ColorModel.id == model_id).first()
+    if row is None:
+        return None
+    if active:
+        # Global single-active invariant: clear everyone else first.
+        db.query(ColorModel).filter(ColorModel.id != model_id, ColorModel.is_active.is_(True)).update(
+            {ColorModel.is_active: False}
+        )
+        row.is_active = True
+    else:
+        row.is_active = False
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _load(row: ColorModel) -> _Loaded | None:
+    path = model_dir() / row.filename
+    if not path.exists():
+        return None
+    key = (row.filename, row.sha256)
+    with _lock:
+        cached = _session_cache.get(key)
+        if cached is not None:
+            return cached
+    meta = _read_metadata(path)
+    if meta is None:
+        return None
+    class_ids = _parse_class_ids(meta)
+    try:
+        input_size = int(meta.get("hive.input_size", "0"))
+    except ValueError:
+        input_size = 0
+    if not class_ids or input_size <= 0:
+        log.warning("color model %s has no usable classes/input_size", row.filename)
+        return None
+    try:
+        so = ort.SessionOptions()
+        so.intra_op_num_threads = 2
+        session = ort.InferenceSession(str(path), sess_options=so, providers=["CPUExecutionProvider"])
+    except Exception as exc:
+        log.warning("color model %s failed to load for inference: %s", row.filename, exc)
+        return None
+    loaded = _Loaded(
+        session=session,
+        input_name=meta.get("hive.input_name") or session.get_inputs()[0].name,
+        output_name=meta.get("hive.output_name") or session.get_outputs()[0].name,
+        input_size=input_size,
+        class_ids=class_ids,
+    )
+    with _lock:
+        _session_cache[key] = loaded
+    return loaded
+
+
+def _preprocess(data: bytes, size: int) -> np.ndarray | None:
+    try:
+        with Image.open(io.BytesIO(data)) as im:
+            im = im.convert("RGB").resize((size, size), Image.BILINEAR)
+            arr = np.asarray(im, dtype=np.float32) / 255.0
+    except Exception:
+        return None
+    return arr.transpose(2, 0, 1)
+
+
+def _palette() -> dict[int, dict[str, Any]]:
+    return {
+        c["id"]: c
+        for c in get_profile_catalog_service().list_bricklink_colors()
+        if isinstance(c.get("id"), int)
+    }
+
+
+def predict(db: Session, images: list) -> dict[str, Any] | None:
+    """Model color prediction for one piece's crops, or None when no model is
+    active / the model can't be loaded / no crop is readable."""
+    row = get_active(db)
+    if row is None:
+        return None
+    loaded = _load(row)
+    if loaded is None:
+        return None
+
+    with_key = [im for im in images if getattr(im, "image_key", None)]
+    used = [im for im in with_key if getattr(im, "used", False)]
+    chosen = (used or with_key)[:MAX_SAMPLES]
+
+    batch: list[np.ndarray] = []
+    for im in chosen:
+        try:
+            data = get_backend().read_bytes(im.image_key)
+        except Exception:
+            continue
+        arr = _preprocess(data, loaded.input_size)
+        if arr is not None:
+            batch.append(arr)
+    if not batch:
+        return None
+
+    x = np.stack(batch, axis=0)
+    logits = loaded.session.run([loaded.output_name], {loaded.input_name: x})[0]
+    logits = logits - logits.max(axis=1, keepdims=True)
+    probs = np.exp(logits)
+    probs /= probs.sum(axis=1, keepdims=True)
+    mean_probs = probs.mean(axis=0)
+    idx = int(np.argmax(mean_probs))
+    if idx >= len(loaded.class_ids):
+        return None
+    color_id = loaded.class_ids[idx]
+    confidence = float(mean_probs[idx])
+
+    color = _palette().get(color_id)
+    return {
+        "method": "color_model",
+        "model_name": row.name,
+        "color_id": color_id,
+        "color_name": color["name"] if color else None,
+        "rgb": (color.get("rgb") or "").replace("#", "") if color else None,
+        "confidence": confidence,
+        "sample_count": len(batch),
+    }
+
+
+def clear_cache() -> None:
+    with _lock:
+        _session_cache.clear()

--- a/software/hive/backend/pyproject.toml
+++ b/software/hive/backend/pyproject.toml
@@ -22,4 +22,5 @@ dependencies = [
     "imagehash>=4.3",
     "numpy>=2.0",
     "scipy>=1.14",
+    "onnxruntime>=1.20",
 ]

--- a/software/hive/backend/uv.lock
+++ b/software/hive/backend/uv.lock
@@ -375,6 +375,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661 },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -429,6 +437,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "imagehash" },
     { name = "numpy" },
+    { name = "onnxruntime" },
     { name = "pillow" },
     { name = "psycopg2-binary" },
     { name = "pydantic", extra = ["email"] },
@@ -451,6 +460,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "imagehash", specifier = ">=4.3" },
     { name = "numpy", specifier = ">=2.0" },
+    { name = "onnxruntime", specifier = ">=1.20" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.7" },
@@ -648,6 +658,33 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/2b/54208fd03ad410480bc17edf4869376362da8bbf46fe186ddf4cb5cc20fe/onnxruntime-1.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:b3e5b58b8c89c2b20e086e890aa9527377e5c240dc3ecc1640d18e07705eeb1c", size = 18432958 },
+    { url = "https://files.pythonhosted.org/packages/ce/88/24fc51fcbb126da6d032372314e47b55c3faad58f2aa78c0e199ccd20b9c/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b3d87eb560ff6a772240506f3c78d6d27c63cafedd5c775672e1194f968cfd", size = 16438180 },
+    { url = "https://files.pythonhosted.org/packages/cb/19/14929c3c2fe0b79b41cce24463062bf3afa4cdd3c19dccf00319caa92bff/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6872443f236a554921cda6f318c900e2d0c226792cf3534d00e5057c6926e5d2", size = 18658445 },
+    { url = "https://files.pythonhosted.org/packages/7f/76/59ed932b0244acd7bbbd6449480053a6d958ea66357f022f932872e19287/onnxruntime-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:760021bca514d64a811837820d351a08a41741f16f8b4c26450da708fecf14e6", size = 13357856 },
+    { url = "https://files.pythonhosted.org/packages/79/51/d1ec60ec7b1e2ae2d7340ba52b8a13529140039cd4407ba8dddbbc046582/onnxruntime-1.27.0-cp313-cp313-win_arm64.whl", hash = "sha256:2fdfa9df40a0ded0028ce6f9cd863264237f3970559dea2b81456e9ac4622b94", size = 13104412 },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/e6bb1c6445c94f708c38cd8fbb7bf0264108c33498b9445c93e60fe6d329/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54c0c4e9202c36c4ecdb1f3443f5dfbfd5ee3b54d1362c4b4c6134110e74fb32", size = 16443331 },
+    { url = "https://files.pythonhosted.org/packages/72/1b/b18b31e806eabc41077810199fbbb36fbc2d5f19912416e5ccfbf73053d1/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b215aa662c8f983f7d6dedafe65a9be72c26e5338e0fe98b3e0422c32c85428", size = 18670967 },
+    { url = "https://files.pythonhosted.org/packages/3a/37/48ab79c39b58a7c9f6f5aac1fa0ff2b993eb2643393d6ed9e839ddb6f347/onnxruntime-1.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0874edc171f470fc4dd2bbb60bc0989612ed1a8b89b365cda016630a93227f13", size = 18433941 },
+    { url = "https://files.pythonhosted.org/packages/6e/24/d535ca8a09dbf697f853377c8dc0820dbcaae5f334316b400b953afbcba8/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b51c014cf1a4fcd93c29a97eac8071fa27710dae05a4d0380bb60a66d60a62c", size = 16439970 },
+    { url = "https://files.pythonhosted.org/packages/f9/b1/ea9ee80c0bdaa4efb13f29f8c236f3740f6655e8c092a2d119515a5a652c/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:445fb702ea5241ba813a3ce2febe2e9408a64f6ad2eb610924322c536165f7cd", size = 18659240 },
+    { url = "https://files.pythonhosted.org/packages/e9/f2/1404507d76a21940e8bf46f414e3d1abd94dc888cb89a30f4a540275846f/onnxruntime-1.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:49e416be0d717338b6d041b99911b716d70c397d277056450724f93bdded3fc2", size = 13685306 },
+    { url = "https://files.pythonhosted.org/packages/10/e5/ca5cf012ccccb806c70e94aadfebca5606acc62b33eb88cec13352d0778f/onnxruntime-1.27.0-cp314-cp314-win_arm64.whl", hash = "sha256:856032937dd3bc7a7c141909c8d7ae4fde3e3f59bddf061ae627b9a051bda95c", size = 13456280 },
+    { url = "https://files.pythonhosted.org/packages/67/7b/dca330a8397e9d816c976d7aed4e24a4a2d279bb1e551e3d0221d1389b1d/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6197a02e3f620c4dc13cff51b80672409fc1ffab3aa2593911b19fd322ff48b", size = 16443274 },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/2bac21f722aa45d876d4a51f26bd0ef30e704068a3cd5021a5a7cd784271/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:370d211e1ceeac4cd5f45301655463ac59e27cdc74d9f7aeb2d19ff4b7a76715", size = 18670781 },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -712,6 +749,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084 },
     { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152 },
     { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579 },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226 },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847 },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030 },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130 },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945 },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996 },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659 },
 ]
 
 [[package]]

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -1002,6 +1002,16 @@ export interface ColorLabelPrediction {
 	color_name: string | null;
 }
 
+export interface ColorModelPrediction {
+	method: string;
+	model_name: string;
+	color_id: number;
+	color_name: string | null;
+	rgb: string | null;
+	confidence: number;
+	sample_count: number;
+}
+
 export interface ColorLabelCorrection {
 	correctable: boolean;
 	part_correct: boolean | null;
@@ -1026,6 +1036,7 @@ export interface ColorLabelPieceDetail {
 	recorded_at: string | null;
 	seen_at: string | null;
 	pixel_guess: ColorLabelPixelGuess | null;
+	model_prediction: ColorModelPrediction | null;
 	images: ColorLabelQueueImage[];
 	my_label: { color_id: number; notes: string | null } | null;
 	my_rejection: { reasons: string[] } | null;
@@ -1066,6 +1077,25 @@ export interface ColorLabelQueueItem {
 export interface ColorLabelQueue {
 	items: ColorLabelQueueItem[];
 	has_more: boolean;
+}
+
+export interface ColorModel {
+	id: string;
+	filename: string;
+	name: string;
+	description: string | null;
+	kind: string;
+	sha256: string;
+	class_count: number;
+	input_size: number;
+	file_size: number;
+	is_active: boolean;
+	updated_at: string | null;
+}
+
+export interface ColorModelsResponse {
+	models: ColorModel[];
+	model_dir: string;
 }
 
 // A "possibly the same piece" upstream C2/C3 crop candidate, ranked by the
@@ -1295,6 +1325,23 @@ export const api = {
 		return request<{ ok: boolean }>(
 			'DELETE',
 			`/api/labeling/piece-crop-link/${machineId}/${encodeURIComponent(pieceUuid)}`
+		);
+	},
+
+	// Color models (admin): scan/list the models on disk and pick the active one.
+	listColorModels() {
+		return request<ColorModelsResponse>('GET', '/api/color-models');
+	},
+	activateColorModel(modelId: string) {
+		return request<{ ok: boolean; model: ColorModel }>(
+			'POST',
+			`/api/color-models/${modelId}/activate`
+		);
+	},
+	deactivateColorModel(modelId: string) {
+		return request<{ ok: boolean; model: ColorModel }>(
+			'POST',
+			`/api/color-models/${modelId}/deactivate`
 		);
 	},
 	createMachine(name: string, description?: string) {

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -196,6 +196,16 @@
 										Teacher Jobs
 									</a>
 									<a
+										href="/admin/color-models"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										onclick={() => { dropdownOpen = false; }}
+									>
+										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" d="M4.098 19.902a3.75 3.75 0 0 0 5.304 0l6.401-6.402M6.75 21A3.75 3.75 0 0 1 3 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 0 0 3.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008Z" />
+										</svg>
+										Color Models
+									</a>
+									<a
 										href="/admin/parts"
 										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
 										onclick={() => { dropdownOpen = false; }}

--- a/software/hive/frontend/src/routes/admin/color-models/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/color-models/+page.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import { auth } from '$lib/auth.svelte';
+	import { api, type ColorModel } from '$lib/api';
+	import { goto } from '$app/navigation';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import { Alert, Button } from '$lib/components/primitives';
+
+	let models = $state<ColorModel[]>([]);
+	let modelDir = $state('');
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let busyId = $state<string | null>(null);
+
+	const activeModel = $derived(models.find((m) => m.is_active) ?? null);
+
+	$effect(() => {
+		// Wait for auth to initialize so a direct load / refresh of this URL
+		// doesn't bounce an admin out before their session is known.
+		if (!auth.initialized) return;
+		if (!auth.isAdmin) {
+			goto('/');
+			return;
+		}
+		void load();
+	});
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const res = await api.listColorModels();
+			models = res.models;
+			modelDir = res.model_dir;
+		} catch (e: unknown) {
+			error = e && typeof e === 'object' && 'error' in e ? String((e as { error: unknown }).error) : 'Failed to load color models';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function activate(model: ColorModel) {
+		if (busyId) return;
+		busyId = model.id;
+		error = null;
+		try {
+			await api.activateColorModel(model.id);
+			models = models.map((m) => ({ ...m, is_active: m.id === model.id }));
+		} catch (e: unknown) {
+			error = e && typeof e === 'object' && 'error' in e ? String((e as { error: unknown }).error) : 'Failed to activate model';
+		} finally {
+			busyId = null;
+		}
+	}
+
+	async function deactivate(model: ColorModel) {
+		if (busyId) return;
+		busyId = model.id;
+		error = null;
+		try {
+			await api.deactivateColorModel(model.id);
+			models = models.map((m) => ({ ...m, is_active: false }));
+		} catch (e: unknown) {
+			error = e && typeof e === 'object' && 'error' in e ? String((e as { error: unknown }).error) : 'Failed to deactivate model';
+		} finally {
+			busyId = null;
+		}
+	}
+
+	function fmtSize(bytes: number): string {
+		if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+		if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+		return `${bytes} B`;
+	}
+</script>
+
+<svelte:head>
+	<title>Color Models · Hive</title>
+</svelte:head>
+
+<div class="space-y-5">
+	<div class="flex flex-wrap items-start justify-between gap-3">
+		<div>
+			<h1 class="text-2xl font-bold text-text">Color models</h1>
+			<p class="mt-1 max-w-2xl text-sm text-text-muted">
+				The active model predicts a piece's color from its crops in the labeling view, alongside the
+				pixel-average guess. Models are ONNX files uploaded to the scan directory on the server; this
+				page reflects whatever is on disk.
+			</p>
+		</div>
+		<Button variant="secondary" size="sm" onclick={load} loading={loading}>Rescan</Button>
+	</div>
+
+	{#if modelDir}
+		<p class="text-xs text-text-muted">
+			Scan directory: <code class="bg-bg px-1.5 py-0.5 text-text">{modelDir}</code>
+		</p>
+	{/if}
+
+	{#if error}
+		<Alert variant="danger">{error}</Alert>
+	{/if}
+
+	{#if loading}
+		<div class="flex justify-center py-16"><Spinner /></div>
+	{:else if models.length === 0}
+		<div class="border border-border bg-surface px-4 py-10 text-center text-sm text-text-muted">
+			No color models found in the scan directory. Upload an <code>.onnx</code> file there and hit Rescan.
+		</div>
+	{:else}
+		<div class="border border-border bg-surface">
+			<div class="flex items-center justify-between border-b border-border bg-bg px-4 py-2">
+				<span class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+					{models.length} model{models.length === 1 ? '' : 's'} on disk
+				</span>
+				<span class="text-xs text-text-muted">
+					{#if activeModel}
+						Active: <span class="font-medium text-text">{activeModel.name}</span>
+					{:else}
+						None active — using pixel-average guess
+					{/if}
+				</span>
+			</div>
+
+			{#each models as m (m.id)}
+				<div class="flex flex-wrap items-center gap-4 border-b border-border px-4 py-3 last:border-b-0 {m.is_active ? 'bg-primary-light/30' : ''}">
+					<div class="min-w-0 flex-1">
+						<div class="flex flex-wrap items-center gap-2">
+							<span class="font-medium text-text">{m.name}</span>
+							{#if m.is_active}
+								<span class="border border-primary/30 bg-primary-light px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-primary">Active</span>
+							{/if}
+						</div>
+						{#if m.description}
+							<p class="mt-0.5 truncate text-xs text-text-muted">{m.description}</p>
+						{/if}
+						<p class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-text-muted">
+							<span><code class="text-text-muted">{m.filename}</code></span>
+							<span>{m.class_count} colors</span>
+							<span>{m.input_size}×{m.input_size}</span>
+							<span>{fmtSize(m.file_size)}</span>
+							<span title={m.sha256}>sha {m.sha256.slice(0, 10)}</span>
+						</p>
+					</div>
+					<div class="flex items-center gap-2">
+						{#if m.is_active}
+							<Button variant="secondary" size="sm" loading={busyId === m.id} onclick={() => deactivate(m)}>
+								Deactivate
+							</Button>
+						{:else}
+							<Button variant="primary" size="sm" loading={busyId === m.id} onclick={() => activate(m)}>
+								Activate
+							</Button>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<p class="text-xs text-text-muted">
+			Only one model is active at a time. Deactivating leaves the labeling view on the pixel-average
+			guess.
+		</p>
+	{/if}
+</div>

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -74,8 +74,19 @@
 	// but Brickognize didn't accept it), or danger (the request itself failed).
 	let feedback = $state<{ variant: 'success' | 'warning' | 'danger'; text: string } | null>(null);
 
+	// The suggestion that seeds the picker: prefer the active color model's
+	// prediction, fall back to the pixel-average guess. Both are still shown in
+	// the piece panel; this just drives which one highlights in the color list.
+	const suggestion = $derived.by(() => {
+		const mp = detail?.model_prediction;
+		if (mp) return { color_id: mp.color_id, rgb: mp.rgb };
+		const pg = detail?.pixel_guess;
+		if (pg) return { color_id: pg.color_id, rgb: pg.rgb };
+		return null;
+	});
+
 	const guessColorId = $derived.by(() => {
-		const id = detail?.pixel_guess?.color_id;
+		const id = suggestion?.color_id;
 		return id != null && colorsById.has(id) ? id : null;
 	});
 
@@ -144,7 +155,7 @@
 	// Rank the palette against the guess, but push exotic finishes way down so the
 	// shortlist is dominated by plain solid colors (a piece is rarely pearl/metal).
 	const similarColors = $derived.by(() => {
-		const target = hexToLab(detail?.pixel_guess?.rgb ?? null);
+		const target = hexToLab(suggestion?.rgb ?? null);
 		if (!target) return [] as BrickLinkColor[];
 		return colors
 			.filter((c) => c.id !== guessColorId && labById.get(c.id) != null)
@@ -484,27 +495,55 @@
 				{/each}
 			</div>
 
-			<div class="mt-4 flex items-center gap-3 border-t border-border pt-3">
-				{#if detail.pixel_guess}
-					<span
-						class="h-10 w-10 shrink-0 border border-border"
-						style={`background:#${detail.pixel_guess.rgb}`}
-						title={`average pixel color #${detail.pixel_guess.rgb}`}
-					></span>
-					<div class="min-w-0 text-xs text-text-muted">
-						<div class="text-xs font-semibold uppercase tracking-wider">Pixel-average guess</div>
-						<div class="mt-0.5 flex items-center gap-1.5">
-							{#if guessColorId != null}
-								{@const gc = colorsById.get(guessColorId)}
-								<span class="inline-block h-3.5 w-3.5 border border-border" style={`background:#${gc?.rgb ?? '000'}`}></span>
-							{/if}
-							<span class="text-text">{detail.pixel_guess.color_name}</span>
-							<span>({detail.pixel_guess.color_id})</span>
-							<span class="ml-2">nearest of {detail.pixel_guess.sample_count} crop{detail.pixel_guess.sample_count === 1 ? '' : 's'}</span>
+			<div class="mt-4 flex flex-col gap-3 border-t border-border pt-3">
+				<!-- Model prediction (primary, when a color model is active) -->
+				{#if detail.model_prediction}
+					{@const mp = detail.model_prediction}
+					<div class="flex items-center gap-3">
+						<span
+							class="h-10 w-10 shrink-0 border border-border"
+							style={`background:#${mp.rgb ?? '888888'}`}
+							title={`model color #${mp.rgb ?? '?'}`}
+						></span>
+						<div class="min-w-0 text-xs text-text-muted">
+							<div class="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider">
+								<Sparkles size={12} class="text-info" /> Model prediction
+								<span class="font-normal normal-case text-text-muted">· {mp.model_name}</span>
+							</div>
+							<div class="mt-0.5 flex items-center gap-1.5">
+								<span class="text-text">{mp.color_name ?? mp.color_id}</span>
+								<span>({mp.color_id})</span>
+								<span class="ml-2">{Math.round(mp.confidence * 100)}% · {mp.sample_count} crop{mp.sample_count === 1 ? '' : 's'}</span>
+							</div>
 						</div>
 					</div>
-				{:else}
-					<span class="text-xs text-text-muted">No pixel guess — crops unavailable.</span>
+				{/if}
+
+				<!-- Pixel-average guess (secondary reference when a model is active) -->
+				{#if detail.pixel_guess}
+					<div class="flex items-center gap-3 {detail.model_prediction ? 'opacity-70' : ''}">
+						<span
+							class="h-10 w-10 shrink-0 border border-border"
+							style={`background:#${detail.pixel_guess.rgb}`}
+							title={`average pixel color #${detail.pixel_guess.rgb}`}
+						></span>
+						<div class="min-w-0 text-xs text-text-muted">
+							<div class="text-xs font-semibold uppercase tracking-wider">Pixel-average guess</div>
+							<div class="mt-0.5 flex items-center gap-1.5">
+								{#if detail.pixel_guess.color_id != null && colorsById.has(detail.pixel_guess.color_id)}
+									{@const pc = colorsById.get(detail.pixel_guess.color_id)}
+									<span class="inline-block h-3.5 w-3.5 border border-border" style={`background:#${pc?.rgb ?? '000'}`}></span>
+								{/if}
+								<span class="text-text">{detail.pixel_guess.color_name}</span>
+								<span>({detail.pixel_guess.color_id})</span>
+								<span class="ml-2">nearest of {detail.pixel_guess.sample_count} crop{detail.pixel_guess.sample_count === 1 ? '' : 's'}</span>
+							</div>
+						</div>
+					</div>
+				{/if}
+
+				{#if !detail.model_prediction && !detail.pixel_guess}
+					<span class="text-xs text-text-muted">No suggestion — crops unavailable.</span>
 				{/if}
 			</div>
 		</div>


### PR DESCRIPTION
## What

Adds an optional, admin-selectable **color classifier** to Hive. When a model is active, the piece-labeling view predicts a piece's color from its crops and shows it as the primary suggestion — with the existing pixel-average guess kept as a dimmed secondary reference. When no model is active, behavior is unchanged (pixel-average only).

## How it works

- **Registry from a dir scan.** Models are ONNX files uploaded out of band to `COLOR_MODEL_DIR` (no upload API). Each `.onnx` is self-describing: a baked-in `hive.*` metadata block carries the display name, input size, preprocess recipe, and the class-index → BrickLink-color-id map. A scan reconciles one `color_models` row per file; the DB holds the metadata + which one is active.
- **Single global active model.** Admins pick it from the new **`/admin/color-models`** page (in the admin nav). Only one is active at a time; deactivating falls back to the pixel-average guess.
- **Inference.** `color_predictor` runs onnxruntime on CPU (cached session), averaging the per-crop softmax over a piece's crops. ~0.4–0.6 ms/piece on a 2‑vCPU box — effectively free.
- **Labeling view.** `piece_detail` returns `model_prediction`; the UI shows it (with confidence + model name) as the primary suggestion that seeds the color picker, pixel-average dimmed below.

## Alembic

The migration **merges the three divergent heads** that had accumulated on `main` from parallel PRs (`a9c4d2b3e5f7` / `b8c9d0e1f2a3` / `d2e3f4a5b6c7`) back into a single head **and** creates `color_models`. Without this merge, the next prod deploy's `alembic upgrade head` would fail on ambiguous heads regardless of this feature.

## Verification (local, real data)

- Migration applies on a fresh Postgres, 3 heads → 1, table created.
- Predictor reproduces **90.9% gold piece accuracy** through the actual service path.
- Full API E2E: login → scan/list → activate → `piece_detail` returns the correct color (White @ 0.98 where the machine's Brickognize guess was wrong) → deactivate → null.
- Browser: admin activate/deactivate + the piece view showing model-primary / pixel-average-secondary.
- `pnpm check` + `build` clean; `onnxruntime` added to `uv.lock`.

## Deploy notes (not done here)

- Add a bind mount for the model dir to `docker-compose.prod.yml` (e.g. `./data/color_models:/app/data/color_models`) and `scp` the `.onnx` there.
- Redeploy runs `alembic upgrade head` (applies the merge + table). Then Activate the model in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
