### PR TITLE
Hive: color-labeling workflow improvements, machine specs reporting, and piece-link model

### DIFF
--- a/software/hive/backend/alembic/versions/a7b8c9d0e1f2_add_link_models.py
+++ b/software/hive/backend/alembic/versions/a7b8c9d0e1f2_add_link_models.py
@@ -1,0 +1,56 @@
+"""add piece_link matcher model registry (and merge divergent heads)
+
+Revision ID: a7b8c9d0e1f2
+Revises: b7d1e2f3a4c5, c5d6e7f8a9b0
+Create Date: 2026-07-14 18:30:00.000000
+
+Registry of uploaded piece_link matcher models. Each model is a pair of ONNX
+graphs (encoder + head) grouped by their baked ``hive.name``; rows are
+reconciled from a dir scan of LINK_MODEL_DIR. At most one is active and scores
+"same physical piece" upstream crops in the labeling view in place of the
+time/angle heuristic.
+
+This also merges the two Alembic heads that had accumulated on this branch
+(b7d1e2f3a4c5 / c5d6e7f8a9b0) back into a single head.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, Sequence[str], None] = ("b7d1e2f3a4c5", "c5d6e7f8a9b0")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "link_models",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("encoder_filename", sa.String(), nullable=False),
+        sa.Column("head_filename", sa.String(), nullable=False),
+        sa.Column("sha256", sa.String(length=64), nullable=False),
+        sa.Column("input_size", sa.Integer(), nullable=False),
+        sa.Column("embed_dim", sa.Integer(), nullable=False),
+        sa.Column("meta_dim", sa.Integer(), nullable=False),
+        sa.Column("file_size", sa.BigInteger(), nullable=False),
+        sa.Column("meta", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_link_models_name"),
+    )
+    op.create_index("ix_link_models_is_active", "link_models", ["is_active"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_link_models_is_active", table_name="link_models")
+    op.drop_table("link_models")

--- a/software/hive/backend/alembic/versions/b7d1e2f3a4c5_add_cant_tell_color_label.py
+++ b/software/hive/backend/alembic/versions/b7d1e2f3a4c5_add_cant_tell_color_label.py
@@ -1,0 +1,39 @@
+"""allow "I can't tell" color labels
+
+Revision ID: b7d1e2f3a4c5
+Revises: f2a3b4c5d6e7
+Create Date: 2026-07-14 16:00:00.000000
+
+A labeler can now answer "I can't tell" for a piece's color — a real answer
+(the color is genuinely indeterminate), distinct from not labeling. Stored in
+the same piece_color_labels row: color_id becomes nullable and a cant_tell flag
+marks the indeterminate answer. Existing rows are all real colors (cant_tell
+false).
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b7d1e2f3a4c5"
+down_revision: Union[str, Sequence[str], None] = "f2a3b4c5d6e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "piece_color_labels",
+        sa.Column("cant_tell", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.alter_column("piece_color_labels", "color_id", existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    # Drop the indeterminate rows so color_id can go back to NOT NULL.
+    op.execute("DELETE FROM piece_color_labels WHERE color_id IS NULL")
+    op.alter_column("piece_color_labels", "color_id", existing_type=sa.Integer(), nullable=False)
+    op.drop_column("piece_color_labels", "cant_tell")

--- a/software/hive/backend/alembic/versions/c5d6e7f8a9b0_add_machine_hardware_reports.py
+++ b/software/hive/backend/alembic/versions/c5d6e7f8a9b0_add_machine_hardware_reports.py
@@ -1,0 +1,49 @@
+"""add machine_hardware_reports
+
+Revision ID: c5d6e7f8a9b0
+Revises: f2a3b4c5d6e7
+Create Date: 2026-07-14
+
+Append-only log of a machine's hardware/software specs over time. The sorter
+attaches a specs snapshot to its heartbeat; a new row lands only when the
+machine reboots or its specs change, so the log tracks the machine's hardware
+across restarts.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "c5d6e7f8a9b0"
+down_revision: Union[str, None] = "f2a3b4c5d6e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "machine_hardware_reports",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("machine_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("boot_id", sa.String(), nullable=True),
+        sa.Column("content_hash", sa.String(), nullable=False),
+        sa.Column("specs", sa.JSON().with_variant(postgresql.JSONB(), "postgresql"), nullable=False),
+        sa.Column("reported_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["machine_id"], ["machines.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_machine_hardware_reports_machine_reported",
+        "machine_hardware_reports",
+        ["machine_id", "reported_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_machine_hardware_reports_machine_reported", table_name="machine_hardware_reports")
+    op.drop_table("machine_hardware_reports")

--- a/software/hive/backend/alembic/versions/f2a3b4c5d6e7_add_access_windows.py
+++ b/software/hive/backend/alembic/versions/f2a3b4c5d6e7_add_access_windows.py
@@ -1,0 +1,43 @@
+"""add per-role visibility windows for piece-bbox data
+
+Revision ID: f2a3b4c5d6e7
+Revises: d5e6f7a8b9c0
+Create Date: 2026-07-14 12:00:00.000000
+
+Bounds what a non-admin user can see/download of the accumulating piece +
+channel-crop dataset. One row per (role, entity); absent rows fall back to code
+defaults in services.access_window, so this table is empty on first deploy and
+the feature still works. Admins have no rows and are unrestricted.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, Sequence[str], None] = "d5e6f7a8b9c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "access_windows",
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("entity", sa.String(), nullable=False),
+        sa.Column("anchor", sa.String(), nullable=False),
+        sa.Column("window_size", sa.Integer(), nullable=False),
+        sa.Column("window_offset", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("role", "entity"),
+        sa.CheckConstraint("anchor IN ('oldest', 'newest')", name="ck_access_windows_anchor"),
+        sa.CheckConstraint("window_size >= 0", name="ck_access_windows_size"),
+        sa.CheckConstraint("window_offset >= 0", name="ck_access_windows_offset"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("access_windows")

--- a/software/hive/backend/app/config.py
+++ b/software/hive/backend/app/config.py
@@ -18,6 +18,12 @@ class Settings(BaseSettings):
     # reconciled into the color_models table; the active one serves piece-color
     # predictions. Model bytes are uploaded here out of band (not through the API).
     COLOR_MODEL_DIR: str = "data/color_models"
+    # Local dir scanned for piece_link matcher models. Each model is a pair of
+    # ONNX graphs (`*.encoder.onnx` + `*.head.onnx`, grouped by their baked
+    # `hive.name`); one row per pair is reconciled into the link_models table.
+    # The active one scores "same physical piece" upstream crops in the labeling
+    # view in place of the time/angle heuristic. Uploaded here out of band.
+    LINK_MODEL_DIR: str = "data/link_models"
     STORAGE_BACKEND: str = "local"
     S3_BUCKET: str = ""
     S3_ENDPOINT_URL: str = ""

--- a/software/hive/backend/app/machine_hardware.py
+++ b/software/hive/backend/app/machine_hardware.py
@@ -1,0 +1,100 @@
+"""Recording and summarizing machine hardware/software specs.
+
+A machine attaches a specs snapshot to its heartbeat. We keep two things from
+it: an append-only history row (the full snapshot, so a machine's hardware can
+be tracked across restarts) and a compact summary on the machine row that the
+dashboard renders. The summary is an explicit allowlist of the fields the
+dashboard shows; the rest stays in the history table.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.machine import Machine
+from app.models.machine_hardware_report import MachineHardwareReport
+
+# Camera fields the dashboard shows (model + capture format).
+_SUMMARY_CAMERA_KEYS = ("model", "width", "height", "fps", "fourcc")
+
+
+def _summary_cameras(cameras: Any) -> dict[str, Any]:
+    if not isinstance(cameras, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for role, entry in cameras.items():
+        if isinstance(entry, dict):
+            out[str(role)] = {key: entry.get(key) for key in _SUMMARY_CAMERA_KEYS}
+    return out
+
+
+def summarize_hardware_specs(specs: Any) -> dict[str, Any] | None:
+    """The compact subset of a specs snapshot that the dashboard renders."""
+    if not isinstance(specs, dict):
+        return None
+    platform_in = specs.get("platform")
+    if not isinstance(platform_in, dict):
+        platform_in = {}
+    return {
+        "schema_version": specs.get("schema_version"),
+        "booted_at": specs.get("booted_at"),
+        "captured_at": specs.get("captured_at"),
+        "platform": {
+            "model": platform_in.get("model"),
+            "arch": platform_in.get("arch"),
+            "os": platform_in.get("os"),
+        },
+        "software": specs.get("software"),
+        "system": specs.get("system"),
+        "config": specs.get("config"),
+        "cameras": _summary_cameras(specs.get("cameras")),
+        "controller_boards": specs.get("controller_boards"),
+    }
+
+
+def _content_hash(summary: dict[str, Any]) -> str:
+    # Hash the stable content so history grows on meaningful spec changes — not
+    # on every heartbeat's fresh capture timestamp.
+    stable = {key: value for key, value in summary.items() if key not in ("captured_at", "booted_at", "schema_version")}
+    encoded = json.dumps(stable, sort_keys=True, default=str)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def record_hardware_report(db: Session, machine: Machine, specs: Any) -> None:
+    """Store the summary on the machine and append a history row when the
+    machine rebooted or its specs changed. Best-effort: a snapshot that isn't a
+    dict is ignored."""
+    summary = summarize_hardware_specs(specs)
+    if summary is None:
+        return
+
+    machine.hardware_info = summary
+
+    content_hash = _content_hash(summary)
+    boot_id = specs.get("boot_id") if isinstance(specs.get("boot_id"), str) else None
+    latest = (
+        db.query(MachineHardwareReport)
+        .filter(MachineHardwareReport.machine_id == machine.id)
+        .order_by(MachineHardwareReport.reported_at.desc())
+        .first()
+    )
+    changed = (
+        latest is None
+        or latest.content_hash != content_hash
+        or (boot_id is not None and latest.boot_id != boot_id)
+    )
+    if changed:
+        db.add(
+            MachineHardwareReport(
+                machine_id=machine.id,
+                boot_id=boot_id,
+                content_hash=content_hash,
+                specs=specs,
+                reported_at=datetime.now(timezone.utc),
+            )
+        )

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -17,6 +17,7 @@ from app.routers import (
     color_models,
     installs,
     leaderboard,
+    link_models,
     machine_config_backups,
     machine_lookup,
     machine_models,
@@ -95,6 +96,7 @@ app.include_router(machine_models.router)
 app.include_router(machine_parts.router)
 app.include_router(piece_color_labels.router)
 app.include_router(color_models.router)
+app.include_router(link_models.router)
 app.include_router(api_keys.router)
 app.include_router(teacher.router)
 app.include_router(leaderboard.router)

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -40,4 +40,5 @@ from app.models.piece_crop_ai_prediction import PieceCropAiPrediction  # noqa: E
 from app.models.piece_rejection import PieceRejection  # noqa: E402, F401
 from app.models.install import Install  # noqa: E402, F401
 from app.models.color_model import ColorModel  # noqa: E402, F401
+from app.models.link_model import LinkModel  # noqa: E402, F401
 from app.models.access_window import AccessWindow  # noqa: E402, F401

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -39,3 +39,4 @@ from app.models.piece_crop_ai_prediction import PieceCropAiPrediction  # noqa: E
 from app.models.piece_rejection import PieceRejection  # noqa: E402, F401
 from app.models.install import Install  # noqa: E402, F401
 from app.models.color_model import ColorModel  # noqa: E402, F401
+from app.models.access_window import AccessWindow  # noqa: E402, F401

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -23,6 +23,7 @@ from app.models.sorting_profile_ai_message import SortingProfileAiMessage  # noq
 from app.models.machine_profile_assignment import MachineProfileAssignment  # noqa: E402, F401
 from app.models.machine_set_progress import MachineSetProgress  # noqa: E402, F401
 from app.models.machine_config_backup import MachineConfigBackup  # noqa: E402, F401
+from app.models.machine_hardware_report import MachineHardwareReport  # noqa: E402, F401
 from app.models.detection_model import DetectionModel, DetectionModelVariant  # noqa: E402, F401
 from app.models.user_api_key import UserApiKey  # noqa: E402, F401
 from app.models.teacher_job import TeacherJob, TeacherJobItem  # noqa: E402, F401

--- a/software/hive/backend/app/models/access_window.py
+++ b/software/hive/backend/app/models/access_window.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Integer, String
+
+from app.models import Base
+
+
+class AccessWindow(Base):
+    """Per-(role, entity) visibility window bounding what a non-admin can see of
+    the accumulating piece-bbox dataset.
+
+    A window is a contiguous slice of an entity ordered by ``created_at`` (id as
+    tiebreak). ``anchor`` picks which end the slice hangs off:
+
+      - ``oldest`` — slice counts from the oldest row. Because rows only ever
+        append at the newest end, an oldest-anchored slice is effectively PINNED:
+        the same rows stay in it until an admin moves ``offset``. Used for plain
+        members so they see a small fixed sample and can't accumulate different
+        slices by polling over time.
+      - ``newest`` — slice counts from the newest row, so it ROLLS forward as new
+        rows arrive. Used for reviewers so their (larger) working set tracks fresh
+        incoming work automatically.
+
+    Admins have no row and are unrestricted. Absent rows fall back to the code
+    defaults in ``services.access_window`` (so the feature works before any admin
+    config), and a size of 0 denies all — the safe default for an unknown role.
+    """
+
+    __tablename__ = "access_windows"
+
+    role = Column(String, primary_key=True)
+    entity = Column(String, primary_key=True)
+    anchor = Column(String, nullable=False)
+    # Mapped off reserved-ish SQL words to keep the DDL unambiguous.
+    size = Column("window_size", Integer, nullable=False)
+    offset = Column("window_offset", Integer, nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        CheckConstraint("anchor IN ('oldest', 'newest')", name="ck_access_windows_anchor"),
+        CheckConstraint("window_size >= 0", name="ck_access_windows_size"),
+        CheckConstraint("window_offset >= 0", name="ck_access_windows_offset"),
+    )

--- a/software/hive/backend/app/models/link_model.py
+++ b/software/hive/backend/app/models/link_model.py
@@ -1,0 +1,49 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import JSON_VARIANT, Base
+
+
+class LinkModel(Base):
+    """Registry of piece_link matcher models available to score which upstream
+    C2/C3 crops are the same physical piece as a classified piece — the learned
+    replacement for the time/angle heuristic (``channel_crop_lookup_params``).
+
+    Unlike a color model (one ``.onnx``), each link model is a PAIR of ONNX
+    graphs — a shared ``CropEncoder`` and a ``LinkHead`` — exported side by side
+    and grouped by their baked ``hive.name``. Rows are reconciled from a dir scan
+    of ``LINK_MODEL_DIR``: one row per name whose two files both parse as a
+    ``piece_link_matcher``. The DB holds the metadata (name, dims, input size,
+    combined sha) while the bytes live on disk and are uploaded out of band.
+
+    At most one row has ``is_active`` true; that model's per-candidate score
+    supersedes the heuristic's pre-selection in the labeling view. ``sha256`` is
+    over both files (sorted) so a scan notices either being replaced and refreshes
+    the cached sessions. ``meta`` keeps the full embedded metadata block.
+    """
+
+    __tablename__ = "link_models"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, nullable=False, unique=True)
+    description = Column(String, nullable=True)
+    kind = Column(String, nullable=False, default="piece_link_matcher")
+    encoder_filename = Column(String, nullable=False)
+    head_filename = Column(String, nullable=False)
+    sha256 = Column(String(64), nullable=False)
+    input_size = Column(Integer, nullable=False, default=0)
+    embed_dim = Column(Integer, nullable=False, default=0)
+    meta_dim = Column(Integer, nullable=False, default=0)
+    file_size = Column(BigInteger, nullable=False, default=0)
+    meta = Column(JSON_VARIANT, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/software/hive/backend/app/models/machine_hardware_report.py
+++ b/software/hive/backend/app/models/machine_hardware_report.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.models import Base, JSON_VARIANT
+
+
+class MachineHardwareReport(Base):
+    """Append-only log of a machine's hardware/software specs over time.
+
+    The sorter attaches a specs snapshot to its heartbeat; a new row is written
+    only when the machine reboots (``boot_id`` changes) or the specs content
+    changes (``content_hash`` differs from the latest row), so the log grows on
+    real events, not on every keep-alive. ``specs`` holds the full snapshot the
+    machine sent; a compact summary of it lives on ``machines.hardware_info``
+    for the dashboard.
+    """
+
+    __tablename__ = "machine_hardware_reports"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    machine_id = Column(UUID(as_uuid=True), ForeignKey("machines.id", ondelete="CASCADE"), nullable=False)
+    boot_id = Column(String, nullable=True)
+    content_hash = Column(String, nullable=False)
+    specs = Column(JSON_VARIANT, nullable=False)
+    reported_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    machine = relationship("Machine")
+
+    __table_args__ = (
+        Index("ix_machine_hardware_reports_machine_reported", "machine_id", "reported_at"),
+    )

--- a/software/hive/backend/app/models/piece_color_label.py
+++ b/software/hive/backend/app/models/piece_color_label.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.models import Base
@@ -30,7 +30,10 @@ class PieceColorLabel(Base):
     machine_id = Column(UUID(as_uuid=True), ForeignKey("machines.id", ondelete="CASCADE"), nullable=False)
     piece_uuid = Column(String, nullable=False)
     labeler_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
-    color_id = Column(Integer, nullable=False)
+    # color_id is null exactly when cant_tell is set — the labeler looked and the
+    # color is genuinely indeterminate (a real answer, not an absent label).
+    color_id = Column(Integer, nullable=True)
+    cant_tell = Column(Boolean, nullable=False, default=False)
     notes = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(

--- a/software/hive/backend/app/routers/admin.py
+++ b/software/hive/backend/app/routers/admin.py
@@ -1,12 +1,14 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.deps import get_db, require_role, verify_csrf
 from app.errors import APIError
 from app.models.user import User
 from app.schemas.auth import AdminUpdateUserRequest, UserResponse
+from app.services import access_window
 from app.services.server_health import get_server_health
 from app.services.storage import delete_machine_files
 
@@ -83,3 +85,41 @@ def delete_user(
     db.delete(user)
     db.commit()
     return {"ok": True}
+
+
+class AccessWindowUpdate(BaseModel):
+    anchor: str
+    size: int = Field(ge=0)
+    offset: int = Field(ge=0)
+
+
+@router.get("/access-windows")
+def get_access_windows(
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+):
+    """Effective piece-bbox visibility windows per (role, entity), with whether
+    each value is a live override or the code default. Admins are unrestricted."""
+    return access_window.list_effective_windows(db)
+
+
+@router.put("/access-windows/{role}/{entity}")
+def put_access_window(
+    role: str,
+    entity: str,
+    data: AccessWindowUpdate,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+    _csrf: None = Depends(verify_csrf),
+):
+    """Set (upsert) the visibility window for a windowed role + entity. 'admin' is
+    unrestricted and cannot be given a window."""
+    if role not in access_window.WINDOWED_ROLES:
+        raise APIError(400, f"Role must be one of {access_window.WINDOWED_ROLES}", "INVALID_ROLE")
+    if entity not in access_window.ENTITIES:
+        raise APIError(400, f"Entity must be one of {access_window.ENTITIES}", "INVALID_ENTITY")
+    if data.anchor not in access_window.ANCHORS:
+        raise APIError(400, f"Anchor must be one of {access_window.ANCHORS}", "INVALID_ANCHOR")
+
+    access_window.set_window(db, role, entity, data.anchor, data.size, data.offset)
+    return access_window.list_effective_windows(db)

--- a/software/hive/backend/app/routers/link_models.py
+++ b/software/hive/backend/app/routers/link_models.py
@@ -1,0 +1,83 @@
+"""Admin management of piece_link matcher models.
+
+Each model is a pair of ONNX graphs (encoder + head) uploaded to LINK_MODEL_DIR
+out of band (scp/manual), grouped by their baked ``hive.name``. This router
+reconciles the DB registry to what's on disk and lets an admin pick the single
+globally-active model whose scores drive the same-piece pre-selection in the
+color-labeling view (in place of the time/angle heuristic).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.deps import get_db, require_role, verify_csrf
+from app.errors import APIError
+from app.models.link_model import LinkModel
+from app.models.user import User
+from app.services import link_predictor
+
+router = APIRouter(prefix="/api/link-models", tags=["link-models"])
+
+
+def _serialize(row: LinkModel) -> dict:
+    return {
+        "id": str(row.id),
+        "name": row.name,
+        "description": row.description,
+        "kind": row.kind,
+        "encoder_filename": row.encoder_filename,
+        "head_filename": row.head_filename,
+        "sha256": row.sha256,
+        "input_size": row.input_size,
+        "embed_dim": row.embed_dim,
+        "meta_dim": row.meta_dim,
+        "file_size": row.file_size,
+        "is_active": bool(row.is_active),
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+@router.get("")
+def list_link_models(
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+) -> dict:
+    """Reconcile the registry to the encoder+head pairs on disk, then list them."""
+    rows = link_predictor.reconcile(db)
+    return {
+        "models": [_serialize(r) for r in rows],
+        "model_dir": str(link_predictor.model_dir()),
+    }
+
+
+@router.post("/{model_id}/activate")
+def activate_link_model(
+    model_id: UUID,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+    _csrf: None = Depends(verify_csrf),
+) -> dict:
+    """Make this the single globally-active model. Clears any prior active one."""
+    row = link_predictor.set_active(db, model_id, True)
+    if row is None:
+        raise APIError(404, "Link model not found", "LINK_MODEL_NOT_FOUND")
+    return {"ok": True, "model": _serialize(row)}
+
+
+@router.post("/{model_id}/deactivate")
+def deactivate_link_model(
+    model_id: UUID,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_role("admin")),
+    _csrf: None = Depends(verify_csrf),
+) -> dict:
+    """Turn this model off. With none active, the labeling view falls back to the
+    time/angle heuristic's pre-selection."""
+    row = link_predictor.set_active(db, model_id, False)
+    if row is None:
+        raise APIError(404, "Link model not found", "LINK_MODEL_NOT_FOUND")
+    return {"ok": True, "model": _serialize(row)}

--- a/software/hive/backend/app/routers/machines.py
+++ b/software/hive/backend/app/routers/machines.py
@@ -593,7 +593,14 @@ def heartbeat(
         machine.last_seen_ip = client_ip
     if data is not None:
         if "hardware_info" in data.model_fields_set:
-            machine.hardware_info = data.hardware_info
+            if isinstance(data.hardware_info, dict) and data.hardware_info.get("schema_version") is not None:
+                # A machine-specs snapshot: summarize for the dashboard + append
+                # the full snapshot to the spec history.
+                from app.machine_hardware import record_hardware_report
+
+                record_hardware_report(db, machine, data.hardware_info)
+            else:
+                machine.hardware_info = data.hardware_info
         local_ui_port = data.local_ui_port if "local_ui_port" in data.model_fields_set else None
         if local_ui_port is None and isinstance(data.hardware_info, dict) and "hardware_info" in data.model_fields_set:
             raw_port = data.hardware_info.get("local_ui_port")

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -39,6 +39,7 @@ from app.services.brickognize_feedback import submit_color_feedback, submit_part
 from app.services.channel_crop_lookup import find_possible_crops
 from app.services.channel_crop_lookup_params import DEFAULT_PARAMS
 from app.services.color_predictor import predict as predict_piece_color
+from app.services import link_predictor
 from app.services.piece_crop_ai_matcher import (
     DEFAULT_MATCH_MODEL,
     AiMatchError,
@@ -1152,32 +1153,61 @@ def _ai_prediction(db: Session, machine_id: UUID, piece_uuid: str) -> PieceCropA
 
 
 def _possible_crops_result(db: Session, machine_id: UUID, piece_uuid: str, labeler_id: UUID) -> dict:
-    """Heuristic candidate set for a piece, annotated with this labeler's saved
-    selection and the stored AI prediction (if any).
+    """The heuristic's time-window candidate set for a piece, annotated with this
+    labeler's saved selection and whichever same-piece prediction is in force.
 
-    Each candidate keeps the heuristic's `predicted` flag (untouched — it feeds
-    the was_predicted training signal). When an AI prediction exists we add
-    `ai_same` per candidate (True/False for crops the model was shown, None for
-    any it didn't see) and set `prediction_source='ai'`; the UI pre-selects
-    `ai_same` over `predicted` when present, falling back to the heuristic."""
+    Three prediction sources, in precedence order:
+    - `ai`    — a stored vision-model (VLM) prediction exists for this piece (an
+                explicit per-piece oracle run); `ai_same` per candidate.
+    - `model` — a link matcher model is active; it scores every candidate crop
+                (`model_score`) and its picks (`model_same`, score ≥ threshold)
+                supersede the heuristic. Candidates are re-ranked by that score.
+    - `heuristic` — neither; the time/angle `predicted` flag drives selection.
+
+    Each candidate always keeps the heuristic's `predicted` flag untouched — it
+    feeds the was_predicted training signal regardless of which source the UI
+    pre-selects from."""
     result = find_possible_crops(db, machine_id, piece_uuid)
     result["my_link"] = _my_link_members(db, machine_id, piece_uuid, labeler_id)
+    candidates = result.get("candidates", [])
+
+    def _reset(c: dict) -> None:
+        c["ai_same"] = None
+        c["model_same"] = None
+        c["model_score"] = None
 
     ai = _ai_prediction(db, machine_id, piece_uuid)
+    model_pred = link_predictor.predict(db, machine_id, piece_uuid, candidates) if ai is None else None
+
+    result["ai_model"] = None
+    result["ai_reasoning"] = None
+    result["link_model"] = None
+
     if ai is not None:
         same_ids = set(ai.same_local_ids or [])
         shown_ids = set(ai.candidate_local_ids or [])
-        for c in result.get("candidates", []):
+        for c in candidates:
+            _reset(c)
             c["ai_same"] = (c["local_id"] in same_ids) if c["local_id"] in shown_ids else None
         result["prediction_source"] = "ai"
         result["ai_model"] = ai.model
         result["ai_reasoning"] = ai.reasoning
+    elif model_pred is not None:
+        scores = model_pred["scores"]
+        threshold = model_pred["threshold"]
+        for c in candidates:
+            _reset(c)
+            s = scores.get(c["local_id"])
+            c["model_score"] = round(s, 3) if s is not None else None
+            c["model_same"] = (s >= threshold) if s is not None else None
+        # re-rank by model score (scored crops first, best first); unscored keep order
+        candidates.sort(key=lambda c: (c["model_score"] is not None, c["model_score"] or 0.0), reverse=True)
+        result["prediction_source"] = "model"
+        result["link_model"] = model_pred["model_name"]
     else:
-        for c in result.get("candidates", []):
-            c["ai_same"] = None
+        for c in candidates:
+            _reset(c)
         result["prediction_source"] = "heuristic"
-        result["ai_model"] = None
-        result["ai_reasoning"] = None
     return result
 
 

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -14,6 +14,7 @@ Rebrickable `colors` external ids). Labels live in Postgres (piece_color_labels)
 from __future__ import annotations
 
 import logging
+import math
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
@@ -45,8 +46,10 @@ from app.services.piece_crop_ai_matcher import (
     store_prediction,
 )
 from app.services.access_window import (
+    _machine_owned_by,
     apply_piece_access,
     channel_crop_access_visible,
+    is_unrestricted,
     piece_access_visible,
     piece_access_visible_by_key,
     scope_to_piece_access,
@@ -906,6 +909,161 @@ def get_piece_image(
     machine's owner (unlike the owner-gated /machines/... image route) — but only
     within the caller's visibility window (admins unrestricted)."""
     if not piece_access_visible_by_key(db, current_user, machine_id, piece_uuid):
+        raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
+    image = (
+        db.query(MachinePieceImage)
+        .filter(
+            MachinePieceImage.machine_id == machine_id,
+            MachinePieceImage.piece_uuid == piece_uuid,
+            MachinePieceImage.seq == seq,
+        )
+        .first()
+    )
+    if image is None or not image.image_key:
+        raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
+    return serve_stored_file(image.image_key, headers={"Cache-Control": PIECE_IMAGE_CACHE_CONTROL})
+
+
+# --- Same-machine labeled reference set ---------------------------------------
+#
+# The reviewing view shows a column of OTHER already-labeled pieces from the same
+# machine, so a labeler can calibrate: "this machine's dark tan looks like THIS,
+# so the lighter one I'm looking at is probably plain tan." Only human-labeled
+# pieces (ground truth), never model outputs. This intentionally reaches past a
+# reviewer's normal visibility window — the exemplars are already vetted, and
+# seeing the machine's full color range is the whole point — but stays gated:
+# members still only see machines they own.
+
+
+def _labeled_reference_visible(db: Session, user: User, machine_id: UUID, piece_uuid: str) -> bool:
+    """Gate for a same-machine labeled reference piece/image. Admins and machine
+    owners always. Reviewers may view any piece that actually carries a human
+    color label (the deliberate window bypass — bounded to vetted exemplars)."""
+    if is_unrestricted(user.role):
+        return True
+    if _machine_owned_by(db, machine_id, user):
+        return True
+    if user.role == "reviewer":
+        return (
+            db.query(PieceColorLabel.id)
+            .filter(
+                PieceColorLabel.machine_id == machine_id,
+                PieceColorLabel.piece_uuid == piece_uuid,
+                PieceColorLabel.color_id.isnot(None),
+            )
+            .first()
+            is not None
+        )
+    return False
+
+
+def _lab_hue_key(rgb_hex: str | None) -> tuple[int, float, float]:
+    """Sort key that reads a color column as a gradient: near-neutral grays first
+    (by lightness), then chromatic colors by hue angle. Keeps look-alike colors
+    (tan / dark tan) adjacent so the eye can compare them."""
+    if not rgb_hex:
+        return (2, 0.0, 0.0)
+    h = rgb_hex.replace("#", "")
+    if len(h) < 6:
+        return (2, 0.0, 0.0)
+    try:
+        rgb = np.array([int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)], dtype=np.float64)
+    except ValueError:
+        return (2, 0.0, 0.0)
+    lab = _srgb_to_lab(rgb)
+    L, a, b = float(lab[0]), float(lab[1]), float(lab[2])
+    if math.hypot(a, b) < 8:
+        return (0, L, 0.0)
+    return (1, math.atan2(b, a), L)
+
+
+@router.get("/machine/{machine_id}/labeled-pieces")
+def machine_labeled_pieces(
+    machine_id: UUID,
+    anchor_piece: str = Query(..., min_length=1),
+    exclude_piece: str | None = Query(None),
+    limit: int = Query(200, ge=1, le=400),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
+) -> dict:
+    """Other human-labeled pieces on the same machine, one per piece (the
+    most-agreed color), sorted into a hue gradient — the color-range reference
+    column on the labeling view. Gated on access to the anchor piece being
+    reviewed; the reference set itself ignores a reviewer's window on purpose."""
+    if not piece_access_visible_by_key(db, current_user, machine_id, anchor_piece):
+        raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
+
+    rows = (
+        db.query(PieceColorLabel.piece_uuid, PieceColorLabel.color_id, func.count().label("n"))
+        .filter(
+            PieceColorLabel.machine_id == machine_id,
+            PieceColorLabel.color_id.isnot(None),
+        )
+        .group_by(PieceColorLabel.piece_uuid, PieceColorLabel.color_id)
+        .all()
+    )
+    # Per piece, the color with the most labeler agreement (ties → lower id).
+    best: dict[str, tuple[int, int]] = {}
+    for puid, cid, n in rows:
+        if exclude_piece and puid == exclude_piece:
+            continue
+        if cid is None:
+            continue
+        cur = best.get(puid)
+        if cur is None or n > cur[0] or (n == cur[0] and cid < cur[1]):
+            best[puid] = (int(n), int(cid))
+    if not best:
+        return {"items": [], "total": 0}
+
+    piece_uuids = list(best.keys())
+    thumb: dict[str, int] = dict(
+        db.query(MachinePieceImage.piece_uuid, func.min(MachinePieceImage.seq))
+        .filter(
+            MachinePieceImage.machine_id == machine_id,
+            MachinePieceImage.piece_uuid.in_(piece_uuids),
+            MachinePieceImage.image_key.isnot(None),
+        )
+        .group_by(MachinePieceImage.piece_uuid)
+        .all()
+    )
+    palette = {c["id"]: c for c in get_profile_catalog_service().list_bricklink_colors()}
+
+    items = []
+    for puid, (n, cid) in best.items():
+        if puid not in thumb:
+            continue  # no viewable crop — skip (nothing to show in the column)
+        col = palette.get(cid)
+        rgb = col.get("rgb") if col else None
+        items.append(
+            {
+                "piece_uuid": puid,
+                "thumb_seq": thumb[puid],
+                "color_id": cid,
+                "color_name": col["name"] if col else str(cid),
+                "rgb": rgb,
+                "is_trans": bool(col.get("is_trans", False)) if col else False,
+                "label_count": n,
+            }
+        )
+    total = len(items)
+    items.sort(key=lambda it: _lab_hue_key(it["rgb"]))
+    return {"items": items[:limit], "total": total}
+
+
+@router.get("/machine/{machine_id}/labeled-pieces/{piece_uuid}/image")
+def get_reference_image(
+    machine_id: UUID,
+    piece_uuid: str,
+    seq: int = Query(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_image")),
+) -> object:
+    """Thumbnail for a same-machine labeled reference piece. Gated by
+    ``_labeled_reference_visible`` — the reviewer window bypass, bounded to
+    pieces that actually carry a human label."""
+    if not _labeled_reference_visible(db, current_user, machine_id, piece_uuid):
         raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
     image = (
         db.query(MachinePieceImage)

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -43,8 +43,16 @@ from app.services.piece_crop_ai_matcher import (
     match_piece_crops,
     store_prediction,
 )
+from app.services.access_window import (
+    apply_piece_access,
+    channel_crop_access_visible,
+    piece_access_visible,
+    piece_access_visible_by_key,
+    scope_to_piece_access,
+)
 from app.services.pixel_color import guess_piece_color
 from app.services.profile_catalog import get_profile_catalog_service
+from app.services.rate_limit import rate_limit
 from app.services.secrets import decrypt_secret
 from app.services.storage import serve_stored_file
 
@@ -114,22 +122,29 @@ def label_stats(
     machine_id: UUID | None = Query(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Dashboard rollup: overall progress plus a histogram of how many distinct
     labelers have color-labeled each piece (drives the coverage chart). Scoped to
-    one machine when machine_id is given, matching the grid's machine filter."""
-    labelable_q = _labelable_query(db)
+    one machine when machine_id is given, matching the grid's machine filter, and
+    to the caller's visibility window (so a member's dashboard reflects only their
+    slice, not global fleet totals; admins see everything)."""
+    labelable_q = apply_piece_access(db, _labelable_query(db), current_user)
     if machine_id is not None:
         labelable_q = labelable_q.filter(MachinePiece.machine_id == machine_id)
     total_labelable = labelable_q.count()
 
     def _color_q():
         q = db.query(PieceColorLabel)
-        return q.filter(PieceColorLabel.machine_id == machine_id) if machine_id is not None else q
+        if machine_id is not None:
+            q = q.filter(PieceColorLabel.machine_id == machine_id)
+        return scope_to_piece_access(db, q, current_user, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid)
 
     def _crop_q():
         q = db.query(PieceCropLink)
-        return q.filter(PieceCropLink.machine_id == machine_id) if machine_id is not None else q
+        if machine_id is not None:
+            q = q.filter(PieceCropLink.machine_id == machine_id)
+        return scope_to_piece_access(db, q, current_user, PieceCropLink.machine_id, PieceCropLink.piece_uuid)
 
     labeled_by_me = _color_q().filter(PieceColorLabel.labeler_id == current_user.id).count()
     crop_links_by_me = _crop_q().filter(PieceCropLink.labeler_id == current_user.id).count()
@@ -233,6 +248,7 @@ def list_pieces(
     with_candidates: bool = Query(False),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Sortable grid of labelable pieces with per-piece label/crop-link counts,
     for the dashboard. Sorts: priority (has same-piece candidates first, then
@@ -310,6 +326,7 @@ def list_pieces(
         q = q.filter(MachinePiece.machine_id == machine_id)
     if with_candidates:
         q = q.filter(has_candidates)
+    q = apply_piece_access(db, q, current_user)
 
     recent_order = (MachinePiece.recorded_at.desc().nullslast(), MachinePiece.created_at.desc())
     if sort == "priority":
@@ -386,6 +403,7 @@ def piece_detail(
     piece_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Everything the single-piece labeling view needs: the piece, its crops, the
     pixel-average guess, and THIS user's saved color label (so revisiting a piece
@@ -395,7 +413,7 @@ def piece_detail(
         .filter(MachinePiece.machine_id == machine_id, MachinePiece.piece_uuid == piece_uuid)
         .first()
     )
-    if piece is None:
+    if piece is None or not piece_access_visible(db, current_user, piece):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
 
     machine_name = db.query(Machine.name).filter(Machine.id == machine_id).scalar()
@@ -485,7 +503,7 @@ def submit_brickognize_feedback(
         .filter(MachinePiece.machine_id == machine_id, MachinePiece.piece_uuid == piece_uuid)
         .first()
     )
-    if piece is None:
+    if piece is None or not piece_access_visible(db, current_user, piece):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
     if not piece.brickognize_listing_id:
         raise APIError(400, "Piece has no Brickognize listing to correct", "NOT_CORRECTABLE")
@@ -576,13 +594,14 @@ def label_queue(
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Pieces to color-label, newest first.
 
     With only_unlabeled=true (default) the labeler's already-labeled pieces drop
     out, so the client just re-fetches from the top as it works — no cursor. Set
     only_unlabeled=false to browse the full set (use offset to page)."""
-    query = _labelable_query(db)
+    query = apply_piece_access(db, _labelable_query(db), current_user)
 
     if only_unlabeled:
         my_label = exists().where(
@@ -684,15 +703,7 @@ def submit_label(
     if payload.color_id not in valid_ids:
         raise APIError(400, f"Unknown BrickLink color id {payload.color_id}", "COLOR_ID_INVALID")
 
-    piece = (
-        db.query(MachinePiece.id)
-        .filter(
-            MachinePiece.machine_id == payload.machine_id,
-            MachinePiece.piece_uuid == payload.piece_uuid,
-        )
-        .first()
-    )
-    if piece is None:
+    if not piece_access_visible_by_key(db, current_user, payload.machine_id, payload.piece_uuid):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
 
     now = datetime.now(timezone.utc)
@@ -760,11 +771,15 @@ def get_piece_image(
     piece_uuid: str,
     seq: int,
     db: Session = Depends(get_db),
-    _user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_image")),
 ) -> object:
     """Stream one synced crop. Any authenticated user may view it — color
     labeling is a community task over the whole synced fleet, not just the
-    machine's owner (unlike the owner-gated /machines/... image route)."""
+    machine's owner (unlike the owner-gated /machines/... image route) — but only
+    within the caller's visibility window (admins unrestricted)."""
+    if not piece_access_visible_by_key(db, current_user, machine_id, piece_uuid):
+        raise APIError(404, "Image not found", "IMAGE_NOT_FOUND")
     image = (
         db.query(MachinePieceImage)
         .filter(
@@ -856,9 +871,12 @@ def possible_crops(
     piece_uuid: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
 ) -> dict:
     """Ranked "possibly the same piece" C2/C3 candidates for a classified piece,
     plus this labeler's saved selection (if any) and any stored AI prediction."""
+    if not piece_access_visible_by_key(db, current_user, machine_id, piece_uuid):
+        raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
     return _possible_crops_result(db, machine_id, piece_uuid, current_user.id)
 
 
@@ -880,6 +898,8 @@ def run_ai_predict(
 
     Open to admins and to any labeler who has added their own OpenRouter key
     (which pays for the call) — mirroring the sample teacher's key gating."""
+    if not piece_access_visible_by_key(db, current_user, machine_id, piece_uuid):
+        raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
     if current_user.role != "admin" and not current_user.openrouter_configured:
         raise APIError(
             403,
@@ -916,11 +936,14 @@ def get_channel_crop_image(
     machine_id: UUID,
     local_id: int,
     db: Session = Depends(get_db),
-    _user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_image")),
 ) -> object:
     """Stream one upstream-channel crop. Any authenticated user may view it —
     same-piece labeling is a community task over the synced fleet, like the color
-    crops above (unlike the owner-gated /machines/... channel-crop route)."""
+    crops above (unlike the owner-gated /machines/... channel-crop route) — but
+    only within the caller's visibility window (admins unrestricted). Channel
+    crops are keyed by a guessable integer local_id, so this gate matters."""
     crop = (
         db.query(MachineChannelCrop)
         .filter(
@@ -929,7 +952,7 @@ def get_channel_crop_image(
         )
         .first()
     )
-    if crop is None or not crop.image_key:
+    if crop is None or not crop.image_key or not channel_crop_access_visible(db, current_user, crop):
         raise APIError(404, "Crop image not found", "CROP_IMAGE_NOT_FOUND")
     return serve_stored_file(crop.image_key, headers={"Cache-Control": PIECE_IMAGE_CACHE_CONTROL})
 
@@ -956,15 +979,7 @@ def save_piece_crop_link(
     """Create or replace the current user's same-piece crop selection for a
     piece. Sent the full presented candidate set (each with the labeler's verdict
     and whether it was a prediction); replaces any prior members wholesale."""
-    piece = (
-        db.query(MachinePiece.id)
-        .filter(
-            MachinePiece.machine_id == payload.machine_id,
-            MachinePiece.piece_uuid == payload.piece_uuid,
-        )
-        .first()
-    )
-    if piece is None:
+    if not piece_access_visible_by_key(db, current_user, payload.machine_id, payload.piece_uuid):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
 
     now = datetime.now(timezone.utc)
@@ -1062,12 +1077,7 @@ def save_piece_rejection(
     if not reasons:
         raise APIError(400, "No valid rejection reasons", "REJECT_REASONS_INVALID")
 
-    piece = (
-        db.query(MachinePiece.id)
-        .filter(MachinePiece.machine_id == payload.machine_id, MachinePiece.piece_uuid == payload.piece_uuid)
-        .first()
-    )
-    if piece is None:
+    if not piece_access_visible_by_key(db, current_user, payload.machine_id, payload.piece_uuid):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
 
     now = datetime.now(timezone.utc)

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -223,7 +223,7 @@ def color_coverage(
     colors are well-covered and which are rare/missing in the labeled data."""
     scoped = scope_to_piece_access(
         db, db.query(PieceColorLabel), current_user, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid
-    )
+    ).filter(PieceColorLabel.color_id.isnot(None))  # exclude "I can't tell" answers
     if machine_id is not None:
         scoped = scoped.filter(PieceColorLabel.machine_id == machine_id)
 
@@ -320,7 +320,7 @@ def _rare_candidate_color_ids(db: Session, user: User, machine_id: UUID | None) 
     these are the ones most likely to actually be a rare color the model fumbled."""
     scoped = scope_to_piece_access(
         db, db.query(PieceColorLabel), user, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid
-    )
+    ).filter(PieceColorLabel.color_id.isnot(None))  # "I can't tell" answers aren't a color
     if machine_id is not None:
         scoped = scoped.filter(PieceColorLabel.machine_id == machine_id)
     per_piece = (
@@ -589,7 +589,9 @@ def piece_detail(
         "images": [
             {"seq": im.seq, "source": im.source, "used": im.used, "score": im.score} for im in images
         ],
-        "my_label": None if label is None else {"color_id": label.color_id, "notes": label.notes},
+        "my_label": None
+        if label is None
+        else {"color_id": label.color_id, "cant_tell": bool(label.cant_tell), "notes": label.notes},
         "my_rejection": None if rejection is None else {"reasons": list(rejection.reasons or [])},
         # Brickognize prediction + correction state. correctable is True only
         # when a listing id was captured (a prerequisite for submitting feedback).
@@ -818,7 +820,10 @@ def label_queue(
 class ColorLabelPayload(BaseModel):
     machine_id: UUID
     piece_uuid: str = Field(min_length=1)
-    color_id: int
+    # A concrete BrickLink color, OR cant_tell=True for "I can't tell" (an
+    # indeterminate-color answer). Exactly one of the two must be provided.
+    color_id: int | None = None
+    cant_tell: bool = False
     notes: str | None = None
 
 
@@ -828,10 +833,17 @@ def submit_label(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
-    """Create or update the current user's color label for a piece."""
-    valid_ids = {c["id"] for c in get_profile_catalog_service().list_bricklink_colors()}
-    if payload.color_id not in valid_ids:
-        raise APIError(400, f"Unknown BrickLink color id {payload.color_id}", "COLOR_ID_INVALID")
+    """Create or update the current user's color label for a piece — either a
+    concrete BrickLink color or an "I can't tell" answer."""
+    if payload.cant_tell:
+        color_id = None
+    else:
+        if payload.color_id is None:
+            raise APIError(400, "A color_id or cant_tell is required", "COLOR_REQUIRED")
+        valid_ids = {c["id"] for c in get_profile_catalog_service().list_bricklink_colors()}
+        if payload.color_id not in valid_ids:
+            raise APIError(400, f"Unknown BrickLink color id {payload.color_id}", "COLOR_ID_INVALID")
+        color_id = payload.color_id
 
     if not piece_access_visible_by_key(db, current_user, payload.machine_id, payload.piece_uuid):
         raise APIError(404, "Piece not found", "PIECE_NOT_FOUND")
@@ -851,13 +863,15 @@ def submit_label(
             machine_id=payload.machine_id,
             piece_uuid=payload.piece_uuid,
             labeler_id=current_user.id,
-            color_id=payload.color_id,
+            color_id=color_id,
+            cant_tell=payload.cant_tell,
             notes=payload.notes,
         )
         db.add(label)
         created = True
     else:
-        label.color_id = payload.color_id
+        label.color_id = color_id
+        label.cant_tell = payload.cant_tell
         label.notes = payload.notes
         label.updated_at = now
         created = False

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -209,6 +209,23 @@ def label_stats(
     }
 
 
+def _labelable_palette_colors() -> list[dict]:
+    """The palette minus non-standard families the machine never meaningfully
+    sorts: Modulex ("Mx …", a separate brick system), Fabuland (its own toy
+    line), and id<=0 ("(Not Applicable)"/[Unknown]). Charting their coverage or
+    hunting them as rare colors is just noise."""
+    out = []
+    for c in get_profile_catalog_service().list_bricklink_colors():
+        cid = c.get("id")
+        if not isinstance(cid, int) or cid <= 0:
+            continue
+        name = str(c.get("name", ""))
+        if name.startswith("Mx ") or name.startswith("Fabuland"):
+            continue
+        out.append(c)
+    return out
+
+
 @router.get("/color-coverage")
 def color_coverage(
     machine_id: UUID | None = Query(None),
@@ -247,7 +264,7 @@ def color_coverage(
         .all()
     )
 
-    palette = get_profile_catalog_service().list_bricklink_colors()
+    palette = _labelable_palette_colors()
     colors = []
     covered = 0
     for c in palette:
@@ -334,7 +351,7 @@ def _rare_candidate_color_ids(db: Session, user: User, machine_id: UUID | None) 
         db.query(per_piece.c.color_id, func.count()).group_by(per_piece.c.color_id).all()
     )
 
-    palette = [c for c in get_profile_catalog_service().list_bricklink_colors() if c.get("rgb")]
+    palette = [c for c in _labelable_palette_colors() if c.get("rgb")]
     rgbs = []
     ids = []
     for c in palette:

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -205,6 +205,68 @@ def label_stats(
     }
 
 
+@router.get("/color-coverage")
+def color_coverage(
+    machine_id: UUID | None = Query(None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(rate_limit("labeling_list")),
+) -> dict:
+    """Per-color coverage across the whole BrickLink palette: how many distinct
+    pieces have been color-labeled as each color, scoped to the caller's
+    visibility (admins see everything). Every palette color is returned, including
+    the ones with zero labels — that's the point of the chart: it reveals which
+    colors are well-covered and which are rare/missing in the labeled data."""
+    scoped = scope_to_piece_access(
+        db, db.query(PieceColorLabel), current_user, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid
+    )
+    if machine_id is not None:
+        scoped = scoped.filter(PieceColorLabel.machine_id == machine_id)
+
+    # Distinct (machine, piece) per color — a piece labeled by three people counts
+    # once toward that color's coverage.
+    per_piece = (
+        scoped.with_entities(
+            PieceColorLabel.color_id,
+            PieceColorLabel.machine_id,
+            PieceColorLabel.piece_uuid,
+        )
+        .group_by(PieceColorLabel.color_id, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid)
+        .subquery()
+    )
+    piece_counts = dict(
+        db.query(per_piece.c.color_id, func.count()).group_by(per_piece.c.color_id).all()
+    )
+    label_counts = dict(
+        scoped.with_entities(PieceColorLabel.color_id, func.count())
+        .group_by(PieceColorLabel.color_id)
+        .all()
+    )
+
+    palette = get_profile_catalog_service().list_bricklink_colors()
+    colors = []
+    covered = 0
+    for c in palette:
+        pieces = int(piece_counts.get(c["id"], 0))
+        if pieces > 0:
+            covered += 1
+        colors.append(
+            {
+                "id": c["id"],
+                "name": c["name"],
+                "rgb": c.get("rgb"),
+                "is_trans": bool(c.get("is_trans", False)),
+                "pieces": pieces,
+                "labels": int(label_counts.get(c["id"], 0)),
+            }
+        )
+    return {
+        "colors": colors,
+        "total_colors": len(palette),
+        "covered_colors": covered,
+    }
+
+
 # Window (before/after the piece's arrival) in which a same-piece candidate crop
 # could exist — mirrors the shared lookup params so ordering agrees with what the
 # labeling view actually surfaces.

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -17,9 +17,10 @@ import logging
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
+import numpy as np
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
-from sqlalchemy import and_, exists, func
+from sqlalchemy import and_, exists, false, func
 from sqlalchemy.orm import Session
 
 from app.deps import get_current_user, get_db, verify_csrf
@@ -50,7 +51,7 @@ from app.services.access_window import (
     piece_access_visible_by_key,
     scope_to_piece_access,
 )
-from app.services.pixel_color import guess_piece_color
+from app.services.pixel_color import _srgb_to_lab, guess_piece_color
 from app.services.profile_catalog import get_profile_catalog_service
 from app.services.rate_limit import rate_limit
 from app.services.secrets import decrypt_secret
@@ -297,8 +298,63 @@ _PIECE_SORTS = {
     "most_color",
     "least_crop",
     "most_crop",
+    "rare_color",
     "needs_me",
 }
+
+# A color is "rare" (under-covered) if this many or fewer distinct pieces have
+# been labeled with it. A predicted color counts as a rare-color *candidate* when
+# it sits within this CIE-Lab distance of some rare color — the pixel/model may
+# have landed on a nearby common color when the piece is actually the rare one.
+_RARE_PIECE_THRESHOLD = 3
+_RARE_LAB_NEAR = 22.0
+
+
+def _rare_candidate_color_ids(db: Session, user: User, machine_id: UUID | None) -> set[str]:
+    """BrickLink color ids (as stored on the piece — strings) that are worth
+    surfacing when hunting rare colors: every under-covered color, plus any color
+    close to one in Lab space. Pieces whose Brickognize color prediction is one of
+    these are the ones most likely to actually be a rare color the model fumbled."""
+    scoped = scope_to_piece_access(
+        db, db.query(PieceColorLabel), user, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid
+    )
+    if machine_id is not None:
+        scoped = scoped.filter(PieceColorLabel.machine_id == machine_id)
+    per_piece = (
+        scoped.with_entities(
+            PieceColorLabel.color_id, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid
+        )
+        .group_by(PieceColorLabel.color_id, PieceColorLabel.machine_id, PieceColorLabel.piece_uuid)
+        .subquery()
+    )
+    piece_counts = dict(
+        db.query(per_piece.c.color_id, func.count()).group_by(per_piece.c.color_id).all()
+    )
+
+    palette = [c for c in get_profile_catalog_service().list_bricklink_colors() if c.get("rgb")]
+    rgbs = []
+    ids = []
+    for c in palette:
+        h = str(c["rgb"]).replace("#", "")
+        if len(h) < 6:
+            continue
+        try:
+            rgbs.append([int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)])
+        except ValueError:
+            continue
+        ids.append(c["id"])
+    if not rgbs:
+        return set()
+
+    labs = _srgb_to_lab(np.array(rgbs, dtype=np.float64))
+    rare_mask = np.array([int(piece_counts.get(cid, 0)) <= _RARE_PIECE_THRESHOLD for cid in ids])
+    if not rare_mask.any():
+        return set()
+    rare_labs = labs[rare_mask]
+    # Min Lab distance from each palette color to any rare color; keep those within
+    # the near threshold (rare colors themselves are distance 0, so included).
+    dists = np.linalg.norm(labs[:, None, :] - rare_labs[None, :, :], axis=2).min(axis=1)
+    return {str(ids[i]) for i in range(len(ids)) if dists[i] <= _RARE_LAB_NEAR}
 
 
 @router.get("/pieces")
@@ -390,6 +446,11 @@ def list_pieces(
         q = q.filter(has_candidates)
     q = apply_piece_access(db, q, current_user)
 
+    if sort == "rare_color":
+        # Only pieces whose predicted color is (near) an under-covered color.
+        rare_ids = _rare_candidate_color_ids(db, current_user, machine_id)
+        q = q.filter(MachinePiece.color_id.in_(rare_ids)) if rare_ids else q.filter(false())
+
     recent_order = (MachinePiece.recorded_at.desc().nullslast(), MachinePiece.created_at.desc())
     if sort == "priority":
         # Candidates first, then the least-color-labeled — pushes effort to pieces
@@ -407,6 +468,10 @@ def list_pieces(
         q = q.order_by(crop_cnt.asc(), *recent_order)
     elif sort == "most_crop":
         q = q.order_by(crop_cnt.desc(), *recent_order)
+    elif sort == "rare_color":
+        # Least-confident predictions first — those are the likeliest to be the
+        # rare color the model missed. Nulls (no confidence) sort last.
+        q = q.order_by(MachinePiece.confidence.asc().nullslast(), *recent_order)
     elif sort == "needs_me":
         q = q.order_by(my_color.asc(), color_cnt.asc(), *recent_order)
 

--- a/software/hive/backend/app/routers/review.py
+++ b/software/hive/backend/app/routers/review.py
@@ -31,6 +31,7 @@ from app.routers.samples import (
     apply_kind_filter,
     attach_my_reviews,
 )
+from app.services.access_window import apply_sample_access, sample_access_visible
 from app.services.condition_analysis import (
     COMPOSITION_VALUES,
     CONDITION_VALUES,
@@ -87,6 +88,10 @@ def get_next_review(
         Sample.archived_at.is_(None),
         Sample.machine.has(Machine.archived_at.is_(None)),
     )
+    # Members only ever get their own machines' samples in the queue; reviewers
+    # and admins get everything. Without this a random member could pull other
+    # people's samples one 'next' at a time.
+    query = apply_sample_access(db, query, current_user)
 
     if not override_mode:
         # Default: hide samples the viewer already reviewed + ones past
@@ -169,7 +174,7 @@ def create_or_update_review(
         raise APIError(400, "Decision must be 'accept' or 'reject'", "INVALID_DECISION")
 
     sample = db.query(Sample).filter(Sample.id == sample_id).first()
-    if not sample:
+    if not sample or not sample_access_visible(db, current_user, sample):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
 
     # Upsert review
@@ -237,7 +242,7 @@ def tag_condition_sample(
         )
 
     sample = db.query(Sample).filter(Sample.id == sample_id).first()
-    if not sample:
+    if not sample or not sample_access_visible(db, current_user, sample):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
 
     # Drop unknown flag keys silently — the writer also filters, but doing
@@ -277,7 +282,7 @@ def get_review_history(
     current_user: User = Depends(get_current_user),
 ):
     sample = db.query(Sample).filter(Sample.id == sample_id).first()
-    if not sample:
+    if not sample or not sample_access_visible(db, current_user, sample):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
 
     reviews = (

--- a/software/hive/backend/app/routers/samples.py
+++ b/software/hive/backend/app/routers/samples.py
@@ -34,6 +34,7 @@ from app.schemas.sample import (
     SaveSampleClassificationRequest,
     SaveSampleClassificationResponse,
 )
+from app.services.access_window import apply_sample_access, sample_access_visible
 from app.services.storage import delete_sample_files, serve_stored_file
 from app.services.sample_payloads import (
     is_classification_payload,
@@ -86,6 +87,10 @@ def _visible_sample_query(
         query = query.filter(Sample.archived_at.is_(None))
     if scope == "mine":
         query = query.filter(Sample.machine.has(owner_id=current_user.id))
+    # Access rule: members only ever see their own machines' samples (regardless
+    # of scope=all); reviewers and admins see everything. Prevents a random
+    # registrant from enumerating the whole corpus.
+    query = apply_sample_access(db, query, current_user)
     return query
 
 
@@ -249,6 +254,15 @@ def attach_my_reviews(items: list, db: Session, viewer_id) -> None:
 def _get_sample_for_read(db: Session, sample_id: UUID) -> Sample:
     sample = db.query(Sample).filter(Sample.id == sample_id).first()
     if not sample:
+        raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
+    return sample
+
+
+def _get_sample_for_read_scoped(db: Session, sample_id: UUID, current_user: User) -> Sample:
+    """Single-sample read gated by access: members only their own machines'
+    samples (404 otherwise, so they can't probe existence); reviewers/admins any."""
+    sample = _get_sample_for_read(db, sample_id)
+    if not sample_access_visible(db, current_user, sample):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
     return sample
 
@@ -780,7 +794,7 @@ def get_similar_samples(
     from sqlalchemy import text
 
     target = db.query(Sample).filter(Sample.id == sample_id).first()
-    if target is None:
+    if target is None or not sample_access_visible(db, current_user, target):
         raise APIError(404, "Sample not found", "SAMPLE_NOT_FOUND")
     if target.phash is None:
         # No hash to compare against. Return an empty list rather than
@@ -792,14 +806,18 @@ def get_similar_samples(
     # bits. We rank by distance, drop self + archived rows + nulls, and
     # cap by ``max_distance`` so a wildly different image doesn't surface.
     bit_distance = text("bit_count(samples.phash # :target_phash)")
-    rows = (
+    similar_q = (
         db.query(Sample, bit_distance.label("distance"))
         .filter(Sample.machine.has(Machine.archived_at.is_(None)))
         .filter(Sample.archived_at.is_(None))
         .filter(Sample.phash.isnot(None))
         .filter(Sample.id != target.id)
         .filter(bit_distance <= int(max_distance))
-        .order_by(text("distance"))
+    )
+    # Members only get similar hits among their own machines' samples.
+    similar_q = apply_sample_access(db, similar_q, current_user)
+    rows = (
+        similar_q.order_by(text("distance"))
         .params(target_phash=int(target.phash))
         .limit(limit)
         .all()
@@ -822,7 +840,7 @@ def get_sample(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SAMPLES_READ)),
 ):
-    sample = _get_sample_for_read(db, sample_id)
+    sample = _get_sample_for_read_scoped(db, sample_id, current_user)
     attach_my_reviews([sample], db, current_user.id)
 
     data = SampleDetailResponse.model_validate(sample)
@@ -1169,7 +1187,7 @@ def get_sample_image(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SAMPLES_READ)),
 ):
-    sample = _get_sample_for_read(db, sample_id)
+    sample = _get_sample_for_read_scoped(db, sample_id, current_user)
 
     return serve_stored_file(sample.image_path, headers={"Cache-Control": ASSET_CACHE_CONTROL})
 
@@ -1180,7 +1198,7 @@ def get_sample_full_frame(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SAMPLES_READ)),
 ):
-    sample = _get_sample_for_read(db, sample_id)
+    sample = _get_sample_for_read_scoped(db, sample_id, current_user)
     if not sample.full_frame_path:
         raise APIError(404, "Full frame not found", "ASSET_NOT_FOUND")
 
@@ -1193,7 +1211,7 @@ def get_sample_overlay(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SAMPLES_READ)),
 ):
-    sample = _get_sample_for_read(db, sample_id)
+    sample = _get_sample_for_read_scoped(db, sample_id, current_user)
     if not sample.overlay_path:
         raise APIError(404, "Overlay not found", "ASSET_NOT_FOUND")
 

--- a/software/hive/backend/app/routers/stats.py
+++ b/software/hive/backend/app/routers/stats.py
@@ -19,7 +19,10 @@ def get_overview(
     # the active fleet, not retired hardware. Admins can re-archive/un-archive via
     # the machine endpoints if a rig comes back.
     machine_query = db.query(Machine).filter(Machine.archived_at.is_(None))
-    if scope == "mine":
+    # Members only ever get counts over their OWN machines — otherwise the overview
+    # leaks the whole corpus's size/composition to any registrant. Reviewers and
+    # admins see fleet-wide totals (respecting an explicit scope=mine).
+    if scope == "mine" or current_user.role not in ("admin", "reviewer"):
         machine_query = machine_query.filter(Machine.owner_id == current_user.id)
     sample_query = db.query(Sample).filter(Sample.machine_id.in_(machine_query.with_entities(Machine.id)))
 

--- a/software/hive/backend/app/services/access_window.py
+++ b/software/hive/backend/app/services/access_window.py
@@ -1,0 +1,304 @@
+"""Per-role access control over the piece-bbox dataset (and owner-scoping for
+samples).
+
+Access rules enforced here:
+  - admin    → everything, unrestricted.
+  - member   → only their OWN machines' data. A random registrant who owns no
+               machines (or someone else's) sees nothing — this is the anti-scrape
+               guarantee.
+  - reviewer → their own PLUS a bounded visibility window (a rolling slice of
+               everyone's data) so review work has fresh material without exposing
+               the whole corpus. Rate-limited on top.
+
+A window is a contiguous slice ordered by upload time (see ``models.access_window``
+for anchor semantics); sizes are tunable live per (role, entity) via the admin API.
+
+Enforcement shape:
+  - list/queue queries → ``apply_piece_access`` / ``apply_sample_access`` narrow
+    the query to what the caller may see.
+  - single-object reads (detail, crop images) → ``piece_access_visible`` /
+    ``channel_crop_access_visible`` / ``sample_access_visible`` gate one row.
+    Callers 404 (not 403) on a miss so a scoped user can't probe for the existence
+    of rows outside their scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import and_, func, or_, select, tuple_
+from sqlalchemy.orm import Session
+
+from app.models.access_window import AccessWindow
+from app.models.machine import Machine
+from app.models.machine_channel_crop import MachineChannelCrop
+from app.models.machine_piece import MachinePiece
+from app.models.sample import Sample
+from app.models.user import User
+
+ENTITY_PIECE = "piece"
+ENTITY_CHANNEL_CROP = "channel_crop"
+ENTITIES = (ENTITY_PIECE, ENTITY_CHANNEL_CROP)
+
+ANCHOR_OLDEST = "oldest"
+ANCHOR_NEWEST = "newest"
+ANCHORS = (ANCHOR_OLDEST, ANCHOR_NEWEST)
+
+# Roles that get a window. 'admin' is intentionally absent — admins are
+# unrestricted. A role with no default and no DB row denies all (size 0).
+WINDOWED_ROLES = ("member", "reviewer")
+
+
+@dataclass(frozen=True)
+class Window:
+    anchor: str
+    size: int
+    offset: int
+
+
+# Starting points, tunable live per (role, entity) via the admin API. Members get
+# a small PINNED (oldest) slice; reviewers a large ROLLING (newest) one. Channel
+# crops are ~10-20x more numerous than pieces, so their windows are sized up.
+_DEFAULTS: dict[tuple[str, str], Window] = {
+    ("member", ENTITY_PIECE): Window(ANCHOR_OLDEST, 200, 0),
+    ("member", ENTITY_CHANNEL_CROP): Window(ANCHOR_OLDEST, 2000, 0),
+    ("reviewer", ENTITY_PIECE): Window(ANCHOR_NEWEST, 5000, 0),
+    ("reviewer", ENTITY_CHANNEL_CROP): Window(ANCHOR_NEWEST, 50000, 0),
+}
+
+# Deny-all fallback for a windowed role with no default configured.
+_DENY = Window(ANCHOR_OLDEST, 0, 0)
+
+
+def is_unrestricted(role: str) -> bool:
+    return role == "admin"
+
+
+def resolve_window(db: Session, role: str, entity: str) -> Window | None:
+    """The effective window for a (role, entity), or None if unrestricted."""
+    if is_unrestricted(role):
+        return None
+    row = (
+        db.query(AccessWindow)
+        .filter(AccessWindow.role == role, AccessWindow.entity == entity)
+        .first()
+    )
+    if row is not None:
+        return Window(row.anchor, int(row.size), int(row.offset))
+    return _DEFAULTS.get((role, entity), _DENY)
+
+
+def _model_for(entity: str):
+    return MachinePiece if entity == ENTITY_PIECE else MachineChannelCrop
+
+
+def _base_filters(entity: str):
+    # Pieces exclude dead/spurious rows from the ordering so a member's small
+    # window isn't wasted on junk. Channel crops have no such flag.
+    if entity == ENTITY_PIECE:
+        return (MachinePiece.dead.is_(False),)
+    return ()
+
+
+def _window_id_select(entity: str, win: Window):
+    model = _model_for(entity)
+    if win.anchor == ANCHOR_OLDEST:
+        order = (model.created_at.asc(), model.id.asc())
+    else:
+        order = (model.created_at.desc(), model.id.desc())
+    stmt = select(model.id)
+    for f in _base_filters(entity):
+        stmt = stmt.where(f)
+    return stmt.order_by(*order).offset(win.offset).limit(win.size)
+
+
+def _strictly_before(model, created_at, pk):
+    return or_(model.created_at < created_at, and_(model.created_at == created_at, model.id < pk))
+
+
+def _strictly_after(model, created_at, pk):
+    return or_(model.created_at > created_at, and_(model.created_at == created_at, model.id > pk))
+
+
+def _rank_visible(db: Session, entity: str, obj, win: Window) -> bool:
+    """True iff ``obj`` falls inside the window, computed from its rank in the
+    canonical ordering — an O(count) index scan, no need to materialize the slice."""
+    if win.size <= 0:
+        return False
+    model = _model_for(entity)
+    cmp = _strictly_after if win.anchor == ANCHOR_NEWEST else _strictly_before
+    q = db.query(func.count()).select_from(model)
+    for f in _base_filters(entity):
+        q = q.filter(f)
+    rank = q.filter(cmp(model, obj.created_at, obj.id)).scalar() or 0
+    return win.offset <= rank < win.offset + win.size
+
+
+def _owned_machine_ids(user: User):
+    return select(Machine.id).where(Machine.owner_id == user.id)
+
+
+def _machine_owned_by(db: Session, machine_id, user: User) -> bool:
+    return (
+        db.query(Machine.id)
+        .filter(Machine.id == machine_id, Machine.owner_id == user.id)
+        .first()
+        is not None
+    )
+
+
+def _piece_window_key_select(win: Window):
+    """Select of (machine_id, piece_uuid) for the pieces in a window — for scoping
+    piece-derived rows (labels, crop-links) that key off that pair rather than id."""
+    if win.anchor == ANCHOR_OLDEST:
+        order = (MachinePiece.created_at.asc(), MachinePiece.id.asc())
+    else:
+        order = (MachinePiece.created_at.desc(), MachinePiece.id.desc())
+    return (
+        select(MachinePiece.machine_id, MachinePiece.piece_uuid)
+        .where(MachinePiece.dead.is_(False))
+        .order_by(*order)
+        .offset(win.offset)
+        .limit(win.size)
+    )
+
+
+# --- Piece-bbox access: admin=all, member=own machines only, reviewer=own+window --
+
+def apply_piece_access(db: Session, query, user: User):
+    """Narrow a MachinePiece query to what ``user`` may see: admins everything;
+    members only their own machines' pieces; reviewers their own PLUS the reviewer
+    visibility window (rolling slice of everyone's)."""
+    if is_unrestricted(user.role):
+        return query
+    owned = MachinePiece.machine_id.in_(_owned_machine_ids(user))
+    if user.role == "reviewer":
+        win = resolve_window(db, "reviewer", ENTITY_PIECE)
+        if win is not None and win.size > 0:
+            return query.filter(or_(owned, MachinePiece.id.in_(_window_id_select(ENTITY_PIECE, win))))
+    return query.filter(owned)
+
+
+def scope_to_piece_access(db: Session, query, user: User, machine_col, piece_uuid_col):
+    """Owner-or-window scoping for piece-derived tables (labels, crop-links) that
+    key off (machine_id, piece_uuid)."""
+    if is_unrestricted(user.role):
+        return query
+    owned = machine_col.in_(_owned_machine_ids(user))
+    if user.role == "reviewer":
+        win = resolve_window(db, "reviewer", ENTITY_PIECE)
+        if win is not None and win.size > 0:
+            return query.filter(
+                or_(owned, tuple_(machine_col, piece_uuid_col).in_(_piece_window_key_select(win)))
+            )
+    return query.filter(owned)
+
+
+def piece_access_visible(db: Session, user: User, piece: MachinePiece) -> bool:
+    if is_unrestricted(user.role):
+        return True
+    if _machine_owned_by(db, piece.machine_id, user):
+        return True
+    if user.role == "reviewer" and not piece.dead:
+        win = resolve_window(db, "reviewer", ENTITY_PIECE)
+        if win is not None:
+            return _rank_visible(db, ENTITY_PIECE, piece, win)
+    return False
+
+
+def piece_access_visible_by_key(db: Session, user: User, machine_id, piece_uuid: str) -> bool:
+    """Access gate for endpoints keyed by (machine_id, piece_uuid) that don't
+    already hold the row. Missing piece reads as not-visible (caller 404s)."""
+    if is_unrestricted(user.role):
+        return True
+    piece = (
+        db.query(MachinePiece)
+        .filter(MachinePiece.machine_id == machine_id, MachinePiece.piece_uuid == piece_uuid)
+        .first()
+    )
+    if piece is None:
+        return False
+    return piece_access_visible(db, user, piece)
+
+
+def channel_crop_access_visible(db: Session, user: User, crop: MachineChannelCrop) -> bool:
+    if is_unrestricted(user.role):
+        return True
+    if _machine_owned_by(db, crop.machine_id, user):
+        return True
+    if user.role == "reviewer":
+        win = resolve_window(db, "reviewer", ENTITY_CHANNEL_CROP)
+        if win is not None:
+            return _rank_visible(db, ENTITY_CHANNEL_CROP, crop, win)
+    return False
+
+
+# --- Samples corpus access: admin+reviewer=all, member=own machines only. -------
+# (No reviewer window on samples yet — that's the deferred "samples pass". The
+# anti-scrape rule that matters — random members only see their own — is enforced.)
+
+def apply_sample_access(db: Session, query, user: User):
+    if user.role in ("admin", "reviewer"):
+        return query
+    return query.filter(Sample.machine.has(Machine.owner_id == user.id))
+
+
+def sample_access_visible(db: Session, user: User, sample: Sample) -> bool:
+    if user.role in ("admin", "reviewer"):
+        return True
+    return sample.machine is not None and str(sample.machine.owner_id) == str(user.id)
+
+
+def list_effective_windows(db: Session) -> dict:
+    """All windowed (role, entity) pairs with their effective values + whether the
+    value comes from a DB override or the code default. Powers the admin view."""
+    overrides = {
+        (r.role, r.entity): r for r in db.query(AccessWindow).all()
+    }
+    windows = []
+    for role in WINDOWED_ROLES:
+        for entity in ENTITIES:
+            row = overrides.get((role, entity))
+            if row is not None:
+                windows.append(
+                    {
+                        "role": role,
+                        "entity": entity,
+                        "anchor": row.anchor,
+                        "size": int(row.size),
+                        "offset": int(row.offset),
+                        "source": "override",
+                        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+                    }
+                )
+            else:
+                d = _DEFAULTS.get((role, entity), _DENY)
+                windows.append(
+                    {
+                        "role": role,
+                        "entity": entity,
+                        "anchor": d.anchor,
+                        "size": d.size,
+                        "offset": d.offset,
+                        "source": "default",
+                        "updated_at": None,
+                    }
+                )
+    return {"admin": "unrestricted", "windows": windows}
+
+
+def set_window(db: Session, role: str, entity: str, anchor: str, size: int, offset: int) -> AccessWindow:
+    row = (
+        db.query(AccessWindow)
+        .filter(AccessWindow.role == role, AccessWindow.entity == entity)
+        .first()
+    )
+    if row is None:
+        row = AccessWindow(role=role, entity=entity)
+        db.add(row)
+    row.anchor = anchor
+    row.size = size
+    row.offset = offset
+    db.commit()
+    db.refresh(row)
+    return row

--- a/software/hive/backend/app/services/link_predictor.py
+++ b/software/hive/backend/app/services/link_predictor.py
@@ -1,0 +1,382 @@
+"""Serve piece_link "same physical piece" scores from an uploaded ONNX pair.
+
+The active model (one global row in ``link_models``) replaces the time/angle
+heuristic's pre-selection in the labeling view. Each model is TWO ``.onnx``
+graphs living in ``LINK_MODEL_DIR`` and uploaded out of band: a shared
+``CropEncoder`` (64×64 RGB crop → 64-d L2-normalized embedding, mean/std baked
+in) and a ``LinkHead`` (emb_anchor, emb_candidate, 11-d meta → P(same),
+sigmoid baked in). Both files carry a ``hive.*`` metadata block and are grouped
+by their ``hive.name``; a dir scan needs no sidecar files.
+
+Scoring path (per piece): take the heuristic's time-window candidate set (the
+recall net, from ``find_possible_crops``), embed the piece's C4 anchor once and
+every candidate crop, build each candidate's meta feature vector, and run the
+head to get a same-piece probability per candidate. ``candidateMeta`` is copied
+byte-for-byte from the training repo (color-model/piece_link/dataset.py) — the
+model's meta inputs must match training exactly, so keep the two in sync.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import logging
+import math
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+from uuid import UUID
+
+import numpy as np
+import onnxruntime as ort
+from PIL import Image
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.link_model import LinkModel
+from app.models.machine_channel_crop import MachineChannelCrop
+from app.models.machine_piece_image import MachinePieceImage
+from app.services.channel_crop_lookup_params import DEFAULT_PARAMS
+from app.services.storage_backend import get_backend
+
+log = logging.getLogger(__name__)
+
+_HIVE_KIND = "piece_link_matcher"
+# sigmoid prob at/above which a candidate is the model's "same piece" pick.
+PREDICT_THRESHOLD = 0.5
+MAX_ANCHOR_VIEWS = 3
+
+
+def model_dir() -> Path:
+    return Path(settings.LINK_MODEL_DIR)
+
+
+@dataclass
+class _Loaded:
+    encoder: ort.InferenceSession
+    head: ort.InferenceSession
+    enc_input: str
+    input_size: int
+
+
+_lock = threading.Lock()
+_session_cache: dict[tuple[str, str], _Loaded] = {}
+
+
+def _sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _read_metadata(path: Path) -> dict[str, str] | None:
+    """Read a file's ``hive.*`` metadata via a throwaway ort session. Returns
+    None when the file isn't a readable piece_link_matcher graph."""
+    try:
+        so = ort.SessionOptions()
+        so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+        sess = ort.InferenceSession(str(path), sess_options=so, providers=["CPUExecutionProvider"])
+    except Exception as exc:
+        log.warning("link model %s failed to load: %s", path.name, exc)
+        return None
+    meta = sess.get_modelmeta().custom_metadata_map or {}
+    if meta.get("hive.kind") != _HIVE_KIND:
+        return None
+    return dict(meta)
+
+
+def _int(meta: dict[str, str], key: str) -> int:
+    try:
+        return int(meta.get(key, "0"))
+    except ValueError:
+        return 0
+
+
+def scan_models() -> list[dict[str, Any]]:
+    """Every piece_link matcher in LINK_MODEL_DIR, grouped by ``hive.name`` into
+    encoder+head pairs. A name is only surfaced when both roles are present."""
+    directory = model_dir()
+    if not directory.exists():
+        return []
+    by_name: dict[str, dict[str, Any]] = {}
+    for path in sorted(directory.glob("*.onnx")):
+        meta = _read_metadata(path)
+        if meta is None:
+            continue
+        name = meta.get("hive.name") or path.stem
+        role = meta.get("hive.role")
+        entry = by_name.setdefault(name, {"name": name, "meta": meta, "roles": {}})
+        entry["roles"][role] = path
+        # prefer head metadata for display fields (identical across the pair)
+        if role == "head":
+            entry["meta"] = meta
+
+    found: list[dict[str, Any]] = []
+    for name, entry in by_name.items():
+        roles = entry["roles"]
+        encoder = roles.get("encoder")
+        head = roles.get("head")
+        if encoder is None or head is None:
+            log.warning("link model %s is missing its %s graph — skipping", name,
+                        "head" if head is None else "encoder")
+            continue
+        meta = entry["meta"]
+        combined = hashlib.sha256()
+        for p in sorted([encoder, head], key=lambda p: p.name):
+            combined.update(_sha256_of(p).encode())
+        found.append(
+            {
+                "name": name,
+                "description": meta.get("hive.description"),
+                "kind": meta.get("hive.kind", _HIVE_KIND),
+                "encoder_filename": encoder.name,
+                "head_filename": head.name,
+                "sha256": combined.hexdigest(),
+                "input_size": _int(meta, "hive.input_size"),
+                "embed_dim": _int(meta, "hive.embed_dim"),
+                "meta_dim": _int(meta, "hive.meta_dim"),
+                "file_size": encoder.stat().st_size + head.stat().st_size,
+                "meta": meta,
+            }
+        )
+    return sorted(found, key=lambda m: m["name"])
+
+
+def reconcile(db: Session) -> list[LinkModel]:
+    """Sync link_models rows to the pairs on disk: insert new, refresh changed
+    (sha differs), drop vanished. Returns all rows after reconciliation."""
+    scanned = {m["name"]: m for m in scan_models()}
+    existing = {row.name: row for row in db.query(LinkModel).all()}
+
+    for name, m in scanned.items():
+        row = existing.get(name)
+        if row is None:
+            db.add(
+                LinkModel(
+                    name=name,
+                    description=m["description"],
+                    kind=m["kind"],
+                    encoder_filename=m["encoder_filename"],
+                    head_filename=m["head_filename"],
+                    sha256=m["sha256"],
+                    input_size=m["input_size"],
+                    embed_dim=m["embed_dim"],
+                    meta_dim=m["meta_dim"],
+                    file_size=m["file_size"],
+                    meta=m["meta"],
+                )
+            )
+        elif row.sha256 != m["sha256"] or row.encoder_filename != m["encoder_filename"] or row.head_filename != m["head_filename"]:
+            row.description = m["description"]
+            row.kind = m["kind"]
+            row.encoder_filename = m["encoder_filename"]
+            row.head_filename = m["head_filename"]
+            row.sha256 = m["sha256"]
+            row.input_size = m["input_size"]
+            row.embed_dim = m["embed_dim"]
+            row.meta_dim = m["meta_dim"]
+            row.file_size = m["file_size"]
+            row.meta = m["meta"]
+
+    for name, row in existing.items():
+        if name not in scanned:
+            db.delete(row)
+
+    db.commit()
+    return db.query(LinkModel).order_by(LinkModel.name.asc()).all()
+
+
+def get_active(db: Session) -> LinkModel | None:
+    return db.query(LinkModel).filter(LinkModel.is_active.is_(True)).first()
+
+
+def set_active(db: Session, model_id, active: bool) -> LinkModel | None:
+    row = db.query(LinkModel).filter(LinkModel.id == model_id).first()
+    if row is None:
+        return None
+    if active:
+        db.query(LinkModel).filter(LinkModel.id != model_id, LinkModel.is_active.is_(True)).update(
+            {LinkModel.is_active: False}
+        )
+        row.is_active = True
+    else:
+        row.is_active = False
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _load(row: LinkModel) -> _Loaded | None:
+    directory = model_dir()
+    enc_path = directory / row.encoder_filename
+    head_path = directory / row.head_filename
+    if not enc_path.exists() or not head_path.exists():
+        return None
+    key = (row.name, row.sha256)
+    with _lock:
+        cached = _session_cache.get(key)
+        if cached is not None:
+            return cached
+    if row.input_size <= 0:
+        log.warning("link model %s has no usable input_size", row.name)
+        return None
+    try:
+        so = ort.SessionOptions()
+        so.intra_op_num_threads = 2
+        encoder = ort.InferenceSession(str(enc_path), sess_options=so, providers=["CPUExecutionProvider"])
+        head = ort.InferenceSession(str(head_path), sess_options=so, providers=["CPUExecutionProvider"])
+    except Exception as exc:
+        log.warning("link model %s failed to load for inference: %s", row.name, exc)
+        return None
+    loaded = _Loaded(
+        encoder=encoder,
+        head=head,
+        enc_input=encoder.get_inputs()[0].name,
+        input_size=row.input_size,
+    )
+    with _lock:
+        _session_cache[key] = loaded
+    return loaded
+
+
+def _preprocess(data: bytes, size: int) -> np.ndarray | None:
+    try:
+        with Image.open(io.BytesIO(data)) as im:
+            im = im.convert("RGB").resize((size, size), Image.BILINEAR)
+            arr = np.asarray(im, dtype=np.float32) / 255.0
+    except Exception:
+        return None
+    return arr.transpose(2, 0, 1)
+
+
+def _candidate_meta(dt: float, channel: Optional[int], zone_code: Optional[int], deg: Optional[float]) -> np.ndarray:
+    """Port of color-model/piece_link/dataset.py::candidateMeta — keep in sync."""
+    deg_v = deg if deg is not None else 0.0
+    zone = zone_code if zone_code is not None else -1
+    at_exit = zone in (2, 3) or (deg is not None and abs(deg) < 20.0)
+    return np.array(
+        [
+            dt / 30.0,
+            math.log1p(max(dt, 0.0)) / 4.0,
+            1.0 if channel == 2 else 0.0,
+            1.0 if channel == 3 else 0.0,
+            1.0 if zone == 0 else 0.0,
+            1.0 if zone == 1 else 0.0,
+            1.0 if zone == 2 else 0.0,
+            1.0 if zone == 3 else 0.0,
+            deg_v / 180.0,
+            abs(deg_v) / 180.0,
+            1.0 if at_exit else 0.0,
+        ],
+        dtype=np.float32,
+    )
+
+
+def _anchor_keys(db: Session, machine_id: UUID, piece_uuid: str) -> list[str]:
+    rows = (
+        db.query(MachinePieceImage.channel, MachinePieceImage.seq, MachinePieceImage.image_key)
+        .filter(
+            MachinePieceImage.machine_id == machine_id,
+            MachinePieceImage.piece_uuid == piece_uuid,
+            MachinePieceImage.image_key.isnot(None),
+        )
+        .order_by(MachinePieceImage.seq.asc())
+        .all()
+    )
+    c4 = [r.image_key for r in rows if r.channel == DEFAULT_PARAMS.classification_channel_id]
+    keys = c4 if c4 else [r.image_key for r in rows]
+    return keys[:MAX_ANCHOR_VIEWS]
+
+
+def _crop_keys(db: Session, machine_id: UUID, local_ids: list[int]) -> dict[int, str]:
+    if not local_ids:
+        return {}
+    rows = (
+        db.query(MachineChannelCrop.local_id, MachineChannelCrop.image_key)
+        .filter(
+            MachineChannelCrop.machine_id == machine_id,
+            MachineChannelCrop.local_id.in_(local_ids),
+            MachineChannelCrop.image_key.isnot(None),
+        )
+        .all()
+    )
+    return {r.local_id: r.image_key for r in rows}
+
+
+def _embed(loaded: _Loaded, images: list[np.ndarray]) -> np.ndarray:
+    x = np.stack(images, axis=0)
+    return loaded.encoder.run(None, {loaded.enc_input: x})[0]
+
+
+def predict(db: Session, machine_id: UUID, piece_uuid: str, candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Score the heuristic's candidate set with the active link model.
+
+    ``candidates`` are the dicts from ``find_possible_crops`` (need: local_id,
+    channel, dt, zone_code, com_forward_to_exit_deg). Returns
+    ``{model_name, threshold, scores: {local_id: prob}}`` or None when no model
+    is active / the model can't be loaded / no anchor or crop is readable.
+    """
+    row = get_active(db)
+    if row is None:
+        return None
+    loaded = _load(row)
+    if loaded is None:
+        return None
+
+    anchor_imgs: list[np.ndarray] = []
+    for key in _anchor_keys(db, machine_id, piece_uuid):
+        try:
+            arr = _preprocess(get_backend().read_bytes(key), loaded.input_size)
+        except Exception:
+            arr = None
+        if arr is not None:
+            anchor_imgs.append(arr)
+            break  # training eval scores against a single anchor
+    if not anchor_imgs:
+        return None
+
+    local_ids = [c["local_id"] for c in candidates]
+    key_by_id = _crop_keys(db, machine_id, local_ids)
+
+    crop_imgs: list[np.ndarray] = []
+    metas: list[np.ndarray] = []
+    scored_ids: list[int] = []
+    for c in candidates:
+        key = key_by_id.get(c["local_id"])
+        if key is None:
+            continue
+        try:
+            arr = _preprocess(get_backend().read_bytes(key), loaded.input_size)
+        except Exception:
+            arr = None
+        if arr is None:
+            continue
+        crop_imgs.append(arr)
+        metas.append(_candidate_meta(c.get("dt") or 0.0, c.get("channel"), c.get("zone_code"), c.get("com_forward_to_exit_deg")))
+        scored_ids.append(c["local_id"])
+    if not crop_imgs:
+        return None
+
+    emb_a = _embed(loaded, anchor_imgs)[:1]  # (1, embed_dim)
+    emb_c = _embed(loaded, crop_imgs)  # (n, embed_dim)
+    meta = np.stack(metas, axis=0)  # (n, meta_dim)
+    emb_a_tiled = np.repeat(emb_a, len(crop_imgs), axis=0)
+    probs = loaded.head.run(
+        None,
+        {"emb_anchor": emb_a_tiled.astype(np.float32), "emb_candidate": emb_c.astype(np.float32), "meta": meta},
+    )[0]
+    probs = np.asarray(probs).reshape(-1)
+
+    return {
+        "model_name": row.name,
+        "threshold": PREDICT_THRESHOLD,
+        "scores": {lid: float(p) for lid, p in zip(scored_ids, probs)},
+    }
+
+
+def clear_cache() -> None:
+    with _lock:
+        _session_cache.clear()

--- a/software/hive/backend/app/services/rate_limit.py
+++ b/software/hive/backend/app/services/rate_limit.py
@@ -1,0 +1,87 @@
+"""Per-user, role-aware request rate limiting.
+
+A small self-contained token-bucket limiter used to cap how fast a windowed user
+can pull piece-bbox data — the window bounds *how much* of the set they can see,
+this bounds *how fast* they can drain it. Admins are exempt; reviewers get a
+generous cap (real labeling is bursty but bounded); members are tighter.
+
+In-memory and per-process. The dev/prod backend runs a single uvicorn worker so
+this is global there; if the deployment ever fans out to multiple workers the
+cap becomes per-worker (still a meaningful backstop). Move to Redis if a hard
+cross-process guarantee is ever needed.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from fastapi import Depends, HTTPException
+
+from app.deps import get_current_user
+from app.models.user import User
+
+WINDOW_S = 60.0
+
+# requests per WINDOW_S, per user, per bucket. None => unlimited for that role.
+LIMITS: dict[str, dict[str, int | None]] = {
+    # Image byte pulls — the primary exfil vector.
+    "labeling_image": {"member": 120, "reviewer": 600, "admin": None},
+    # Metadata list/detail calls that enumerate the set.
+    "labeling_list": {"member": 30, "reviewer": 180, "admin": None},
+}
+
+
+class _Bucket:
+    __slots__ = ("tokens", "updated")
+
+    def __init__(self, tokens: float, updated: float) -> None:
+        self.tokens = tokens
+        self.updated = updated
+
+
+class RateLimiter:
+    def __init__(self) -> None:
+        self._buckets: dict[str, _Bucket] = {}
+        self._lock = threading.Lock()
+
+    def check(self, key: str, limit: int, window_s: float) -> tuple[bool, int]:
+        """Consume one token. Returns (allowed, retry_after_seconds)."""
+        now = time.monotonic()
+        rate = limit / window_s
+        with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = _Bucket(float(limit), now)
+                self._buckets[key] = bucket
+            else:
+                bucket.tokens = min(float(limit), bucket.tokens + (now - bucket.updated) * rate)
+                bucket.updated = now
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                return True, 0
+            retry_after = int((1.0 - bucket.tokens) / rate) + 1
+            return False, retry_after
+
+
+_limiter = RateLimiter()
+
+
+def rate_limit(bucket: str):
+    """FastAPI dependency factory. Caps the caller on ``bucket`` by their role."""
+
+    def dependency(current_user: User = Depends(get_current_user)) -> None:
+        role_limits = LIMITS.get(bucket, {})
+        # Unknown roles fall back to the tightest configured limit.
+        limit = role_limits.get(current_user.role, role_limits.get("member"))
+        if limit is None:
+            return
+        allowed, retry_after = _limiter.check(f"{bucket}:{current_user.id}", limit, WINDOW_S)
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded. Slow down.",
+                headers={"Retry-After": str(retry_after)},
+            )
+
+    return dependency

--- a/software/hive/backend/app/services/storage_backend.py
+++ b/software/hive/backend/app/services/storage_backend.py
@@ -214,9 +214,21 @@ class S3StorageBackend(StorageBackend):
                 # "Response content shorter than Content-Length" because the
                 # 307 has an empty body. Skip it — the actual S3 GET will
                 # set its own Content-Length.
-                if name.lower() == "content-length":
+                #
+                # Cache-Control from the caller (e.g. "immutable, max-age=1yr")
+                # describes the immutable image BYTES, not this redirect. The
+                # redirect carries a presigned URL that expires after
+                # presigned_expiry seconds, so caching it long-term makes the
+                # browser replay an expired signature — S3 answers 403 and the
+                # image silently breaks. Cap the redirect's own lifetime below
+                # the signature's, so a re-fetch remints a fresh URL in time.
+                if name.lower() in ("content-length", "cache-control"):
                     continue
                 response.headers[name] = value
+            # Buffer under the signature expiry to absorb modest clock skew and
+            # in-flight requests started just before the cached redirect lapses.
+            redirect_ttl = max(0, self.presigned_expiry - 300)
+            response.headers["Cache-Control"] = f"private, max-age={redirect_ttl}"
             return response
 
         try:

--- a/software/hive/docker-compose.prod.yml
+++ b/software/hive/docker-compose.prod.yml
@@ -54,6 +54,9 @@ services:
       # so it survives container recreates — otherwise every redeploy wipes it
       # and forces a full multi-hour re-sync from Rebrickable.
       - ./data/profile_builder:/app/data/profile_builder
+      # Color-classifier ONNX models, uploaded out of band (scp) and scanned
+      # into the color_models table. Bind-mounted so they survive recreates.
+      - ./data/color_models:/app/data/color_models
     networks:
       - default
       - web

--- a/software/hive/docker-compose.prod.yml
+++ b/software/hive/docker-compose.prod.yml
@@ -57,6 +57,9 @@ services:
       # Color-classifier ONNX models, uploaded out of band (scp) and scanned
       # into the color_models table. Bind-mounted so they survive recreates.
       - ./data/color_models:/app/data/color_models
+      # piece_link matcher models (encoder+head ONNX pairs), uploaded out of band
+      # (scp) and scanned into the link_models table. Bind-mounted to survive recreates.
+      - ./data/link_models:/app/data/link_models
     networks:
       - default
       - web

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -1177,11 +1177,36 @@ export interface ColorModelsResponse {
 	model_dir: string;
 }
 
-// A "possibly the same piece" upstream C2/C3 crop candidate, ranked by the
-// shared time/angle heuristic. `predicted` = the heuristic's default selection.
-// `ai_same` = a stored vision-model verdict (true/false for crops it was shown,
-// null when it wasn't shown this crop or no AI prediction has been run). The UI
-// pre-selects `ai_same` over `predicted` when a prediction exists.
+// A piece_link matcher model: a pair of ONNX graphs (encoder + head) grouped by
+// name. The active one scores same-piece upstream crops in the labeling view.
+export interface LinkModel {
+	id: string;
+	name: string;
+	description: string | null;
+	kind: string;
+	encoder_filename: string;
+	head_filename: string;
+	sha256: string;
+	input_size: number;
+	embed_dim: number;
+	meta_dim: number;
+	file_size: number;
+	is_active: boolean;
+	updated_at: string | null;
+}
+
+export interface LinkModelsResponse {
+	models: LinkModel[];
+	model_dir: string;
+}
+
+// A "possibly the same piece" upstream C2/C3 crop candidate. `score` +
+// `predicted` are the shared time/angle heuristic's confidence and default
+// selection (kept untouched — they feed the was_predicted training signal).
+// `ai_same` = a stored vision-model (VLM) verdict; `model_same`/`model_score` =
+// the active link matcher model's pick and probability (null when not scored /
+// no model active). The UI pre-selects, in precedence order, `ai_same` →
+// `model_same` → `predicted`, per `prediction_source`.
 export interface PossibleCropCandidate {
 	local_id: number;
 	channel: number | null;
@@ -1193,6 +1218,8 @@ export interface PossibleCropCandidate {
 	score: number;
 	predicted: boolean;
 	ai_same: boolean | null;
+	model_same: boolean | null;
+	model_score: number | null;
 	available: boolean;
 }
 
@@ -1206,9 +1233,11 @@ export interface PossibleCropsResult {
 	arrival_ts: string | null;
 	candidates: PossibleCropCandidate[];
 	my_link: PieceCropLinkMember[];
-	prediction_source: 'ai' | 'heuristic';
+	prediction_source: 'ai' | 'model' | 'heuristic';
 	ai_model: string | null;
 	ai_reasoning: string | null;
+	// Name of the active link matcher model when prediction_source === 'model'.
+	link_model: string | null;
 	// Present only on the ai-predict POST response.
 	ai_cost_usd?: number | null;
 	ai_elapsed_ms?: number | null;
@@ -1482,6 +1511,24 @@ export const api = {
 		return request<{ ok: boolean; model: ColorModel }>(
 			'POST',
 			`/api/color-models/${modelId}/deactivate`
+		);
+	},
+
+	// Link models (admin): scan/list the piece_link matcher pairs on disk and
+	// pick the active one that scores same-piece crops in the labeling view.
+	listLinkModels() {
+		return request<LinkModelsResponse>('GET', '/api/link-models');
+	},
+	activateLinkModel(modelId: string) {
+		return request<{ ok: boolean; model: LinkModel }>(
+			'POST',
+			`/api/link-models/${modelId}/activate`
+		);
+	},
+	deactivateLinkModel(modelId: string) {
+		return request<{ ok: boolean; model: LinkModel }>(
+			'POST',
+			`/api/link-models/${modelId}/deactivate`
 		);
 	},
 	createMachine(name: string, description?: string) {

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -978,6 +978,21 @@ export interface ColorLabelStats {
 	labeler_histogram: { '0': number; '1': number; '2': number; '3+': number };
 }
 
+export interface ColorCoverageEntry {
+	id: number;
+	name: string;
+	rgb: string | null;
+	is_trans: boolean;
+	pieces: number;
+	labels: number;
+}
+
+export interface ColorCoverageResponse {
+	colors: ColorCoverageEntry[];
+	total_colors: number;
+	covered_colors: number;
+}
+
 export type ColorLabelSort =
 	| 'priority'
 	| 'recent'
@@ -986,6 +1001,7 @@ export type ColorLabelSort =
 	| 'most_color'
 	| 'least_crop'
 	| 'most_crop'
+	| 'rare_color'
 	| 'needs_me';
 
 export interface ColorLabelPieceCard {
@@ -1261,6 +1277,10 @@ export const api = {
 	colorLabelStats(opts: { machineId?: string | null } = {}) {
 		const qs = opts.machineId ? `?machine_id=${opts.machineId}` : '';
 		return request<ColorLabelStats>('GET', `/api/labeling/stats${qs}`);
+	},
+	colorCoverage(opts: { machineId?: string | null } = {}) {
+		const qs = opts.machineId ? `?machine_id=${opts.machineId}` : '';
+		return request<ColorCoverageResponse>('GET', `/api/labeling/color-coverage${qs}`);
 	},
 	colorLabelQueue(opts: { onlyUnlabeled?: boolean; limit?: number; offset?: number } = {}) {
 		const params = new URLSearchParams();

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -1148,6 +1148,21 @@ export interface PossibleCropsResult {
 	ai_elapsed_ms?: number | null;
 }
 
+export interface AccessWindow {
+	role: string;
+	entity: string;
+	anchor: 'oldest' | 'newest';
+	size: number;
+	offset: number;
+	source: 'override' | 'default';
+	updated_at: string | null;
+}
+
+export interface AccessWindowsResponse {
+	admin: string;
+	windows: AccessWindow[];
+}
+
 export const api = {
 	// Auth
 	register(email: string, password: string, display_name: string) {
@@ -1791,6 +1806,14 @@ export const api = {
 	},
 	deleteUser(id: string) {
 		return request<void>('DELETE', `/api/admin/users/${id}`);
+	},
+
+	// Admin: access windows (how much of the piece-bbox dataset each role can see)
+	getAccessWindows() {
+		return request<AccessWindowsResponse>('GET', '/api/admin/access-windows');
+	},
+	updateAccessWindow(role: string, entity: string, data: { anchor: string; size: number; offset: number }) {
+		return request<AccessWindowsResponse>('PUT', `/api/admin/access-windows/${role}/${entity}`, data);
 	},
 
 	// Admin: parts catalog DB browser

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -105,6 +105,41 @@ export interface MachineOverviewStats {
 	computed_at: string | null;
 }
 
+export interface MachineCameraSpec {
+	model?: string | null;
+	width?: number | null;
+	height?: number | null;
+	fps?: number | null;
+	fourcc?: string | null;
+}
+
+export interface MachineControllerBoardSpec {
+	family?: string | null;
+	role?: string | null;
+	device_name?: string | null;
+	port?: string | null;
+}
+
+export interface MachineHardwareSpecs {
+	schema_version?: number | null;
+	booted_at?: string | null;
+	captured_at?: string | null;
+	platform?: {
+		model?: string | null;
+		arch?: string | null;
+		os?: { name?: string | null; sorter_os_version?: string | null } | null;
+	} | null;
+	software?: { version?: string | null; channel?: string | null; commit?: string | null } | null;
+	system?: { ram_bytes?: number | null; disk_total_bytes?: number | null; cpu_count?: number | null } | null;
+	config?: {
+		machine_setup?: string | null;
+		feeder_mode?: string | null;
+		classification_channel_mode?: string | null;
+	} | null;
+	cameras?: Record<string, MachineCameraSpec> | null;
+	controller_boards?: Record<string, MachineControllerBoardSpec> | null;
+}
+
 export interface MachineOverview {
 	machine: {
 		id: string;
@@ -117,7 +152,7 @@ export interface MachineOverview {
 		local_ui_port: string | null;
 		created_at: string | null;
 		token_prefix: string;
-		hardware_info: Record<string, unknown> | null;
+		hardware_info: MachineHardwareSpecs | null;
 		owner: { display_name: string | null; email: string | null };
 	};
 	stats: MachineOverviewStats;
@@ -1082,7 +1117,7 @@ export interface ColorLabelPieceDetail {
 	pixel_guess: ColorLabelPixelGuess | null;
 	model_prediction: ColorModelPrediction | null;
 	images: ColorLabelQueueImage[];
-	my_label: { color_id: number; notes: string | null } | null;
+	my_label: { color_id: number | null; cant_tell: boolean; notes: string | null } | null;
 	my_rejection: { reasons: string[] } | null;
 	prediction: ColorLabelPrediction;
 	correction: ColorLabelCorrection;
@@ -1115,7 +1150,7 @@ export interface ColorLabelQueueItem {
 	part: { part_id: string | null; part_name: string | null };
 	pixel_guess: ColorLabelPixelGuess | null;
 	images: ColorLabelQueueImage[];
-	my_label: { color_id: number; notes: string | null } | null;
+	my_label: { color_id: number | null; notes: string | null } | null;
 }
 
 export interface ColorLabelQueue {
@@ -1329,7 +1364,13 @@ export const api = {
 			`/api/labeling/piece/${machineId}/${encodeURIComponent(pieceUuid)}`
 		);
 	},
-	submitColorLabel(body: { machine_id: string; piece_uuid: string; color_id: number; notes?: string | null }) {
+	submitColorLabel(body: {
+		machine_id: string;
+		piece_uuid: string;
+		color_id?: number | null;
+		cant_tell?: boolean;
+		notes?: string | null;
+	}) {
 		return request<{ ok: boolean; created: boolean; labeled_by_me: number }>(
 			'POST',
 			'/api/labeling',

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -739,6 +739,19 @@ function resolveApiPath(path: string): string {
 	return `${base}${path}`;
 }
 
+// Stored-image endpoints briefly shipped a 1-year `immutable` Cache-Control that
+// (in S3 redirect mode) landed on the 307 redirect, poisoning browser caches
+// with presigned URLs that expire in an hour — thumbnails then 403'd forever
+// and a reload couldn't evict an `immutable` entry. Bump this to change the URL
+// and force a one-time re-fetch past those poisoned entries. Only needs bumping
+// again if a stale long-lived cache header ever ships anew.
+const IMAGE_CACHE_BUST = '2';
+
+function resolveImagePath(path: string): string {
+	const sep = path.includes('?') ? '&' : '?';
+	return resolveApiPath(`${path}${sep}cb=${IMAGE_CACHE_BUST}`);
+}
+
 function getCsrfToken(): string | null {
 	const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/);
 	return match ? decodeURIComponent(match[1]) : null;
@@ -1203,7 +1216,7 @@ export const api = {
 		);
 	},
 	machinePieceImageUrl(machineId: string, pieceUuid: string, seq: number) {
-		return resolveApiPath(
+		return resolveImagePath(
 			`/api/machines/${machineId}/pieces/${encodeURIComponent(pieceUuid)}/images/${seq}`
 		);
 	},
@@ -1223,7 +1236,7 @@ export const api = {
 		);
 	},
 	machineChannelCropImageUrl(machineId: string, localId: number) {
-		return resolveApiPath(`/api/machines/${machineId}/channel-crops/${localId}/image`);
+		return resolveImagePath(`/api/machines/${machineId}/channel-crops/${localId}/image`);
 	},
 
 	// Color labeling
@@ -1291,7 +1304,7 @@ export const api = {
 		);
 	},
 	colorLabelImageUrl(machineId: string, pieceUuid: string, seq: number) {
-		return resolveApiPath(
+		return resolveImagePath(
 			`/api/labeling/pieces/${machineId}/${encodeURIComponent(pieceUuid)}/images/${seq}`
 		);
 	},
@@ -1311,7 +1324,7 @@ export const api = {
 		);
 	},
 	channelCropLabelImageUrl(machineId: string, localId: number) {
-		return resolveApiPath(`/api/labeling/channel-crops/${machineId}/${localId}/image`);
+		return resolveImagePath(`/api/labeling/channel-crops/${machineId}/${localId}/image`);
 	},
 	savePieceCropLink(body: {
 		machine_id: string;

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -1026,6 +1026,21 @@ export interface ColorLabelPiecesPage {
 	sort: ColorLabelSort;
 }
 
+export interface MachineLabeledPiece {
+	piece_uuid: string;
+	thumb_seq: number | null;
+	color_id: number;
+	color_name: string;
+	rgb: string | null;
+	is_trans: boolean;
+	label_count: number;
+}
+
+export interface MachineLabeledPiecesResponse {
+	items: MachineLabeledPiece[];
+	total: number;
+}
+
 export interface ColorLabelPrediction {
 	color_id: string | null;
 	color_name: string | null;
@@ -1360,6 +1375,25 @@ export const api = {
 	},
 	channelCropLabelImageUrl(machineId: string, localId: number) {
 		return resolveImagePath(`/api/labeling/channel-crops/${machineId}/${localId}/image`);
+	},
+
+	// Same-machine labeled reference pieces (color-range calibration column)
+	machineLabeledPieces(
+		machineId: string,
+		opts: { anchorPiece: string; excludePiece?: string | null; limit?: number }
+	) {
+		const params = new URLSearchParams({ anchor_piece: opts.anchorPiece });
+		if (opts.excludePiece) params.set('exclude_piece', opts.excludePiece);
+		if (opts.limit) params.set('limit', String(opts.limit));
+		return request<MachineLabeledPiecesResponse>(
+			'GET',
+			`/api/labeling/machine/${machineId}/labeled-pieces?${params.toString()}`
+		);
+	},
+	machineLabeledPieceImageUrl(machineId: string, pieceUuid: string, seq: number) {
+		return resolveImagePath(
+			`/api/labeling/machine/${machineId}/labeled-pieces/${encodeURIComponent(pieceUuid)}/image?seq=${seq}`
+		);
 	},
 	savePieceCropLink(body: {
 		machine_id: string;

--- a/software/hive/frontend/src/lib/components/MachineLabeledPieces.svelte
+++ b/software/hive/frontend/src/lib/components/MachineLabeledPieces.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { api, type MachineLabeledPiece } from '$lib/api';
 	import Spinner from '$lib/components/Spinner.svelte';
+	import ZoomImage from '$lib/components/ZoomImage.svelte';
 
 	// Color-range reference column: other already-labeled pieces on THIS machine,
 	// human ground-truth only (never model output), sorted into a hue gradient so
@@ -66,10 +67,9 @@
 				>
 					<div class="flex h-12 w-12 shrink-0 items-center justify-center bg-bg">
 						{#if it.thumb_seq != null}
-							<img
+							<ZoomImage
 								src={api.machineLabeledPieceImageUrl(machineId, it.piece_uuid, it.thumb_seq)}
 								alt={it.color_name}
-								loading="lazy"
 								class="h-12 w-12 bg-transparent object-contain"
 							/>
 						{/if}

--- a/software/hive/frontend/src/lib/components/MachineLabeledPieces.svelte
+++ b/software/hive/frontend/src/lib/components/MachineLabeledPieces.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import { api, type MachineLabeledPiece } from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
+
+	// Color-range reference column: other already-labeled pieces on THIS machine,
+	// human ground-truth only (never model output), sorted into a hue gradient so
+	// the labeler can calibrate — "this machine's dark tan looks like that, so the
+	// lighter one I'm on is probably plain tan."
+	let { machineId, pieceUuid }: { machineId: string; pieceUuid: string } = $props();
+
+	let items = $state<MachineLabeledPiece[]>([]);
+	let total = $state(0);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	async function load(mid: string, puid: string) {
+		loading = true;
+		error = null;
+		try {
+			const res = await api.machineLabeledPieces(mid, {
+				anchorPiece: puid,
+				excludePiece: puid,
+				limit: 200
+			});
+			items = res.items;
+			total = res.total;
+		} catch {
+			error = 'Failed to load';
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		const mid = machineId;
+		const puid = pieceUuid;
+		if (mid && puid) void load(mid, puid);
+	});
+</script>
+
+<div class="border border-border bg-surface">
+	<div class="border-b border-border px-3 py-2">
+		<div class="text-sm font-medium text-text">Labeled on this machine</div>
+		<div class="text-xs text-text-muted">
+			{#if !loading && total > 0}
+				{total} labeled piece{total === 1 ? '' : 's'} · color range for reference
+			{:else}
+				this machine's known colors, for reference
+			{/if}
+		</div>
+	</div>
+
+	{#if loading}
+		<div class="flex justify-center py-8"><Spinner /></div>
+	{:else if error}
+		<div class="p-3 text-sm text-primary">{error}</div>
+	{:else if items.length === 0}
+		<p class="p-4 text-sm text-text-muted">This machine has no pieces labeled yet.</p>
+	{:else}
+		<div class="flex flex-col">
+			{#each items as it (it.piece_uuid)}
+				<a
+					href={`/piece-bboxes/${machineId}/${encodeURIComponent(it.piece_uuid)}`}
+					class="flex items-center gap-2 border-b border-border px-2 py-1.5 last:border-b-0 hover:bg-bg"
+					title={`${it.color_name} (${it.color_id}) · ${it.label_count} labeler${it.label_count === 1 ? '' : 's'}`}
+				>
+					<div class="flex h-12 w-12 shrink-0 items-center justify-center bg-bg">
+						{#if it.thumb_seq != null}
+							<img
+								src={api.machineLabeledPieceImageUrl(machineId, it.piece_uuid, it.thumb_seq)}
+								alt={it.color_name}
+								loading="lazy"
+								class="h-12 w-12 bg-transparent object-contain"
+							/>
+						{/if}
+					</div>
+					<span
+						class="h-4 w-4 shrink-0 border border-border {it.is_trans ? 'opacity-70' : ''}"
+						style={`background:#${it.rgb ?? '000'}`}
+					></span>
+					<span class="min-w-0 flex-1 truncate text-xs text-text-muted">{it.color_name}</span>
+				</a>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/software/hive/frontend/src/lib/components/PaletteCoverage.svelte
+++ b/software/hive/frontend/src/lib/components/PaletteCoverage.svelte
@@ -20,7 +20,7 @@
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let open = $state(false);
-	let showAll = $state(false);
+	let showAll = $state(true);
 
 	function isExotic(c: ColorCoverageEntry): boolean {
 		return c.is_trans || EXOTIC_FINISH.test(c.name);
@@ -143,33 +143,7 @@
 					</div>
 				</div>
 
-				<!-- Gaps: what we're missing -->
-				{#if gaps.length > 0}
-					<div class="mb-1.5 flex items-baseline gap-2">
-						<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">Coverage gaps</span>
-						<span class="text-xs text-text-muted">
-							no labeled pieces yet · {solidGapCount} solid
-						</span>
-					</div>
-					<div class="mb-4 flex flex-wrap gap-1.5">
-						{#each gaps as c (c.id)}
-							<span
-								class="flex items-center gap-1.5 border border-dashed border-border bg-bg py-0.5 pl-0.5 pr-1.5"
-								title={`${c.name} (${c.id}) — no labeled pieces`}
-							>
-								<span
-									class="h-4 w-4 shrink-0 border border-border {c.is_trans ? 'opacity-70' : ''}"
-									style={`background:#${c.rgb ?? '000'}`}
-								></span>
-								<span class="max-w-[9rem] truncate text-xs text-text-muted">{c.name}</span>
-							</span>
-						{/each}
-					</div>
-				{:else}
-					<p class="mb-4 text-sm text-text-muted">Every palette color has at least one labeled piece.</p>
-				{/if}
-
-				<!-- Full palette, clustered by hue -->
+				<!-- Full palette, clustered by hue (open by default) -->
 				<button
 					type="button"
 					class="mb-2 flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-text-muted hover:text-text"
@@ -179,7 +153,7 @@
 					Full palette ({totalColors})
 				</button>
 				{#if showAll}
-					<div class="flex flex-wrap gap-1">
+					<div class="mb-4 flex flex-wrap gap-1">
 						{#each sortedByHue as c (c.id)}
 							<span
 								class="flex h-9 w-9 flex-col items-center justify-center border text-[10px] leading-none tabular-nums {c.pieces ===
@@ -197,6 +171,32 @@
 							</span>
 						{/each}
 					</div>
+				{/if}
+
+				<!-- Gaps: what we're missing -->
+				{#if gaps.length > 0}
+					<div class="mb-1.5 flex items-baseline gap-2">
+						<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">Coverage gaps</span>
+						<span class="text-xs text-text-muted">
+							no labeled pieces yet · {solidGapCount} solid
+						</span>
+					</div>
+					<div class="flex flex-wrap gap-1.5">
+						{#each gaps as c (c.id)}
+							<span
+								class="flex items-center gap-1.5 border border-dashed border-border bg-bg py-0.5 pl-0.5 pr-1.5"
+								title={`${c.name} (${c.id}) — no labeled pieces`}
+							>
+								<span
+									class="h-4 w-4 shrink-0 border border-border {c.is_trans ? 'opacity-70' : ''}"
+									style={`background:#${c.rgb ?? '000'}`}
+								></span>
+								<span class="max-w-[9rem] truncate text-xs text-text-muted">{c.name}</span>
+							</span>
+						{/each}
+					</div>
+				{:else}
+					<p class="text-sm text-text-muted">Every palette color has at least one labeled piece.</p>
 				{/if}
 			{/if}
 		</div>

--- a/software/hive/frontend/src/lib/components/PaletteCoverage.svelte
+++ b/software/hive/frontend/src/lib/components/PaletteCoverage.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+	import { api, type ColorCoverageEntry } from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import ChevronDown from 'lucide-svelte/icons/chevron-down';
+	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+
+	// Palette-coverage view: how well the labeled data covers the BrickLink color
+	// palette. Surfaces the gaps — "we have plenty of white, nothing from metallic
+	// grey" — so labelers know which colors to hunt for.
+	let { machineId = null }: { machineId?: string | null } = $props();
+
+	// Same non-solid finishes the picker down-weights; a labeled example of a plain
+	// solid colour is far more valuable, so the gaps list leads with solids.
+	const EXOTIC_FINISH =
+		/pearl|metallic|chrome|satin|trans|glow|speckle|glitter|glitr|milky|opal|iridescent|holo|copper|bionicle|\bgold\b|\bsilver\b/i;
+
+	let colors = $state<ColorCoverageEntry[]>([]);
+	let totalColors = $state(0);
+	let coveredColors = $state(0);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let open = $state(true);
+	let showAll = $state(false);
+
+	function isExotic(c: ColorCoverageEntry): boolean {
+		return c.is_trans || EXOTIC_FINISH.test(c.name);
+	}
+
+	// hex → HSL, for clustering visually-similar colors in the palette grid.
+	function hsl(hex: string | null): [number, number, number] {
+		if (!hex) return [0, 0, 0];
+		const m = hex.replace('#', '');
+		if (m.length < 6) return [0, 0, 0];
+		const r = parseInt(m.slice(0, 2), 16) / 255;
+		const g = parseInt(m.slice(2, 4), 16) / 255;
+		const b = parseInt(m.slice(4, 6), 16) / 255;
+		if ([r, g, b].some(Number.isNaN)) return [0, 0, 0];
+		const max = Math.max(r, g, b);
+		const min = Math.min(r, g, b);
+		const l = (max + min) / 2;
+		const d = max - min;
+		let h = 0;
+		const s = d === 0 ? 0 : d / (1 - Math.abs(2 * l - 1));
+		if (d !== 0) {
+			if (max === r) h = ((g - b) / d) % 6;
+			else if (max === g) h = (b - r) / d + 2;
+			else h = (r - g) / d + 4;
+			h *= 60;
+			if (h < 0) h += 360;
+		}
+		return [h, s, l];
+	}
+
+	// Grays (low saturation) sort as one block by lightness; the rest sort by hue,
+	// so a run of empty greys/metallics sits together and reads as a gap.
+	const sortedByHue = $derived.by(() => {
+		return [...colors].sort((a, b) => {
+			const [ha, sa, la] = hsl(a.rgb);
+			const [hb, sb, lb] = hsl(b.rgb);
+			const ga = sa < 0.15;
+			const gb = sb < 0.15;
+			if (ga !== gb) return ga ? -1 : 1;
+			if (ga && gb) return la - lb;
+			if (Math.abs(ha - hb) > 1) return ha - hb;
+			return la - lb;
+		});
+	});
+
+	// Actionable gap list: uncovered colors, solids first, then by name. Exotics
+	// still appear but after every solid gap.
+	const gaps = $derived.by(() =>
+		colors
+			.filter((c) => c.pieces === 0)
+			.sort((a, b) => {
+				const ea = isExotic(a) ? 1 : 0;
+				const eb = isExotic(b) ? 1 : 0;
+				if (ea !== eb) return ea - eb;
+				return a.name.localeCompare(b.name);
+			})
+	);
+	const solidGapCount = $derived(gaps.filter((c) => !isExotic(c)).length);
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const res = await api.colorCoverage({ machineId });
+			colors = res.colors;
+			totalColors = res.total_colors;
+			coveredColors = res.covered_colors;
+		} catch {
+			error = 'Failed to load coverage';
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		void machineId;
+		void load();
+	});
+</script>
+
+<div class="mb-6 border border-border bg-surface">
+	<button
+		type="button"
+		class="flex w-full items-center gap-2 px-4 py-2.5 text-left hover:bg-bg"
+		onclick={() => (open = !open)}
+	>
+		{#if open}<ChevronDown size={16} class="shrink-0 text-text-muted" />{:else}<ChevronRight
+				size={16}
+				class="shrink-0 text-text-muted"
+			/>{/if}
+		<span class="text-sm font-semibold text-text">Palette coverage</span>
+		{#if !loading}
+			<span class="text-xs text-text-muted">
+				{coveredColors} of {totalColors} colors have labeled pieces
+				{#if gaps.length > 0}· <span class="text-warning">{gaps.length} with none</span>{/if}
+			</span>
+		{/if}
+	</button>
+
+	{#if open}
+		<div class="border-t border-border p-4">
+			{#if loading}
+				<div class="flex justify-center py-8"><Spinner /></div>
+			{:else if error}
+				<div class="bg-primary/8 p-3 text-sm text-primary">{error}</div>
+			{:else}
+				<!-- Coverage bar -->
+				<div class="mb-4">
+					<div class="mb-1 flex h-2 w-full overflow-hidden border border-border">
+						<div
+							class="bg-success"
+							style={`width:${totalColors ? (coveredColors / totalColors) * 100 : 0}%`}
+							title={`${coveredColors} covered`}
+						></div>
+						<div class="flex-1 bg-border" title={`${gaps.length} uncovered`}></div>
+					</div>
+					<div class="text-xs text-text-muted">
+						<span class="text-text tabular-nums">{Math.round((coveredColors / Math.max(1, totalColors)) * 100)}%</span>
+						of the palette has at least one labeled piece.
+					</div>
+				</div>
+
+				<!-- Gaps: what we're missing -->
+				{#if gaps.length > 0}
+					<div class="mb-1.5 flex items-baseline gap-2">
+						<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">Coverage gaps</span>
+						<span class="text-xs text-text-muted">
+							no labeled pieces yet · {solidGapCount} solid
+						</span>
+					</div>
+					<div class="mb-4 flex flex-wrap gap-1.5">
+						{#each gaps as c (c.id)}
+							<span
+								class="flex items-center gap-1.5 border border-dashed border-border bg-bg py-0.5 pl-0.5 pr-1.5"
+								title={`${c.name} (${c.id}) — no labeled pieces`}
+							>
+								<span
+									class="h-4 w-4 shrink-0 border border-border {c.is_trans ? 'opacity-70' : ''}"
+									style={`background:#${c.rgb ?? '000'}`}
+								></span>
+								<span class="max-w-[9rem] truncate text-xs text-text-muted">{c.name}</span>
+							</span>
+						{/each}
+					</div>
+				{:else}
+					<p class="mb-4 text-sm text-text-muted">Every palette color has at least one labeled piece.</p>
+				{/if}
+
+				<!-- Full palette, clustered by hue -->
+				<button
+					type="button"
+					class="mb-2 flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-text-muted hover:text-text"
+					onclick={() => (showAll = !showAll)}
+				>
+					{#if showAll}<ChevronDown size={13} />{:else}<ChevronRight size={13} />{/if}
+					Full palette ({totalColors})
+				</button>
+				{#if showAll}
+					<div class="flex flex-wrap gap-1">
+						{#each sortedByHue as c (c.id)}
+							<span
+								class="flex h-9 w-9 flex-col items-center justify-center border text-[10px] leading-none tabular-nums {c.pieces ===
+								0
+									? 'border-dashed border-border text-text-muted'
+									: 'border-border text-text'}"
+								style={c.pieces > 0 ? `background:#${c.rgb ?? '000'}22` : ''}
+								title={`${c.name} (${c.id}) — ${c.pieces} piece${c.pieces === 1 ? '' : 's'}, ${c.labels} label${c.labels === 1 ? '' : 's'}`}
+							>
+								<span
+									class="mb-0.5 h-3.5 w-3.5 border border-border {c.is_trans ? 'opacity-70' : ''}"
+									style={`background:#${c.rgb ?? '000'}`}
+								></span>
+								{c.pieces}
+							</span>
+						{/each}
+					</div>
+				{/if}
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/software/hive/frontend/src/lib/components/PaletteCoverage.svelte
+++ b/software/hive/frontend/src/lib/components/PaletteCoverage.svelte
@@ -19,7 +19,7 @@
 	let coveredColors = $state(0);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
-	let open = $state(true);
+	let open = $state(false);
 	let showAll = $state(false);
 
 	function isExotic(c: ColorCoverageEntry): boolean {

--- a/software/hive/frontend/src/lib/components/ZoomImage.svelte
+++ b/software/hive/frontend/src/lib/components/ZoomImage.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	// Product-page style hover zoom: renders a thumbnail that, on hover, shows a
+	// large floating preview of the same image following the cursor. The preview
+	// is portaled to <body> so scrolling/overflow columns never clip it.
+	let {
+		src,
+		alt = '',
+		title = '',
+		class: cls = '',
+		zoom = 380
+	}: { src: string; alt?: string; title?: string; class?: string; zoom?: number } = $props();
+
+	let show = $state(false);
+	let mx = $state(0);
+	let my = $state(0);
+
+	const PAD = 10;
+	const style = $derived.by(() => {
+		if (typeof window === 'undefined') return '';
+		const size = zoom + 10;
+		// Prefer to the right of the cursor; flip left near the right edge.
+		let left = mx + 28;
+		if (left + size > window.innerWidth - PAD) left = mx - size - 28;
+		left = Math.max(PAD, left);
+		let top = my - size / 2;
+		top = Math.max(PAD, Math.min(top, window.innerHeight - size - PAD));
+		return `left:${left}px;top:${top}px;width:${zoom}px;height:${zoom}px;`;
+	});
+
+	function portal(node: HTMLElement) {
+		document.body.appendChild(node);
+		return { destroy: () => node.remove() };
+	}
+</script>
+
+<img
+	{src}
+	{alt}
+	{title}
+	loading="lazy"
+	class="{cls} cursor-zoom-in"
+	onmouseenter={() => (show = true)}
+	onmouseleave={() => (show = false)}
+	onmousemove={(e) => {
+		mx = e.clientX;
+		my = e.clientY;
+	}}
+/>
+
+{#if show}
+	<div
+		use:portal
+		class="pointer-events-none fixed z-[60] border border-border bg-surface p-1 shadow-xl"
+		style={style}
+	>
+		<img {src} alt="" class="h-full w-full bg-transparent object-contain" />
+	</div>
+{/if}

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -255,7 +255,11 @@
 		</nav>
 	{/if}
 
-	<main class="mx-auto max-w-7xl px-4 py-6">
+	<!-- The single-piece labeling view runs wider — it carries a reference column,
+	     the piece, and the color picker side by side. -->
+	<main
+		class="mx-auto px-4 py-6 {/^\/piece-bboxes\/.+/.test(page.url.pathname) ? 'max-w-[100rem]' : 'max-w-7xl'}"
+	>
 		{@render children()}
 	</main>
 {/if}

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -216,6 +216,16 @@
 										Parts Database
 									</a>
 									<a
+										href="/admin/access-windows"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										onclick={() => { dropdownOpen = false; }}
+									>
+										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+										</svg>
+										Access Windows
+									</a>
+									<a
 										href="/settings/catalog-sync"
 										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
 										onclick={() => { dropdownOpen = false; }}

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -206,6 +206,16 @@
 										Color Models
 									</a>
 									<a
+										href="/admin/link-models"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										onclick={() => { dropdownOpen = false; }}
+									>
+										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+											<path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+										</svg>
+										Link Models
+									</a>
+									<a
 										href="/admin/parts"
 										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
 										onclick={() => { dropdownOpen = false; }}

--- a/software/hive/frontend/src/routes/admin/access-windows/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/access-windows/+page.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import { auth } from '$lib/auth.svelte';
+	import { api, type AccessWindow } from '$lib/api';
+	import { goto } from '$app/navigation';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import Badge from '$lib/components/Badge.svelte';
+	import { Button } from '$lib/components/primitives';
+
+	let windows = $state<AccessWindow[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let savingKey = $state<string | null>(null);
+	let flash = $state<string | null>(null);
+
+	$effect(() => {
+		if (!auth.isAdmin) {
+			goto('/');
+			return;
+		}
+		load();
+	});
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const resp = await api.getAccessWindows();
+			windows = resp.windows;
+		} catch (e: any) {
+			error = e.error || 'Failed to load access windows';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function keyOf(w: AccessWindow) {
+		return `${w.role}/${w.entity}`;
+	}
+
+	async function save(w: AccessWindow) {
+		savingKey = keyOf(w);
+		error = null;
+		flash = null;
+		try {
+			const resp = await api.updateAccessWindow(w.role, w.entity, {
+				anchor: w.anchor,
+				size: w.size,
+				offset: w.offset
+			});
+			windows = resp.windows;
+			flash = `Saved ${w.role} / ${entityLabel(w.entity)}.`;
+		} catch (e: any) {
+			error = e.error || 'Failed to save window';
+		} finally {
+			savingKey = null;
+		}
+	}
+
+	function entityLabel(entity: string) {
+		return entity === 'piece' ? 'Pieces' : 'Channel crops';
+	}
+</script>
+
+<svelte:head>
+	<title>Access Windows - Hive</title>
+</svelte:head>
+
+<div class="mb-2 flex items-center justify-between">
+	<h1 class="text-2xl font-bold text-text">Access Windows</h1>
+	<span class="text-sm text-text-muted">Admins are unrestricted</span>
+</div>
+
+<p class="mb-6 max-w-3xl text-sm text-text-muted">
+	Bounds how much of the accumulating piece-bbox dataset each non-admin role can see and download.
+	A window is a contiguous slice ordered by upload time. <strong class="text-text">Oldest</strong> anchors
+	the slice to the start of the dataset, so it stays pinned to the same rows as new data arrives —
+	intended for plain members. <strong class="text-text">Newest</strong> anchors to the end, so it rolls
+	forward with fresh uploads — intended for reviewers. <strong class="text-text">Size</strong> is how many
+	rows are visible; <strong class="text-text">offset</strong> skips that many rows from the anchor.
+	Admins bypass all of this.
+</p>
+
+{#if error}
+	<div class="mb-4 bg-primary/8 p-3 text-sm text-primary">{error}</div>
+{/if}
+{#if flash}
+	<div class="mb-4 bg-success/[0.08] p-3 text-sm text-success">{flash}</div>
+{/if}
+
+{#if loading}
+	<div class="flex justify-center py-12">
+		<Spinner />
+	</div>
+{:else}
+	<div class="overflow-x-auto border border-border bg-surface">
+		<table class="min-w-full divide-y divide-border">
+			<thead class="bg-bg">
+				<tr>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Role</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Data</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Anchor</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Size</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Offset</th>
+					<th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-muted">Source</th>
+					<th class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-text-muted">Actions</th>
+				</tr>
+			</thead>
+			<tbody class="divide-y divide-border">
+				{#each windows as w (keyOf(w))}
+					<tr class="hover:bg-bg">
+						<td class="whitespace-nowrap px-6 py-4 text-sm font-medium capitalize text-text">{w.role}</td>
+						<td class="whitespace-nowrap px-6 py-4 text-sm text-text">{entityLabel(w.entity)}</td>
+						<td class="whitespace-nowrap px-6 py-4">
+							<select
+								bind:value={w.anchor}
+								class="border border-border bg-surface px-2 py-1 text-sm text-text"
+							>
+								<option value="oldest">oldest (pinned)</option>
+								<option value="newest">newest (rolling)</option>
+							</select>
+						</td>
+						<td class="whitespace-nowrap px-6 py-4">
+							<input
+								type="number"
+								min="0"
+								bind:value={w.size}
+								class="w-28 border border-border bg-surface px-2 py-1 text-sm text-text"
+							/>
+						</td>
+						<td class="whitespace-nowrap px-6 py-4">
+							<input
+								type="number"
+								min="0"
+								bind:value={w.offset}
+								class="w-24 border border-border bg-surface px-2 py-1 text-sm text-text"
+							/>
+						</td>
+						<td class="whitespace-nowrap px-6 py-4">
+							<Badge
+								text={w.source}
+								variant={w.source === 'override' ? 'info' : 'neutral'}
+							/>
+						</td>
+						<td class="whitespace-nowrap px-6 py-4 text-right">
+							<Button
+								variant="primary"
+								size="sm"
+								loading={savingKey === keyOf(w)}
+								onclick={() => save(w)}
+							>
+								Save
+							</Button>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+{/if}

--- a/software/hive/frontend/src/routes/admin/link-models/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/link-models/+page.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import { auth } from '$lib/auth.svelte';
+	import { api, type LinkModel } from '$lib/api';
+	import { goto } from '$app/navigation';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import { Alert, Button } from '$lib/components/primitives';
+
+	let models = $state<LinkModel[]>([]);
+	let modelDir = $state('');
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let busyId = $state<string | null>(null);
+
+	const activeModel = $derived(models.find((m) => m.is_active) ?? null);
+
+	$effect(() => {
+		// Wait for auth to initialize so a direct load / refresh of this URL
+		// doesn't bounce an admin out before their session is known.
+		if (!auth.initialized) return;
+		if (!auth.isAdmin) {
+			goto('/');
+			return;
+		}
+		void load();
+	});
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const res = await api.listLinkModels();
+			models = res.models;
+			modelDir = res.model_dir;
+		} catch (e: unknown) {
+			error = e && typeof e === 'object' && 'error' in e ? String((e as { error: unknown }).error) : 'Failed to load link models';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function activate(model: LinkModel) {
+		if (busyId) return;
+		busyId = model.id;
+		error = null;
+		try {
+			await api.activateLinkModel(model.id);
+			models = models.map((m) => ({ ...m, is_active: m.id === model.id }));
+		} catch (e: unknown) {
+			error = e && typeof e === 'object' && 'error' in e ? String((e as { error: unknown }).error) : 'Failed to activate model';
+		} finally {
+			busyId = null;
+		}
+	}
+
+	async function deactivate(model: LinkModel) {
+		if (busyId) return;
+		busyId = model.id;
+		error = null;
+		try {
+			await api.deactivateLinkModel(model.id);
+			models = models.map((m) => ({ ...m, is_active: false }));
+		} catch (e: unknown) {
+			error = e && typeof e === 'object' && 'error' in e ? String((e as { error: unknown }).error) : 'Failed to deactivate model';
+		} finally {
+			busyId = null;
+		}
+	}
+
+	function fmtSize(bytes: number): string {
+		if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+		if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+		return `${bytes} B`;
+	}
+</script>
+
+<svelte:head>
+	<title>Link Models · Hive</title>
+</svelte:head>
+
+<div class="space-y-5">
+	<div class="flex flex-wrap items-start justify-between gap-3">
+		<div>
+			<h1 class="text-2xl font-bold text-text">Link models</h1>
+			<p class="mt-1 max-w-2xl text-sm text-text-muted">
+				The active model scores which upstream C2/C3 crops are the same physical piece as a
+				classified piece, and its picks pre-select the same-piece panel in the labeling view — in
+				place of the time/angle heuristic. Each model is a pair of ONNX graphs
+				(<code>*.encoder.onnx</code> + <code>*.head.onnx</code>) uploaded to the scan directory on
+				the server; this page reflects whatever is on disk.
+			</p>
+		</div>
+		<Button variant="secondary" size="sm" onclick={load} loading={loading}>Rescan</Button>
+	</div>
+
+	{#if modelDir}
+		<p class="text-xs text-text-muted">
+			Scan directory: <code class="bg-bg px-1.5 py-0.5 text-text">{modelDir}</code>
+		</p>
+	{/if}
+
+	{#if error}
+		<Alert variant="danger">{error}</Alert>
+	{/if}
+
+	{#if loading}
+		<div class="flex justify-center py-16"><Spinner /></div>
+	{:else if models.length === 0}
+		<div class="border border-border bg-surface px-4 py-10 text-center text-sm text-text-muted">
+			No link models found in the scan directory. Upload an encoder+head <code>.onnx</code> pair there
+			and hit Rescan.
+		</div>
+	{:else}
+		<div class="border border-border bg-surface">
+			<div class="flex items-center justify-between border-b border-border bg-bg px-4 py-2">
+				<span class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+					{models.length} model{models.length === 1 ? '' : 's'} on disk
+				</span>
+				<span class="text-xs text-text-muted">
+					{#if activeModel}
+						Active: <span class="font-medium text-text">{activeModel.name}</span>
+					{:else}
+						None active — using time/angle heuristic
+					{/if}
+				</span>
+			</div>
+
+			{#each models as m (m.id)}
+				<div class="flex flex-wrap items-center gap-4 border-b border-border px-4 py-3 last:border-b-0 {m.is_active ? 'bg-primary-light/30' : ''}">
+					<div class="min-w-0 flex-1">
+						<div class="flex flex-wrap items-center gap-2">
+							<span class="font-medium text-text">{m.name}</span>
+							{#if m.is_active}
+								<span class="border border-primary/30 bg-primary-light px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-primary">Active</span>
+							{/if}
+						</div>
+						{#if m.description}
+							<p class="mt-0.5 truncate text-xs text-text-muted">{m.description}</p>
+						{/if}
+						<p class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-text-muted">
+							<span><code class="text-text-muted">{m.encoder_filename}</code> + <code class="text-text-muted">{m.head_filename}</code></span>
+							<span>{m.input_size}×{m.input_size}</span>
+							<span>{m.embed_dim}-d embed</span>
+							<span>{m.meta_dim} meta</span>
+							<span>{fmtSize(m.file_size)}</span>
+							<span title={m.sha256}>sha {m.sha256.slice(0, 10)}</span>
+						</p>
+					</div>
+					<div class="flex items-center gap-2">
+						{#if m.is_active}
+							<Button variant="secondary" size="sm" loading={busyId === m.id} onclick={() => deactivate(m)}>
+								Deactivate
+							</Button>
+						{:else}
+							<Button variant="primary" size="sm" loading={busyId === m.id} onclick={() => activate(m)}>
+								Activate
+							</Button>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<p class="text-xs text-text-muted">
+			Only one model is active at a time. Deactivating leaves the labeling view on the time/angle
+			heuristic.
+		</p>
+	{/if}
+</div>

--- a/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
@@ -26,6 +26,9 @@
 	const machine = $derived(overview?.machine ?? null);
 	const stats = $derived(overview?.stats ?? null);
 	const isOwner = $derived(overview?.is_owner ?? false);
+	const specs = $derived(machine?.hardware_info ?? null);
+	const cameraSpecs = $derived(Object.entries(specs?.cameras ?? {}));
+	const boardSpecs = $derived(Object.entries(specs?.controller_boards ?? {}));
 	const isOnline = $derived(
 		!!machine?.last_seen_at && Date.now() - new Date(machine.last_seen_at).getTime() < 5 * 60 * 1000
 	);
@@ -60,6 +63,29 @@
 		const h = seconds / 3600;
 		if (h >= 1) return `${h.toFixed(1)}h`;
 		return `${Math.round(seconds / 60)}m`;
+	}
+
+	function prettyRole(role: string): string {
+		return role.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+
+	function bytesToGb(n: number | null | undefined): string {
+		if (!n || n <= 0) return '—';
+		const gb = n / 1e9;
+		return `${gb >= 100 ? Math.round(gb) : gb.toFixed(1)} GB`;
+	}
+
+	function resolution(cam: { width?: number | null; height?: number | null; fps?: number | null }): string {
+		const res = cam.width && cam.height ? `${cam.width}×${cam.height}` : null;
+		const fps = cam.fps ? `${cam.fps} fps` : null;
+		return [res, fps].filter(Boolean).join(' · ') || '—';
+	}
+
+	function boardLabel(board: {
+		family?: string | null;
+		device_name?: string | null;
+	}): string {
+		return [board.device_name, board.family].filter(Boolean).join(' · ') || '—';
 	}
 
 	function triggerVariant(trigger: string): 'success' | 'neutral' | 'warning' {
@@ -370,6 +396,92 @@
 						{/each}
 					</div>
 				{/if}
+			</section>
+		{/if}
+
+		<!-- Machine specs (owner + admins only; the page itself is already owner/admin-gated) -->
+		{#if specs && (isOwner || overview.viewer_is_admin)}
+			<section class="mt-8">
+				<h2 class="text-lg font-semibold text-text">Machine specs</h2>
+				<div class="mt-3 border border-border bg-surface p-5">
+					<dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
+						<div>
+							<dt class="text-text-muted">Platform</dt>
+							<dd class="text-text">{specs.platform?.model || '—'}</dd>
+						</div>
+						<div>
+							<dt class="text-text-muted">Operating system</dt>
+							<dd class="text-text">
+								{specs.platform?.os?.name || '—'}
+								{#if specs.platform?.os?.sorter_os_version}
+									<span class="text-text-muted"> · {specs.platform.os.sorter_os_version}</span>
+								{/if}
+							</dd>
+						</div>
+						<div>
+							<dt class="text-text-muted">Software</dt>
+							<dd class="text-text">
+								{specs.software?.version || '—'}
+								{#if specs.software?.channel}
+									<span class="text-text-muted"> · {specs.software.channel}</span>
+								{/if}
+							</dd>
+						</div>
+						{#if specs.system?.ram_bytes}
+							<div>
+								<dt class="text-text-muted">Memory</dt>
+								<dd class="text-text">{bytesToGb(specs.system.ram_bytes)}</dd>
+							</div>
+						{/if}
+						{#if specs.system?.disk_total_bytes}
+							<div>
+								<dt class="text-text-muted">Storage</dt>
+								<dd class="text-text">{bytesToGb(specs.system.disk_total_bytes)}</dd>
+							</div>
+						{/if}
+						{#if specs.config?.machine_setup}
+							<div>
+								<dt class="text-text-muted">Setup</dt>
+								<dd class="text-text">{specs.config.machine_setup}</dd>
+							</div>
+						{/if}
+					</dl>
+
+					{#if cameraSpecs.length > 0}
+						<div class="mt-5 border-t border-border pt-4">
+							<h3 class="text-xs font-medium uppercase tracking-wider text-text-muted">Cameras</h3>
+							<dl class="mt-2 grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-3">
+								{#each cameraSpecs as [role, cam] (role)}
+									<div>
+										<dt class="text-text">{prettyRole(role)}</dt>
+										<dd class="text-text-muted">
+											{cam.model || 'Camera'}
+											<span class="block tabular-nums">{resolution(cam)}</span>
+										</dd>
+									</div>
+								{/each}
+							</dl>
+						</div>
+					{/if}
+
+					{#if boardSpecs.length > 0}
+						<div class="mt-5 border-t border-border pt-4">
+							<h3 class="text-xs font-medium uppercase tracking-wider text-text-muted">Controller boards</h3>
+							<dl class="mt-2 grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-3">
+								{#each boardSpecs as [key, board] (key)}
+									<div>
+										<dt class="text-text">{prettyRole(board.role || key)}</dt>
+										<dd class="text-text-muted">{boardLabel(board)}</dd>
+									</div>
+								{/each}
+							</dl>
+						</div>
+					{/if}
+
+					{#if specs.captured_at}
+						<p class="mt-4 text-xs text-text-muted">As of {formatDate(specs.captured_at)}.</p>
+					{/if}
+				</div>
 			</section>
 		{/if}
 	{/if}

--- a/software/hive/frontend/src/routes/piece-bboxes/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/+page.svelte
@@ -23,6 +23,7 @@
 
 	const SORTS: { value: ColorLabelSort; label: string }[] = [
 		{ value: 'priority', label: 'Priority (candidates, least-labeled)' },
+		{ value: 'rare_color', label: 'Likely rare color (low-confidence, near a rare color)' },
 		{ value: 'needs_me', label: 'Needs my label' },
 		{ value: 'least_color', label: 'Fewest color labels' },
 		{ value: 'most_color', label: 'Most color labels' },

--- a/software/hive/frontend/src/routes/piece-bboxes/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/+page.svelte
@@ -7,8 +7,10 @@
 		type ColorLabelStats,
 		type Machine
 	} from '$lib/api';
+	import { auth } from '$lib/auth.svelte';
 	import * as nav from '$lib/colorLabelNav';
 	import FilterGroup from '$lib/components/FilterGroup.svelte';
+	import PaletteCoverage from '$lib/components/PaletteCoverage.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import { Button } from '$lib/components/primitives';
 	import ArrowRight from 'lucide-svelte/icons/arrow-right';
@@ -227,6 +229,12 @@
 			</div>
 		</div>
 	</div>
+{/if}
+
+<!-- Palette coverage — for reviewers/admins: which colors are well-covered vs
+     rare or missing in what's actually been labeled. -->
+{#if auth.isReviewer}
+	<PaletteCoverage {machineId} />
 {/if}
 
 {#snippet filterBtn(label: string, selected: boolean, onClick: () => void)}

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -46,6 +46,7 @@
 
 	let detail = $state<ColorLabelPieceDetail | null>(null);
 	let myColorId = $state<number | null>(null); // saved color for THIS piece (restored)
+	let cantTell = $state(false); // saved "I can't tell" answer for THIS piece
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let submitting = $state(false);
@@ -100,7 +101,7 @@
 	});
 
 	// --- Per-characteristic completion state (extensible) ---------------------
-	const colorState = $derived<CharState>(myColorId != null ? 'ready' : 'empty');
+	const colorState = $derived<CharState>(myColorId != null || cantTell ? 'ready' : 'empty');
 	const piecesState = $derived<CharState>(
 		cropCandidates.length === 0 ? 'empty' : cropDirty ? 'progress' : cropSaved ? 'ready' : 'empty'
 	);
@@ -196,6 +197,7 @@
 			if (pieceKey !== k) return; // navigated away mid-load
 			detail = d;
 			myColorId = d.my_label?.color_id ?? null;
+			cantTell = d.my_label?.cant_tell ?? false;
 			rejectOpen = false;
 			rejected = d.my_rejection != null;
 			rejectReasons = new Set(d.my_rejection?.reasons ?? []);
@@ -278,11 +280,74 @@
 		try {
 			await api.submitColorLabel({ machine_id: machineId, piece_uuid: pieceUuid, color_id: colorId });
 			myColorId = colorId;
+			cantTell = false;
 		} catch (e: unknown) {
 			error = errMsg(e, 'Failed to save color');
 		} finally {
 			submitting = false;
 		}
+	}
+
+	// "I can't tell" — a real answer (color is indeterminate), saved like a color
+	// pick. Clears any concrete color for this piece.
+	async function pickCantTell() {
+		if (submitting) return;
+		if (cantTell) {
+			// Toggle off: remove the answer entirely.
+			await clearColorAnswer();
+			return;
+		}
+		submitting = true;
+		error = null;
+		try {
+			await api.submitColorLabel({ machine_id: machineId, piece_uuid: pieceUuid, cant_tell: true });
+			cantTell = true;
+			myColorId = null;
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to save');
+		} finally {
+			submitting = false;
+		}
+	}
+
+	async function clearColorAnswer() {
+		if (submitting) return;
+		submitting = true;
+		error = null;
+		try {
+			if (myColorId != null || cantTell) await api.deleteColorLabel(machineId, pieceUuid);
+			myColorId = null;
+			cantTell = false;
+		} catch (e: unknown) {
+			error = errMsg(e, 'Failed to clear');
+		} finally {
+			submitting = false;
+		}
+	}
+
+	// Skip: discard whatever was recorded for this piece (a skip almost always
+	// means the earlier input was a mistake) and move on without saving.
+	async function skipAndReset() {
+		if (myColorId != null || cantTell) {
+			try {
+				await api.deleteColorLabel(machineId, pieceUuid);
+			} catch {
+				/* already gone */
+			}
+		}
+		if (cropSaved) {
+			try {
+				await api.deletePieceCropLink(machineId, pieceUuid);
+			} catch {
+				/* already gone */
+			}
+		}
+		myColorId = null;
+		cantTell = false;
+		cropSelected = new Set();
+		cropSaved = false;
+		cropDirty = false;
+		await goNext();
 	}
 
 	function toggleCrop(localId: number) {
@@ -406,7 +471,7 @@
 			void commitAndAdvance();
 		} else if (e.key === 'ArrowRight' || e.key === ' ') {
 			e.preventDefault();
-			void goNext();
+			void skipAndReset();
 		} else if (e.key === 'ArrowLeft') {
 			e.preventDefault();
 			void goPrev();
@@ -469,7 +534,7 @@
 			{/each}
 		</div>
 		<div class="ml-auto flex items-center gap-2">
-			<span class="hidden text-xs text-text-muted md:inline">Enter · →/Space skip · ← back</span>
+			<span class="hidden text-xs text-text-muted md:inline">Enter accept · →/Space skip · ← back</span>
 			<!-- Reject this bbox sample (with reason(s)) — left of the skip/continue CTA -->
 			<div class="relative">
 				<Button
@@ -508,14 +573,15 @@
 					</div>
 				{/if}
 			</div>
-			<Button
-				variant={touched.length > 0 ? 'primary' : 'secondary'}
-				size="sm"
-				loading={cropSaving}
-				onclick={commitAndAdvance}
-			>
-				{ctaLabel} <ArrowRight size={14} />
-			</Button>
+			<!-- Skip is always available; skipping resets whatever was recorded for
+			     this piece (see skipAndReset). Accept/Continue appears once the
+			     labeler has actually entered something. -->
+			<Button variant="ghost" size="sm" onclick={skipAndReset}>Skip</Button>
+			{#if touched.length > 0}
+				<Button variant="primary" size="sm" loading={cropSaving} onclick={commitAndAdvance}>
+					{ctaLabel} <ArrowRight size={14} />
+				</Button>
+			{/if}
 		</div>
 	</div>
 
@@ -736,6 +802,19 @@
 					{#if selected}<Check size={14} class="shrink-0 text-success" />{/if}
 				</button>
 			{/snippet}
+
+			<!-- "I can't tell" — an explicit indeterminate-color answer -->
+			<button
+				class="mb-3 flex items-center gap-2 border px-2 py-1 text-left text-sm hover:border-primary disabled:opacity-50 {cantTell
+					? 'border-success bg-success/10 text-text'
+					: 'border-border text-text-muted'}"
+				onclick={pickCantTell}
+				disabled={submitting}
+			>
+				<Ban size={14} class="shrink-0 {cantTell ? 'text-success' : 'text-text-muted'}" />
+				<span class="flex-1">I can't tell the color</span>
+				{#if cantTell}<Check size={14} class="shrink-0 text-success" />{/if}
+			</button>
 
 			{#if guessColorId != null}
 				{@const gc = colorsById.get(guessColorId)}

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -115,6 +115,8 @@
 	const ctaLabel = $derived.by(() => {
 		if (touched.length === 0) return 'Skip';
 		if (touched.length === characteristics.length) return 'Continue';
+		// An "I can't tell" color isn't something to "accept" — just move on.
+		if (cantTell && touched.length === 1 && touched[0].key === 'color') return 'Move on';
 		return 'Accept ' + touched.map((c) => c.label.toLowerCase()).join(' + ');
 	});
 

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -12,6 +12,7 @@
 	import * as nav from '$lib/colorLabelNav';
 	import MachineLabeledPieces from '$lib/components/MachineLabeledPieces.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
+	import ZoomImage from '$lib/components/ZoomImage.svelte';
 	import { Alert, Button } from '$lib/components/primitives';
 	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
 	import ArrowRight from 'lucide-svelte/icons/arrow-right';
@@ -606,10 +607,9 @@
 
 			<div class="flex flex-wrap gap-2">
 				{#each detail.images as img (img.seq)}
-					<img
+					<ZoomImage
 						src={api.colorLabelImageUrl(machineId, pieceUuid, img.seq)}
 						alt={`crop ${img.seq}`}
-						loading="lazy"
 						title={`seq ${img.seq}${img.source ? ` · ${img.source}` : ''}`}
 						class="h-28 w-28 border-2 bg-transparent object-contain {img.used ? 'border-success' : 'border-border'}"
 					/>

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -318,9 +318,24 @@
 		}
 	}
 
+	// When the labeler's true color disagrees with Brickognize's own color guess,
+	// quietly send a "color incorrect" correction to Brickognize. Fire-and-forget:
+	// the server records it regardless of the network result, and we're leaving the
+	// piece. We never surface Brickognize's predicted color in the UI — this just
+	// compares against it under the hood. Skips when it agrees (don't spam) or when
+	// Brickognize had no color to contradict.
+	function autoSubmitColorDisagreement() {
+		if (!correction?.correctable || correction.color_feedback_submitted) return;
+		if (myColorId == null) return;
+		const predicted = detail?.prediction.color_id;
+		if (predicted == null || String(myColorId) === String(predicted)) return;
+		void api.submitBrickognizeFeedback(machineId, pieceUuid, { color_corrected_id: myColorId });
+	}
+
 	// The summary action: commit anything still in progress, then move on.
 	async function commitAndAdvance() {
 		if (cropDirty) await saveCrops();
+		autoSubmitColorDisagreement();
 		await goNext();
 	}
 
@@ -352,20 +367,17 @@
 		}
 	}
 
-	// Send the part verdict (and, unless already sent, the corrected color) to
-	// Brickognize. Passes the user's selected true color explicitly so a save
-	// isn't required first; the server falls back to the saved label if omitted.
+	// Send the PART verdict to Brickognize. (Color feedback is handled
+	// automatically on advance — see autoSubmitColorDisagreement — and its
+	// prediction is never shown here.)
 	async function sendBrickognizeFeedback() {
 		if (sendingFeedback || !correction) return;
 		sendingFeedback = true;
 		feedback = null;
 		try {
-			const body: { part_correct?: boolean | null; color_corrected_id?: number | null } = {};
+			const body: { part_correct?: boolean | null } = {};
 			if (!correction.part_feedback_submitted && partVerdict != null) {
 				body.part_correct = partVerdict;
-			}
-			if (!correction.color_feedback_submitted && myColorId != null) {
-				body.color_corrected_id = myColorId;
 			}
 			const res = await api.submitBrickognizeFeedback(machineId, pieceUuid, body);
 			correction = res.correction;
@@ -375,10 +387,10 @@
 					variant: 'warning',
 					text: `Saved, but Brickognize didn't accept it: ${res.submit_error}`
 				};
-			} else if (res.part_submitted || res.color_submitted) {
-				feedback = { variant: 'success', text: 'Correction sent to Brickognize.' };
+			} else if (res.part_submitted) {
+				feedback = { variant: 'success', text: 'Sent to Brickognize.' };
 			} else {
-				feedback = { variant: 'success', text: 'Correction saved.' };
+				feedback = { variant: 'success', text: 'Saved.' };
 			}
 		} catch (e: unknown) {
 			feedback = { variant: 'danger', text: errMsg(e, 'Failed to send correction') };
@@ -691,10 +703,12 @@
 			</div>
 		</div>
 
-		<!-- Sidebar: color picker + Brickognize correction -->
-		<div class="flex flex-col gap-6 lg:w-96">
+		<!-- Sidebar: color picker + Brickognize correction. Sticky, capped to the
+		     viewport; the color list fills the space and scrolls internally so the
+		     Brickognize box below always stays on-screen. -->
+		<div class="flex flex-col gap-6 lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:w-96">
 		<!-- Color picker -->
-		<div class="flex flex-col border bg-surface p-4 {stateBorder(colorState)}">
+		<div class="flex min-h-0 flex-1 flex-col border bg-surface p-4 {stateBorder(colorState)}">
 			<div class="mb-3 flex items-center justify-between gap-2">
 				<span class="text-sm font-medium text-text">True color</span>
 				{@render statusBadge(colorState)}
@@ -749,7 +763,7 @@
 				class="mb-3 w-full border border-border bg-bg px-3 py-1.5 text-sm text-text placeholder:text-text-muted focus:border-primary focus:outline-none"
 			/>
 
-			<div class="flex max-h-[46vh] flex-col gap-0.5 overflow-y-auto pr-1">
+			<div class="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto pr-1">
 				{#each filteredColors as color (color.id)}
 					{@render colorRow(color, false)}
 				{/each}
@@ -759,22 +773,22 @@
 			{/if}
 		</div>
 
-		<!-- Brickognize correction — only when the piece has a Brickognize listing -->
+		<!-- Brickognize part correction — only when the piece has a Brickognize
+		     listing. Color feedback is sent automatically on advance when the
+		     labeler's true color disagrees with Brickognize's (its predicted color
+		     is intentionally not shown). -->
 		{#if correction?.correctable}
 			{@const partSent = correction.part_feedback_submitted}
-			{@const colorSent = correction.color_feedback_submitted}
 			{@const canSendPart = !partSent && partVerdict != null}
-			{@const canSendColor = !colorSent && myColorId != null}
-			<div class="flex flex-col border border-border bg-surface p-4">
+			<div class="flex shrink-0 flex-col border border-border bg-surface p-4">
 				<div class="mb-3 flex items-center justify-between gap-2">
-					<span class="text-sm font-medium text-text">Correct Brickognize</span>
-					{#if partSent && colorSent}
+					<span class="text-sm font-medium text-text">Is this the right part?</span>
+					{#if partSent}
 						<span class="flex items-center gap-1 text-xs text-success"><CircleCheck size={13} /> Sent</span>
 					{/if}
 				</div>
 
 				<!-- Predicted part + verdict -->
-				<div class="mb-1 text-xs font-semibold uppercase tracking-wider text-text-muted">Predicted part</div>
 				<div class="mb-2 flex items-center gap-2 text-sm text-text">
 					<span class="truncate">{detail.part.part_name || detail.part.part_id || 'Unidentified'}</span>
 					{#if detail.part.part_id}
@@ -806,33 +820,6 @@
 					{/if}
 				</div>
 
-				<!-- Predicted color + corrected color -->
-				<div class="mb-1 text-xs font-semibold uppercase tracking-wider text-text-muted">Color</div>
-				<div class="mb-3 flex flex-col gap-1 text-sm">
-					<div class="flex items-center gap-2 text-text-muted">
-						<span>Predicted:</span>
-						<span class="text-text">{detail.prediction.color_name ?? '—'}</span>
-						{#if detail.prediction.color_id}<span class="text-xs">({detail.prediction.color_id})</span>{/if}
-					</div>
-					<div class="flex items-center gap-2 text-text-muted">
-						<span>Corrected to:</span>
-						{#if myColorId != null}
-							{@const cc = colorsById.get(myColorId)}
-							<span class="inline-block h-3.5 w-3.5 border border-border" style={`background:#${cc?.rgb ?? '000'}`}></span>
-							<span class="text-text">{cc?.name ?? myColorId}</span>
-						{:else if colorSent && correction.color_corrected_id}
-							<span class="text-text">{correction.color_corrected_id}</span>
-						{:else}
-							<span class="text-text-muted">pick a true color above</span>
-						{/if}
-						{#if colorSent}
-							<span class="ml-auto flex items-center gap-1 text-xs text-success" title="already sent to Brickognize">
-								<CircleCheck size={13} /> sent
-							</span>
-						{/if}
-					</div>
-				</div>
-
 				{#if feedback}
 					<div class="mb-2">
 						<Alert variant={feedback.variant}>{feedback.text}</Alert>
@@ -843,13 +830,13 @@
 					variant="primary"
 					size="sm"
 					loading={sendingFeedback}
-					disabled={!canSendPart && !canSendColor}
+					disabled={!canSendPart}
 					onclick={sendBrickognizeFeedback}
 				>
-					{#if partSent && colorSent}
+					{#if partSent}
 						Sent to Brickognize
 					{:else}
-						Send correction to Brickognize
+						Send to Brickognize
 					{/if}
 				</Button>
 			</div>

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -63,10 +63,11 @@
 	let cropSaved = $state(false); // a selection is committed to the db
 	let cropDirty = $state(false); // toggled since last save/load
 	let cropError = $state<string | null>(null);
-	// Which model drove the pre-selection: the time/angle heuristic or a stored
-	// vision-model prediction. The AI "Run" action is open to admins or anyone
-	// with their own OpenRouter key on file.
-	let predictionSource = $state<'ai' | 'heuristic'>('heuristic');
+	// Which source drove the pre-selection: the time/angle heuristic, the active
+	// link matcher model, or a stored vision-model (AI) prediction. The AI "Run"
+	// action is open to admins or anyone with their own OpenRouter key on file.
+	let predictionSource = $state<'ai' | 'model' | 'heuristic'>('heuristic');
+	let linkModel = $state<string | null>(null); // active link model name when source === 'model'
 	let aiReasoning = $state<string | null>(null);
 	let aiRunning = $state(false);
 	const canRunAi = $derived(auth.isAdmin || auth.user?.openrouter_configured === true);
@@ -216,14 +217,28 @@
 		}
 	}
 
+	// Whether a candidate is the active source's pre-selected pick: the AI's
+	// verdict, the link model's pick, or the time/angle heuristic's flag.
+	function isPredictionPick(
+		c: import('$lib/api').PossibleCropCandidate,
+		source: 'ai' | 'model' | 'heuristic'
+	): boolean {
+		if (source === 'ai') return c.ai_same === true;
+		if (source === 'model') return c.model_same === true;
+		return c.predicted;
+	}
+
+	const SOURCE_PICK_LABEL = { ai: 'AI', model: 'model', heuristic: 'heuristic' } as const;
+
 	// Load a possible-crops result into state. If the user already saved a
-	// selection, restore it; otherwise pre-select the AI's picks when a stored
-	// prediction exists, else the time/angle heuristic's picks.
+	// selection, restore it; otherwise pre-select the active source's picks — the
+	// AI's stored prediction, else the link model's scores, else the heuristic.
 	function applyCrops(crops: import('$lib/api').PossibleCropsResult, preferAi = false) {
 		cropCandidates = crops.candidates;
 		cropArrivalTs = crops.arrival_ts;
 		cropDirty = false;
 		predictionSource = crops.prediction_source;
+		linkModel = crops.link_model;
 		aiReasoning = crops.ai_reasoning;
 		const savedPos = crops.my_link.filter((m) => m.is_same).map((m) => m.local_id);
 		// A just-run AI prediction overrides the saved selection in the UI so the
@@ -233,9 +248,9 @@
 			cropSelected = new Set(savedPos.filter((id) => present.has(id)));
 			cropSaved = true;
 		} else {
-			const useAi = preferAi || crops.prediction_source === 'ai';
+			const source = preferAi ? 'ai' : crops.prediction_source;
 			cropSelected = new Set(
-				crops.candidates.filter((c) => (useAi ? c.ai_same === true : c.predicted)).map((c) => c.local_id)
+				crops.candidates.filter((c) => isPredictionPick(c, source)).map((c) => c.local_id)
 			);
 			cropSaved = crops.my_link.length > 0;
 		}
@@ -714,6 +729,11 @@
 					<span class="text-text-muted">
 						Picks from a vision model{aiReasoning ? `: ${aiReasoning}` : '.'}
 					</span>
+				{:else if predictionSource === 'model'}
+					<Sparkles size={12} class="shrink-0 text-info" />
+					<span class="text-text-muted">
+						Picks from the link matcher model{linkModel ? ` (${linkModel})` : ''}.{canRunAi ? ' Run AI for a vision-model guess.' : ''}
+					</span>
 				{:else}
 					<span class="text-text-muted">
 						Picks from the time-and-angle heuristic.{canRunAi ? ' Run AI for a vision-model guess.' : ''}
@@ -731,11 +751,11 @@
 				<div class="flex max-h-[42vh] flex-wrap gap-2 overflow-y-auto pr-1">
 					{#each cropCandidates as c (c.local_id)}
 						{@const selected = cropSelected.has(c.local_id)}
-						{@const isPick = predictionSource === 'ai' ? c.ai_same === true : c.predicted}
+						{@const isPick = isPredictionPick(c, predictionSource)}
 						<button
 							type="button"
 							onclick={() => toggleCrop(c.local_id)}
-							title={`C${c.channel} · ${ZONE_LABEL[c.zone_code ?? 0] ?? '?'} · ${c.dt != null ? c.dt + 's before arrival' : 'unknown dt'} · ${c.com_forward_to_exit_deg != null ? Math.round(c.com_forward_to_exit_deg) + '° to exit' : ''} · score ${c.score}${isPick ? (predictionSource === 'ai' ? ' · AI pick' : ' · heuristic pick') : ''}`}
+							title={`C${c.channel} · ${ZONE_LABEL[c.zone_code ?? 0] ?? '?'} · ${c.dt != null ? c.dt + 's before arrival' : 'unknown dt'} · ${c.com_forward_to_exit_deg != null ? Math.round(c.com_forward_to_exit_deg) + '° to exit' : ''} · score ${c.score}${predictionSource === 'model' && c.model_score != null ? ` · model ${c.model_score}` : ''}${isPick ? ` · ${SOURCE_PICK_LABEL[predictionSource]} pick` : ''}`}
 							class="relative flex flex-col items-center gap-1 border-2 p-1 hover:border-primary {selected
 								? 'border-success bg-success/10'
 								: 'border-border opacity-70 hover:opacity-100'}"
@@ -759,7 +779,7 @@
 							{#if isPick}
 								<span
 									class="absolute right-0.5 top-0.5 flex items-center bg-info/80 p-0.5 text-white"
-									title={predictionSource === 'ai' ? 'AI prediction' : 'heuristic prediction'}
+									title={`${SOURCE_PICK_LABEL[predictionSource]} prediction`}
 								>
 									<Sparkles size={11} />
 								</span>

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -10,6 +10,7 @@
 	} from '$lib/api';
 	import { auth } from '$lib/auth.svelte';
 	import * as nav from '$lib/colorLabelNav';
+	import MachineLabeledPieces from '$lib/components/MachineLabeledPieces.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import { Alert, Button } from '$lib/components/primitives';
 	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
@@ -507,6 +508,11 @@
 	</div>
 
 	<div class="flex flex-col gap-6 lg:flex-row lg:items-start">
+		<!-- Reference column: this machine's already-labeled colors (ground truth) -->
+		<aside class="shrink-0 lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:w-52 lg:overflow-y-auto">
+			<MachineLabeledPieces {machineId} {pieceUuid} />
+		</aside>
+
 		<div class="flex min-w-0 flex-col gap-6 lg:flex-1">
 			<!-- Piece under review -->
 			<div class="border border-border bg-surface p-4">

--- a/software/sorter/backend/hive_telemetry.py
+++ b/software/sorter/backend/hive_telemetry.py
@@ -45,6 +45,12 @@ TELEMETRY_FIELDS: tuple[dict[str, Any], ...] = (
         "description": "Unlabeled bbox crops of pieces on the upstream feeder channels, tagged with position for same-piece lookup. Off by default — experimental, high volume.",
         "default": False,
     },
+    {
+        "key": "machine_specs",
+        "label": "Machine specs",
+        "description": "Basic hardware and software details — camera, controller board, platform and operating system — shown on the machine's dashboard and used for compatibility and support.",
+        "default": True,
+    },
 )
 
 _TELEMETRY_FIELD_KEYS = tuple(field["key"] for field in TELEMETRY_FIELDS)
@@ -312,12 +318,17 @@ class HiveTelemetryClient:
             **kwargs,
         )
 
-    def heartbeat(self) -> bool:
-        # Empty keep-alive so target reachability shows in the UI; carries no
-        # machine data. A future status upload must add a registry field and
-        # be gated on it.
+    def heartbeat(self, machine_specs: dict[str, Any] | None = None) -> bool:
+        # Keep-alive so target reachability shows in the UI. It also carries the
+        # machine-specs snapshot when one is supplied and the "machine_specs"
+        # field is enabled for this target; reachability still works when the
+        # field is off (the body is simply omitted), so toggling specs off never
+        # makes the machine look offline.
+        body: dict[str, Any] | None = None
+        if machine_specs is not None and getTargetTelemetrySettings(self._target_id).get("machine_specs", False):
+            body = {"hardware_info": machine_specs}
         try:
-            response = self._session.post(f"{self._url}/api/machine/heartbeat", timeout=10)
+            response = self._session.post(f"{self._url}/api/machine/heartbeat", json=body, timeout=10)
             return response.status_code < 500
         except requests.RequestException:
             return False

--- a/software/sorter/backend/machine_specs.py
+++ b/software/sorter/backend/machine_specs.py
@@ -1,0 +1,257 @@
+"""Machine specs snapshot — the "what is this machine" details we report to a
+registered Hive account.
+
+Unlike status_ping (anonymous, install-scoped), this rides the account-scoped
+heartbeat so the specs land on the machine's own Hive dashboard. It answers the
+basic compatibility/support questions: what camera, what controller board, what
+platform and OS. Collection is entirely best-effort — a missing /proc file, an
+uninitialized camera, or a machine still in standby just yields a smaller
+snapshot, never an error that touches the sorting path.
+
+The choke point (hive_telemetry.HiveTelemetryClient) gates the whole snapshot on
+the "machine_specs" telemetry field, so an operator can turn it off per target.
+
+BOOT_ID is fresh per process, so every restart produces a new snapshot the
+server can distinguish from the previous one even when nothing else changed —
+that is how the account dashboard can show a report per restart over time.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import socket
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+BOOT_ID = str(uuid.uuid4())
+_BOOTED_AT = datetime.now(timezone.utc).isoformat()
+
+
+def _v4l2CameraModel(index: int) -> str | None:
+    try:
+        with open(f"/sys/class/video4linux/video{index}/name") as handle:
+            name = handle.read().strip()
+            return name or None
+    except OSError:
+        return None
+
+
+def _cameraEntry(role_value: Any) -> dict[str, Any]:
+    # A role in the TOML is either a bare device index or a dict carrying the
+    # index/url plus capture settings. Normalize both into one shape.
+    entry: dict[str, Any] = {
+        "device_index": None,
+        "url": None,
+        "width": None,
+        "height": None,
+        "fps": None,
+        "fourcc": None,
+        "model": None,
+    }
+    if isinstance(role_value, dict):
+        raw_index = role_value.get("device_index")
+        if isinstance(raw_index, int) and not isinstance(raw_index, bool):
+            entry["device_index"] = raw_index
+        url = role_value.get("url")
+        if isinstance(url, str) and url.strip():
+            entry["url"] = url.strip()
+        for key in ("width", "height", "fps"):
+            value = role_value.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                entry[key] = value
+        fourcc = role_value.get("fourcc")
+        if isinstance(fourcc, str) and fourcc.strip():
+            entry["fourcc"] = fourcc.strip()
+    elif isinstance(role_value, int) and not isinstance(role_value, bool):
+        entry["device_index"] = role_value
+
+    if entry["url"] is None and isinstance(entry["device_index"], int) and entry["device_index"] >= 0:
+        entry["model"] = _v4l2CameraModel(entry["device_index"])
+    return entry
+
+
+def _liveCameras() -> dict[str, Any]:
+    # The running camera service holds the resolution each camera actually
+    # opened with, which the raw TOML setup may not carry.
+    try:
+        from server import shared_state
+
+        service = shared_state.camera_service
+        devices = service.devices if service is not None else {}
+    except Exception:
+        return {}
+    cameras: dict[str, Any] = {}
+    for role, device in (devices or {}).items():
+        config = getattr(device, "config", None)
+        if config is None:
+            continue
+        index = getattr(config, "device_index", None)
+        index = index if isinstance(index, int) and not isinstance(index, bool) else None
+        url = getattr(config, "url", None)
+        url = url.strip() if isinstance(url, str) and url.strip() else None
+        if index is None and url is None:
+            continue
+        entry: dict[str, Any] = {
+            "device_index": index,
+            "url": url,
+            "width": getattr(config, "width", None),
+            "height": getattr(config, "height", None),
+            "fps": getattr(config, "fps", None),
+            "fourcc": getattr(config, "fourcc", None),
+            "model": None,
+        }
+        if url is None and index is not None and index >= 0:
+            entry["model"] = _v4l2CameraModel(index)
+        cameras[str(role)] = entry
+    return cameras
+
+
+def _cameras() -> dict[str, Any]:
+    live = _liveCameras()
+    if live:
+        return live
+    # Fall back to the TOML setup when the camera service isn't up yet.
+    try:
+        from blob_manager import getCameraSetup
+
+        setup = getCameraSetup()
+    except Exception:
+        return {}
+    if not isinstance(setup, dict):
+        return {}
+    cameras: dict[str, Any] = {}
+    for role, value in setup.items():
+        if value is None:
+            continue
+        entry = _cameraEntry(value)
+        if entry["device_index"] is not None or entry["url"] is not None:
+            cameras[role] = entry
+    return cameras
+
+
+def _controllerBoards() -> dict[str, Any]:
+    # Populated only once hardware has been discovered (homing/ready); a machine
+    # sitting in standby reports no boards, which the dashboard renders as "—".
+    try:
+        from server import shared_state
+
+        irl = shared_state.getActiveIRL()
+    except Exception:
+        return {}
+    boards = getattr(irl, "control_boards", None) if irl is not None else None
+    if not isinstance(boards, dict):
+        return {}
+    result: dict[str, Any] = {}
+    for key, board in boards.items():
+        identity = getattr(board, "identity", None)
+        if identity is None:
+            continue
+        result[str(key)] = {
+            "family": getattr(identity, "family", None),
+            "role": getattr(identity, "role", None),
+            "device_name": getattr(identity, "device_name", None),
+            "port": getattr(identity, "port", None),
+        }
+    return result
+
+
+def _system() -> dict[str, Any]:
+    info: dict[str, Any] = {"ram_bytes": None, "disk_total_bytes": None, "cpu_count": os.cpu_count()}
+    try:
+        with open("/proc/meminfo") as handle:
+            for line in handle:
+                if line.startswith("MemTotal:"):
+                    info["ram_bytes"] = int(line.split()[1]) * 1024
+                    break
+    except Exception:
+        pass
+    try:
+        import shutil
+
+        info["disk_total_bytes"] = int(shutil.disk_usage("/").total)
+    except Exception:
+        pass
+    return info
+
+
+def _macAddresses() -> list[str]:
+    macs: set[str] = set()
+    try:
+        base = "/sys/class/net"
+        for iface in os.listdir(base):
+            if iface == "lo":
+                continue
+            try:
+                with open(f"{base}/{iface}/address") as handle:
+                    mac = handle.read().strip()
+                if mac and mac != "00:00:00:00:00:00":
+                    macs.add(mac)
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return sorted(macs)
+
+
+def _localIps() -> list[str]:
+    ips: set[str] = set()
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None):
+            addr = info[4][0]
+            if isinstance(addr, str) and not addr.startswith("127.") and addr != "::1":
+                ips.add(addr)
+    except Exception:
+        pass
+    return sorted(ips)
+
+
+def _cpuSerial() -> str | None:
+    try:
+        with open("/proc/cpuinfo") as handle:
+            for line in handle:
+                if line.startswith("Serial"):
+                    value = line.split(":", 1)[1].strip()
+                    return value or None
+    except Exception:
+        pass
+    return None
+
+
+def _host() -> dict[str, Any]:
+    return {
+        "hostname": socket.gethostname() or None,
+        "local_ips": _localIps(),
+        "mac_addresses": _macAddresses(),
+        "cpu_serial": _cpuSerial(),
+    }
+
+
+def buildMachineSpecs() -> dict[str, Any]:
+    from status_ping import _configInfo, _hardwareInfo, _osInfo, _softwareInfo
+
+    hardware = _hardwareInfo()
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "boot_id": BOOT_ID,
+        "booted_at": _BOOTED_AT,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "platform": {
+            "model": hardware.get("model"),
+            "arch": platform.machine() or None,
+            "python": platform.python_version(),
+            "os": _osInfo(),
+        },
+        "software": _softwareInfo(),
+        "system": _system(),
+        "config": _configInfo(),
+        "cameras": _cameras(),
+        "controller_boards": _controllerBoards(),
+        # Host/network details. The dashboard shows a compact summary, so this
+        # block is retained in the report history rather than rendered.
+        "host": _host(),
+    }
+    return payload

--- a/software/sorter/backend/perception/channel_crop_capture.py
+++ b/software/sorter/backend/perception/channel_crop_capture.py
@@ -65,8 +65,10 @@ class ChannelCropCaptureConfig:
             _ZONE_NONE: _ZoneCadence(advance_deg=18.0, max_captures=2),
         }
     )
-    # C2 is far upstream — Spencer wants roughly two crops per pass, no more.
-    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=25.0, max_captures=2)
+    # C2 is far upstream — up to two crops per pass, no more. advance_deg is
+    # ~30% tighter than the original 25.0 so captures recur sooner and more
+    # passes reach their second crop (roughly 30% more C2 crops overall).
+    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=19.2, max_captures=2)
 
 
 @dataclass

--- a/software/sorter/backend/perception/channel_crop_capture.py
+++ b/software/sorter/backend/perception/channel_crop_capture.py
@@ -65,10 +65,10 @@ class ChannelCropCaptureConfig:
             _ZONE_NONE: _ZoneCadence(advance_deg=18.0, max_captures=2),
         }
     )
-    # C2 is far upstream — up to two crops per pass, no more. advance_deg is
-    # ~30% tighter than the original 25.0 so captures recur sooner and more
-    # passes reach their second crop (roughly 30% more C2 crops overall).
-    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=19.2, max_captures=2)
+    # C2 is far upstream. advance_deg is ~30% tighter than the original 25.0 so
+    # captures recur sooner; up to 5 crops of a single piece as it crosses C2
+    # (most won't travel far enough to hit that ceiling).
+    c2_cadence: _ZoneCadence = _ZoneCadence(advance_deg=19.2, max_captures=5)
 
 
 @dataclass

--- a/software/sorter/backend/server/hive_sync.py
+++ b/software/sorter/backend/server/hive_sync.py
@@ -7,8 +7,22 @@ pushes only the gap in id order. That makes months of backlog syncable without
 redundant re-uploads, and — because every Hive ingest endpoint upserts by
 natural key — retries and at-least-once delivery never duplicate.
 
-Syncs to EVERY enabled target in the hive config, each with its own watermark,
-so the same machine drains its full history into prod and staging independently.
+Every enabled target syncs on its OWN thread with its own watermark and
+backoff, so a slow or unreachable target (e.g. a local hive that 401s) can
+never stall the others — each drains prod/staging/local independently.
+
+Throughput is adaptive:
+  - While a sort is running (gc.runtime_stats._is_running) uploads stay gentle,
+    throttled exactly as before so they never compete with live sorting.
+  - When the machine is idle, uploads blast back-to-back (network/disk bound).
+A single concurrency gate caps total uploads in flight across ALL targets —
+1 while sorting (identical to the old serial behavior), a few when idle — so
+the worst-case load stays bounded no matter how many targets are configured.
+
+Ordering matters: the server watermark is MAX(local_id), so a gap that gets
+skipped is lost on the next restart. Each target therefore uploads strictly
+serially and in id order; the gate parallelizes ACROSS targets, never within
+one target's id stream.
 """
 
 from __future__ import annotations
@@ -16,7 +30,8 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator
 
 import requests
 
@@ -35,21 +50,51 @@ DATA_TYPE_CORRECTIONS = "piece_corrections"
 
 RECORDS_BATCH = 500
 CORRECTIONS_BATCH = 500
-CORRECTIONS_THROTTLE_S = 0.15
-# Images push one file per request (multipart), so a small chunk per cycle keeps
-# each pass short and interleaves fairly across targets.
+# Images/crops push one file per request (multipart). Small chunks while
+# sorting keep each pass short and responsive to a mode change; bigger chunks
+# when idle cut the per-chunk requery overhead during a backlog blast.
 IMAGES_CHUNK = 10
 CROPS_CHUNK = 10
+IMAGES_CHUNK_IDLE = 50
+CROPS_CHUNK_IDLE = 100
 
+# Gentle throttles applied only while a sort is running — identical to the
+# pre-adaptive behavior, so backlog draining never competes with live sorting
+# more than it used to.
 RECORDS_THROTTLE_S = 0.15
+CORRECTIONS_THROTTLE_S = 0.15
 IMAGES_THROTTLE_S = 0.8
-# Channel crops are high-volume but small; push them a touch faster than piece
-# images so the backlog keeps up with capture during a run.
 CROPS_THROTTLE_S = 0.3
-IDLE_POLL_S = 10.0
+# Idle: standby, so upload back-to-back. The concurrency gate still bounds how
+# many run at once.
+IDLE_THROTTLE_S = 0.0
 
+IDLE_POLL_S = 10.0
 SERVER_DOWN_BACKOFF_S = 10.0
 SERVER_DOWN_MAX_BACKOFF_S = 120.0
+
+# Total uploads in flight across ALL targets. 1 while sorting reproduces the old
+# single-threaded load exactly; a few when idle lets targets drain in parallel.
+# A hard ceiling regardless of how many targets get configured later.
+BUSY_MAX_CONCURRENT = 1
+IDLE_MAX_CONCURRENT = 3
+
+# Retention marking is a periodic sweep, not per-upload: coalesce it so an idle
+# blast doesn't fire an UPDATE per image.
+RETENTION_MARK_INTERVAL_S = 5.0
+
+
+def _machineBusy(gc: Any) -> bool:
+    # Gentle while a sort is running; blast when idle. Any uncertainty falls
+    # back to "busy" so we never upload more aggressively than the machine can
+    # afford.
+    try:
+        stats = getattr(gc, "runtime_stats", None)
+        if stats is None:
+            return True
+        return bool(getattr(stats, "_is_running", True))
+    except Exception:
+        return True
 
 
 def _is_transient(exc: Exception) -> bool:
@@ -135,15 +180,70 @@ def _cropToMeta(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-class HiveSyncWorker:
-    def __init__(self, gc: Any) -> None:
+class _ConcurrencyGate:
+    """Caps total uploads in flight across all target threads.
+
+    The limit is evaluated per acquire, so the same gate tightens to
+    BUSY_MAX_CONCURRENT the moment a sort starts and loosens again when it
+    stops — without recreating anything.
+    """
+
+    def __init__(self, busy_limit: int, idle_limit: int, busy_fn: Callable[[], bool]) -> None:
+        self._busy_limit = max(1, busy_limit)
+        self._idle_limit = max(1, idle_limit)
+        self._busy_fn = busy_fn
+        self._cond = threading.Condition()
+        self._active = 0
+
+    def _limit(self) -> int:
+        return self._busy_limit if self._busy_fn() else self._idle_limit
+
+    @contextmanager
+    def slot(self) -> Iterator[None]:
+        with self._cond:
+            # Re-poll the limit on a timeout so a busy->idle (or idle->busy)
+            # transition while waiting takes effect within a second.
+            while self._active >= self._limit():
+                self._cond.wait(timeout=1.0)
+            self._active += 1
+        try:
+            yield
+        finally:
+            with self._cond:
+                self._active -= 1
+                self._cond.notify()
+
+
+class _TargetSyncer:
+    """Drains local history to a single Hive target on its own thread."""
+
+    def __init__(
+        self,
+        gc: Any,
+        target: dict[str, Any],
+        gate: _ConcurrencyGate,
+        mark_retention: Callable[[], None],
+    ) -> None:
         self._gc = gc
-        self._lock = threading.Lock()
-        self._targets: dict[str, dict[str, Any]] = {}
+        self._id = target["id"]
+        self._name = target["name"]
+        self._url = target["url"]
+        self._gate = gate
+        self._mark_retention = mark_retention
+        self._client = HiveTelemetryClient(self._url, target["token"], self._id)
+        self._wm: dict[str, int | None] = {
+            DATA_TYPE_RECORDS: None,
+            DATA_TYPE_IMAGES: None,
+            DATA_TYPE_CROPS: None,
+            DATA_TYPE_CORRECTIONS: None,
+        }
+        self._state_ok = False
+        self._backoff_s = SERVER_DOWN_BACKOFF_S
         self._wake = threading.Event()
         self._stop = threading.Event()
-        self._reloadConfig()
-        self._thread = threading.Thread(target=self._loop, daemon=True, name="hive-sync")
+        self._thread = threading.Thread(
+            target=self._loop, daemon=True, name=f"hive-sync-{self._id[:8]}"
+        )
 
     def start(self) -> None:
         self._thread.start()
@@ -152,98 +252,49 @@ class HiveSyncWorker:
         self._stop.set()
         self._wake.set()
 
-    def reload(self) -> None:
-        with self._lock:
-            self._reloadConfig()
-        self._wake.set()
-
     def poke(self) -> None:
         self._wake.set()
 
-    def _reloadConfig(self) -> None:
-        config = getHiveConfig()
-        targets = config.get("targets") if isinstance(config, dict) else None
-        previous = self._targets
-        self._targets = {}
-        if not isinstance(targets, list):
-            return
-        for raw in targets:
-            if not isinstance(raw, dict):
-                continue
-            target_id = raw.get("id")
-            url = raw.get("url")
-            token = raw.get("api_token")
-            if not isinstance(target_id, str) or not target_id:
-                continue
-            if not isinstance(url, str) or not url or not isinstance(token, str) or not token:
-                continue
-            enabled = bool(raw.get("enabled", False))
-            prev = previous.get(target_id, {})
-            state: dict[str, Any] = {
-                "id": target_id,
-                "name": raw.get("name") if isinstance(raw.get("name"), str) else url,
-                "url": url,
-                "enabled": enabled,
-                "client": None,
-                "state_ok": False,
-                "wm": dict(prev.get("wm", {DATA_TYPE_RECORDS: None, DATA_TYPE_IMAGES: None, DATA_TYPE_CROPS: None, DATA_TYPE_CORRECTIONS: None})),
-                "backoff_s": float(prev.get("backoff_s", SERVER_DOWN_BACKOFF_S)),
-                "retry_after": float(prev.get("retry_after", 0.0)),
-                "last_error": prev.get("last_error"),
-            }
-            if enabled:
-                try:
-                    state["client"] = HiveTelemetryClient(url, token, target_id)
-                    log.info("Hive sync enabled: %s (%s)", state["name"], url)
-                except Exception as exc:
-                    state["enabled"] = False
-                    state["last_error"] = str(exc)
-                    log.warning("Hive sync disabled for %s: %s", url, exc)
-            self._targets[target_id] = state
+    def watermark(self, data_type: str) -> int | None:
+        return self._wm.get(data_type)
+
+    def stateOk(self) -> bool:
+        return self._state_ok
 
     def _loop(self) -> None:
+        log.info("Hive sync enabled: %s (%s)", self._name, self._url)
         while not self._stop.is_set():
             try:
                 progressed = self._runOnce()
+                self._backoff_s = SERVER_DOWN_BACKOFF_S
             except Exception as exc:
-                log.warning("hive_sync: unexpected loop error: %s", exc)
-                progressed = False
+                self._noteBackoff(exc)
+                self._wake.wait(self._backoff_s)
+                self._wake.clear()
+                continue
             if progressed and not self._stop.is_set():
                 continue
             self._wake.wait(IDLE_POLL_S)
             self._wake.clear()
 
     def _runOnce(self) -> bool:
-        with self._lock:
-            targets = [t for t in self._targets.values() if t["enabled"] and t["client"] is not None]
-        now = time.time()
-        any_progress = False
-        for target in targets:
-            if now < target["retry_after"]:
-                continue
-            try:
-                self._ensureState(target)
-                # Drain channel crops on its own leg rather than short-circuited
-                # behind records/images: piece-image capture is continuous during
-                # a run, so an `or` chain would starve crops behind that backlog.
-                records_or_images = self._drainRecords(target) or self._drainImages(target)
-                crops = self._drainChannelCrops(target)
-                corrections = self._drainCorrections(target)
-                progressed = records_or_images or crops or corrections
-                target["state_ok"] = True
-                target["backoff_s"] = SERVER_DOWN_BACKOFF_S
-                target["last_error"] = None
-                any_progress = any_progress or progressed
-            except Exception as exc:
-                self._backoff(target, exc)
-        if any_progress:
-            self._markImageRetention(targets)
-        return any_progress
+        self._ensureState()
+        # Drain crops on their own leg rather than short-circuited behind
+        # records/images: piece-image capture is continuous during a run, so an
+        # `or` chain would starve crops behind that backlog.
+        records_or_images = self._drainRecords() or self._drainImages()
+        crops = self._drainChannelCrops()
+        corrections = self._drainCorrections()
+        self._state_ok = True
+        progressed = records_or_images or crops or corrections
+        if progressed:
+            self._mark_retention()
+        return progressed
 
-    def _ensureState(self, target: dict[str, Any]) -> None:
-        if target["state_ok"] and target["wm"][DATA_TYPE_RECORDS] is not None:
+    def _ensureState(self) -> None:
+        if self._state_ok and self._wm[DATA_TYPE_RECORDS] is not None:
             return
-        state = target["client"].getSyncState()
+        state = self._client.getSyncState()
         for data_type in (
             DATA_TYPE_RECORDS,
             DATA_TYPE_IMAGES,
@@ -252,109 +303,211 @@ class HiveSyncWorker:
         ):
             raw = state.get(data_type) if isinstance(state, dict) else None
             value = raw.get("max_local_id") if isinstance(raw, dict) else 0
-            target["wm"][data_type] = int(value or 0)
+            self._wm[data_type] = int(value or 0)
 
-    def _drainRecords(self, target: dict[str, Any]) -> bool:
-        if not telemetryAllows(target["id"], "piece_metadata"):
+    def _throttle(self, busy_value: float) -> None:
+        delay = busy_value if _machineBusy(self._gc) else IDLE_THROTTLE_S
+        if delay > 0:
+            time.sleep(delay)
+
+    def _drainRecords(self) -> bool:
+        if not telemetryAllows(self._id, "piece_metadata"):
             return False
-        wm = int(target["wm"][DATA_TYPE_RECORDS] or 0)
+        wm = int(self._wm[DATA_TYPE_RECORDS] or 0)
         if piece_records.getMaxRecordId() <= wm:
             return False
         rows = piece_records.listRecordsAfter(wm, RECORDS_BATCH)
         if not rows:
             return False
-        new_max = target["client"].pushPieceRecords([_recordToPayload(r) for r in rows])
-        target["wm"][DATA_TYPE_RECORDS] = max(wm, int(new_max), int(rows[-1]["id"]))
-        time.sleep(RECORDS_THROTTLE_S)
+        with self._gate.slot():
+            new_max = self._client.pushPieceRecords([_recordToPayload(r) for r in rows])
+        self._wm[DATA_TYPE_RECORDS] = max(wm, int(new_max), int(rows[-1]["id"]))
+        self._throttle(RECORDS_THROTTLE_S)
         return True
 
-    def _drainImages(self, target: dict[str, Any]) -> bool:
+    def _drainImages(self) -> bool:
         # Skip instead of pushing metadata-only rows: with images disabled the
         # watermark freezes here and the backlog drains if re-enabled later.
-        if not telemetryAllows(target["id"], "detection_images"):
+        if not telemetryAllows(self._id, "detection_images"):
             return False
-        wm = int(target["wm"][DATA_TYPE_IMAGES] or 0)
+        wm = int(self._wm[DATA_TYPE_IMAGES] or 0)
         if piece_image_store.getMaxImageId() <= wm:
             return False
-        rows = piece_image_store.listImagesAfter(wm, IMAGES_CHUNK)
+        chunk = IMAGES_CHUNK if _machineBusy(self._gc) else IMAGES_CHUNK_IDLE
+        rows = piece_image_store.listImagesAfter(wm, chunk)
         if not rows:
             return False
         for row in rows:
+            if self._stop.is_set():
+                break
             file_path = None if row["evicted_locally"] else piece_image_store.getImageFileById(row["id"])
-            new_max = target["client"].pushPieceImage(_imageToMeta(row), file_path)
-            target["wm"][DATA_TYPE_IMAGES] = max(int(target["wm"][DATA_TYPE_IMAGES] or 0), int(new_max), int(row["id"]))
-            time.sleep(IMAGES_THROTTLE_S)
+            with self._gate.slot():
+                new_max = self._client.pushPieceImage(_imageToMeta(row), file_path)
+            self._wm[DATA_TYPE_IMAGES] = max(int(self._wm[DATA_TYPE_IMAGES] or 0), int(new_max), int(row["id"]))
+            self._throttle(IMAGES_THROTTLE_S)
         return True
 
-    def _drainChannelCrops(self, target: dict[str, Any]) -> bool:
+    def _drainChannelCrops(self) -> bool:
         # Gated on its own channel_crops field (default off) so experimental
         # crops never leak to production — enable it per-target. With it off the
         # watermark freezes here and the backlog drains if enabled later.
-        if not telemetryAllows(target["id"], "channel_crops"):
+        if not telemetryAllows(self._id, "channel_crops"):
             return False
-        wm = int(target["wm"][DATA_TYPE_CROPS] or 0)
+        wm = int(self._wm[DATA_TYPE_CROPS] or 0)
         if channel_crop_store.getMaxCropId() <= wm:
             return False
-        rows = channel_crop_store.listCropsAfter(wm, CROPS_CHUNK)
+        chunk = CROPS_CHUNK if _machineBusy(self._gc) else CROPS_CHUNK_IDLE
+        rows = channel_crop_store.listCropsAfter(wm, chunk)
         if not rows:
             return False
         for row in rows:
+            if self._stop.is_set():
+                break
             file_path = None if row["evicted_locally"] else channel_crop_store.getCropFileById(row["id"])
-            new_max = target["client"].pushChannelCrop(_cropToMeta(row), file_path)
-            target["wm"][DATA_TYPE_CROPS] = max(int(target["wm"][DATA_TYPE_CROPS] or 0), int(new_max), int(row["id"]))
-            time.sleep(CROPS_THROTTLE_S)
+            with self._gate.slot():
+                new_max = self._client.pushChannelCrop(_cropToMeta(row), file_path)
+            self._wm[DATA_TYPE_CROPS] = max(int(self._wm[DATA_TYPE_CROPS] or 0), int(new_max), int(row["id"]))
+            self._throttle(CROPS_THROTTLE_S)
         return True
 
-    def _drainCorrections(self, target: dict[str, Any]) -> bool:
+    def _drainCorrections(self) -> bool:
         # Correction edits are piece metadata, so they follow the same gate as
         # piece_records. The append-only piece_corrections log gives a clean
         # monotonic cursor; Hive upserts the latest edit per piece.
-        if not telemetryAllows(target["id"], "piece_metadata"):
+        if not telemetryAllows(self._id, "piece_metadata"):
             return False
-        wm = int(target["wm"][DATA_TYPE_CORRECTIONS] or 0)
+        wm = int(self._wm[DATA_TYPE_CORRECTIONS] or 0)
         if piece_records.getMaxCorrectionId() <= wm:
             return False
         rows = piece_records.listCorrectionsAfter(wm, CORRECTIONS_BATCH)
         if not rows:
             return False
-        new_max = target["client"].pushPieceCorrections(
-            [_correctionToPayload(r) for r in rows]
-        )
-        target["wm"][DATA_TYPE_CORRECTIONS] = max(wm, int(new_max), int(rows[-1]["id"]))
-        time.sleep(CORRECTIONS_THROTTLE_S)
+        with self._gate.slot():
+            new_max = self._client.pushPieceCorrections(
+                [_correctionToPayload(r) for r in rows]
+            )
+        self._wm[DATA_TYPE_CORRECTIONS] = max(wm, int(new_max), int(rows[-1]["id"]))
+        self._throttle(CORRECTIONS_THROTTLE_S)
         return True
 
-    def _markImageRetention(self, targets: list[dict[str, Any]]) -> None:
-        # Stamp synced_at up to the MIN watermark across enabled targets so
-        # retention only evicts a crop once EVERY hive has it — per store.
-        def _min_wm(data_type: str) -> int | None:
-            watermarks = [
-                int(t["wm"][data_type])
-                for t in targets
-                if t["state_ok"] and t["wm"][data_type] is not None
-            ]
-            if watermarks and len(watermarks) == len(targets):
-                return min(watermarks)
-            return None
+    def _noteBackoff(self, exc: Exception) -> None:
+        self._state_ok = False  # re-fetch watermark on recovery (handles a hive DB reset)
+        self._backoff_s = min(
+            max(float(self._backoff_s), SERVER_DOWN_BACKOFF_S) * 1.5,
+            SERVER_DOWN_MAX_BACKOFF_S,
+        )
+        level = "debug" if _is_transient(exc) else "warning"
+        getattr(log, level)(
+            "hive_sync: %s unreachable, backing off %.0fs: %s",
+            self._name, self._backoff_s, exc,
+        )
 
+
+class HiveSyncWorker:
+    def __init__(self, gc: Any) -> None:
+        self._gc = gc
+        self._lock = threading.Lock()
+        self._syncers: dict[str, _TargetSyncer] = {}
+        self._started = False
+        self._gate = _ConcurrencyGate(
+            BUSY_MAX_CONCURRENT, IDLE_MAX_CONCURRENT, lambda: _machineBusy(gc)
+        )
+        self._retention_lock = threading.Lock()
+        self._last_retention = 0.0
+
+    def start(self) -> None:
+        with self._lock:
+            self._started = True
+            self._rebuildLocked()
+
+    def stop(self) -> None:
+        with self._lock:
+            for syncer in self._syncers.values():
+                syncer.stop()
+            self._syncers = {}
+            self._started = False
+
+    def reload(self) -> None:
+        with self._lock:
+            if self._started:
+                self._rebuildLocked()
+
+    def poke(self) -> None:
+        with self._lock:
+            for syncer in self._syncers.values():
+                syncer.poke()
+
+    def _rebuildLocked(self) -> None:
+        # Config edits are rare (a target add/remove/enable), so just tear the
+        # target threads down and rebuild from fresh config. Each new thread
+        # re-fetches its watermark from the server, so no progress is lost — the
+        # brief overlap with an exiting thread is harmless: both push in id
+        # order and Hive upserts idempotently, so no gap can open.
+        for syncer in self._syncers.values():
+            syncer.stop()
+        self._syncers = {}
+        config = getHiveConfig()
+        targets = config.get("targets") if isinstance(config, dict) else None
+        if not isinstance(targets, list):
+            return
+        for raw in targets:
+            parsed = self._parseTarget(raw)
+            if parsed is None:
+                continue
+            try:
+                syncer = _TargetSyncer(self._gc, parsed, self._gate, self._markRetention)
+            except Exception as exc:
+                log.warning("Hive sync disabled for %s: %s", parsed["url"], exc)
+                continue
+            self._syncers[parsed["id"]] = syncer
+            syncer.start()
+
+    @staticmethod
+    def _parseTarget(raw: Any) -> dict[str, Any] | None:
+        if not isinstance(raw, dict):
+            return None
+        target_id = raw.get("id")
+        url = raw.get("url")
+        token = raw.get("api_token")
+        if not isinstance(target_id, str) or not target_id:
+            return None
+        if not isinstance(url, str) or not url:
+            return None
+        if not isinstance(token, str) or not token:
+            return None
+        if not bool(raw.get("enabled", False)):
+            return None
+        name = raw.get("name") if isinstance(raw.get("name"), str) else url
+        return {"id": target_id, "url": url, "token": token, "name": name}
+
+    def _markRetention(self) -> None:
         now = time.time()
+        with self._retention_lock:
+            if now - self._last_retention < RETENTION_MARK_INTERVAL_S:
+                return
+            self._last_retention = now
+        with self._lock:
+            syncers = list(self._syncers.values())
+        if not syncers:
+            return
+
+        # Stamp synced_at up to the MIN watermark across enabled targets so
+        # retention only evicts a crop once EVERY hive has it — per store. A
+        # target that isn't state_ok (e.g. a local hive that 401s) makes the
+        # set incomplete, freezing retention rather than evicting data a broken
+        # target never received.
+        def _min_wm(data_type: str) -> int | None:
+            watermarks: list[int] = []
+            for syncer in syncers:
+                wm = syncer.watermark(data_type)
+                if not syncer.stateOk() or wm is None:
+                    return None  # incomplete set -> freeze retention, don't evict
+                watermarks.append(int(wm))
+            return min(watermarks) if watermarks else None
+
         images_wm = _min_wm(DATA_TYPE_IMAGES)
         if images_wm is not None:
             piece_image_store.markImagesSyncedUpTo(images_wm, now)
         crops_wm = _min_wm(DATA_TYPE_CROPS)
         if crops_wm is not None:
             channel_crop_store.markSyncedUpTo(crops_wm, now)
-
-    def _backoff(self, target: dict[str, Any], exc: Exception) -> None:
-        target["state_ok"] = False  # re-fetch watermark on recovery (handles a hive DB reset)
-        target["backoff_s"] = min(
-            max(float(target.get("backoff_s", SERVER_DOWN_BACKOFF_S)), SERVER_DOWN_BACKOFF_S) * 1.5,
-            SERVER_DOWN_MAX_BACKOFF_S,
-        )
-        target["retry_after"] = time.time() + target["backoff_s"]
-        target["last_error"] = str(exc)
-        level = "debug" if _is_transient(exc) else "warning"
-        getattr(log, level)(
-            "hive_sync: %s unreachable, backing off %.0fs: %s",
-            target["name"], target["backoff_s"], exc,
-        )

--- a/software/sorter/backend/server/hive_uploader.py
+++ b/software/sorter/backend/server/hive_uploader.py
@@ -23,6 +23,14 @@ UPLOAD_MAX_RETRIES = 3
 UPLOAD_RETRY_BASE_S = 2.0
 UPLOAD_THROTTLE_S = 0.8
 HEARTBEAT_INTERVAL_S = 30.0
+# How often the heartbeat also carries a full machine-specs snapshot. The first
+# heartbeat after start always sends one (so every restart lands a fresh
+# timestamped report), then only every half hour to keep the history table from
+# growing on each keep-alive. The server hash-dedupes anyway. When the snapshot
+# is still incomplete because hardware hasn't finished coming up (no controller
+# boards discovered yet), retry on the shorter interval until it fills in.
+SPECS_INTERVAL_S = 1800.0
+SPECS_RETRY_INTERVAL_S = 60.0
 SERVER_DOWN_BACKOFF_S = 10.0
 SERVER_DOWN_MAX_BACKOFF_S = 120.0
 
@@ -119,6 +127,7 @@ class HiveUploader:
         self._reload_config()
         self._worker = threading.Thread(target=self._worker_loop, daemon=True, name="hive-uploader")
         self._worker.start()
+        self._specs_next_at = 0.0  # 0 => send specs on the first heartbeat
         self._heartbeat_thread = threading.Thread(
             target=self._heartbeat_loop,
             daemon=True,
@@ -493,9 +502,17 @@ class HiveUploader:
                     if target.get("enabled") and target.get("client") is not None
                 ]
 
+            # Build the specs snapshot at most once per cycle (identical across
+            # targets); the client drops it per-target if the field is off.
+            machine_specs = None
+            if heartbeat_targets and time.time() >= self._specs_next_at:
+                machine_specs = self._collect_machine_specs()
+                complete = bool(machine_specs and machine_specs.get("controller_boards"))
+                self._specs_next_at = time.time() + (SPECS_INTERVAL_S if complete else SPECS_RETRY_INTERVAL_S)
+
             for target_id, target_name, client in heartbeat_targets:
                 try:
-                    reachable = client.heartbeat()
+                    reachable = client.heartbeat(machine_specs=machine_specs)
                 except Exception:
                     reachable = False
 
@@ -513,6 +530,16 @@ class HiveUploader:
                     log.info("Hive server is back online: %s", target_name)
                 elif not reachable and not was_down:
                     log.warning("Hive server is unreachable: %s", target_name)
+
+    @staticmethod
+    def _collect_machine_specs() -> dict[str, Any] | None:
+        try:
+            from machine_specs import buildMachineSpecs
+
+            return buildMachineSpecs()
+        except Exception as exc:
+            log.debug("Machine specs collection failed: %s", exc)
+            return None
 
     def _worker_loop(self) -> None:
         while True:


### PR DESCRIPTION
Batch of Hive improvements since we last synced with main, centered on the color-labeling workflow plus some supporting infrastructure.

## Color labeling
- Palette-coverage chart on the labeling dashboard; full palette shown above coverage gaps, open by default; collapse coverage by default and drop non-standard colors
- "Likely rare color" ordering so under-covered colors surface first
- Same-machine labeled-color reference column on the labeling view
- "I can't tell" color answer with a "Move on" CTA; skipping resets the piece
- Viewport-fit color column and automatic Brickognize color feedback
- Product-style hover zoom on labeling crops

## piece_link matcher model
- New link-predictor model type, served and configured the same way as the color models (admin link-models page + ONNX serving)

## Machine specs reporting
- Machines optionally attach a hardware/software snapshot (platform, OS, software version, cameras, controller boards) to their heartbeat, gated on a default-on `machine_specs` telemetry field. Hive keeps a per-machine history and shows a specs section on the machine dashboard for the owner and admins.

## Infrastructure / fixes
- Hive sync reworked with per-target threads and idle-adaptive throughput
- Role-based access control for piece-bbox and samples data; admin access-windows page
- C2 channel crops: capture ~30% more often, raise per-piece cap from 2 to 5
- Persist uploaded color models via a bind-mounted `color_models` dir
- Storage: cache-bust stored-image URLs to evict poisoned entries; cap presigned-redirect cache below signature expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)