### PR TITLE
Hive: presigned-redirect cache fixes + role-based access control for training data

### DIFF
--- a/software/hive/backend/alembic/versions/f2a3b4c5d6e7_add_access_windows.py
+++ b/software/hive/backend/alembic/versions/f2a3b4c5d6e7_add_access_windows.py
@@ -1,0 +1,43 @@
+"""add per-role visibility windows for piece-bbox data
+
+Revision ID: f2a3b4c5d6e7
+Revises: d5e6f7a8b9c0
+Create Date: 2026-07-14 12:00:00.000000
+
+Bounds what a non-admin user can see/download of the accumulating piece +
+channel-crop dataset. One row per (role, entity); absent rows fall back to code
+defaults in services.access_window, so this table is empty on first deploy and
+the feature still works. Admins have no rows and are unrestricted.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, Sequence[str], None] = "d5e6f7a8b9c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "access_windows",
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("entity", sa.String(), nullable=False),
+        sa.Column("anchor", sa.String(), nullable=False),
+        sa.Column("window_size", sa.Integer(), nullable=False),
+        sa.Column("window_offset", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("role", "entity"),
+        sa.CheckConstraint("anchor IN ('oldest', 'newest')", name="ck_access_windows_anchor"),
+        sa.CheckConstraint("window_size >= 0", name="ck_access_windows_size"),
+        sa.CheckConstraint("window_offset >= 0", name="ck_access_windows_offset"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("access_windows")

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -39,3 +39,4 @@ from app.models.piece_crop_ai_prediction import PieceCropAiPrediction  # noqa: E
 from app.models.piece_rejection import PieceRejection  # noqa: E402, F401
 from app.models.install import Install  # noqa: E402, F401
 from app.models.color_model import ColorModel  # noqa: E402, F401
+from app.models.access_window import AccessWindow  # noqa: E402, F401

--- a/software/hive/backend/app/models/access_window.py
+++ b/software/hive/backend/app/models/access_window.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Integer, String
+
+from app.models import Base
+
+
+class AccessWindow(Base):
+    """Per-(role, entity) visibility window bounding what a non-admin can see of
+    the accumulating piece-bbox dataset.
+
+    A window is a contiguous slice of an entity ordered by ``created_at`` (id as
+    tiebreak). ``anchor`` picks which end the slice hangs off:
+
+      - ``oldest`` — slice counts from the oldest row. Because rows only ever
+        append at the newest end, an oldest-anchored slice is effectively PINNED:
+        the same rows stay in it until an admin moves ``offset``. Used for plain
+        members so they see a small fixed sample and can't accumulate different
+        slices by polling over time.
+      - ``newest`` — slice counts from the newest row, so it ROLLS forward as new
+        rows arrive. Used for reviewers so their (larger) working set tracks fresh
+        incoming work automatically.
+
+    Admins have no row and are unrestricted. Absent rows fall back to the code
+    defaults in ``services.access_window`` (so the feature works before any admin
+    config), and a size of 0 denies all — the safe default for an unknown role.
+    """
+
+    __tablename__ = "access_windows"
+
+    role = Column(String, primary_key=True)
+    entity = Column(String, primary_key=True)
+    anchor = Column(String, nullable=False)
+    # Mapped off reserved-ish SQL words to keep the DDL unambiguous.
+    size = Column("window_size", Integer, nullable=False)
+    offset = Column("window_offset", Integer, nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        CheckConstraint("anchor IN ('oldest', 'newest')", name="ck_access_windows_anchor"),
+        CheckConstraint("window_size >= 0", name="ck_access_windows_size"),
+        CheckConstraint("window_offset >= 0", name="ck_access_windows_offset"),
+    )

--- a/software/hive/backend/app/routers/admin.py
+++ b/software/hive/backend/app/routers/admin.py
@@ -1,12 +1,14 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.deps import get_db, require_role, verify_csrf
 from app.errors import APIError
 from app.models.user import User
 from app.schemas.auth import AdminUpdateUserRequest, UserResponse
+from app.services import access_window
 from app.services.server_health import get_server_health
 from app.services.storage import delete_machine_files
 
@@ -83,3 +85,41 @@ def delete_user(
     db.delete(user)
     db.commit()
     return {"ok": True}
+
+
+class AccessWindowUpdate(BaseModel):
+    anchor: str
+    size: int = Field(ge=0)
+    offset: int = Field(ge=0)
+
+
+@router.get("/access-windows")
+def get_access_windows(
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+):
+    """Effective piece-bbox visibility windows per (role, entity), with whether
+    each value is a live override or the code default. Admins are unrestricted."""
+    return access_window.list_effective_windows(db)
+
+
+@router.put("/access-windows/{role}/{entity}")
+def put_access_window(
+    role: str,
+    entity: str,
+    data: AccessWindowUpdate,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+    _csrf: None = Depends(verify_csrf),
+):
+    """Set (upsert) the visibility window for a windowed role + entity. 'admin' is
+    unrestricted and cannot be given a window."""
+    if role not in access_window.WINDOWED_ROLES:
+        raise APIError(400, f"Role must be one of {access_window.WINDOWED_ROLES}", "INVALID_ROLE")
+    if entity not in access_window.ENTITIES:
+        raise APIError(400, f"Entity must be one of {access_window.ENTITIES}", "INVALID_ENTITY")
+    if data.anchor not in access_window.ANCHORS:
+        raise APIError(400, f"Anchor must be one of {access_window.ANCHORS}", "INVALID_ANCHOR")
+
+    access_window.set_window(db, role, entity, data.anchor, data.size, data.offset)
+    return access_window.list_effective_windows(db)

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -43,8 +43,16 @@ from app.services.piece_crop_ai_matcher import (
     match_piece_crops,
     store_prediction,
 )
+from app.services.access_window import (
+    apply_piece_access,
+    channel_crop_access_visible,
+    piece_access_visible,
+    piece_access_visible_by_key,
+    scope_to_piece_access,
+)
 from app.services.pixel_color import guess_piece_color
 from app.services.profile_catalog import get_profile_catalog_service
+from app.services.rate_limit import rate_limit
 from app.services.secrets import decrypt_secret
 from app.services.storage import serve_stored_file
 
@@ -114,22 +122,29 @@ def label_stats(
     machine_id: UUID | None = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Dashboard rollup: overall progress plus a histogram of how many distinct
     labelers have color-labeled each piece (drives the coverage chart). Scoped to
-    one machine when machine_id is given, matching the grid's machine filter."""
-    labelable_q = _labelable_query(db)
+    one machine when machine_id is given, matching the grid's machine filter, and
+    to the caller's visibility window (so a member's dashboard reflects only their
+    slice, not global fleet totals; admins see everything)."""
+    labelable_q = apply_piece_access(db, _labelable_query(db), current_user)
     if machine_id is not None:
         labelable_q = labelable_q.filter(MachinePiece.machine_id == machine_id)
     total_labelable = labelable_q.count()
 
     def _color_q():
         q = db.query(PieceColorLabel)
-        return q.filter(PieceColorLabel.machine_id == machine_id) if machine_id is not None else q
+        if machine_id is not None:
+            q = q.filter(PieceColorLabel.machine_id == machine_id)
+        return scope_to_piece_access(db, q, current_user, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid)
 
     def _crop_q():
         q = db.query(PieceCropLink)
-        return q.filter(PieceCropLink.machine_id == machine_id) if machine_id is not None else q
+        if machine_id is not None:
+            q = q.filter(PieceCropLink.machine_id == machine_id)
+        return scope_to_piece_access(db, q, current_user, PieceCropLink.machine_id, PieceCropLink.piece_uuid)
 
     labeled_by_me = _color_q().filter(PieceColorLabel.labeler_id == current_user.id).count()
     crop_links_by_me = _crop_q().filter(PieceCropLink.labeler_id == current_user.id).count()
@@ -233,6 +248,7 @@ def list_pieces(
     with_candidates: bool = Query(False),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Sortable grid of labelable pieces with per-piece label/crop-link counts,
     for the dashboard. Sorts: priority (has same-piece candidates first, then
@@ -310,6 +326,7 @@ def list_pieces(
         q = q.filter(MachinePiece.machine_id == machine_id)
     if with_candidates:
         q = q.filter(has_candidates)
+    q = apply_piece_access(db, q, current_user)
 
     recent_order = (MachinePiece.recorded_at.desc().nullslast(), MachinePiece.created_at.desc())
     if sort == "priority":
@@ -386,6 +403,7 @@ def piece_detail(
     piece_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Everything the single-piece labeling view needs: the piece, its crops, the
     pixel-average guess, and THIS user's saved color label (so revisiting a piece
@@ -395,7 +413,7 @@ def piece_detail(
         .filter(MachinePiece.machine_id == machine_id, MachinePiece.piece_uuid == piece_uuid)
         .first()
     )
-    if piece is None:
+    if piece is None or not piece_access_visible(db, current_user, piece):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
 
     machine_name = db.query(Machine.name).filter(Machine.id == machine_id).scalar()
@@ -485,7 +503,7 @@ def submit_brickognize_feedback(
         .filter(MachinePiece.machine_id == machine_id, MachinePiece.piece_uuid == piece_uuid)
         .first()
     )
-    if piece is None:
+    if piece is None or not piece_access_visible(db, current_user, piece):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
     if not piece.brickognize_listing_id:
         raise APIError(400, "Piece has no Brickognize listing to correct", "NOT_CORRECTABLE")
@@ -576,13 +594,14 @@ def label_queue(
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Pieces to color-label, newest first.
 
     With only_unlabeled=true (default) the labeler's already-labeled pieces drop
     out, so the client just re-fetches from the top as it works — no cursor. Set
     only_unlabeled=false to browse the full set (use offset to page)."""
