### PR TITLE
Hive: fast piece-bboxes dashboard (URL filters, back-nav cache, candidates matview, postgres shm fix)

### DIFF
--- a/software/hive/backend/alembic/versions/a8c1d2e3f4a5_piece_has_candidates_matview.py
+++ b/software/hive/backend/alembic/versions/a8c1d2e3f4a5_piece_has_candidates_matview.py
@@ -1,0 +1,65 @@
+"""piece_has_candidates materialized view
+
+Revision ID: a8c1d2e3f4a5
+Revises: a7b8c9d0e1f2
+Create Date: 2026-07-16 18:00:00.000000
+
+The labeling grid's "has same-piece candidates" flag was a correlated EXISTS
+over machine_channel_crops per piece. Postgres planned the WHERE-clause copy as
+a hash semi join on machine_id alone (only ~a dozen distinct machines), leaving
+the ts-window as a join filter — every piece scanned its machine's entire crop
+set, blowing past 100s (and, with parallel workers, the container's /dev/shm).
+
+Precompute the set instead: pieces are hidden from the grid until 15 minutes
+old (_old_enough), so "does this piece have candidate crops" is effectively
+static by the time anyone can see it. A materialized view holds the (machine,
+piece) keys, refreshed every few minutes by CandidateMatviewWorker; the grid
+LEFT JOINs it (a cheap hash join on the real composite key).
+
+The window constants mirror channel_crop_lookup_params.DEFAULT_PARAMS
+(lookback_window_s = 60, fwd_slop_s = 1.5) — the crop-side condition
+  c.ts BETWEEN arrival - 60s AND arrival + 1.5s
+is inverted here to drive the build from the crops side:
+  arrival BETWEEN c.ts - 1.5s AND c.ts + 60s
+which the expression index on (machine_id, coalesce(seen_at, recorded_at))
+makes an index probe per crop instead of a scan per piece.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "a8c1d2e3f4a5"
+down_revision: Union[str, None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX ix_machine_pieces_machine_arrival "
+        "ON machine_pieces (machine_id, (coalesce(seen_at, recorded_at)))"
+    )
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW piece_has_candidates AS
+        SELECT DISTINCT p.machine_id, p.piece_uuid
+        FROM machine_channel_crops c
+        JOIN machine_pieces p
+          ON p.machine_id = c.machine_id
+         AND coalesce(p.seen_at, p.recorded_at) >= c.ts - interval '1.5 seconds'
+         AND coalesce(p.seen_at, p.recorded_at) <= c.ts + interval '60 seconds'
+        WHERE c.ts IS NOT NULL
+        """
+    )
+    # Unique index is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
+    op.execute(
+        "CREATE UNIQUE INDEX uq_piece_has_candidates_machine_piece "
+        "ON piece_has_candidates (machine_id, piece_uuid)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS piece_has_candidates")
+    op.drop_index("ix_machine_pieces_machine_arrival", table_name="machine_pieces")

--- a/software/hive/backend/app/database.py
+++ b/software/hive/backend/app/database.py
@@ -13,5 +13,11 @@ engine = create_engine(
     pool_size=20,
     max_overflow=20,
     pool_recycle=1800,
+    # Kill any query still running after 60s. Cloudflare returns 524 at 100s and
+    # the browser retries, so without this a pathological query keeps executing
+    # per retry and they pile up until Postgres starves (2026-07-16). Workers
+    # that legitimately run longer must opt out per-connection
+    # (SET statement_timeout = 0 — see candidate_matview).
+    connect_args={"options": "-c statement_timeout=60000"},
 )
 SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -37,6 +37,7 @@ from app.routers import (
     upload,
 )
 from app.services.profile_catalog import get_existing_profile_catalog_service, get_profile_catalog_service
+from app.services.candidate_matview import get_candidate_matview_worker
 from app.services.condition_worker import get_condition_worker
 from app.services.machine_stats import get_machine_stats_worker
 from app.services.teacher_worker import get_teacher_worker
@@ -51,9 +52,11 @@ async def lifespan(_app: FastAPI):
     get_teacher_worker().start()
     get_condition_worker().start()
     get_machine_stats_worker().start()
+    get_candidate_matview_worker().start()
     try:
         yield
     finally:
