### PR TITLE
Docs: affiliate link component with asterisk footnote

### DIFF
--- a/docs/_includes/affiliate-footnotes.html
+++ b/docs/_includes/affiliate-footnotes.html
@@ -1,0 +1,12 @@
+{%- comment -%}
+Footnote block for affiliate-link.html. Put at the bottom of any page that
+uses affiliate links; renders nothing if the page has none.
+{%- endcomment -%}
+{%- if affiliate_notes -%}
+<div class="affiliate-notes" id="affiliate-notes">
+  <p>* Links marked with an asterisk carry our Amazon affiliate tag — as an Amazon Associate we earn from qualifying purchases. The same listings without the tag:</p>
+  <ul>
+    {{ affiliate_notes }}
+  </ul>
+</div>
+{%- endif -%}

--- a/docs/_includes/affiliate-link.html
+++ b/docs/_includes/affiliate-link.html
@@ -1,0 +1,11 @@
+{%- comment -%}
+Product link with the project's Amazon affiliate tag, plus a tiny link to the
+same listing without the tag.
+Usage: {% include affiliate-link.html url="https://www.amazon.com/dp/XXXX" text="heat-set insert press" %}
+{%- endcomment -%}
+{%- if include.url contains "?" -%}
+  {%- assign affiliate_url = include.url | append: "&tag=sorterv2-20" -%}
+{%- else -%}
+  {%- assign affiliate_url = include.url | append: "?tag=sorterv2-20" -%}
+{%- endif -%}
+<span class="affiliate-link"><a href="{{ affiliate_url }}" target="_blank" rel="noopener">{{ include.text }}</a>&nbsp;<a class="affiliate-link-plain" href="{{ include.url }}" target="_blank" rel="noopener" title="The same listing, without the referral tag">not&nbsp;affiliate</a></span>{%- comment -%}{%- endcomment -%}

--- a/docs/_includes/affiliate-link.html
+++ b/docs/_includes/affiliate-link.html
@@ -1,6 +1,8 @@
 {%- comment -%}
-Product link with the project's Amazon affiliate tag, plus a tiny link to the
-same listing without the tag.
+Product link with the project's Amazon affiliate tag. Renders the link plus an
+asterisk that jumps to a footnote at the bottom of the page listing the same
+listings without the tag. Pages using this must end with
+{% include affiliate-footnotes.html %}.
 Usage: {% include affiliate-link.html url="https://www.amazon.com/dp/XXXX" text="heat-set insert press" %}
 {%- endcomment -%}
 {%- if include.url contains "?" -%}
@@ -8,4 +10,6 @@ Usage: {% include affiliate-link.html url="https://www.amazon.com/dp/XXXX" text=
 {%- else -%}
   {%- assign affiliate_url = include.url | append: "?tag=sorterv2-20" -%}
 {%- endif -%}
-<span class="affiliate-link"><a href="{{ affiliate_url }}" target="_blank" rel="noopener">{{ include.text }}</a>&nbsp;<a class="affiliate-link-plain" href="{{ include.url }}" target="_blank" rel="noopener" title="The same listing, without the referral tag">not&nbsp;affiliate</a></span>{%- comment -%}{%- endcomment -%}
+{%- capture affiliate_note_entry -%}<li><a href="{{ include.url }}" target="_blank" rel="noopener">{{ include.text }}</a></li>{%- endcapture -%}
+{%- assign affiliate_notes = affiliate_notes | append: affiliate_note_entry -%}
+<span class="affiliate-link"><a href="{{ affiliate_url }}" target="_blank" rel="noopener">{{ include.text }}</a><sup class="affiliate-star"><a href="#affiliate-notes" title="Affiliate link — non-affiliate version at the bottom of the page">*</a></sup></span>{%- comment -%}{%- endcomment -%}

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -661,16 +661,32 @@ body {
   margin: 0;
 }
 
-/* Affiliate product links: main link carries the referral tag, tiny link opts out. */
-.affiliate-link-plain {
-  font-size: 0.72rem;
+/* Affiliate product links: main link carries the referral tag, asterisk jumps
+   to a bottom-of-page footnote with the non-affiliate listings. */
+.affiliate-star a {
   color: var(--muted);
-  text-decoration: underline dotted;
-  text-underline-offset: 3px;
+  text-decoration: none;
 }
 
-.affiliate-link-plain:hover {
+.affiliate-star a:hover {
   color: var(--ink);
+}
+
+.affiliate-notes {
+  margin-top: 2.4rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--line);
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.affiliate-notes p {
+  margin: 0 0 0.4rem;
+}
+
+.affiliate-notes ul {
+  margin: 0;
+  padding-left: 1.4rem;
 }
 
 /* Inline documentation media. */

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -661,6 +661,18 @@ body {
   margin: 0;
 }
 
+/* Affiliate product links: main link carries the referral tag, tiny link opts out. */
+.affiliate-link-plain {
+  font-size: 0.72rem;
+  color: var(--muted);
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+.affiliate-link-plain:hover {
+  color: var(--ink);
+}
+
 /* Inline documentation media. */
 .doc-figure {
   display: block;

--- a/docs/hardware/helpers/heat-inserts.md
+++ b/docs/hardware/helpers/heat-inserts.md
@@ -21,3 +21,5 @@ Easiest with a {% include affiliate-link.html url="https://www.amazon.com/Vertic
     allowfullscreen
     loading="lazy"></iframe>
 </div>
+
+{% include affiliate-footnotes.html %}

--- a/docs/hardware/helpers/heat-inserts.md
+++ b/docs/hardware/helpers/heat-inserts.md
@@ -11,7 +11,7 @@ permalink: /hardware/helpers/heat-inserts/
 
 <img class="doc-figure" src="{{ '/assets/img/tools/heat-insert-press.jpg' | relative_url }}" alt="Benchtop heat-set insert press with a set of tips">
 
-Easiest with a heat-set insert press. You can also use a regular soldering iron.
+Easiest with a {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-Heat-Insertion-Threaded-Components/dp/B0FRXF1ZH6" text="heat-set insert press" %}. You can also use a regular soldering iron.
 
 <div class="video-embed video-embed-wide">
   <iframe


### PR DESCRIPTION
Adds a reusable affiliate-link include for the docs site and uses it on the heat-inserts page.

- `_includes/affiliate-link.html` — renders a product link with the `sorterv2-20` Amazon tag plus an asterisk that jumps to a bottom-of-page footnote
- `_includes/affiliate-footnotes.html` — footnote block listing the same listings without the tag, with the Amazon Associates disclosure
- Heat-inserts page links the heat-set insert press (B0FRXF1ZH6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)