### PR TITLE
Piece corrections: one-click color accept + live-piece fix

### DIFF
--- a/software/sorter/backend/piece_records.py
+++ b/software/sorter/backend/piece_records.py
@@ -163,14 +163,34 @@ def recordPiece(
     recorded_at = piece.get("distributed_at") or time.time()
     dead = 1 if piece.get("dead") else 0
     with _connection() as conn:
+        # Upsert (not INSERT OR IGNORE): a piece can be recorded early by the
+        # correction API straight from memory (so a just-classified piece is
+        # correctable before it distributes), then re-recorded at distribution
+        # with its bin. On conflict we refresh the classification/bin columns but
+        # NEVER touch the correction columns (part_correct, color_corrected_id,
+        # *_feedback_submitted, correction_updated_at) so a recorded correction
+        # survives the distribution write.
         conn.execute(
-            "INSERT OR IGNORE INTO piece_records "
+            "INSERT INTO piece_records "
             "(uuid, run_id, machine_id, seen_at, recorded_at, classification_status, "
             "part_id, part_name, color_id, color_name, category_id, confidence, "
             "bin_x, bin_y, bin_z, dead, brickognize_preview_url, "
             "brickognize_listing_id, brickognize_item_rank, brickognize_item_type, "
             "brickognize_color_rank) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(uuid) DO UPDATE SET "
+            "run_id=excluded.run_id, machine_id=excluded.machine_id, "
+            "seen_at=excluded.seen_at, recorded_at=excluded.recorded_at, "
+            "classification_status=excluded.classification_status, "
+            "part_id=excluded.part_id, part_name=excluded.part_name, "
+            "color_id=excluded.color_id, color_name=excluded.color_name, "
+            "category_id=excluded.category_id, confidence=excluded.confidence, "
+            "bin_x=excluded.bin_x, bin_y=excluded.bin_y, bin_z=excluded.bin_z, "
+            "dead=excluded.dead, brickognize_preview_url=excluded.brickognize_preview_url, "
+            "brickognize_listing_id=excluded.brickognize_listing_id, "
+            "brickognize_item_rank=excluded.brickognize_item_rank, "
+            "brickognize_item_type=excluded.brickognize_item_type, "
+            "brickognize_color_rank=excluded.brickognize_color_rank",
             (
                 uuid_val,
                 run_id,

--- a/software/sorter/backend/server/routers/pieces.py
+++ b/software/sorter/backend/server/routers/pieces.py
@@ -401,6 +401,48 @@ class CorrectionResponse(BaseModel):
     submit_error: Optional[str] = None
 
 
+def _ensurePieceRecorded(gc: Any, uuid: str) -> None:
+    # A piece is correctable the instant it's classified (the live payload
+    # carries the Brickognize listing), which is BEFORE it's written to
+    # piece_records at distribution. If a correction lands in that window,
+    # persist the piece straight from the in-memory KnownObject so the correction
+    # has a row to attach to. recordPiece upserts, so the later distribution write
+    # still fills in the bin.
+    import piece_records
+
+    if gc is None or getattr(gc, "runtime_stats", None) is None:
+        return
+    payload = gc.runtime_stats.lookupKnownObject(uuid)
+    if payload is None:
+        return
+    status = payload.get("classification_status")
+    if isinstance(status, Enum):
+        status = status.value
+    piece_records.recordPiece(
+        {
+            "uuid": uuid,
+            "created_at": payload.get("created_at"),
+            "distributed_at": payload.get("distributed_at"),
+            "classification_status": status,
+            "part_id": payload.get("part_id"),
+            "part_name": payload.get("part_name"),
+            "color_id": payload.get("color_id"),
+            "color_name": payload.get("color_name"),
+            "category_id": payload.get("category_id"),
+            "confidence": payload.get("confidence"),
+            "destination_bin": payload.get("destination_bin"),
+            "dead": payload.get("dead"),
+            "brickognize_preview_url": payload.get("brickognize_preview_url"),
+            "brickognize_listing_id": payload.get("brickognize_listing_id"),
+            "brickognize_item_rank": payload.get("brickognize_item_rank"),
+            "brickognize_item_type": payload.get("brickognize_item_type"),
+            "brickognize_color_rank": payload.get("brickognize_color_rank"),
+        },
+        run_id=getattr(gc, "run_id", None),
+        machine_id=getattr(gc, "machine_id", None),
+    )
+
+
 @router.post("/api/pieces/{uuid}/correction", response_model=CorrectionResponse)
 def submitPieceCorrection(uuid: str, body: CorrectionRequest) -> CorrectionResponse:
     import piece_records
@@ -411,6 +453,10 @@ def submitPieceCorrection(uuid: str, body: CorrectionRequest) -> CorrectionRespo
 
     gc = shared_state.gc_ref
     ctx = piece_records.getCorrectionContext(uuid)
+    if ctx is None:
+        # Not recorded yet — persist it from memory, then retry.
+        _ensurePieceRecorded(gc, uuid)
+        ctx = piece_records.getCorrectionContext(uuid)
     if ctx is None:
         raise HTTPException(status_code=404, detail="not found")
 

--- a/software/sorter/frontend/src/lib/components/PieceCorrection.svelte
+++ b/software/sorter/frontend/src/lib/components/PieceCorrection.svelte
@@ -153,12 +153,12 @@
 		}
 	}
 
-	async function confirmColor() {
-		if (colorBusy || !selectedId) return;
+	async function submitColor(id: string | null) {
+		if (colorBusy || !id) return;
 		colorBusy = true;
 		feedback = null;
 		try {
-			const resp = await postCorrection({ color_corrected_id: selectedId, submit: true });
+			const resp = await postCorrection({ color_corrected_id: id, submit: true });
 			if (resp) {
 				applyResponse(resp, 'Color correction', resp.color_submitted);
 				pickerOpen = false;
@@ -168,6 +168,17 @@
 		} finally {
 			colorBusy = false;
 		}
+	}
+
+	// One click: the predicted color is right (submits the prediction, which
+	// Brickognize records as an accept).
+	function acceptPredictedColor() {
+		void submitColor(predictedColorId);
+	}
+
+	// The dropdown's Confirm: submit whatever the user staged (possibly different).
+	function confirmColor() {
+		void submitColor(selectedId);
 	}
 
 	function chooseColor(id: string) {
@@ -184,11 +195,18 @@
 	const partSent = $derived(Boolean(piece.part_feedback_submitted));
 	const colorSent = $derived(Boolean(piece.color_feedback_submitted));
 
-	// The color currently shown on the trigger button: the committed correction
-	// if any, otherwise the Brickognize prediction.
-	const shownColorId = $derived(committedColorId ?? predictedColorId);
-	const shownColorName = $derived(colorNameFor(shownColorId) ?? piece.color_name ?? null);
-	const shownColorHex = $derived(swatchHex(colorRgbFor(shownColorId)));
+	// The Brickognize-predicted color (what "Yes" accepts).
+	const predictedColorName = $derived(colorNameFor(predictedColorId) ?? piece.color_name ?? null);
+	const predictedColorHex = $derived(swatchHex(colorRgbFor(predictedColorId)));
+	// The committed correction, if the user chose a different color.
+	const committedColorName = $derived(colorNameFor(committedColorId));
+	const committedColorHex = $derived(swatchHex(colorRgbFor(committedColorId)));
+	const acceptedPrediction = $derived(
+		committedColorId != null && committedColorId === predictedColorId
+	);
+	const correctedToDifferent = $derived(
+		committedColorId != null && committedColorId !== predictedColorId
+	);
 
 	const gap = $derived(compact ? 'gap-2' : 'gap-3');
 </script>
@@ -247,36 +265,62 @@
 		<div class="flex flex-col gap-1.5">
 			<div class="flex flex-wrap items-center gap-2">
 				<span class="text-xs font-semibold tracking-wider text-text-muted uppercase">
-					True color
+					Color correct?
+				</span>
+				<!-- The predicted color, with a one-click "yes it's right". -->
+				<span
+					class="inline-flex items-center gap-1.5 text-sm text-text"
+					title="Brickognize predicted this color"
+				>
+					{#if predictedColorHex}
+						<span
+							class="inline-block h-3.5 w-3.5 border border-border"
+							style:background-color={predictedColorHex}
+						></span>
+					{/if}
+					<span>{predictedColorName ?? '—'}</span>
 				</span>
 				<button
 					type="button"
-					onclick={() => (pickerOpen ? closePicker() : openPicker())}
-					class="inline-flex items-center gap-1.5 border border-border bg-surface px-2 py-1 text-sm text-text transition-colors hover:bg-bg"
+					onclick={acceptPredictedColor}
+					disabled={colorBusy || predictedColorId == null}
+					title="The predicted color is correct"
+					aria-label="Mark predicted color correct"
+					class="inline-flex items-center gap-1 border border-border px-2 py-1 text-sm transition-colors disabled:opacity-50 {acceptedPrediction
+						? 'bg-success/15 text-success'
+						: 'text-text-muted hover:text-success'}"
 				>
-					{#if shownColorHex}
+					<Check size={14} />
+					Yes
+				</button>
+				<!-- Or open the dropdown to submit a different, correct color. -->
+				<button
+					type="button"
+					onclick={() => (pickerOpen ? closePicker() : openPicker())}
+					title="Pick the correct color instead"
+					class="inline-flex items-center gap-1.5 border px-2 py-1 text-sm transition-colors {correctedToDifferent
+						? 'border-danger/50 bg-danger/[0.12] text-danger'
+						: 'border-border bg-surface text-text-muted hover:bg-bg'}"
+				>
+					{#if correctedToDifferent && committedColorHex}
 						<span
 							class="inline-block h-3.5 w-3.5 border border-border"
-							style:background-color={shownColorHex}
+							style:background-color={committedColorHex}
 						></span>
-					{/if}
-					<span>{shownColorName ?? 'Pick a color'}</span>
-				</button>
-				{#if committedColorId}
-					{#if colorSent}
-						<span
-							class="inline-flex items-center border border-success/50 bg-success/[0.12] px-1.5 py-0.5 text-xs font-semibold tracking-wider text-success uppercase"
-							title="This color correction has been sent to Brickognize"
-						>
-							Sent
-						</span>
 					{:else}
-						<span
-							class="inline-flex items-center border border-border bg-surface px-1.5 py-0.5 text-xs font-semibold tracking-wider text-text-muted uppercase"
-						>
-							Locked in
-						</span>
+						<Search size={14} />
 					{/if}
+					<span>{correctedToDifferent ? committedColorName : 'No — pick color'}</span>
+				</button>
+				{#if colorBusy}
+					<Spinner size={12} />
+				{:else if colorSent}
+					<span
+						class="inline-flex items-center border border-success/50 bg-success/[0.12] px-1.5 py-0.5 text-xs font-semibold tracking-wider text-success uppercase"
+						title="This color correction has been sent to Brickognize"
+					>
+						Sent
+					</span>
 				{/if}
 			</div>
 

--- a/software/sorter/frontend/src/lib/components/RecentObjects.svelte
+++ b/software/sorter/frontend/src/lib/components/RecentObjects.svelte
@@ -63,11 +63,13 @@
 	// shared PieceCorrection component in a modal. The summary is derived live
 	// from the store so a correction updates in place.
 	let correctingUuid = $state<string | null>(null);
-	const correctingSummary = $derived.by<PieceSummary | null>(() => {
+	const correctingPiece = $derived.by<Piece | null>(() => {
 		if (!correctingUuid) return null;
-		const p = storePieces.find((x) => x.uuid === correctingUuid);
-		return p ? pieceToSummary(p) : null;
+		return storePieces.find((x) => x.uuid === correctingUuid) ?? null;
 	});
+	const correctingSummary = $derived(
+		correctingPiece ? pieceToSummary(correctingPiece) : null
+	);
 	const correctionOpen = $derived(correctingSummary !== null);
 
 	function openCorrection(uuid: string, event: MouseEvent) {
@@ -812,6 +814,48 @@
 
 <Modal open={correctionOpen} title="Correct prediction" on:close={() => (correctingUuid = null)}>
 	{#if correctingSummary}
+		{@const capturedSrc =
+			dataImageUrl(
+				correctingPiece?.ws?.thumbnail ?? correctingPiece?.ws?.latest_captured_crop
+			) ?? correctingSummary.preview_url}
+		{@const legoColor = lookupLegoColor(
+			correctingSummary.color_id,
+			correctingSummary.color_name
+		)}
+		<div class="mb-3 flex items-center gap-3 border-b border-border pb-3">
+			{#if capturedSrc}
+				<img
+					src={capturedSrc}
+					alt=""
+					class="h-16 w-16 flex-shrink-0 border border-border object-cover"
+				/>
+			{/if}
+			<div class="flex min-w-0 flex-col gap-1">
+				<span class="truncate text-sm font-semibold text-text">
+					{correctingSummary.part_name ?? correctingSummary.part_id ?? 'Unknown part'}
+				</span>
+				{#if correctingSummary.part_id && correctingSummary.part_name}
+					<span class="font-mono text-xs text-text-muted">{correctingSummary.part_id}</span>
+				{/if}
+				<span class="inline-flex items-center gap-1.5 text-sm text-text">
+					{#if legoColor}
+						<span
+							class="inline-block h-3.5 w-3.5 flex-shrink-0 border border-border"
+							style:background-color={legoColor.hex}
+						></span>
+					{/if}
+					<span>{correctingSummary.color_name ?? '—'}</span>
+				</span>
+			</div>
+			{#if correctingSummary.preview_url}
+				<img
+					src={correctingSummary.preview_url}
+					alt="Brickognize reference"
+					title="Brickognize reference image"
+					class="ml-auto h-16 w-16 flex-shrink-0 border border-border bg-surface object-contain"
+				/>
+			{/if}
+		</div>
 		<PieceCorrection
 			piece={correctingSummary}
 			endpointBase={effectiveBase()}


### PR DESCRIPTION
Follow-ups to the Brickognize correction feature:

- Color: one click accepts the predicted color, or pick the correct one from the dropdown.
- Fix "failed to reach the machine" when correcting a just-classified piece — persist it from memory if it isn't recorded yet.
- Show the piece photo, name, and predicted color in the correction modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)