### PR TITLE
Fix ugly credit caption on bottom interface doc

### DIFF
--- a/docs/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -39,10 +39,12 @@ The bottom interface stacks the chute mount, a spacer ring, the Lazy Susan beari
 
 Once assembled, it mounts into the machine frame:
 
-<figure class="doc-figure">
-  <img src="{{ '/assets/img/assembly/bottom-interface/mounted-in-frame.png' | relative_url }}" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
-  <figcaption>Diagram pictures courtesy of Adrianbaker in the basically Discord.</figcaption>
-</figure>
+<div class="img-row">
+  <figure>
+    <img src="{{ '/assets/img/assembly/bottom-interface/mounted-in-frame.png' | relative_url }}" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
+    <figcaption>Diagram pictures courtesy of Adrianbaker in the basically Discord.</figcaption>
+  </figure>
+</div>
 
 {% include step.html n="1" title="Mount the Lazy Susan to the chute mount" %}
 


### PR DESCRIPTION
The credit was wrapped in `<figure class="doc-figure">`, which borders the whole figure and leaves `<figcaption>` unstyled — rendering as raw text in a bordered box. Switches to the standard `img-row` figure+figcaption pattern (muted, centered, small caption; border on the image only), matching the Step 2 figures already on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)