-    query = _labelable_query(db)
+    query = apply_piece_access(db, _labelable_query(db), current_user)
 
     if only_unlabeled:
         my_label = exists().where(
@@ -684,15 +703,7 @@ def submit_label(
     if payload.color_id not in valid_ids:
         raise APIError(400, f"Unknown BrickLink color id {payload.color_id}", "COLOR_ID_INVALID")
 
-    piece = (
-        db.query(MachinePiece.id)
-        .filter(
-            MachinePiece.machine_id == payload.machine_id,
-            MachinePiece.piece_uuid == payload.piece_uuid,
-        )
-        .first()
-    )
-    if piece is None:
+    if not piece_access_visible_by_key(db, current_user, payload.machine_id, payload.piece_uuid):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
 
     now = datetime.now(timezone.utc)
@@ -760,11 +771,15 @@ def get_piece_image(
     piece_uuid: str,
     seq: int,
     db: Session = Depends(get_db),
-    _user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_image")),
 ) -> object:
     """Stream one synced crop. Any authenticated user may view it — color
     labeling is a community task over the whole synced fleet, not just the
-    machine's owner (unlike the owner-gated /machines/... image route)."""
+    machine's owner (unlike the owner-gated /machines/... image route) — but only
+    within the caller's visibility window (admins unrestricted)."""
+    if not piece_access_visible_by_key(db, current_user, machine_id, piece_uuid):
+        raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
     image = (
         db.query(MachinePieceImage)
         .filter(
@@ -856,9 +871,12 @@ def possible_crops(
     piece_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Ranked "possibly the same piece" C2/C3 candidates for a classified piece,
     plus this labeler's saved selection (if any) and any stored AI prediction."""
+    if not piece_access_visible_by_key(db, current_user, machine_id, piece_uuid):
+        raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
     return _possible_crops_result(db, machine_id, piece_uuid, current_user.id)
 
 
@@ -880,6 +898,8 @@ def run_ai_predict(
 
     Open to admins and to any labeler who has added their own OpenRouter key
     (which pays for the call) — mirroring the sample teacher's key gating."""
+    if not piece_access_visible_by_key(db, current_user, machine_id, piece_uuid):
+        raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
     if current_user.role != "admin" and not current_user.openrouter_configured:
         raise APIError(
             403,
@@ -916,11 +936,14 @@ def get_channel_crop_image(
     machine_id: UUID,
     local_id: int,
     db: Session = Depends(get_db),
-    _user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_image")),
 ) -> object:
     """Stream one upstream-channel crop. Any authenticated user may view it —
     same-piece labeling is a community task over the synced fleet, like the color
-    crops above (unlike the owner-gated /machines/... channel-crop route)."""
+    crops above (unlike the owner-gated /machines/... channel-crop route) — but
+    only within the caller's visibility window (admins unrestricted). Channel
+    crops are keyed by a guessable integer local_id, so this gate matters."""
     crop = (
         db.query(MachineChannelCrop)
         .filter(
@@ -929,7 +952,7 @@ def get_channel_crop_image(
         )
         .first()
     )
-    if crop is None or not crop.image_key:
+    if crop is None or not crop.image_key or not channel_crop_access_visible(db, current_user, crop):
         raise APIError(404, "Crop image not found", "CROP_IMAGE_NOT_FOUND")
     return serve_stored_file(crop.image_key, headers={"Cache-Control": PIECE_IMAGE_CACHE_CONTROL})
 
@@ -956,15 +979,7 @@ def save_piece_crop_link(
     """Create or replace the current user's same-piece crop selection for a
     piece. Sent the full presented candidate set (each with the labeler's verdict
     and whether it was a prediction); replaces any prior members wholesale."""
-    piece = (
-        db.query(MachinePiece.id)
-        .filter(
-            MachinePiece.machine_id == payload.machine_id,
-            MachinePiece.piece_uuid == payload.piece_uuid,
-        )
-        .first()
-    )
-    if piece is None:
+    if not piece_access_visible_by_key(db, current_user, payload.machine_id, payload.piece_uuid):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
 
     now = datetime.now(timezone.utc)
@@ -1062,12 +1077,7 @@ def save_piece_rejection(
     if not reasons:
         raise APIError(400, "No valid rejection reasons", "REJECT_REASONS_INVALID")
 
-    piece = (
-        db.query(MachinePiece.id)
-        .filter(MachinePiece.machine_id == payload.machine_id, MachinePiece.piece_uuid == payload.piece_uuid)
-        .first()
-    )
-    if piece is None:
+    if not piece_access_visible_by_key(db, current_user, payload.machine_id, payload.piece_uuid):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
 
     now = datetime.now(timezone.utc)

--- a/software/hive/backend/app/routers/review.py
+++ b/software/hive/backend/app/routers/review.py
@@ -31,6 +31,7 @@ from app.routers.samples import (
     apply_kind_filter,
     attach_my_reviews,
 )
+from app.services.access_window import apply_sample_access, sample_access_visible
 from app.services.condition_analysis import (
     COMPOSITION_VALUES,
     CONDITION_VALUES,
@@ -87,6 +88,10 @@ def get_next_review(
         Sample.archived_at.is_(None),
         Sample.machine.has(Machine.archived_at.is_(None)),
     )
+    # Members only ever get their own machines' samples in the queue; reviewers
+    # and admins get everything. Without this a random member could pull other
+    # people's samples one 'next' at a time.
+    query = apply_sample_access(db, query, current_user)
 
     if not override_mode:
         # Default: hide samples the viewer already reviewed + ones past
@@ -169,7 +174,7 @@ def create_or_update_review(
         raise APIError(400, "Decision must be 'accept' or 'reject'", "INVALID_DECISION")
 
     sample = db.query(Sample).filter(Sample.id == sample_id).first()
-    if not sample:
+    if not sample or not sample_access_visible(db, current_user, sample):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
 
     # Upsert review
@@ -237,7 +242,7 @@ def tag_condition_sample(
         )
 
     sample = db.query(Sample).filter(Sample.id == sample_id).first()
-    if not sample:
+    if not sample or not sample_access_visible(db, current_user, sample):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
 
     # Drop unknown flag keys silently — the writer also filters, but doing
@@ -277,7 +282,7 @@ def get_review_history(
     current_user: User = Depends(get_current_user),
 ):
     sample = db.query(Sample).filter(Sample.id == sample_id).first()
-    if not sample:
+    if not sample or not sample_access_visible(db, current_user, sample):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
 
     reviews = (

--- a/software/hive/backend/app/routers/samples.py
+++ b/software/hive/backend/app/routers/samples.py
@@ -34,6 +34,7 @@ from app.schemas.sample import (
     SaveSampleClassificationRequest,
     SaveSampleClassificationResponse,
 )
+from app.services.access_window import apply_sample_access, sample_access_visible
 from app.services.storage import delete_sample_files, serve_stored_file
 from app.services.sample_payloads import (
     is_classification_payload,
@@ -86,6 +87,10 @@ def _visible_sample_query(
         query = query.filter(Sample.archived_at.is_(None))
     if scope == "mine":
         query = query.filter(Sample.machine.has(owner_id=current_user.id))
+    # Access rule: members only ever see their own machines' samples (regardless
+    # of scope=all); reviewers and admins see everything. Prevents a random
+    # registrant from enumerating the whole corpus.
+    query = apply_sample_access(db, query, current_user)
     return query
 
 
@@ -249,6 +254,15 @@ def attach_my_reviews(items: list, db: Session, viewer_id) -> None:
 def _get_sample_for_read(db: Session, sample_id: UUID) -> Sample:
     sample = db.query(Sample).filter(Sample.id == sample_id).first()
     if not sample:
+        raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
+    return sample
+
+
+def _get_sample_for_read_scoped(db: Session, sample_id: UUID, current_user: User) -> Sample:
+    """Single-sample read gated by access: members only their own machines'
+    samples (404 otherwise, so they can't probe existence); reviewers/admins any."""
+    sample = _get_sample_for_read(db, sample_id)
+    if not sample_access_visible(db, current_user, sample):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
     return sample
 
@@ -780,7 +794,7 @@ def get_similar_samples(
     from sqlalchemy import text
 
     target = db.query(Sample).filter(Sample.id == sample_id).first()
-    if target is None:
+    if target is None or not sample_access_visible(db, current_user, target):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
     if target.phash is None:
         # No hash to compare against. Return an empty list rather than
@@ -792,14 +806,18 @@ def get_similar_samples(
     # bits. We rank by distance, drop self + archived rows + nulls, and
     # cap by ``max_distance`` so a wildly different image doesn't surface.
     bit_distance = text("bit_count(samples.phash # :target_phash)")
-    rows = (
+    similar_q = (
         db.query(Sample, bit_distance.label("distance"))
         .filter(Sample.machine.has(Machine.archived_at.is_(None)))
         .filter(Sample.archived_at.is_(None))
         .filter(Sample.phash.isnot(None))
         .filter(Sample.id != target.id)
         .filter(bit_distance <= int(max_distance))
-        .order_by(text("distance"))
+    )
+    # Members only get similar hits among their own machines' samples.
+    similar_q = apply_sample_access(db, similar_q, current_user)
+    rows = (
+        similar_q.order_by(text("distance"))
         .params(target_phash=int(target.phash))
         .limit(limit)
         .all()
@@ -822,7 +840,7 @@ def get_sample(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SAMPLES_READ)),
 ):
-    sample = _get_sample_for_read(db, sample_id)
+    sample = _get_sample_for_read_scoped(db, sample_id, current_user)
     attach_my_reviews([sample], db, current_user.id)
 
     data = SampleDetailResponse.model_validate(sample)
@@ -1169,7 +1187,7 @@ def get_sample_image(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SAMPLES_READ)),
 ):
-    sample = _get_sample_for_read(db, sample_id)
+    sample = _get_sample_for_read_scoped(db, sample_id, current_user)
 
     return serve_stored_file(sample.image_path, headers={"Cache-Control": ASSET_CACHE_CONTROL})
 
@@ -1180,7 +1198,7 @@ def get_sample_full_frame(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SAMPLES_READ)),
 ):
-    sample = _get_sample_for_read(db, sample_id)
+    sample = _get_sample_for_read_scoped(db, sample_id, current_user)
     if not sample.full_frame_path:
         raise APIError(404, "Full frame not found", "ASSET_NOT_FOUND")
 
@@ -1193,7 +1211,7 @@ def get_sample_overlay(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SAMPLES_READ)),
 ):
-    sample = _get_sample_for_read(db, sample_id)
+    sample = _get_sample_for_read_scoped(db, sample_id, current_user)
     if not sample.overlay_path:
         raise APIError(404, "Overlay not found", "ASSET_NOT_FOUND")
 

--- a/software/hive/backend/app/routers/stats.py
+++ b/software/hive/backend/app/routers/stats.py
@@ -19,7 +19,10 @@ def get_overview(
     # the active fleet, not retired hardware. Admins can re-archive/un-archive via
     # the machine endpoints if a rig comes back.
     machine_query = db.query(Machine).filter(Machine.archived_at.is_(None))
-    if scope == "mine":
+    # Members only ever get counts over their OWN machines — otherwise the overview
+    # leaks the whole corpus's size/composition to any registrant. Reviewers and
+    # admins see fleet-wide totals (respecting an explicit scope=mine).
+    if scope == "mine" or current_user.role not in ("admin", "reviewer"):
         machine_query = machine_query.filter(Machine.owner_id == current_user.id)
     sample_query = db.query(Sample).filter(Sample.machine_id.in_(machine_query.with_entities(Machine.id)))
 

--- a/software/hive/backend/app/services/access_window.py
+++ b/software/hive/backend/app/services/access_window.py
@@ -1,0 +1,304 @@
+"""Per-role access control over the piece-bbox dataset (and owner-scoping for
+samples).
+
+Access rules enforced here:
+  - admin    → everything, unrestricted.
+  - member   → only their OWN machines' data. A random registrant who owns no
+               machines (or someone else's) sees nothing — this is the anti-scrape
+               guarantee.
+  - reviewer → their own PLUS a bounded visibility window (a rolling slice of
+               everyone's data) so review work has fresh material without exposing
+               the whole corpus. Rate-limited on top.
+
+A window is a contiguous slice ordered by upload time (see ``models.access_window``
+for anchor semantics); sizes are tunable live per (role, entity) via the admin API.
+
+Enforcement shape:
+  - list/queue queries → ``apply_piece_access`` / ``apply_sample_access`` narrow
+    the query to what the caller may see.
+  - single-object reads (detail, crop images) → ``piece_access_visible`` /
+    ``channel_crop_access_visible`` / ``sample_access_visible`` gate one row.
+    Callers 404 (not 403) on a miss so a scoped user can't probe for the existence
+    of rows outside their scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import and_, func, or_, select, tuple_
+from sqlalchemy.orm import Session
+
+from app.models.access_window import AccessWindow
+from app.models.machine import Machine
+from app.models.machine_channel_crop import MachineChannelCrop
+from app.models.machine_piece import MachinePiece
+from app.models.sample import Sample
+from app.models.user import User
+
+ENTITY_PIECE = "piece"
+ENTITY_CHANNEL_CROP = "channel_crop"
+ENTITIES = (ENTITY_PIECE, ENTITY_CHANNEL_CROP)
+
+ANCHOR_OLDEST = "oldest"
+ANCHOR_NEWEST = "newest"
+ANCHORS = (ANCHOR_OLDEST, ANCHOR_NEWEST)
+
+# Roles that get a window. 'admin' is intentionally absent — admins are
+# unrestricted. A role with no default and no DB row denies all (size 0).
+WINDOWED_ROLES = ("member", "reviewer")
+
+
+@dataclass(frozen=True)
+class Window:
+    anchor: str
+    size: int
+    offset: int
+
+
+# Starting points, tunable live per (role, entity) via the admin API. Members get
+# a small PINNED (oldest) slice; reviewers a large ROLLING (newest) one. Channel
+# crops are ~10-20x more numerous than pieces, so their windows are sized up.
+_DEFAULTS: dict[tuple[str, str], Window] = {
+    ("member", ENTITY_PIECE): Window(ANCHOR_OLDEST, 200, 0),
+    ("member", ENTITY_CHANNEL_CROP): Window(ANCHOR_OLDEST, 2000, 0),
+    ("reviewer", ENTITY_PIECE): Window(ANCHOR_NEWEST, 5000, 0),
+    ("reviewer", ENTITY_CHANNEL_CROP): Window(ANCHOR_NEWEST, 50000, 0),
+}
+
+# Deny-all fallback for a windowed role with no default configured.
+_DENY = Window(ANCHOR_OLDEST, 0, 0)
+
+
+def is_unrestricted(role: str) -> bool:
+    return role == "admin"
+
+
+def resolve_window(db: Session, role: str, entity: str) -> Window | None:
+    """The effective window for a (role, entity), or None if unrestricted."""
+    if is_unrestricted(role):
+        return None
+    row = (
+        db.query(AccessWindow)
+        .filter(AccessWindow.role == role, AccessWindow.entity == entity)
+        .first()
+    )
+    if row is not None:
+        return Window(row.anchor, int(row.size), int(row.offset))
+    return _DEFAULTS.get((role, entity), _DENY)
+
+
+def _model_for(entity: str):
+    return MachinePiece if entity == ENTITY_PIECE else MachineChannelCrop
+
+
+def _base_filters(entity: str):
+    # Pieces exclude dead/spurious rows from the ordering so a member's small
+    # window isn't wasted on junk. Channel crops have no such flag.
+    if entity == ENTITY_PIECE:
+        return (MachinePiece.dead.is_(False),)
+    return ()
+
+
+def _window_id_select(entity: str, win: Window):
+    model = _model_for(entity)
+    if win.anchor == ANCHOR_OLDEST:
+        order = (model.created_at.asc(), model.id.asc())
+    else:
+        order = (model.created_at.desc(), model.id.desc())
+    stmt = select(model.id)
+    for f in _base_filters(entity):
+        stmt = stmt.where(f)
+    return stmt.order_by(*order).offset(win.offset).limit(win.size)
+
+
+def _strictly_before(model, created_at, pk):
+    return or_(model.created_at < created_at, and_(model.created_at == created_at, model.id < pk))
+
+
+def _strictly_after(model, created_at, pk):
+    return or_(model.created_at > created_at, and_(model.created_at == created_at, model.id > pk))
+
+
+def _rank_visible(db: Session, entity: str, obj, win: Window) -> bool:
+    """True iff ``obj`` falls inside the window, computed from its rank in the
+    canonical ordering — an O(count) index scan, no need to materialize the slice."""
+    if win.size <= 0:
+        return False
+    model = _model_for(entity)
+    cmp = _strictly_after if win.anchor == ANCHOR_NEWEST else _strictly_before
+    q = db.query(func.count()).select_from(model)
+    for f in _base_filters(entity):
+        q = q.filter(f)
+    rank = q.filter(cmp(model, obj.created_at, obj.id)).scalar() or 0
+    return win.offset <= rank < win.offset + win.size
+
+
+def _owned_machine_ids(user: User):
+    return select(Machine.id).where(Machine.owner_id == user.id)
+
+
+def _machine_owned_by(db: Session, machine_id, user: User) -> bool:
+    return (
+        db.query(Machine.id)
+        .filter(Machine.id == machine_id, Machine.owner_id == user.id)
+        .first()
+        is not None
+    )
+
+
+def _piece_window_key_select(win: Window):
+    """Select of (machine_id, piece_uuid) for the pieces in a window — for scoping
+    piece-derived rows (labels, crop-links) that key off that pair rather than id."""
+    if win.anchor == ANCHOR_OLDEST:
+        order = (MachinePiece.created_at.asc(), MachinePiece.id.asc())
+    else:
+        order = (MachinePiece.created_at.desc(), MachinePiece.id.desc())
+    return (
+        select(MachinePiece.machine_id, MachinePiece.piece_uuid)
+        .where(MachinePiece.dead.is_(False))
+        .order_by(*order)
+        .offset(win.offset)
+        .limit(win.size)
+    )
+
+
+# --- Piece-bbox access: admin=all, member=own machines only, reviewer=own+window --
+
+def apply_piece_access(db: Session, query, user: User):
+    """Narrow a MachinePiece query to what ``user`` may see: admins everything;
+    members only their own machines' pieces; reviewers their own PLUS the reviewer
+    visibility window (rolling slice of everyone's)."""
+    if is_unrestricted(user.role):
+        return query
+    owned = MachinePiece.machine_id.in_(_owned_machine_ids(user))
+    if user.role == "reviewer":
+        win = resolve_window(db, "reviewer", ENTITY_PIECE)
+        if win is not None and win.size > 0:
+            return query.filter(or_(owned, MachinePiece.id.in_(_window_id_select(ENTITY_PIECE, win))))
+    return query.filter(owned)
+
+
+def scope_to_piece_access(db: Session, query, user: User, machine_col, piece_uuid_col):
+    """Owner-or-window scoping for piece-derived tables (labels, crop-links) that
+    key off (machine_id, piece_uuid)."""
+    if is_unrestricted(user.role):
+        return query
+    owned = machine_col.in_(_owned_machine_ids(user))
+    if user.role == "reviewer":
+        win = resolve_window(db, "reviewer", ENTITY_PIECE)
+        if win is not None and win.size > 0:
+            return query.filter(
+                or_(owned, tuple_(machine_col, piece_uuid_col).in_(_piece_window_key_select(win)))
+            )
+    return query.filter(owned)
+
+
+def piece_access_visible(db: Session, user: User, piece: MachinePiece) -> bool:
+    if is_unrestricted(user.role):
+        return True
+    if _machine_owned_by(db, piece.machine_id, user):
+        return True
+    if user.role == "reviewer" and not piece.dead:
+        win = resolve_window(db, "reviewer", ENTITY_PIECE)
+        if win is not None:
+            return _rank_visible(db, ENTITY_PIECE, piece, win)
+    return False
+
+
+def piece_access_visible_by_key(db: Session, user: User, machine_id, piece_uuid: str) -> bool:
+    """Access gate for endpoints keyed by (machine_id, piece_uuid) that don't
+    already hold the row. Missing piece reads as not-visible (caller 404s)."""
+    if is_unrestricted(user.role):
+        return True
+    piece = (
+        db.query(MachinePiece)
+        .filter(MachinePiece.machine_id == machine_id, MachinePiece.piece_uuid == piece_uuid)
+        .first()
+    )
+    if piece is None:
+        return False
+    return piece_access_visible(db, user, piece)
+
+
+def channel_crop_access_visible(db: Session, user: User, crop: MachineChannelCrop) -> bool:
+    if is_unrestricted(user.role):
+        return True
+    if _machine_owned_by(db, crop.machine_id, user):
+        return True
+    if user.role == "reviewer":
+        win = resolve_window(db, "reviewer", ENTITY_CHANNEL_CROP)
+        if win is not None:
+            return _rank_visible(db, ENTITY_CHANNEL_CROP, crop, win)
+    return False
+
+
+# --- Samples corpus access: admin+reviewer=all, member=own machines only. -------
+# (No reviewer window on samples yet — that's the deferred "samples pass". The
+# anti-scrape rule that matters — random members only see their own — is enforced.)
+
+def apply_sample_access(db: Session, query, user: User):
+    if user.role in ("admin", "reviewer"):
+        return query
+    return query.filter(Sample.machine.has(Machine.owner_id == user.id))
+
+
+def sample_access_visible(db: Session, user: User, sample: Sample) -> bool:
+    if user.role in ("admin", "reviewer"):
+        return True
+    return sample.machine is not None and str(sample.machine.owner_id) == str(user.id)
+
+
+def list_effective_windows(db: Session) -> dict:
+    """All windowed (role, entity) pairs with their effective values + whether the
+    value comes from a DB override or the code default. Powers the admin view."""
+    overrides = {
+        (r.role, r.entity): r for r in db.query(AccessWindow).all()
+    }
+    windows = []
+    for role in WINDOWED_ROLES:
+        for entity in ENTITIES:
+            row = overrides.get((role, entity))
+            if row is not None:
+                windows.append(
+                    {
+                        "role": role,
+                        "entity": entity,
+                        "anchor": row.anchor,
+                        "size": int(row.size),
+                        "offset": int(row.offset),
+                        "source": "override",
+                        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+                    }
+                )
+            else:
+                d = _DEFAULTS.get((role, entity), _DENY)
+                windows.append(
+                    {
+                        "role": role,
+                        "entity": entity,
+                        "anchor": d.anchor,
+                        "size": d.size,
+                        "offset": d.offset,
+                        "source": "default",
+                        "updated_at": None,
+                    }
+                )
+    return {"admin": "unrestricted", "windows": windows}
+
+
+def set_window(db: Session, role: str, entity: str, anchor: str, size: int, offset: int) -> AccessWindow:
+    row = (
+        db.query(AccessWindow)
+        .filter(AccessWindow.role == role, AccessWindow.entity == entity)
+        .first()
+    )
+    if row is None:
+        row = AccessWindow(role=role, entity=entity)
+        db.add(row)
+    row.anchor = anchor
+    row.size = size
+    row.offset = offset
+    db.commit()
+    db.refresh(row)
+    return row

--- a/software/hive/backend/app/services/rate_limit.py
+++ b/software/hive/backend/app/services/rate_limit.py
@@ -1,0 +1,87 @@
+"""Per-user, role-aware request rate limiting.
+
+A small self-contained token-bucket limiter used to cap how fast a windowed user
+can pull piece-bbox data — the window bounds *how much* of the set they can see,
+this bounds *how fast* they can drain it. Admins are exempt; reviewers get a
+generous cap (real labeling is bursty but bounded); members are tighter.
+
+In-memory and per-process. The dev/prod backend runs a single uvicorn worker so
+this is global there; if the deployment ever fans out to multiple workers the
+cap becomes per-worker (still a meaningful backstop). Move to Redis if a hard
+cross-process guarantee is ever needed.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from fastapi import Depends, HTTPException
+
+from app.deps import get_current_user
+from app.models.user import User
+
+WINDOW_S = 60.0
+
+# requests per WINDOW_S, per user, per bucket. None => unlimited for that role.
+LIMITS: dict[str, dict[str, int | None]] = {
+    # Image byte pulls — the primary exfil vector.
+    "labeling_image": {"member": 120, "reviewer": 600, "admin": None},
+    # Metadata list/detail calls that enumerate the set.
+    "labeling_list": {"member": 30, "reviewer": 180, "admin": None},
+}
+
+
+class _Bucket:
+    __slots__ = ("tokens", "updated")
+
+    def __init__(self, tokens: float, updated: float) -> None:
+        self.tokens = tokens
+        self.updated = updated
+
+
+class RateLimiter:
+    def __init__(self) -> None:
+        self._buckets: dict[str, _Bucket] = {}
+        self._lock = threading.Lock()
+
+    def check(self, key: str, limit: int, window_s: float) -> tuple[bool, int]:
+        """Consume one token. Returns (allowed, retry_after_seconds)."""
+        now = time.monotonic()
+        rate = limit / window_s
+        with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = _Bucket(float(limit), now)
+                self._buckets[key] = bucket
+            else:
+                bucket.tokens = min(float(limit), bucket.tokens + (now - bucket.updated) * rate)
+                bucket.updated = now
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                return True, 0
+            retry_after = int((1.0 - bucket.tokens) / rate) + 1
+            return False, retry_after
+
+
+_limiter = RateLimiter()
+
+
+def rate_limit(bucket: str):
+    """FastAPI dependency factory. Caps the caller on ``bucket`` by their role."""
+
+    def dependency(current_user: User = Depends(get_current_user)) -> None:
+        role_limits = LIMITS.get(bucket, {})
+        # Unknown roles fall back to the tightest configured limit.
+        limit = role_limits.get(current_user.role, role_limits.get("member"))
+        if limit is None:
+            return
+        allowed, retry_after = _limiter.check(f"{bucket}:{current_user.id}", limit, WINDOW_S)
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded. Slow down.",
+                headers={"Retry-After": str(retry_after)},
+            )
+
+    return dependency

--- a/software/hive/backend/app/services/storage_backend.py
+++ b/software/hive/backend/app/services/storage_backend.py
@@ -214,9 +214,21 @@ class S3StorageBackend(StorageBackend):
                 # "Response content shorter than Content-Length" because the
                 # 307 has an empty body. Skip it — the actual S3 GET will
                 # set its own Content-Length.
-                if name.lower() == "content-length":
+                #
+                # Cache-Control from the caller (e.g. "immutable, max-age=1yr")
+                # describes the immutable image BYTES, not this redirect. The
+                # redirect carries a presigned URL that expires after
+                # presigned_expiry seconds, so caching it long-term makes the
+                # browser replay an expired signature — S3 answers 403 and the
+                # image silently breaks. Cap the redirect's own lifetime below
+                # the signature's, so a re-fetch remints a fresh URL in time.
+                if name.lower() in ("content-length", "cache-control"):
                     continue
                 response.headers[name] = value
+            # Buffer under the signature expiry to absorb modest clock skew and
+            # in-flight requests started just before the cached redirect lapses.
+            redirect_ttl = max(0, self.presigned_expiry - 300)
+            response.headers["Cache-Control"] = f"private, max-age={redirect_ttl}"
             return response
 
         try:

--- a/software/hive/docker-compose.prod.yml
+++ b/software/hive/docker-compose.prod.yml
@@ -54,6 +54,9 @@ services:
       # so it survives container recreates — otherwise every redeploy wipes it
       # and forces a full multi-hour re-sync from Rebrickable.
       - ./data/profile_builder:/app/data/profile_builder
+      # Color-classifier ONNX models, uploaded out of band (scp) and scanned
+      # into the color_models table. Bind-mounted so they survive recreates.
+      - ./data/color_models:/app/data/color_models
     networks:
       - default
       - web

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -1148,6 +1148,21 @@ export interface PossibleCropsResult {
 	ai_elapsed_ms?: number | null;
 }
 
+export interface AccessWindow {
+	role: string;
+	entity: string;
+	anchor: 'oldest' | 'newest';
+	size: number;
+	offset: number;
+	source: 'override' | 'default';
+	updated_at: string | null;
+}
+
+export interface AccessWindowsResponse {
+	admin: string;
+	windows: AccessWindow[];
+}
+
 export const api = {
 	// Auth
 	register(email: string, password: string, display_name: string) {
@@ -1791,6 +1806,14 @@ export const api = {
 	},
 	deleteUser(id: string) {
 		return request<void>('DELETE', `/api/admin/users/${id}`);
+	},
+
+	// Admin: access windows (how much of the piece-bbox dataset each role can see)
+	getAccessWindows() {
+		return request<AccessWindowsResponse>('GET', '/api/admin/access-windows');
+	},
+	updateAccessWindow(role: string, entity: string, data: { anchor: string; size: number; offset: number }) {
+		return request<AccessWindowsResponse>('PUT', `/api/admin/access-windows/${role}/${entity}`, data);
 	},
 
 	// Admin: parts catalog DB browser

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -739,6 +739,19 @@ function resolveApiPath(path: string): string {
 	return `${base}${path}`;
 }
 
+// Stored-image endpoints briefly shipped a 1-year `immutable` Cache-Control that
+// (in S3 redirect mode) landed on the 307 redirect, poisoning browser caches
+// with presigned URLs that expire in an hour — thumbnails then 403'd forever
+// and a reload couldn't evict an `immutable` entry. Bump this to change the URL
+// and force a one-time re-fetch past those poisoned entries. Only needs bumping
+// again if a stale long-lived cache header ever ships anew.
+const IMAGE_CACHE_BUST = '2';
+
+function resolveImagePath(path: string): string {
+	const sep = path.includes('?') ? '&' : '?';
+	return resolveApiPath(`${path}${sep}cb=${IMAGE_CACHE_BUST}`);
+}
+
 function getCsrfToken(): string | null {
 	const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/);
 	return match ? decodeURIComponent(match[1]) : null;
@@ -1203,7 +1216,7 @@ export const api = {
 		);
 	},
 	machinePieceImageUrl(machineId: string, pieceUuid: string, seq: number) {
-		return resolveApiPath(
+		return resolveImagePath(
 			`/api/machines/${machineId}/pieces/${encodeURIComponent(pieceUuid)}/images/${seq}`
 		);
 	},
@@ -1223,7 +1236,7 @@ export const api = {
 		);
 	},
 	machineChannelCropImageUrl(machineId: string, localId: number) {
-		return resolveApiPath(`/api/machines/${machineId}/channel-crops/${localId}/image`);
+		return resolveImagePath(`/api/machines/${machineId}/channel-crops/${localId}/image`);
 	},
 
 	// Color labeling
@@ -1291,7 +1304,7 @@ export const api = {
 		);
 	},
 	colorLabelImageUrl(machineId: string, pieceUuid: string, seq: number) {
-		return resolveApiPath(
+		return resolveImagePath(
 			`/api/labeling/pieces/${machineId}/${encodeURIComponent(pieceUuid)}/images/${seq}`
 		);
 	},
@@ -1311,7 +1324,7 @@ export const api = {
 		);
 	},
 	channelCropLabelImageUrl(machineId: string, localId: number) {
-		return resolveApiPath(`/api/labeling/channel-crops/${machineId}/${localId}/image`);
+		return resolveImagePath(`/api/labeling/channel-crops/${machineId}/${localId}/image`);
 	},
 	savePieceCropLink(body: {
 		machine_id: string;

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -216,6 +216,16 @@
 										Parts Database
 									</a>
 									<a
+										href="/admin/access-windows"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										onclick={() => { dropdownOpen = false; }}
+									>
+										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+										</svg>
+										Access Windows
+									</a>
+									<a
 										href="/settings/catalog-sync"
 										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
 										onclick={() => { dropdownOpen = false; }}

--- a/software/hive/frontend/src/routes/admin/access-windows/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/access-windows/+page.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import { auth } from '$lib/auth.svelte';
+	import { api, type AccessWindow } from '$lib/api';
+	import { goto } from '$app/navigation';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import Badge from '$lib/components/Badge.svelte';
+	import { Button } from '$lib/components/primitives';
+
+	let windows = $state<AccessWindow[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let savingKey = $state<string | null>(null);
+	let flash = $state<string | null>(null);
+
+	$effect(() => {
+		if (!auth.isAdmin) {
+			goto('/');
+			return;
+		}
+		load();
+	});
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const resp = await api.getAccessWindows();
+			windows = resp.windows;
+		} catch (e: any) {
+			error = e.error || 'Failed to load access windows';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function keyOf(w: AccessWindow) {
+		return `${w.role}/${w.entity}`;
+	}
+
+	async function save(w: AccessWindow) {
+		savingKey = keyOf(w);
+		error = null;
+		flash = null;
+		try {
+			const resp = await api.updateAccessWindow(w.role, w.entity, {
+				anchor: w.anchor,
+				size: w.size,
+				offset: w.offset
+			});
+			windows = resp.windows;
+			flash = `Saved ${w.role} / ${entityLabel(w.entity)}.`;
+		} catch (e: any) {
+			error = e.error || 'Failed to save window';
+		} finally {
+			savingKey = null;
+		}
+	}
+
+	function entityLabel(entity: string) {
+		return entity === 'piece' ? 'Pieces' : 'Channel crops';
+	}
+</script>
+
+<svelte:head>
+	<title>Access Windows - Hive</title>
+</svelte:head>
+
+<div class="mb-2 flex items-center justify-between">
+	<h1 class="text-2xl font-bold text-text">Access Windows</h1>
+	<span class="text-sm text-text-muted">Admins are unrestricted</span>
+</div>
+
+<p class="mb-6 max-w-3xl text-sm text-text-muted">
+	Bounds how much of the accumulating piece-bbox dataset each non-admin role can see and download.
+	A window is a contiguous slice ordered by upload time. <strong class="text-text">Oldest</strong> anchors
+	the slice to the start of the dataset, so it stays pinned to the same rows as new data arrives —
+	intended for plain members. <strong class="text-text">Newest</strong> anchors to the end, so it rolls
+	forward with fresh uploads — intended for reviewers. <strong class="text-text">Size</strong> is how many
+	rows are visible; <strong class="text-text">offset</strong> skips that many rows from the anchor.
+	Admins bypass all of this.
+</p>
+
+{#if error}
+	<div class="mb-4 bg-primary/8 p-3 text-sm text-primary">{error}</div>
+{/if}
+{#if flash}
+	<div class="mb-4 bg-success/[0.08] p-3 text-sm text-success">{flash}</div>
+{/if}
+
+{#if loading}
+	<div class="flex justify-center py-12">
+		<Spinner />
+	</div>
+{:else}
+	<div class="overflow-x-auto border border-border bg-surface">
+		<table class="min-w-full divide-y divide-border">
+			<thead class="bg-bg">
+				<tr>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Role</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Data</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Anchor</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Size</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Offset</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Source</th>
+					<th class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">Actions</th>
+				</tr>
+			</thead>
+			<tbody class="divide-y divide-border">
+				{#each windows as w (keyOf(w))}
+					<tr class="hover:bg-bg">
+						<td class="whitespace-nowrap px-6 py-4 text-sm font-medium capitalize text-text">{w.role}</td>
+						<td class="whitespace-nowrap px-6 py-4 text-sm text-text">{entityLabel(w.entity)}</td>
+						<td class="whitespace-nowrap px-6 py-4">
+							<select
+								bind:value={w.anchor}
+								class="border border-border bg-surface px-2 py-1 text-sm text-text"
+							>
+								<option value="oldest">oldest (pinned)</option>
+								<option value="newest">newest (rolling)</option>
+							</select>
+						</td>
+						<td class="whitespace-nowrap px-6 py-4">
+							<input
+								type="number"
+								min="0"
+								bind:value={w.size}
+								class="w-28 border border-border bg-surface px-2 py-1 text-sm text-text"
+							/>
+						</td>
+						<td class="whitespace-nowrap px-6 py-4">
+							<input
+								type="number"
+								min="0"
+								bind:value={w.offset}
+								class="w-24 border border-border bg-surface px-2 py-1 text-sm text-text"
+							/>
+						</td>
+						<td class="whitespace-nowrap px-6 py-4">
+							<Badge
+								text={w.source}
+								variant={w.source === 'override' ? 'info' : 'neutral'}
+							/>
+						</td>
+						<td class="whitespace-nowrap px-6 py-4 text-right">
+							<Button
+								variant="primary"
+								size="sm"
+								loading={savingKey === keyOf(w)}
+								onclick={() => save(w)}
+							>
+								Save
+							</Button>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+{/if}

--- a/software/sorter/backend/perception/channel_crop_capture.py
+++ b/software/sorter/backend/perception/channel_crop_capture.py
@@ -65,8 +65,10 @@ class ChannelCropCaptureConfig:
             _ZONE_NONE: _ZoneCadence(advance_deg=18.0, max_captures=2),
         }
     )
-    # C2 is far upstream — Spencer wants roughly two crops per pass, no more.
-    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=25.0, max_captures=2)
+    # C2 is far upstream — up to two crops per pass, no more. advance_deg is
+    # ~30% tighter than the original 25.0 so captures recur sooner and more
+    # passes reach their second crop (roughly 30% more C2 crops overall).
+    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=19.2, max_captures=2)
 
 
 @dataclass

--- a/software/sorter/backend/perception/channel_crop_capture.py
+++ b/software/sorter/backend/perception/channel_crop_capture.py
@@ -65,10 +65,10 @@ class ChannelCropCaptureConfig:
             _ZONE_NONE: _ZoneCadence(advance_deg=18.0, max_captures=2),
         }
     )
-    # C2 is far upstream — up to two crops per pass, no more. advance_deg is
-    # ~30% tighter than the original 25.0 so captures recur sooner and more
-    # passes reach their second crop (roughly 30% more C2 crops overall).
-    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=19.2, max_captures=2)
+    # C2 is far upstream. advance_deg is ~30% tighter than the original 25.0 so
+    # captures recur sooner; up to 5 crops of a single piece as it crosses C2
+    # (most won't travel far enough to hit that ceiling).
+    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=19.2, max_captures=5)
 
 
 @dataclass

--- a/software/sorter/backend/server/hive_sync.py
+++ b/software/sorter/backend/server/hive_sync.py
@@ -7,8 +7,22 @@ pushes only the gap in id order. That makes months of backlog syncable without
 redundant re-uploads, and — because every Hive ingest endpoint upserts by
 natural key — retries and at-least-once delivery never duplicate.
 
-Syncs to EVERY enabled target in the hive config, each with its own watermark,
-so the same machine drains its full history into prod and staging independently.
+Every enabled target syncs on its OWN thread with its own watermark and
+backoff, so a slow or unreachable target (e.g. a local hive that 401s) can
+never stall the others — each drains prod/staging/local independently.
+
+Throughput is adaptive:
+  - While a sort is running (gc.runtime_stats._is_running) uploads stay gentle,
+    throttled exactly as before so they never compete with live sorting.
+  - When the machine is idle, uploads blast back-to-back (network/disk bound).
+A single concurrency gate caps total uploads in flight across ALL targets —
+1 while sorting (identical to the old serial behavior), a few when idle — so
+the worst-case load stays bounded no matter how many targets are configured.
+
+Ordering matters: the server watermark is MAX(local_id), so a gap that gets
+skipped is lost on the next restart. Each target therefore uploads strictly
+serially and in id order; the gate parallelizes ACROSS targets, never within
+one target's id stream.
 """
 
 from __future__ import annotations
@@ -16,7 +30,8 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator
 
 import requests
 
@@ -35,21 +50,51 @@ DATA_TYPE_CORRECTIONS = "piece_corrections"
 
 RECORDS_BATCH = 500
 CORRECTIONS_BATCH = 500
-CORRECTIONS_THROTTLE_S = 0.15
-# Images push one file per request (multipart), so a small chunk per cycle keeps
-# each pass short and interleaves fairly across targets.
+# Images/crops push one file per request (multipart). Small chunks while
+# sorting keep each pass short and responsive to a mode change; bigger chunks
+# when idle cut the per-chunk requery overhead during a backlog blast.
 IMAGES_CHUNK = 10
 CROPS_CHUNK = 10
+IMAGES_CHUNK_IDLE = 50
+CROPS_CHUNK_IDLE = 100
 
+# Gentle throttles applied only while a sort is running — identical to the
+# pre-adaptive behavior, so backlog draining never competes with live sorting
+# more than it used to.
 RECORDS_THROTTLE_S = 0.15
+CORRECTIONS_THROTTLE_S = 0.15
 IMAGES_THROTTLE_S = 0.8
-# Channel crops are high-volume but small; push them a touch faster than piece
-# images so the backlog keeps up with capture during a run.
 CROPS_THROTTLE_S = 0.3
-IDLE_POLL_S = 10.0
+# Idle: standby, so upload back-to-back. The concurrency gate still bounds how
+# many run at once.
+IDLE_THROTTLE_S = 0.0
 
+IDLE_POLL_S = 10.0
 SERVER_DOWN_BACKOFF_S = 10.0
 SERVER_DOWN_MAX_BACKOFF_S = 120.0
+
+# Total uploads in flight across ALL targets. 1 while sorting reproduces the old
+# single-threaded load exactly; a few when idle lets targets drain in parallel.
+# A hard ceiling regardless of how many targets get configured later.
+BUSY_MAX_CONCURRENT = 1
+IDLE_MAX_CONCURRENT = 3
+
+# Retention marking is a periodic sweep, not per-upload: coalesce it so an idle
+# blast doesn't fire an UPDATE per image.
+RETENTION_MARK_INTERVAL_S = 5.0
+
+
+def _machineBusy(gc: Any) -> bool:
+    # Gentle while a sort is running; blast when idle. Any uncertainty falls
+    # back to "busy" so we never upload more aggressively than the machine can
+    # afford.
+    try:
+        stats = getattr(gc, "runtime_stats", None)
+        if stats is None:
+            return True
+        return bool(getattr(stats, "_is_running", True))
+    except Exception:
+        return True
 
 
 def _is_transient(exc: Exception) -> bool:
@@ -135,15 +180,70 @@ def _cropToMeta(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-class HiveSyncWorker:
-    def __init__(self, gc: Any) -> None:
+class _ConcurrencyGate:
+    """Caps total uploads in flight across all target threads.
+
+    The limit is evaluated per acquire, so the same gate tightens to
+    BUSY_MAX_CONCURRENT the moment a sort starts and loosens again when it
+    stops — without recreating anything.
+    """
+
+    def __init__(self, busy_limit: int, idle_limit: int, busy_fn: Callable[[], bool]) -> None:
+        self._busy_limit = max(1, busy_limit)
+        self._idle_limit = max(1, idle_limit)
+        self._busy_fn = busy_fn
+        self._cond = threading.Condition()
+        self._active = 0
+
+    def _limit(self) -> int:
+        return self._busy_limit if self._busy_fn() else self._idle_limit
+
+    @contextmanager
+    def slot(self) -> Iterator[None]:
+        with self._cond:
+            # Re-poll the limit on a timeout so a busy->idle (or idle->busy)
+            # transition while waiting takes effect within a second.
+            while self._active >= self._limit():
+                self._cond.wait(timeout=1.0)
+            self._active += 1
+        try:
+            yield
+        finally:
+            with self._cond:
+                self._active -= 1
+                self._cond.notify()
+
+
+class _TargetSyncer:
+    """Drains local history to a single Hive target on its own thread."""
+
+    def __init__(
+        self,
+        gc: Any,
+        target: dict[str, Any],
+        gate: _ConcurrencyGate,
+        mark_retention: Callable[[], None],
+    ) -> None:
         self._gc = gc
-        self._lock = threading.Lock()
-        self._targets: dict[str, dict[str, Any]] = {}
+        self._id = target["id"]
+        self._name = target["name"]
+        self._url = target["url"]
+        self._gate = gate
+        self._mark_retention = mark_retention
+        self._client = HiveTelemetryClient(self._url, target["token"], self._id)
+        self._wm: dict[str, int | None] = {
+            DATA_TYPE_RECORDS: None,
+            DATA_TYPE_IMAGES: None,
+            DATA_TYPE_CROPS: None,
+            DATA_TYPE_CORRECTIONS: None,
+        }
+        self._state_ok = False
+        self._backoff_s = SERVER_DOWN_BACKOFF_S
         self._wake = threading.Event()
         self._stop = threading.Event()
-        self._reloadConfig()
-        self._thread = threading.Thread(target=self._loop, daemon=True, name="hive-sync")
+        self._thread = threading.Thread(
+            target=self._loop, daemon=True, name=f"hive-sync-{self._id[:8]}"
+        )
 
     def start(self) -> None:
         self._thread.start()
@@ -152,98 +252,49 @@ class HiveSyncWorker:
         self._stop.set()
         self._wake.set()
 
-    def reload(self) -> None:
-        with self._lock:
-            self._reloadConfig()
-        self._wake.set()
-
     def poke(self) -> None:
         self._wake.set()
 
-    def _reloadConfig(self) -> None:
-        config = getHiveConfig()
-        targets = config.get("targets") if isinstance(config, dict) else None
-        previous = self._targets
-        self._targets = {}
-        if not isinstance(targets, list):
-            return
-        for raw in targets:
-            if not isinstance(raw, dict):
-                continue
-            target_id = raw.get("id")
-            url = raw.get("url")
-            token = raw.get("api_token")
-            if not isinstance(target_id, str) or not target_id:
-                continue
-            if not isinstance(url, str) or not url or not isinstance(token, str) or not token:
-                continue
-            enabled = bool(raw.get("enabled", False))
-            prev = previous.get(target_id, {})
-            state: dict[str, Any] = {
-                "id": target_id,
-                "name": raw.get("name") if isinstance(raw.get("name"), str) else url,
-                "url": url,
-                "enabled": enabled,
-                "client": None,
-                "state_ok": False,
-                "wm": dict(prev.get("wm", {DATA_TYPE_RECORDS: None, DATA_TYPE_IMAGES: None, DATA_TYPE_CROPS: None, DATA_TYPE_CORRECTIONS: None})),
-                "backoff_s": float(prev.get("backoff_s", SERVER_DOWN_BACKOFF_S)),
-                "retry_after": float(prev.get("retry_after", 0.0)),
-                "last_error": prev.get("last_error"),
-            }
-            if enabled:
-                try:
-                    state["client"] = HiveTelemetryClient(url, token, target_id)
-                    log.info("Hive sync enabled: %s (%s)", state["name"], url)
-                except Exception as exc:
-                    state["enabled"] = False
-                    state["last_error"] = str(exc)
-                    log.warning("Hive sync disabled for %s: %s", url, exc)
-            self._targets[target_id] = state
+    def watermark(self, data_type: str) -> int | None:
+        return self._wm.get(data_type)
+
+    def stateOk(self) -> bool:
+        return self._state_ok
 
     def _loop(self) -> None:
+        log.info("Hive sync enabled: %s (%s)", self._name, self._url)
         while not self._stop.is_set():
             try:
                 progressed = self._runOnce()
+                self._backoff_s = SERVER_DOWN_BACKOFF_S
             except Exception as exc:
-                log.warning("hive_sync: unexpected loop error: %s", exc)
-                progressed = False
+                self._noteBackoff(exc)
+                self._wake.wait(self._backoff_s)
+                self._wake.clear()
+                continue
             if progressed and not self._stop.is_set():
                 continue
             self._wake.wait(IDLE_POLL_S)
             self._wake.clear()
 
     def _runOnce(self) -> bool:
-        with self._lock:
-            targets = [t for t in self._targets.values() if t["enabled"] and t["client"] is not None]
-        now = time.time()
-        any_progress = False
-        for target in targets:
-            if now < target["retry_after"]:
-                continue
-            try:
-                self._ensureState(target)
-                # Drain channel crops on its own leg rather than short-circuited
-                # behind records/images: piece-image capture is continuous during
-                # a run, so an `or` chain would starve crops behind that backlog.
-                records_or_images = self._drainRecords(target) or self._drainImages(target)
-                crops = self._drainChannelCrops(target)
-                corrections = self._drainCorrections(target)
-                progressed = records_or_images or crops or corrections
-                target["state_ok"] = True
-                target["backoff_s"] = SERVER_DOWN_BACKOFF_S
-                target["last_error"] = None
-                any_progress = any_progress or progressed
-            except Exception as exc:
-                self._backoff(target, exc)
-        if any_progress:
-            self._markImageRetention(targets)
-        return any_progress
+        self._ensureState()
+        # Drain crops on their own leg rather than short-circuited behind
+        # records/images: piece-image capture is continuous during a run, so an
+        # `or` chain would starve crops behind that backlog.
+        records_or_images = self._drainRecords() or self._drainImages()
+        crops = self._drainChannelCrops()
+        corrections = self._drainCorrections()
+        self._state_ok = True
+        progressed = records_or_images or crops or corrections
+        if progressed:
+            self._mark_retention()
+        return progressed
 
-    def _ensureState(self, target: dict[str, Any]) -> None:
-        if target["state_ok"] and target["wm"][DATA_TYPE_RECORDS] is not None:
+    def _ensureState(self) -> None:
+        if self._state_ok and self._wm[DATA_TYPE_RECORDS] is not None:
             return
-        state = target["client"].getSyncState()
+        state = self._client.getSyncState()
         for data_type in (
             DATA_TYPE_RECORDS,
             DATA_TYPE_IMAGES,
@@ -252,109 +303,211 @@ class HiveSyncWorker:
         ):
             raw = state.get(data_type) if isinstance(state, dict) else None
             value = raw.get("max_local_id") if isinstance(raw, dict) else 0
-            target["wm"][data_type] = int(value or 0)
+            self._wm[data_type] = int(value or 0)
 
-    def _drainRecords(self, target: dict[str, Any]) -> bool:
-        if not telemetryAllows(target["id"], "piece_metadata"):
+    def _throttle(self, busy_value: float) -> None:
+        delay = busy_value if _machineBusy(self._gc) else IDLE_THROTTLE_S
+        if delay > 0:
+            time.sleep(delay)
+
+    def _drainRecords(self) -> bool:
+        if not telemetryAllows(self._id, "piece_metadata"):
             return False
-        wm = int(target["wm"][DATA_TYPE_RECORDS] or 0)
+        wm = int(self._wm[DATA_TYPE_RECORDS] or 0)
         if piece_records.getMaxRecordId() <= wm:
             return False
         rows = piece_records.listRecordsAfter(wm, RECORDS_BATCH)
         if not rows:
             return False
-        new_max = target["client"].pushPieceRecords([_recordToPayload(r) for r in rows])
-        target["wm"][DATA_TYPE_RECORDS] = max(wm, int(new_max), int(rows[-1]["id"]))
-        time.sleep(RECORDS_THROTTLE_S)
+        with self._gate.slot():
+            new_max = self._client.pushPieceRecords([_recordToPayload(r) for r in rows])
+        self._wm[DATA_TYPE_RECORDS] = max(wm, int(new_max), int(rows[-1]["id"]))
+        self._throttle(RECORDS_THROTTLE_S)
         return True
 
-    def _drainImages(self, target: dict[str, Any]) -> bool:
+    def _drainImages(self) -> bool:
         # Skip instead of pushing metadata-only rows: with images disabled the
         # watermark freezes here and the backlog drains if re-enabled later.
-        if not telemetryAllows(target["id"], "detection_images"):
+        if not telemetryAllows(self._id, "detection_images"):
             return False
-        wm = int(target["wm"][DATA_TYPE_IMAGES] or 0)
+        wm = int(self._wm[DATA_TYPE_IMAGES] or 0)
         if piece_image_store.getMaxImageId() <= wm:
             return False
-        rows = piece_image_store.listImagesAfter(wm, IMAGES_CHUNK)
+        chunk = IMAGES_CHUNK if _machineBusy(self._gc) else IMAGES_CHUNK_IDLE
+        rows = piece_image_store.listImagesAfter(wm, chunk)
         if not rows:
             return False
         for row in rows:
+            if self._stop.is_set():
+                break
             file_path = None if row["evicted_locally"] else piece_image_store.getImageFileById(row["id"])
-            new_max = target["client"].pushPieceImage(_imageToMeta(row), file_path)
-            target["wm"][DATA_TYPE_IMAGES] = max(int(target["wm"][DATA_TYPE_IMAGES] or 0), int(new_max), int(row["id"]))
-            time.sleep(IMAGES_THROTTLE_S)
+            with self._gate.slot():
+                new_max = self._client.pushPieceImage(_imageToMeta(row), file_path)
+            self._wm[DATA_TYPE_IMAGES] = max(int(self._wm[DATA_TYPE_IMAGES] or 0), int(new_max), int(row["id"]))
+            self._throttle(IMAGES_THROTTLE_S)
         return True
 
-    def _drainChannelCrops(self, target: dict[str, Any]) -> bool:
+    def _drainChannelCrops(self) -> bool:
         # Gated on its own channel_crops field (default off) so experimental
         # crops never leak to production — enable it per-target. With it off the
         # watermark freezes here and the backlog drains if enabled later.
-        if not telemetryAllows(target["id"], "channel_crops"):
+        if not telemetryAllows(self._id, "channel_crops"):
             return False
-        wm = int(target["wm"][DATA_TYPE_CROPS] or 0)
+        wm = int(self._wm[DATA_TYPE_CROPS] or 0)
         if channel_crop_store.getMaxCropId() <= wm:
             return False
-        rows = channel_crop_store.listCropsAfter(wm, CROPS_CHUNK)
+        chunk = CROPS_CHUNK if _machineBusy(self._gc) else CROPS_CHUNK_IDLE
+        rows = channel_crop_store.listCropsAfter(wm, chunk)
         if not rows:
             return False
         for row in rows:
+            if self._stop.is_set():
+                break
             file_path = None if row["evicted_locally"] else channel_crop_store.getCropFileById(row["id"])
-            new_max = target["client"].pushChannelCrop(_cropToMeta(row), file_path)
-            target["wm"][DATA_TYPE_CROPS] = max(int(target["wm"][DATA_TYPE_CROPS] or 0), int(new_max), int(row["id"]))
-            time.sleep(CROPS_THROTTLE_S)
+            with self._gate.slot():
+                new_max = self._client.pushChannelCrop(_cropToMeta(row), file_path)
+            self._wm[DATA_TYPE_CROPS] = max(int(self._wm[DATA_TYPE_CROPS] or 0), int(new_max), int(row["id"]))
+            self._throttle(CROPS_THROTTLE_S)
         return True
 
-    def _drainCorrections(self, target: dict[str, Any]) -> bool:
+    def _drainCorrections(self) -> bool:
         # Correction edits are piece metadata, so they follow the same gate as
         # piece_records. The append-only piece_corrections log gives a clean
         # monotonic cursor; Hive upserts the latest edit per piece.
-        if not telemetryAllows(target["id"], "piece_metadata"):
+        if not telemetryAllows(self._id, "piece_metadata"):
             return False
-        wm = int(target["wm"][DATA_TYPE_CORRECTIONS] or 0)
+        wm = int(self._wm[DATA_TYPE_CORRECTIONS] or 0)
         if piece_records.getMaxCorrectionId() <= wm:
             return False
         rows = piece_records.listCorrectionsAfter(wm, CORRECTIONS_BATCH)
         if not rows:
             return False
-        new_max = target["client"].pushPieceCorrections(
-            [_correctionToPayload(r) for r in rows]
-        )
-        target["wm"][DATA_TYPE_CORRECTIONS] = max(wm, int(new_max), int(rows[-1]["id"]))
-        time.sleep(CORRECTIONS_THROTTLE_S)
+        with self._gate.slot():
+            new_max = self._client.pushPieceCorrections(
+                [_correctionToPayload(r) for r in rows]
+            )
+        self._wm[DATA_TYPE_CORRECTIONS] = max(wm, int(new_max), int(rows[-1]["id"]))
+        self._throttle(CORRECTIONS_THROTTLE_S)
         return True
 
-    def _markImageRetention(self, targets: list[dict[str, Any]]) -> None:
-        # Stamp synced_at up to the MIN watermark across enabled targets so
-        # retention only evicts a crop once EVERY hive has it — per store.
-        def _min_wm(data_type: str) -> int | None:
-            watermarks = [
-                int(t["wm"][data_type])
-                for t in targets
-                if t["state_ok"] and t["wm"][data_type] is not None
-            ]
-            if watermarks and len(watermarks) == len(targets):
-                return min(watermarks)
-            return None
+    def _noteBackoff(self, exc: Exception) -> None:
+        self._state_ok = False  # re-fetch watermark on recovery (handles a hive DB reset)
+        self._backoff_s = min(
+            max(float(self._backoff_s), SERVER_DOWN_BACKOFF_S) * 1.5,
+            SERVER_DOWN_MAX_BACKOFF_S,
+        )
+        level = "debug" if _is_transient(exc) else "warning"
+        getattr(log, level)(
+            "hive_sync: %s unreachable, backing off %.0fs: %s",
+            self._name, self._backoff_s, exc,
+        )
 
+
+class HiveSyncWorker:
+    def __init__(self, gc: Any) -> None:
+        self._gc = gc
+        self._lock = threading.Lock()
+        self._syncers: dict[str, _TargetSyncer] = {}
+        self._started = False
+        self._gate = _ConcurrencyGate(
+            BUSY_MAX_CONCURRENT, IDLE_MAX_CONCURRENT, lambda: _machineBusy(gc)
+        )
+        self._retention_lock = threading.Lock()
+        self._last_retention = 0.0
+
+    def start(self) -> None:
+        with self._lock:
+            self._started = True
+            self._rebuildLocked()
+
+    def stop(self) -> None:
+        with self._lock:
+            for syncer in self._syncers.values():
+                syncer.stop()
+            self._syncers = {}
+            self._started = False
+
+    def reload(self) -> None:
+        with self._lock:
+            if self._started:
+                self._rebuildLocked()
+
+    def poke(self) -> None:
+        with self._lock:
+            for syncer in self._syncers.values():
+                syncer.poke()
+
+    def _rebuildLocked(self) -> None:
+        # Config edits are rare (a target add/remove/enable), so just tear the
+        # target threads down and rebuild from fresh config. Each new thread
+        # re-fetches its watermark from the server, so no progress is lost — the
+        # brief overlap with an exiting thread is harmless: both push in id
+        # order and Hive upserts idempotently, so no gap can open.
+        for syncer in self._syncers.values():
+            syncer.stop()
+        self._syncers = {}
+        config = getHiveConfig()
+        targets = config.get("targets") if isinstance(config, dict) else None
+        if not isinstance(targets, list):
+            return
+        for raw in targets:
+            parsed = self._parseTarget(raw)
+            if parsed is None:
+                continue
+            try:
+                syncer = _TargetSyncer(self._gc, parsed, self._gate, self._markRetention)
+            except Exception as exc:
+                log.warning("Hive sync disabled for %s: %s", parsed["url"], exc)
+                continue
+            self._syncers[parsed["id"]] = syncer
+            syncer.start()
+
+    @staticmethod
+    def _parseTarget(raw: Any) -> dict[str, Any] | None:
+        if not isinstance(raw, dict):
+            return None
+        target_id = raw.get("id")
+        url = raw.get("url")
+        token = raw.get("api_token")
+        if not isinstance(target_id, str) or not target_id:
+            return None
+        if not isinstance(url, str) or not url:
+            return None
+        if not isinstance(token, str) or not token:
+            return None
+        if not bool(raw.get("enabled", False)):
+            return None
+        name = raw.get("name") if isinstance(raw.get("name"), str) else url
+        return {"id": target_id, "url": url, "token": token, "name": name}
+
+    def _markRetention(self) -> None:
         now = time.time()
+        with self._retention_lock:
+            if now - self._last_retention < RETENTION_MARK_INTERVAL_S:
+                return
+            self._last_retention = now
+        with self._lock:
+            syncers = list(self._syncers.values())
+        if not syncers:
+            return
+
+        # Stamp synced_at up to the MIN watermark across enabled targets so
+        # retention only evicts a crop once EVERY hive has it — per store. A
+        # target that isn't state_ok (e.g. a local hive that 401s) makes the
+        # set incomplete, freezing retention rather than evicting data a broken
+        # target never received.
+        def _min_wm(data_type: str) -> int | None:
+            watermarks: list[int] = []
+            for syncer in syncers:
+                wm = syncer.watermark(data_type)
+                if not syncer.stateOk() or wm is None:
+                    return None  # incomplete set -> freeze retention, don't evict
+                watermarks.append(int(wm))
+            return min(watermarks) if watermarks else None
+
         images_wm = _min_wm(DATA_TYPE_IMAGES)
         if images_wm is not None:
             piece_image_store.markImagesSyncedUpTo(images_wm, now)
         crops_wm = _min_wm(DATA_TYPE_CROPS)
         if crops_wm is not None:
             channel_crop_store.markSyncedUpTo(crops_wm, now)
-
-    def _backoff(self, target: dict[str, Any], exc: Exception) -> None:
-        target["state_ok"] = False  # re-fetch watermark on recovery (handles a hive DB reset)
-        target["backoff_s"] = min(
-            max(float(target.get("backoff_s", SERVER_DOWN_BACKOFF_S)), SERVER_DOWN_BACKOFF_S) * 1.5,
-            SERVER_DOWN_MAX_BACKOFF_S,
-        )
-        target["retry_after"] = time.time() + target["backoff_s"]
-        target["last_error"] = str(exc)
-        level = "debug" if _is_transient(exc) else "warning"
-        getattr(log, level)(
-            "hive_sync: %s unreachable, backing off %.0fs: %s",
-            target["name"], target["backoff_s"], exc,
-        )


### PR DESCRIPTION
Two related pieces of Hive work on one branch.

## 1. S3 presigned-redirect cache fixes (earlier commits)
- Cap the presigned-redirect `Cache-Control` below the signature expiry so browsers remint a fresh signature instead of replaying a dead one (was causing intermittent 403s on thumbnails).
- Cache-bust the four stored-image URL builders (`?cb=`) to evict browser caches already poisoned by the old 1-year `immutable` header.
- Bind-mount the `color_models` dir so uploaded ONNX models persist.

## 2. Role-based access control for piece-bbox + samples data
Stops random registrants from scraping the accumulating training data. Rules enforced across `/api/labeling`, `/api/samples`, `/api/review`, `/api/stats`:

| Role | Piece-bbox | Samples |
|---|---|---|
| **member** | own machines only | own machines only |
| **reviewer** | own + rolling window | all |
| **admin** | everything | everything |

**New:**
- `access_windows` table + service — per-`(role, entity)` visibility windows, tunable live via an admin API and a new `/admin/access-windows` UI page (no redeploy).
- A self-contained per-user, role-aware rate-limit module on the heavy labeling read/image endpoints.

**Gaps closed** (surfaced by an API audit): the samples review flow (`review.py`: queue/next, submit-review, condition-tag, history) and `stats.py /overview` had no owner scoping and leaked other owners' data / corpus-wide counts to members.

## Verification
- Alembic migration applied locally; new head `f2a3b4c5d6e7`.
- 13 service-level + 7 HTTP access checks pass against real data: non-owner member sees nothing (empty list + 404s), reviewer sees only the window slice, admin sees all.
- Frontend `pnpm check` (0 errors) + `pnpm build` green.
- Security review: no newly-introduced vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)