+        get_candidate_matview_worker().stop()
         get_teacher_worker().stop()
         get_condition_worker().stop()
         get_machine_stats_worker().stop()

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -22,7 +22,10 @@ from uuid import UUID
 import numpy as np
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
-from sqlalchemy import and_, exists, false, func
+from sqlalchemy import String, and_, exists, false, func
+from sqlalchemy import column as sa_column
+from sqlalchemy import table as sa_table
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Session
 
 from app.deps import get_current_user, get_db, verify_csrf
@@ -38,7 +41,6 @@ from app.models.piece_rejection import PieceRejection
 from app.models.user import User
 from app.services.brickognize_feedback import submit_color_feedback, submit_part_feedback
 from app.services.channel_crop_lookup import find_possible_crops
-from app.services.channel_crop_lookup_params import DEFAULT_PARAMS
 from app.services.color_predictor import predict as predict_piece_color
 from app.services import link_predictor
 from app.services.piece_crop_ai_matcher import (
@@ -313,26 +315,17 @@ def color_coverage(
     }
 
 
-# Window (before/after the piece's arrival) in which a same-piece candidate crop
-# could exist — mirrors the shared lookup params so ordering agrees with what the
-# labeling view actually surfaces.
-_CANDIDATE_WINDOW = timedelta(seconds=DEFAULT_PARAMS.lookback_window_s)
-_CANDIDATE_SLOP = timedelta(seconds=DEFAULT_PARAMS.fwd_slop_s)
-
-
-def _has_candidates_exists():
-    """Correlated EXISTS: this piece's machine has at least one channel crop
-    within its arrival window — i.e. the same-piece panel will have candidates.
-    Cheap via the (machine_id, ts) index; arrival approximated by seen_at."""
-    arrival = func.coalesce(MachinePiece.seen_at, MachinePiece.recorded_at)
-    return exists().where(
-        and_(
-            MachineChannelCrop.machine_id == MachinePiece.machine_id,
-            MachineChannelCrop.ts.isnot(None),
-            MachineChannelCrop.ts >= arrival - _CANDIDATE_WINDOW,
-            MachineChannelCrop.ts <= arrival + _CANDIDATE_SLOP,
-        )
-    )
+# "Has same-piece candidates" — a channel crop exists within the piece's
+# arrival window (DEFAULT_PARAMS lookback/slop). Computed live this was a
+# correlated EXISTS that Postgres planned as a machine_id-only hash semi join
+# (scanning each machine's whole crop set per piece, >100s); it's precomputed
+# into the piece_has_candidates materialized view instead (a8c1d2e3f4a5
+# migration, refreshed by CandidateMatviewWorker) and hash-joined here.
+_piece_has_candidates = sa_table(
+    "piece_has_candidates",
+    sa_column("machine_id", PGUUID(as_uuid=True)),
+    sa_column("piece_uuid", String),
+)
 
 
 _PIECE_SORTS = {
@@ -456,7 +449,9 @@ def list_pieces(
             PieceCropLink.labeler_id == current_user.id,
         )
     )
-    has_candidates = _has_candidates_exists()
+    # LEFT JOIN against the precomputed matview: one hash build, O(1) per piece —
+    # both the with_candidates filter and the priority sort key come from it.
+    has_candidates = _piece_has_candidates.c.machine_id.isnot(None)
     # A piece this user rejected is handled — drop it from their queue.
     my_rejection = exists().where(
         and_(
@@ -482,6 +477,13 @@ def list_pieces(
         .outerjoin(
             crop_cnt_sq,
             and_(crop_cnt_sq.c.mid == MachinePiece.machine_id, crop_cnt_sq.c.puid == MachinePiece.piece_uuid),
+        )
+        .outerjoin(
+            _piece_has_candidates,
+            and_(
+                _piece_has_candidates.c.machine_id == MachinePiece.machine_id,
+                _piece_has_candidates.c.piece_uuid == MachinePiece.piece_uuid,
+            ),
         )
         .filter(MachinePiece.dead.is_(False), _available_image_exists(), _old_enough(), ~my_rejection)
     )

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import math
+import time
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
@@ -102,6 +103,32 @@ def _labelable_query(db: Session):
     )
 
 
+# The labelable-piece count is a full scan over machine_pieces with a
+# per-row image EXISTS — by far the heaviest part of the stats rollup (it's
+# the query that tipped Postgres over when /dev/shm ran out). It only changes
+# as new pieces sync in, never from labeling activity, so a short TTL cache is
+# safe and keeps every label-derived counter in the response live-accurate.
+_LABELABLE_COUNT_TTL_S = 300.0
+_labelable_count_cache: dict[tuple[object, str | None], tuple[float, int]] = {}
+
+
+def _cached_labelable_count(db: Session, user: User, machine_id: UUID | None) -> int:
+    key = (user.id, str(machine_id) if machine_id is not None else None)
+    hit = _labelable_count_cache.get(key)
+    now = time.monotonic()
+    if hit is not None and now - hit[0] < _LABELABLE_COUNT_TTL_S:
+        return hit[1]
+    q = apply_piece_access(db, _labelable_query(db), user)
+    if machine_id is not None:
+        q = q.filter(MachinePiece.machine_id == machine_id)
+    count = q.count()
+    if len(_labelable_count_cache) > 512:
+        for k in [k for k, (ts, _) in _labelable_count_cache.items() if now - ts >= _LABELABLE_COUNT_TTL_S]:
+            _labelable_count_cache.pop(k, None)
+    _labelable_count_cache[key] = (now, count)
+    return count
+
+
 class ColorOut(BaseModel):
     id: int
     name: str
@@ -134,10 +161,7 @@ def label_stats(
     one machine when machine_id is given, matching the grid's machine filter, and
     to the caller's visibility window (so a member's dashboard reflects only their
     slice, not global fleet totals; admins see everything)."""
-    labelable_q = apply_piece_access(db, _labelable_query(db), current_user)
-    if machine_id is not None:
-        labelable_q = labelable_q.filter(MachinePiece.machine_id == machine_id)
-    total_labelable = labelable_q.count()
+    total_labelable = _cached_labelable_count(db, current_user, machine_id)
 
     def _color_q():
         q = db.query(PieceColorLabel)

--- a/software/hive/backend/app/services/candidate_matview.py
+++ b/software/hive/backend/app/services/candidate_matview.py
@@ -1,0 +1,79 @@
+"""Background refresh of the piece_has_candidates materialized view.
+
+The view (see the a8c1d2e3f4a5 migration) precomputes which pieces have
+same-piece candidate crops so the labeling grid can hash-join it instead of
+running a correlated EXISTS per piece. Pieces only become visible in the grid
+15 minutes after arrival (_old_enough), so as long as the refresh cadence is
+comfortably inside that window the view is indistinguishable from live data.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+from sqlalchemy import text
+
+from app.database import engine
+
+logger = logging.getLogger(__name__)
+
+REFRESH_INTERVAL_S = 300.0
+
+
+class CandidateMatviewWorker:
+    """Daemon thread that refreshes piece_has_candidates on a fixed cadence."""
+
+    def __init__(self) -> None:
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._start_lock = threading.Lock()
+
+    def start(self) -> None:
+        with self._start_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._thread = threading.Thread(
+                target=self._loop, daemon=True, name="candidate-matview-worker"
+            )
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def _loop(self) -> None:
+        logger.info("CandidateMatviewWorker: started")
+        while not self._stop_event.is_set():
+            self._stop_event.wait(timeout=REFRESH_INTERVAL_S)
+            if self._stop_event.is_set():
+                break
+            self._refresh_once()
+        logger.info("CandidateMatviewWorker: stopped")
+
+    def _refresh_once(self) -> None:
+        started = time.monotonic()
+        try:
+            # CONCURRENTLY can't run inside a transaction, and the refresh is
+            # allowed to outlive the app-wide statement timeout.
+            with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+                conn.execute(text("SET statement_timeout = 0"))
+                conn.execute(text("REFRESH MATERIALIZED VIEW CONCURRENTLY piece_has_candidates"))
+            logger.info(
+                "CandidateMatviewWorker: refreshed in %.1fs", time.monotonic() - started
+            )
+        except Exception:
+            logger.exception("CandidateMatviewWorker: refresh failed")
+
+
+_worker: CandidateMatviewWorker | None = None
+_worker_lock = threading.Lock()
+
+
+def get_candidate_matview_worker() -> CandidateMatviewWorker:
+    global _worker
+    with _worker_lock:
+        if _worker is None:
+            _worker = CandidateMatviewWorker()
+        return _worker

--- a/software/hive/docker-compose.prod.yml
+++ b/software/hive/docker-compose.prod.yml
@@ -3,6 +3,10 @@ services:
     image: postgres:16-alpine
     container_name: hive-postgres
     restart: unless-stopped
+    # Docker's default 64MB /dev/shm starves Postgres parallel workers on big
+    # scans (psycopg2 DiskFull: "could not resize shared memory segment") —
+    # took the labeling endpoints down on 2026-07-16.
+    shm_size: 1gb
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}

--- a/software/hive/docker-compose.yml
+++ b/software/hive/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   postgres:
     image: postgres:16-alpine
+    # Match prod: Docker's default 64MB /dev/shm starves parallel workers.
+    shm_size: 1gb
     environment:
       POSTGRES_USER: hive
       POSTGRES_PASSWORD: hive_dev

--- a/software/hive/frontend/src/lib/colorLabelNav.ts
+++ b/software/hive/frontend/src/lib/colorLabelNav.ts
@@ -4,7 +4,14 @@
 // end. A module singleton so the order survives client-side navigation between
 // /piece-bboxes and /piece-bboxes/[machine_id]/[piece_uuid].
 
-import { api, type BrickLinkColor, type ColorLabelSort } from '$lib/api';
+import {
+	api,
+	type BrickLinkColor,
+	type ColorLabelPieceCard,
+	type ColorLabelSort,
+	type ColorLabelStats,
+	type Machine
+} from '$lib/api';
 
 export type PieceKey = { machine_id: string; piece_uuid: string };
 
@@ -22,6 +29,83 @@ export async function getColors(): Promise<BrickLinkColor[]> {
 }
 
 export type NavFilters = { sort: ColorLabelSort; machineId?: string | null; withCandidates?: boolean };
+
+const SORT_VALUES: ColorLabelSort[] = [
+	'priority',
+	'recent',
+	'oldest',
+	'least_color',
+	'most_color',
+	'least_crop',
+	'most_crop',
+	'rare_color',
+	'needs_me'
+];
+
+// Filters ↔ URL query params, so the dashboard's filter state survives
+// navigation (back from a piece lands on the same filtered list). Defaults
+// (priority / all machines / has-candidates) are omitted to keep URLs clean.
+export function filtersToSearch(f: NavFilters): string {
+	const params = new URLSearchParams();
+	if (f.sort !== 'priority') params.set('sort', f.sort);
+	if (f.machineId) params.set('machine', f.machineId);
+	if (f.withCandidates === false) params.set('candidates', '0');
+	return params.toString();
+}
+
+export function filtersFromSearch(sp: URLSearchParams): NavFilters {
+	const rawSort = sp.get('sort');
+	const sort = SORT_VALUES.includes(rawSort as ColorLabelSort) ? (rawSort as ColorLabelSort) : 'priority';
+	return {
+		sort,
+		machineId: sp.get('machine') || null,
+		withCandidates: sp.get('candidates') !== '0'
+	};
+}
+
+export function filtersKey(f: NavFilters): string {
+	return `${f.sort}|${f.machineId ?? ''}|${f.withCandidates === false ? 0 : 1}`;
+}
+
+// Where "back to the dashboard" should land: the list under the filters the
+// working queue was seeded from.
+export function dashboardUrl(): string {
+	const qs = filtersToSearch(filters);
+	return `/piece-bboxes${qs ? `?${qs}` : ''}`;
+}
+
+// Snapshot of the dashboard grid (items + stats + scroll) so returning from a
+// piece restores the exact list instantly; the page revalidates in the
+// background. Module singleton — survives client-side navigation like `queue`.
+export type GridSnapshot = {
+	key: string;
+	items: ColorLabelPieceCard[];
+	stats: ColorLabelStats | null;
+	offset: number;
+	hasMore: boolean;
+	scrollY: number;
+};
+
+let gridSnapshot: GridSnapshot | null = null;
+
+export function saveGrid(snap: GridSnapshot): void {
+	gridSnapshot = snap;
+}
+
+export function getGrid(key: string): GridSnapshot | null {
+	return gridSnapshot != null && gridSnapshot.key === key ? gridSnapshot : null;
+}
+
+// The machine list for the filter sidebar is fleet metadata that changes
+// rarely — cache it for the session instead of refetching on every visit.
+let machinesCache: Machine[] | null = null;
+
+export async function getMachinesCached(): Promise<Machine[]> {
+	if (machinesCache == null) {
+		machinesCache = await api.getMachines({ scope: 'all' });
+	}
+	return machinesCache;
+}
 
 let queue: PieceKey[] = [];
 let filters: NavFilters = { sort: 'priority', withCandidates: true };

--- a/software/hive/frontend/src/routes/piece-bboxes/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { goto, replaceState } from '$app/navigation';
+	import { page } from '$app/state';
+	import { onMount, tick } from 'svelte';
 	import {
 		api,
 		type ColorLabelPieceCard,
@@ -33,12 +35,16 @@
 		{ value: 'oldest', label: 'Oldest' }
 	];
 
+	// Filters initialize from the URL so a shared/back-navigated link restores
+	// the same list. Defaults: priority sort, all machines, has-candidates only.
+	const initialFilters = nav.filtersFromSearch(page.url.searchParams);
+
 	let stats = $state<ColorLabelStats | null>(null);
 	let machines = $state<Machine[]>([]);
-	let sort = $state<ColorLabelSort>('priority');
-	let machineId = $state<string | null>(null);
+	let sort = $state<ColorLabelSort>(initialFilters.sort);
+	let machineId = $state<string | null>(initialFilters.machineId ?? null);
 	// Default: only feed pieces that actually have a same-piece candidate list.
-	let withCandidates = $state(true);
+	let withCandidates = $state(initialFilters.withCandidates !== false);
 	let items = $state<ColorLabelPieceCard[]>([]);
 	let hasMore = $state(true);
 	let offset = 0;
@@ -82,6 +88,51 @@
 
 	function currentFilters(): nav.NavFilters {
 		return { sort, machineId, withCandidates };
+	}
+
+	// Mirror the filters into the URL (replace, not push — filter tweaks aren't
+	// history entries) so back-nav from a piece returns to this exact list.
+	function syncUrl() {
+		const qs = nav.filtersToSearch(currentFilters());
+		replaceState(`/piece-bboxes${qs ? `?${qs}` : ''}`, {});
+	}
+
+	function snapshot(): nav.GridSnapshot {
+		return {
+			key: nav.filtersKey(currentFilters()),
+			items: $state.snapshot(items) as ColorLabelPieceCard[],
+			stats: stats ? ($state.snapshot(stats) as ColorLabelStats) : null,
+			offset,
+			hasMore,
+			scrollY: window.scrollY
+		};
+	}
+
+	// Re-fetch what a restored snapshot is showing (first pages + stats) and
+	// swap it in quietly — stale-while-revalidate, no spinner, no scroll jump.
+	async function revalidate(key: string) {
+		try {
+			const limit = Math.min(Math.max(items.length, BATCH), 200);
+			const [s, pageRes] = await Promise.all([
+				api.colorLabelStats({ machineId }),
+				api.colorLabelPieces({ sort, machineId, withCandidates, limit, offset: 0 })
+			]);
+			if (nav.filtersKey(currentFilters()) !== key) return;
+			stats = s;
+			seenKeys = new Set();
+			const fresh: ColorLabelPieceCard[] = [];
+			for (const c of pageRes.items) {
+				if (!seenKeys.has(cardKey(c))) {
+					seenKeys.add(cardKey(c));
+					fresh.push(c);
+				}
+			}
+			items = fresh;
+			offset = pageRes.items.length;
+			hasMore = pageRes.has_more;
+		} catch {
+			// Keep showing the snapshot — it was good enough to render.
+		}
 	}
 
 	async function loadAll() {
@@ -132,22 +183,27 @@
 	function setSort(next: ColorLabelSort) {
 		if (next === sort) return;
 		sort = next;
+		syncUrl();
 		void loadAll();
 	}
 	function setMachine(next: string | null) {
 		if (next === machineId) return;
 		machineId = next;
+		syncUrl();
 		void loadAll();
 	}
 	function setWithCandidates(next: boolean) {
 		if (next === withCandidates) return;
 		withCandidates = next;
+		syncUrl();
 		void loadAll();
 	}
 
 	function open(card: ColorLabelPieceCard) {
-		// Seed the working list so the piece view steps through this same filtered
-		// order, then jump in.
+		// Snapshot the grid so coming back restores this exact list + scroll
+		// instantly, and seed the working list so the piece view steps through
+		// this same filtered order. Then jump in.
+		nav.saveGrid(snapshot());
 		nav.seed(items, currentFilters(), offset, hasMore);
 		void goto(`/piece-bboxes/${card.machine_id}/${encodeURIComponent(card.piece_uuid)}`);
 	}
@@ -155,19 +211,33 @@
 		if (items.length > 0) open(items[0]);
 	}
 
-	$effect(() => {
-		void loadAll();
-	});
+	onMount(() => {
+		const key = nav.filtersKey(currentFilters());
+		const snap = nav.getGrid(key);
+		if (snap) {
+			// Instant restore, then quietly re-fetch in the background.
+			stats = snap.stats;
+			items = [...snap.items];
+			seenKeys = new Set(snap.items.map(cardKey));
+			offset = snap.offset;
+			hasMore = snap.hasMore;
+			loading = false;
+			// After paint, so it lands after SvelteKit's own popstate scroll
+			// restoration (which has a stale position from before the grid
+			// existed) — last write wins.
+			void tick().then(() =>
+				requestAnimationFrame(() => window.scrollTo(0, snap.scrollY))
+			);
+			void revalidate(key);
+		} else {
+			void loadAll();
+		}
 
-	// Machines list for the filter — fetched once, independent of the filters.
-	$effect(() => {
-		void (async () => {
-			try {
-				machines = await api.getMachines({ scope: 'all' });
-			} catch {
-				machines = [];
-			}
-		})();
+		// Machines list for the filter — session-cached, independent of filters.
+		void nav
+			.getMachinesCached()
+			.then((m) => (machines = m))
+			.catch(() => (machines = []));
 	});
 </script>
 

--- a/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/[machine_id]/[piece_uuid]/+page.svelte
@@ -279,14 +279,14 @@
 		search = '';
 		const next = await nav.nextAfter({ machine_id: machineId, piece_uuid: pieceUuid });
 		if (next) gotoKey(next);
-		else void goto('/piece-bboxes');
+		else void goto(nav.dashboardUrl());
 	}
 
 	async function goPrev() {
 		search = '';
 		const prev = await nav.prevBefore({ machine_id: machineId, piece_uuid: pieceUuid });
 		if (prev) gotoKey(prev);
-		else void goto('/piece-bboxes');
+		else void goto(nav.dashboardUrl());
 	}
 
 	// Pick a color: writes immediately and highlights with a check. Does NOT
@@ -512,7 +512,7 @@
 <svelte:window on:keydown={onKey} />
 
 <div class="mb-4 flex items-center justify-between gap-3">
-	<a href="/piece-bboxes" class="flex items-center gap-1 text-sm text-text-muted hover:text-text">
+	<a href={nav.dashboardUrl()} class="flex items-center gap-1 text-sm text-text-muted hover:text-text">
 		<ArrowLeft size={14} /> All pieces
 	</a>
 	{#if pos.total > 0 && pos.index >= 0}


### PR DESCRIPTION
## What

Hive-only changes, already deployed to prod hive and verified.

### Outage fixes
- **postgres `shm_size: 1gb`** (prod + dev compose): Docker's 64MB `/dev/shm` default starved parallel workers (`psycopg2.errors.DiskFull`), 500-ing the labeling endpoints on 2026-07-16.
- **`piece_has_candidates` materialized view**: the grid's "has same-piece candidates" correlated EXISTS was planned as a hash semi join on `machine_id` alone (~a dozen distinct values), scanning each machine's entire crop set per piece — >100s per request (Cloudflare 524), and browser retries piled up parallel workers until Postgres starved. The view is built crops-side via a new `(machine_id, coalesce(seen_at, recorded_at))` expression index and LEFT JOINed by `list_pieces`: **554ms on prod vs >100s**. Refreshed every 5 min by `CandidateMatviewWorker` (pieces are hidden for 15 min by `_old_enough`, so the lag is invisible).
- **app engine `statement_timeout=60s`** so abandoned queries can't pile up again; long-running workers opt out per-connection.
- `/api/labeling/stats` TTL-caches the labelable-piece full-scan count (5 min, per user+machine); label-derived counters stay live.

### Dashboard UX
- `/piece-bboxes` filters live in the URL (`?sort=…&machine=…&candidates=0`) — deep-linkable, and back-nav from a piece restores the same filtered list.
- Grid snapshot (items + stats + scroll) restores instantly on back-nav, then revalidates in the background.
- Piece detail exits (back link, prev/next at list ends) return to the filtered dashboard URL; machine list session-cached.

## Verification
- Verified end-to-end in the browser locally (URL params, instant back-nav restore, scroll restore, single background revalidate request).
- Matview contents checked against the old EXISTS semantics: symmetric diff = 0.
- Deployed to prod hive; `EXPLAIN ANALYZE` of the grid query: 554ms. Refresh worker observed running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)