### PR TITLE
Hive sorting profiles: AI cost logging, spend panel, rename affordance

### DIFF
--- a/software/hive/backend/alembic/versions/a4d6f8b0c2e5_add_ai_usage_events.py
+++ b/software/hive/backend/alembic/versions/a4d6f8b0c2e5_add_ai_usage_events.py
@@ -1,0 +1,56 @@
+"""add ai usage events
+
+Revision ID: a4d6f8b0c2e5
+Revises: a3c5e7b9d1f4
+Create Date: 2026-07-29 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "a4d6f8b0c2e5"
+down_revision: Union[str, None] = "a3c5e7b9d1f4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_usage_events",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("profile_id", sa.UUID(), nullable=True),
+        sa.Column("message_id", sa.UUID(), nullable=True),
+        sa.Column("purpose", sa.String(), nullable=False),
+        sa.Column("model", sa.String(), nullable=True),
+        sa.Column("generation_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("call_count", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("prompt_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("completion_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cached_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cache_write_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cost_usd", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["profile_id"], ["sorting_profiles.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["message_id"], ["sorting_profile_ai_messages.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_ai_usage_events_user_id", "ai_usage_events", ["user_id"], unique=False)
+    op.create_index("ix_ai_usage_events_profile_id", "ai_usage_events", ["profile_id"], unique=False)
+    op.create_index("ix_ai_usage_events_created_at", "ai_usage_events", ["created_at"], unique=False)
+    op.create_index("ix_ai_usage_events_user_created", "ai_usage_events", ["user_id", "created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ai_usage_events_user_created", table_name="ai_usage_events")
+    op.drop_index("ix_ai_usage_events_created_at", table_name="ai_usage_events")
+    op.drop_index("ix_ai_usage_events_profile_id", table_name="ai_usage_events")
+    op.drop_index("ix_ai_usage_events_user_id", table_name="ai_usage_events")
+    op.drop_table("ai_usage_events")

--- a/software/hive/backend/app/config.py
+++ b/software/hive/backend/app/config.py
@@ -83,7 +83,9 @@ class Settings(BaseSettings):
     # server-health page (server_storage_cache). The walk lists every S3 key so
     # it's slow; a few hours is plenty. Clamped to a 5min floor in the worker.
     SERVER_STORAGE_REFRESH_INTERVAL_MINUTES: int = 180
-    DEFAULT_AI_MODEL: str = "anthropic/claude-sonnet-4.6"
+    # Best intelligence-per-dollar on OpenRouter as of 2026-07 (~$0.7/M in,
+    # ~$2.2/M out). Frontend settings page mirrors this in aiModelGroups.
+    DEFAULT_AI_MODEL: str = "z-ai/glm-5.2"
     PROFILE_AI_PROMPT_CACHE_ENABLED: bool = True
     PROFILE_AI_PROMPT_CACHE_TTL: str | None = None
     SECRET_ENCRYPTION_KEY: str | None = None

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -11,6 +11,8 @@ from app.errors import APIError, api_error_handler, http_exception_handler, unha
 from app.routers import (
     admin,
     admin_parts,
+    ai_models,
+    ai_usage,
     analytics,
     api_keys,
     auth,
@@ -115,6 +117,8 @@ app.include_router(link_models.router)
 app.include_router(api_keys.router)
 app.include_router(teacher.router)
 app.include_router(leaderboard.router)
+app.include_router(ai_models.router)
+app.include_router(ai_usage.router)
 
 
 @app.get("/api/health")

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -54,3 +54,4 @@ from app.models.color_prediction import ColorPrediction  # noqa: E402, F401
 from app.models.color_model import ColorModel  # noqa: E402, F401
 from app.models.link_model import LinkModel  # noqa: E402, F401
 from app.models.access_window import AccessWindow  # noqa: E402, F401
+from app.models.ai_usage_event import AiUsageEvent  # noqa: E402, F401

--- a/software/hive/backend/app/models/ai_usage_event.py
+++ b/software/hive/backend/app/models/ai_usage_event.py
@@ -1,0 +1,43 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.models import Base, JSON_VARIANT
+
+
+class AiUsageEvent(Base):
+    __tablename__ = "ai_usage_events"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    profile_id = Column(UUID(as_uuid=True), ForeignKey("sorting_profiles.id", ondelete="SET NULL"), nullable=True)
+    message_id = Column(UUID(as_uuid=True), ForeignKey("sorting_profile_ai_messages.id", ondelete="SET NULL"), nullable=True)
+    # what the spend was for: profile_chat, change_note, ...
+    purpose = Column(String, nullable=False)
+    model = Column(String, nullable=True)
+    # one chat turn can be several OpenRouter calls, hence a list
+    generation_ids = Column(JSON_VARIANT, nullable=True)
+    call_count = Column(Integer, nullable=False, default=1)
+    prompt_tokens = Column(Integer, nullable=False, default=0)
+    completion_tokens = Column(Integer, nullable=False, default=0)
+    total_tokens = Column(Integer, nullable=False, default=0)
+    cached_tokens = Column(Integer, nullable=False, default=0)
+    cache_write_tokens = Column(Integer, nullable=False, default=0)
+    # OpenRouter credits, which are USD. Null when the provider did not report a
+    # price (some free models, or a call that failed after being billed nothing).
+    cost_usd = Column(Float, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    user = relationship("User")
+    profile = relationship("SortingProfile")
+    message = relationship("SortingProfileAiMessage")
+
+    __table_args__ = (
+        Index("ix_ai_usage_events_user_id", "user_id"),
+        Index("ix_ai_usage_events_profile_id", "profile_id"),
+        Index("ix_ai_usage_events_created_at", "created_at"),
+        Index("ix_ai_usage_events_user_created", "user_id", "created_at"),
+    )

--- a/software/hive/backend/app/routers/ai_models.py
+++ b/software/hive/backend/app/routers/ai_models.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends, Query
+
+from app.deps import get_current_user
+from app.models.user import User
+from app.services.secrets import decrypt_secret
+from app.services.openrouter_catalog import listCuratedModels
+
+router = APIRouter(prefix="/api/ai", tags=["ai-models"])
+
+
+@router.get("/models")
+def list_ai_models(
+    refresh: bool = Query(default=False),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    # The catalog endpoint is public, but sending the user's key keeps the
+    # request attributed and avoids anonymous rate limits.
+    api_key = decrypt_secret(current_user.openrouter_api_key_encrypted)
+    return listCuratedModels(api_key=api_key, force_refresh=refresh)

--- a/software/hive/backend/app/routers/ai_usage.py
+++ b/software/hive/backend/app/routers/ai_usage.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.deps import get_current_user, get_db
+from app.models.user import User
+from app.services.ai_usage import usage_summary
+
+router = APIRouter(prefix="/api/ai", tags=["ai-usage"])
+
+
+@router.get("/usage")
+def get_ai_usage(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    return usage_summary(db, user_id=current_user.id)

--- a/software/hive/backend/app/routers/profiles.py
+++ b/software/hive/backend/app/routers/profiles.py
@@ -54,6 +54,7 @@ from app.services.profile_ai import (
     generate_profile_ai_proposal,
     generate_profile_ai_proposal_streaming,
 )
+from app.services.ai_usage import record_ai_usage
 from app.services.secrets import decrypt_secret
 from app.services.machine_set_progress import summarize_machine_set_progress
 from app.services.profile_catalog import PROFILE_CATALOG_SYNC_TYPES, get_profile_catalog_service
@@ -83,6 +84,28 @@ def _build_ai_usage_payload(proposal_result: AiProposalResult) -> dict[str, obje
     if performance:
         usage_with_trace["performance"] = performance
     return usage_with_trace or None
+
+
+def _record_chat_usage(
+    db: Session,
+    current_user: User,
+    profile: SortingProfile,
+    assistant_message: SortingProfileAiMessage,
+    proposal_result: AiProposalResult,
+) -> None:
+    performance = getattr(proposal_result, "performance", None) or {}
+    generation_ids = performance.get("generation_ids") or None
+    record_ai_usage(
+        db,
+        user_id=current_user.id,
+        profile_id=profile.id,
+        message_id=assistant_message.id,
+        purpose="profile_chat",
+        model=proposal_result.model,
+        usage=proposal_result.usage,
+        generation_ids=generation_ids if isinstance(generation_ids, list) else None,
+        call_count=int(performance.get("round_count") or 1),
+    )
 
 
 @router.get("/profile-catalog/status")
@@ -493,11 +516,22 @@ def suggest_change_note(
     if not api_key:
         raise APIError(400, "OpenRouter API key required", "OPENROUTER_KEY_MISSING")
     try:
-        note = generate_change_note_from_diff(
+        result = generate_change_note_from_diff(
             api_key=api_key,
             old_rules=payload.old_rules,
             new_rules=payload.new_rules,
         )
+        note = result.text
+        record_ai_usage(
+            db,
+            user_id=current_user.id,
+            profile_id=profile.id,
+            purpose="change_note",
+            model=result.model,
+            usage=result.usage,
+            generation_ids=[result.generation_id] if result.generation_id else None,
+        )
+        db.commit()
     except APIError:
         raise
     except Exception:
@@ -634,6 +668,8 @@ def create_profile_ai_message(
             proposal_json=proposal_result.proposal,
         )
         db.add(assistant_message)
+        db.flush()
+        _record_chat_usage(db, current_user, profile, assistant_message, proposal_result)
         db.commit()
         db.refresh(assistant_message)
 
@@ -740,6 +776,8 @@ def create_profile_ai_message_stream(
                 proposal_json=proposal_result.proposal,
             )
             db.add(assistant_message)
+            db.flush()
+            _record_chat_usage(db, current_user, profile, assistant_message, proposal_result)
             db.commit()
             db.refresh(assistant_message)
 
@@ -853,10 +891,21 @@ def apply_profile_ai_message(
         try:
             from app.services.profile_ai import get_user_openrouter_key
             api_key = get_user_openrouter_key(current_user)
-            change_note = generate_change_note(
+            note_result = generate_change_note(
                 api_key=api_key,
                 user_message=user_text,
                 proposal=message.proposal_json,
+            )
+            change_note = note_result.text
+            record_ai_usage(
+                db,
+                user_id=current_user.id,
+                profile_id=profile.id,
+                message_id=message.id,
+                purpose="change_note",
+                model=note_result.model,
+                usage=note_result.usage,
+                generation_ids=[note_result.generation_id] if note_result.generation_id else None,
             )
         except Exception as exc:
             import logging

--- a/software/hive/backend/app/services/ai_usage.py
+++ b/software/hive/backend/app/services/ai_usage.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.models.ai_usage_event import AiUsageEvent
+
+logger = logging.getLogger(__name__)
+
+PERIOD_DAYS = {"week": 7, "month": 30, "year": 365}
+
+
+@dataclass
+class AiUsageTotals:
+    cost_usd: float
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    call_count: int
+    message_count: int
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def record_ai_usage(
+    db: Session,
+    *,
+    user_id: UUID,
+    purpose: str,
+    model: str | None,
+    usage: dict[str, Any] | None,
+    profile_id: UUID | None = None,
+    message_id: UUID | None = None,
+    generation_ids: list[str] | None = None,
+    call_count: int = 1,
+) -> AiUsageEvent | None:
+    usage = usage or {}
+    details = usage.get("prompt_tokens_details")
+    details = details if isinstance(details, dict) else {}
+
+    event = AiUsageEvent(
+        user_id=user_id,
+        profile_id=profile_id,
+        message_id=message_id,
+        purpose=purpose,
+        model=model,
+        generation_ids=generation_ids or None,
+        call_count=max(1, call_count),
+        prompt_tokens=_int(usage.get("prompt_tokens")),
+        completion_tokens=_int(usage.get("completion_tokens")),
+        total_tokens=_int(usage.get("total_tokens")),
+        cached_tokens=_int(details.get("cached_tokens")),
+        cache_write_tokens=_int(details.get("cache_write_tokens")),
+        cost_usd=_float_or_none(usage.get("cost")),
+    )
+    db.add(event)
+
+    logger.info(
+        "ai_usage.recorded purpose=%s user=%s profile=%s message=%s model=%s cost_usd=%s tokens=%s calls=%s",
+        purpose,
+        user_id,
+        profile_id,
+        message_id,
+        model,
+        event.cost_usd,
+        event.total_tokens,
+        event.call_count,
+    )
+    return event
+
+
+def usage_totals(db: Session, *, user_id: UUID, since: datetime | None) -> AiUsageTotals:
+    query = db.query(
+        func.coalesce(func.sum(AiUsageEvent.cost_usd), 0.0),
+        func.coalesce(func.sum(AiUsageEvent.prompt_tokens), 0),
+        func.coalesce(func.sum(AiUsageEvent.completion_tokens), 0),
+        func.coalesce(func.sum(AiUsageEvent.total_tokens), 0),
+        func.coalesce(func.sum(AiUsageEvent.call_count), 0),
+        func.count(AiUsageEvent.id),
+    ).filter(AiUsageEvent.user_id == user_id)
+    if since is not None:
+        query = query.filter(AiUsageEvent.created_at >= since)
+
+    try:
+        row = query.one()
+    except SQLAlchemyError:
+        logger.exception("ai_usage.totals_failed user=%s", user_id)
+        return AiUsageTotals(0.0, 0, 0, 0, 0, 0)
+
+    return AiUsageTotals(
+        cost_usd=round(float(row[0] or 0.0), 6),
+        prompt_tokens=_int(row[1]),
+        completion_tokens=_int(row[2]),
+        total_tokens=_int(row[3]),
+        call_count=_int(row[4]),
+        message_count=_int(row[5]),
+    )
+
+
+def usage_summary(db: Session, *, user_id: UUID) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    periods: dict[str, Any] = {}
+    for name, days in PERIOD_DAYS.items():
+        totals = usage_totals(db, user_id=user_id, since=now - timedelta(days=days))
+        periods[name] = totals.__dict__
+    periods["all_time"] = usage_totals(db, user_id=user_id, since=None).__dict__
+
+    first_event = (
+        db.query(func.min(AiUsageEvent.created_at))
+        .filter(AiUsageEvent.user_id == user_id)
+        .scalar()
+    )
+    return {**periods, "since": first_event}

--- a/software/hive/backend/app/services/openrouter.py
+++ b/software/hive/backend/app/services/openrouter.py
@@ -24,6 +24,7 @@ class OpenRouterResponse:
     usage: dict[str, Any] | None
     tool_calls: list[ToolCall] = field(default_factory=list)
     finish_reason: str | None = None
+    generation_id: str | None = None
 
 
 def run_openrouter_chat(
@@ -42,6 +43,10 @@ def run_openrouter_chat(
         "messages": messages,
         "temperature": temperature,
         "max_tokens": max_tokens,
+        # Without this OpenRouter returns token counts but no price, and the
+        # only other way to get the cost of a call is a follow-up request to
+        # /generation with the generation id.
+        "usage": {"include": True},
     }
     if response_format is not None:
         payload["response_format"] = response_format
@@ -69,16 +74,16 @@ def run_openrouter_chat(
     except HTTPError as exc:
         raw = exc.read().decode(errors="replace")
         try:
-            payload = json.loads(raw)
+            error_payload = json.loads(raw)
         except json.JSONDecodeError:
-            payload = None
+            error_payload = None
         message = None
-        if isinstance(payload, dict):
-            error_obj = payload.get("error")
+        if isinstance(error_payload, dict):
+            error_obj = error_payload.get("error")
             if isinstance(error_obj, dict):
                 message = error_obj.get("message")
             if not message:
-                message = payload.get("message")
+                message = error_payload.get("message")
         raise APIError(
             502,
             f"OpenRouter request failed: {message or f'HTTP {exc.code}'}",
@@ -119,4 +124,5 @@ def run_openrouter_chat(
         usage=data.get("usage") if isinstance(data.get("usage"), dict) else None,
         tool_calls=parsed_tool_calls,
         finish_reason=finish_reason,
+        generation_id=str(data["id"]) if data.get("id") else None,
     )

--- a/software/hive/backend/app/services/openrouter_catalog.py
+++ b/software/hive/backend/app/services/openrouter_catalog.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+import requests
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+# Cost baseline. Every model's cost factor is expressed relative to this one, so
+# "~1x" always means "about as expensive as Sonnet".
+BASELINE_MODEL_ID = "anthropic/claude-sonnet-5"
+
+# A blended price weights output tokens more than input because the profile
+# prompts are long but the completions are what actually vary between models.
+# Nothing depends on the exact split; it just keeps the factor honest for models
+# that are cheap to prompt and expensive to generate.
+INPUT_WEIGHT = 0.75
+OUTPUT_WEIGHT = 0.25
+
+CACHE_TTL_SECONDS = 6 * 60 * 60
+
+# Curated roster. Order within a group is the order shown. Every id must exist on
+# OpenRouter; ids that 404 out of the catalog are dropped at serve time rather
+# than shown as broken options.
+CURATED_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "Recommended",
+        (
+            "z-ai/glm-5.2",
+            "anthropic/claude-sonnet-5",
+            "openai/gpt-5.4",
+            "deepseek/deepseek-v4-pro",
+            "google/gemini-3.6-flash",
+        ),
+    ),
+    (
+        "Anthropic",
+        (
+            "anthropic/claude-fable-5",
+            "anthropic/claude-opus-4.7",
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-sonnet-4.6",
+            "anthropic/claude-haiku-4.5",
+        ),
+    ),
+    (
+        "OpenAI",
+        (
+            "openai/gpt-5.5-pro",
+            "openai/gpt-5.5",
+            "openai/gpt-5.4-pro",
+            "openai/gpt-5.4",
+            "openai/gpt-5.4-mini",
+            "openai/gpt-5.6-terra",
+            "openai/gpt-5.6-luna",
+        ),
+    ),
+    (
+        "Google",
+        (
+            "google/gemini-3.6-flash",
+            "google/gemini-3.5-flash",
+            "google/gemini-3.1-pro-preview",
+            "google/gemini-3-flash-preview",
+            "google/gemini-3.1-flash-lite",
+        ),
+    ),
+    (
+        "Z.ai (GLM)",
+        (
+            "z-ai/glm-5.2",
+            "z-ai/glm-5.1",
+            "z-ai/glm-5",
+            "z-ai/glm-5-turbo",
+            "z-ai/glm-4.7",
+            "z-ai/glm-4.7-flash",
+        ),
+    ),
+    (
+        "DeepSeek",
+        (
+            "deepseek/deepseek-v4-pro",
+            "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v3.2",
+        ),
+    ),
+    (
+        "Qwen",
+        (
+            "qwen/qwen3.7-max",
+            "qwen/qwen3.6-max-preview",
+            "qwen/qwen3-max",
+            "qwen/qwen3-vl-235b-a22b-instruct",
+        ),
+    ),
+    (
+        "Moonshot (Kimi)",
+        (
+            "moonshotai/kimi-k3",
+            "moonshotai/kimi-k2.6",
+            "moonshotai/kimi-k2-thinking",
+        ),
+    ),
+    (
+        "MiniMax",
+        (
+            "minimax/minimax-m3",
+            "minimax/minimax-m2.7",
+            "minimax/minimax-m2.5",
+        ),
+    ),
+    (
+        "xAI (Grok)",
+        (
+            "x-ai/grok-4.5",
+            "x-ai/grok-4.3",
+        ),
+    ),
+)
+
+_cache_lock = threading.Lock()
+_cache: dict[str, Any] | None = None
+_cache_fetched_at: float = 0.0
+
+
+def _perMillion(price: Any) -> float | None:
+    try:
+        value = float(price)
+    except (TypeError, ValueError):
+        return None
+    if value <= 0:
+        return None
+    return value * 1_000_000
+
+
+def _blendedPrice(input_price: float | None, output_price: float | None) -> float | None:
+    if input_price is None or output_price is None:
+        return None
+    return INPUT_WEIGHT * input_price + OUTPUT_WEIGHT * output_price
+
+
+def _factorLabel(factor: float | None) -> str | None:
+    if factor is None:
+        return None
+    if factor >= 10:
+        return f"~{factor:.0f}x"
+    if factor >= 1:
+        return f"~{round(factor, 1):g}x"
+    return f"~{round(factor, 2):g}x"
+
+
+def _fetchCatalog(api_key: str | None) -> dict[str, dict]:
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    response = requests.get(OPENROUTER_MODELS_URL, headers=headers, timeout=15)
+    response.raise_for_status()
+    payload = response.json()
+    entries = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(entries, list):
+        return {}
+    catalog: dict[str, dict] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        model_id = entry.get("id")
+        if not isinstance(model_id, str):
+            continue
+        raw_pricing = entry.get("pricing")
+        pricing: dict[str, Any] = raw_pricing if isinstance(raw_pricing, dict) else {}
+        catalog[model_id] = {
+            "name": entry.get("name") if isinstance(entry.get("name"), str) else model_id,
+            "input_per_million": _perMillion(pricing.get("prompt")),
+            "output_per_million": _perMillion(pricing.get("completion")),
+            "context_length": entry.get("context_length"),
+        }
+    return catalog
+
+
+def _cachedCatalog(api_key: str | None, force: bool = False) -> dict[str, dict]:
+    global _cache, _cache_fetched_at
+    with _cache_lock:
+        fresh = _cache is not None and (time.time() - _cache_fetched_at) < CACHE_TTL_SECONDS
+        if fresh and not force:
+            return _cache  # type: ignore[return-value]
+    try:
+        catalog = _fetchCatalog(api_key)
+    except Exception as exc:
+        logger.warning("openrouter catalog fetch failed: %s", exc)
+        with _cache_lock:
+            # A stale catalog beats no pricing at all; only a cold cache gives up.
+            return _cache or {}
+    with _cache_lock:
+        _cache = catalog
+        _cache_fetched_at = time.time()
+    return catalog
+
+
+def listCuratedModels(api_key: str | None = None, force_refresh: bool = False) -> dict[str, Any]:
+    catalog = _cachedCatalog(api_key, force=force_refresh)
+
+    baseline = catalog.get(BASELINE_MODEL_ID) or {}
+    baseline_blended = _blendedPrice(
+        baseline.get("input_per_million"), baseline.get("output_per_million")
+    )
+
+    groups: list[dict[str, Any]] = []
+    for label, model_ids in CURATED_GROUPS:
+        models: list[dict[str, Any]] = []
+        for model_id in model_ids:
+            entry = catalog.get(model_id)
+            if entry is None:
+                continue
+            blended = _blendedPrice(entry["input_per_million"], entry["output_per_million"])
+            factor = (
+                blended / baseline_blended
+                if blended is not None and baseline_blended
+                else None
+            )
+            models.append(
+                {
+                    "id": model_id,
+                    "name": entry["name"],
+                    "input_per_million": entry["input_per_million"],
+                    "output_per_million": entry["output_per_million"],
+                    "cost_factor": round(factor, 4) if factor is not None else None,
+                    "cost_factor_label": _factorLabel(factor),
+                    "context_length": entry.get("context_length"),
+                }
+            )
+        if models:
+            groups.append({"label": label, "models": models})
+
+    return {
+        "default_model": settings.DEFAULT_AI_MODEL,
+        "baseline_model": BASELINE_MODEL_ID,
+        "pricing_available": bool(catalog),
+        "groups": groups,
+    }

--- a/software/hive/backend/app/services/profile_ai.py
+++ b/software/hive/backend/app/services/profile_ai.py
@@ -219,6 +219,14 @@ class AiProgressEvent:
 
 
 @dataclass
+class AiTextResult:
+    text: str
+    model: str
+    usage: dict[str, Any] | None
+    generation_id: str | None = None
+
+
+@dataclass
 class AiProposalResult:
     content: str
     proposal: dict[str, Any] | None
@@ -320,7 +328,8 @@ def generate_profile_ai_proposal(
         messages.extend(normalized_history)
         messages.append({"role": "user", "content": message})
 
-        total_usage: dict[str, int] = {}
+        total_usage: dict[str, Any] = {}
+        generation_ids: list[str] = []
         final_model = model
         tool_trace: list[AiToolTraceEntry] = []
         set_search_observations: list[dict[str, Any]] = []
@@ -344,6 +353,8 @@ def generate_profile_ai_proposal(
             llm_total_ms += llm_ms
             final_model = response.model
             _accumulate_usage(total_usage, response.usage)
+            if response.generation_id:
+                generation_ids.append(response.generation_id)
             response_cache_metrics = _usage_cache_metrics(response.usage)
             aggregate_cache_metrics = _usage_cache_metrics(total_usage)
 
@@ -357,6 +368,8 @@ def generate_profile_ai_proposal(
                 "total_tokens": total_usage.get("total_tokens"),
                 "cached_tokens": aggregate_cache_metrics.get("cached_tokens", 0),
                 "cache_write_tokens": aggregate_cache_metrics.get("cache_write_tokens", 0),
+                "cost": _coerce_cost((response.usage or {}).get("cost")),
+                "total_cost": total_usage.get("cost"),
             }
             rounds.append(round_summary)
             _log_ai_event(
@@ -455,6 +468,8 @@ def generate_profile_ai_proposal(
             "tool_ms": round(tool_total_ms, 1),
             "total_ms": _elapsed_ms(started_at),
             **_usage_cache_metrics(total_usage),
+            "cost": total_usage.get("cost"),
+            "generation_ids": generation_ids,
             "rounds": rounds,
         }
         _log_ai_event(
@@ -549,7 +564,8 @@ def generate_profile_ai_proposal_streaming(
         messages.extend(normalized_history)
         messages.append({"role": "user", "content": message})
 
-        total_usage: dict[str, int] = {}
+        total_usage: dict[str, Any] = {}
+        generation_ids: list[str] = []
         final_model = model
         tool_trace: list[AiToolTraceEntry] = []
         set_search_observations: list[dict[str, Any]] = []
@@ -575,6 +591,8 @@ def generate_profile_ai_proposal_streaming(
             llm_total_ms += llm_ms
             final_model = response.model
             _accumulate_usage(total_usage, response.usage)
+            if response.generation_id:
+                generation_ids.append(response.generation_id)
             response_cache_metrics = _usage_cache_metrics(response.usage)
             aggregate_cache_metrics = _usage_cache_metrics(total_usage)
 
@@ -588,6 +606,8 @@ def generate_profile_ai_proposal_streaming(
                 "total_tokens": total_usage.get("total_tokens"),
                 "cached_tokens": aggregate_cache_metrics.get("cached_tokens", 0),
                 "cache_write_tokens": aggregate_cache_metrics.get("cache_write_tokens", 0),
+                "cost": _coerce_cost((response.usage or {}).get("cost")),
+                "total_cost": total_usage.get("cost"),
             }
             rounds.append(round_summary)
             _log_ai_event(
@@ -701,6 +721,8 @@ def generate_profile_ai_proposal_streaming(
             "tool_ms": round(tool_total_ms, 1),
             "total_ms": _elapsed_ms(started_at),
             **_usage_cache_metrics(total_usage),
+            "cost": total_usage.get("cost"),
+            "generation_ids": generation_ids,
             "rounds": rounds,
         }
         _log_ai_event(
@@ -742,6 +764,11 @@ def _accumulate_usage(total: dict[str, Any], usage: dict[str, Any] | None) -> No
     for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
         if key in usage:
             total[key] = total.get(key, 0) + int(usage[key])
+    # OpenRouter reports cost per call in credits (USD); one chat turn can span
+    # several calls, so the message-level cost is their sum.
+    cost = _coerce_cost(usage.get("cost"))
+    if cost is not None:
+        total["cost"] = round(float(total.get("cost") or 0.0) + cost, 10)
     details = usage.get("prompt_tokens_details")
     if isinstance(details, dict):
         total_details = total.setdefault("prompt_tokens_details", {})
@@ -749,6 +776,15 @@ def _accumulate_usage(total: dict[str, Any], usage: dict[str, Any] | None) -> No
             for key in ("cached_tokens", "cache_write_tokens"):
                 if key in details:
                     total_details[key] = int(total_details.get(key, 0)) + int(details[key])
+
+
+def _coerce_cost(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _elapsed_ms(started_at: float) -> float:
@@ -1703,7 +1739,7 @@ def generate_change_note(
     api_key: str,
     user_message: str,
     proposal: dict[str, Any],
-) -> str:
+) -> AiTextResult:
     """Use Haiku to generate a concise change note from the user request and AI proposal."""
     summary = proposal.get("summary", "")
 
@@ -1743,7 +1779,12 @@ def generate_change_note(
         temperature=0.0,
         max_tokens=120,
     )
-    return resp.content.strip().strip('"')
+    return AiTextResult(
+        text=resp.content.strip().strip('"'),
+        model=resp.model,
+        usage=resp.usage,
+        generation_id=resp.generation_id,
+    )
 
 
 def generate_change_note_from_diff(
@@ -1751,7 +1792,7 @@ def generate_change_note_from_diff(
     api_key: str,
     old_rules: list[dict[str, Any]],
     new_rules: list[dict[str, Any]],
-) -> str:
+) -> AiTextResult:
     """Use Haiku to generate a concise change note by comparing old and new rule trees."""
 
     def _rule_names(rules: list[dict[str, Any]]) -> set[str]:
@@ -1815,7 +1856,12 @@ def generate_change_note_from_diff(
         temperature=0.0,
         max_tokens=120,
     )
-    return resp.content.strip().strip('"')
+    return AiTextResult(
+        text=resp.content.strip().strip('"'),
+        model=resp.model,
+        usage=resp.usage,
+        generation_id=resp.generation_id,
+    )
 
 
 def _prompt_rule_snapshot(rule: dict[str, Any] | None, *, expand_custom_parts: bool = False) -> dict[str, Any] | None:

--- a/software/hive/backend/tests/test_ai_usage.py
+++ b/software/hive/backend/tests/test_ai_usage.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.ai_usage_event import AiUsageEvent
+from app.routers import profiles as profiles_router
+
+
+def _create_profile(client: TestClient, auth_headers: dict[str, str]) -> dict:
+    response = client.post(
+        "/api/profiles",
+        json={"name": "Usage Profile", "visibility": "private"},
+        headers=auth_headers,
+    )
+    assert response.status_code in (200, 201), response.text
+    return response.json()
+
+
+class TestAiUsageLogging:
+    def test_chat_message_records_usage_event(
+        self, client: TestClient, auth_headers: dict[str, str], db: Session, monkeypatch: object
+    ) -> None:
+        profile = _create_profile(client, auth_headers)
+        profile_id = profile["id"]
+        version_id = profile["current_version"]["id"]
+
+        def fake_generate(**_kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                content="Sure.",
+                model="anthropic/claude-sonnet-4.6",
+                usage={
+                    "prompt_tokens": 1200,
+                    "completion_tokens": 300,
+                    "total_tokens": 1500,
+                    "cost": 0.0042,
+                    "prompt_tokens_details": {"cached_tokens": 800},
+                },
+                tool_trace=[],
+                proposal=None,
+                performance={"round_count": 2, "generation_ids": ["gen-1", "gen-2"]},
+            )
+
+        monkeypatch.setattr(profiles_router, "generate_profile_ai_proposal", fake_generate)
+
+        response = client.post(
+            f"/api/profiles/{profile_id}/ai/messages",
+            json={"message": "Add a Technic category.", "version_id": version_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200, response.text
+
+        event = db.query(AiUsageEvent).one()
+        assert event.purpose == "profile_chat"
+        assert str(event.profile_id) == profile_id
+        assert event.message_id is not None
+        assert event.model == "anthropic/claude-sonnet-4.6"
+        assert event.cost_usd == 0.0042
+        assert event.prompt_tokens == 1200
+        assert event.completion_tokens == 300
+        assert event.total_tokens == 1500
+        assert event.cached_tokens == 800
+        assert event.call_count == 2
+        assert event.generation_ids == ["gen-1", "gen-2"]
+
+    def test_usage_summary_totals(
+        self, client: TestClient, auth_headers: dict[str, str], monkeypatch: object
+    ) -> None:
+        profile = _create_profile(client, auth_headers)
+        version_id = profile["current_version"]["id"]
+
+        def fake_generate(**_kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(
+                content="Sure.",
+                model="anthropic/claude-sonnet-4.6",
+                usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "cost": 0.25},
+                tool_trace=[],
+                proposal=None,
+                performance={"round_count": 1},
+            )
+
+        monkeypatch.setattr(profiles_router, "generate_profile_ai_proposal", fake_generate)
+
+        for _ in range(2):
+            response = client.post(
+                f"/api/profiles/{profile['id']}/ai/messages",
+                json={"message": "Again.", "version_id": version_id},
+                headers=auth_headers,
+            )
+            assert response.status_code == 200, response.text
+
+        summary = client.get("/api/ai/usage", headers=auth_headers)
+        assert summary.status_code == 200, summary.text
+        body = summary.json()
+
+        for period in ("week", "month", "year", "all_time"):
+            assert body[period]["cost_usd"] == 0.5
+            assert body[period]["total_tokens"] == 30
+            assert body[period]["message_count"] == 2
+        assert body["since"] is not None
+
+    def test_usage_summary_is_empty_for_a_user_with_no_calls(
+        self, client: TestClient, auth_headers: dict[str, str]
+    ) -> None:
+        body = client.get("/api/ai/usage", headers=auth_headers).json()
+        assert body["all_time"]["cost_usd"] == 0.0
+        assert body["all_time"]["message_count"] == 0
+        assert body["since"] is None

--- a/software/hive/backend/tests/test_profile_ai_set_search.py
+++ b/software/hive/backend/tests/test_profile_ai_set_search.py
@@ -685,7 +685,10 @@ def test_generate_profile_ai_proposal_enables_prompt_cache_for_claude(
     monkeypatch.setattr(profile_ai, "run_openrouter_chat", fake_chat)
     monkeypatch.setattr(profile_ai, "get_user_openrouter_key", lambda user: "or-key")
 
-    user = SimpleNamespace(preferred_ai_model=None, openrouter_api_key_encrypted=None)
+    user = SimpleNamespace(
+        preferred_ai_model="anthropic/claude-sonnet-5",
+        openrouter_api_key_encrypted=None,
+    )
     catalog = SimpleNamespace(
         parts_data=SimpleNamespace(
             parts={"3001": {"name": "Brick 2 x 4"}},

--- a/software/hive/frontend/CLAUDE.md
+++ b/software/hive/frontend/CLAUDE.md
@@ -44,6 +44,39 @@ import { Button, Alert, Tooltip } from '$lib/components/primitives';
 
 Extend primitives rather than re-deriving their styles inline. If a one-off needs a new variant, add it to the primitive and showcase it in `src/routes/styleguide/+page.svelte`.
 
+## Icons — always `lucide-svelte`, never hand-written SVG
+
+`lucide-svelte` is a dependency. Every icon comes from it, imported per-icon so
+the bundle stays small:
+
+```svelte
+import Pencil from 'lucide-svelte/icons/pencil';
+…
+<Pencil size={16} />
+```
+
+**Never paste an inline `<svg><path d="…">` into a component.** Hand-rolled path
+data is unreviewable, renders at the wrong optical weight next to real icons, and
+has repeatedly come out visually wrong. If Lucide doesn't have the icon, say so
+rather than drawing one. Inline SVGs still present in older files are legacy —
+replace them with the Lucide equivalent when you touch that markup.
+
+## Verifying dev Hive — use Claude in Chrome
+
+Dev Hive runs on this Mac (frontend [http://flux.tailf1686d.ts.net:5174](http://flux.tailf1686d.ts.net:5174)).
+**Always verify Hive changes with the `mcp__claude-in-chrome__*` tools.** Every
+interesting route is behind auth, so the browser the extension is connected to
+has to be signed in as the agent account (`claude@sorterdev.com`, see
+`sorter-v2-agent-notes/documentation/projects/hive/dev-hive.md`). Agents cannot
+type passwords — if a route bounces to `/login`, say so and have Spencer sign
+that browser in once; the session then persists for later sessions.
+
+Do **not** use the Browser pane (`preview_start` / `mcp__Claude_Browser__*`) for
+Hive: it has no session, so every authed route renders "Profile not found", and
+it does not need its own dev server — one is already running on `:5174` with HMR,
+so edits are live the moment they're saved. Do not build throwaway static HTML
+mockups to eyeball a change; look at the real page.
+
 ## Svelte 5 conventions
 
 - Props: `let { foo, onclose }: Props = $props();`

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -793,6 +793,47 @@ export interface ProfileCatalogStatus {
 	types: Record<string, CatalogSyncTypeState>;
 }
 
+export interface AiModelOption {
+	id: string;
+	name: string;
+	input_per_million: number | null;
+	output_per_million: number | null;
+	// Blended price relative to the baseline model; null when OpenRouter didn't
+	// price the model (e.g. the catalog fetch failed and nothing was cached).
+	cost_factor: number | null;
+	cost_factor_label: string | null;
+	context_length: number | null;
+}
+
+export interface AiModelGroup {
+	label: string;
+	models: AiModelOption[];
+}
+
+export interface AiModelCatalog {
+	default_model: string;
+	baseline_model: string;
+	pricing_available: boolean;
+	groups: AiModelGroup[];
+}
+
+export interface AiUsageTotals {
+	cost_usd: number;
+	prompt_tokens: number;
+	completion_tokens: number;
+	total_tokens: number;
+	call_count: number;
+	message_count: number;
+}
+
+export interface AiUsageSummary {
+	week: AiUsageTotals;
+	month: AiUsageTotals;
+	year: AiUsageTotals;
+	all_time: AiUsageTotals;
+	since: string | null;
+}
+
 export interface ProfileCatalogSearchResult {
 	part_num: string;
 	name: string;
@@ -1961,6 +2002,15 @@ export const api = {
 		preferred_teacher_model?: string | null;
 	}) {
 		return request<User>('PATCH', '/api/auth/me', data);
+	},
+
+	// AI models
+	listAiModels(refresh = false) {
+		return request<AiModelCatalog>('GET', `/api/ai/models${refresh ? '?refresh=true' : ''}`);
+	},
+
+	getAiUsage() {
+		return request<AiUsageSummary>('GET', '/api/ai/usage');
 	},
 
 	// Profile Catalog

--- a/software/hive/frontend/src/lib/components/AiUsagePanel.svelte
+++ b/software/hive/frontend/src/lib/components/AiUsagePanel.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api, type AiUsageSummary, type AiUsageTotals } from '$lib/api';
+
+	let summary = $state<AiUsageSummary | null>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	const periods: { key: keyof AiUsageSummary; label: string }[] = [
+		{ key: 'week', label: 'Last 7 days' },
+		{ key: 'month', label: 'Last 30 days' },
+		{ key: 'year', label: 'Last year' },
+		{ key: 'all_time', label: 'All time' }
+	];
+
+	onMount(async () => {
+		try {
+			summary = await api.getAiUsage();
+		} catch (e: any) {
+			error = e?.error || 'Failed to load AI usage';
+		} finally {
+			loading = false;
+		}
+	});
+
+	function totalsFor(key: keyof AiUsageSummary): AiUsageTotals | null {
+		const value = summary?.[key];
+		return value && typeof value === 'object' ? (value as AiUsageTotals) : null;
+	}
+
+	// Single chat turns land around a tenth of a cent, so a flat 2dp would render
+	// most of this panel as $0.00.
+	function formatCost(cost: number): string {
+		if (!cost) return '$0.00';
+		if (cost < 0.01) return `$${cost.toFixed(4)}`;
+		return `$${cost.toFixed(2)}`;
+	}
+
+	function formatCount(value: number): string {
+		return value.toLocaleString();
+	}
+</script>
+
+<div class="border border-border bg-bg p-4">
+	<div class="mb-3 flex items-baseline justify-between gap-2">
+		<h3 class="text-sm font-medium text-text">AI Spend</h3>
+		<span class="text-xs text-text-muted">billed to your OpenRouter key</span>
+	</div>
+
+	{#if loading}
+		<p class="text-xs text-text-muted">Loading…</p>
+	{:else if error}
+		<p class="text-xs text-text-muted">{error}</p>
+	{:else if summary}
+		<div class="grid grid-cols-2 gap-px bg-border sm:grid-cols-4">
+			{#each periods as period (period.key)}
+				{@const totals = totalsFor(period.key)}
+				<div class="bg-bg p-3">
+					<div class="text-xs text-text-muted">{period.label}</div>
+					<div class="mt-1 text-lg font-semibold text-text">
+						{formatCost(totals?.cost_usd ?? 0)}
+					</div>
+					<div class="mt-1 text-xs text-text-muted">
+						{formatCount(totals?.message_count ?? 0)} requests · {formatCount(totals?.total_tokens ?? 0)} tokens
+					</div>
+				</div>
+			{/each}
+		</div>
+		<p class="mt-2 text-xs text-text-muted">
+			{#if summary.since}
+				Tracked since {new Date(summary.since).toLocaleDateString()}.
+			{:else}
+				No AI requests recorded yet.
+			{/if}
+		</p>
+	{/if}
+</div>

--- a/software/hive/frontend/src/lib/components/charts/AnalyticsDashboard.svelte
+++ b/software/hive/frontend/src/lib/components/charts/AnalyticsDashboard.svelte
@@ -83,16 +83,34 @@
 	}
 
 	const statusSegments = $derived<DonutSegment[]>(
-		(data?.distributions.by_status ?? []).map((s) => ({ label: s.label, value: s.value, color: statusColor(s.label) }))
+		(data?.distributions.by_status ?? []).map((s) => ({ key: s.label, label: s.label, value: s.value, color: statusColor(s.label) }))
 	);
-	const machineSegments = $derived<DonutSegment[]>(
-		(data?.distributions.by_machine ?? []).map((m, i) => ({ label: m.label, value: m.value, color: PALETTE[i % PALETTE.length] }))
-	);
+	const machineSegments = $derived.by<DonutSegment[]>(() => {
+		const rows = data?.distributions.by_machine ?? [];
+		// Machine names aren't unique across the fleet — tag the collisions so the
+		// legend doesn't show three identical rows.
+		const dupes = new Set(rows.map((m) => m.label).filter((l, i, all) => all.indexOf(l) !== i));
+		return rows.map((m, i) => ({
+			key: m.machine_id,
+			label: dupes.has(m.label) ? `${m.label} · ${m.machine_id.slice(0, 6)}` : m.label,
+			value: m.value,
+			color: PALETTE[i % PALETTE.length]
+		}));
+	});
 	const topParts = $derived<BarItem[]>(
-		(data?.distributions.top_parts ?? []).map((p) => ({ label: p.part_name || p.part_id || '—', sublabel: p.part_id, value: p.value }))
+		(data?.distributions.top_parts ?? []).map((p, i) => ({
+			key: p.part_id ?? `part-${i}`,
+			label: p.part_name || p.part_id || '—',
+			sublabel: p.part_id,
+			value: p.value
+		}))
 	);
 	const topColors = $derived<BarItem[]>(
-		(data?.distributions.top_colors ?? []).map((c) => ({ label: c.color_name || c.color_id || '—', value: c.value }))
+		(data?.distributions.top_colors ?? []).map((c, i) => ({
+			key: c.color_id ?? `color-${i}`,
+			label: c.color_name || c.color_id || '—',
+			value: c.value
+		}))
 	);
 
 	function num(n: number | null | undefined): string {

--- a/software/hive/frontend/src/lib/components/charts/BarList.svelte
+++ b/software/hive/frontend/src/lib/components/charts/BarList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	// Horizontal bar list for ranked categorical data (top parts, top colors).
-	export type BarItem = { label: string; sublabel?: string | null; value: number; swatch?: string | null };
+	// `key` must be unique — labels are not (two colors can share a name).
+	export type BarItem = { key: string; label: string; sublabel?: string | null; value: number; swatch?: string | null };
 
 	let {
 		items,
@@ -17,7 +18,7 @@
 	<div class="flex h-24 items-center justify-center text-sm text-text-muted">No data yet.</div>
 {:else}
 	<div class="flex flex-col gap-1.5">
-		{#each items as item (item.label + (item.sublabel ?? ''))}
+		{#each items as item (item.key)}
 			<div class="flex items-center gap-2 text-sm">
 				{#if item.swatch}
 					<span class="h-3 w-3 flex-shrink-0 border border-border" style:background-color={item.swatch}></span>

--- a/software/hive/frontend/src/lib/components/charts/DonutChart.svelte
+++ b/software/hive/frontend/src/lib/components/charts/DonutChart.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	// Hand-rolled SVG donut. Segments drawn with stroke-dasharray on a circle so
 	// there's no arc math; the legend carries the exact numbers.
-	export type DonutSegment = { label: string; value: number; color: string };
+	// `key` must be unique — labels are not (two machines can share a name).
+	export type DonutSegment = { key: string; label: string; value: number; color: string };
 
 	let {
 		segments,
@@ -39,7 +40,7 @@
 	<div class="flex flex-wrap items-center gap-4">
 		<svg viewBox="0 0 120 120" class="h-36 w-36 flex-shrink-0" role="img">
 			<circle cx="60" cy="60" r={R} fill="none" stroke="var(--color-border)" stroke-width={STROKE} />
-			{#each arcs as a (a.label)}
+			{#each arcs as a (a.key)}
 				<circle
 					cx="60"
 					cy="60"
@@ -64,7 +65,7 @@
 			{/if}
 		</svg>
 		<div class="flex min-w-0 flex-1 flex-col gap-1">
-			{#each arcs as a (a.label)}
+			{#each arcs as a (a.key)}
 				<div class="flex items-center gap-2 text-sm">
 					<span class="h-3 w-3 flex-shrink-0 border border-border" style:background-color={a.color}></span>
 					<span class="truncate text-text">{a.label}</span>

--- a/software/hive/frontend/src/lib/components/primitives/ModelSelect.svelte
+++ b/software/hive/frontend/src/lib/components/primitives/ModelSelect.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+	import type { AiModelGroup, AiModelOption } from '$lib/api';
+
+	let {
+		value = $bindable(),
+		groups,
+		baselineModel,
+		disabled = false,
+		id
+	}: {
+		value: string;
+		groups: AiModelGroup[];
+		baselineModel?: string;
+		disabled?: boolean;
+		id?: string;
+	} = $props();
+
+	let open = $state(false);
+	let query = $state('');
+	let container = $state<HTMLDivElement | null>(null);
+	let searchInput = $state<HTMLInputElement | null>(null);
+	let highlighted = $state(0);
+
+	const allModels = $derived(groups.flatMap((g) => g.models));
+	const selected = $derived(allModels.find((m) => m.id === value));
+
+	const filteredGroups = $derived.by(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) return groups;
+		return groups
+			.map((g) => ({
+				label: g.label,
+				models: g.models.filter(
+					(m) => m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q)
+				)
+			}))
+			.filter((g) => g.models.length > 0);
+	});
+
+	// Flat order drives keyboard navigation; the grouped render walks the same list.
+	const flatFiltered = $derived(filteredGroups.flatMap((g) => g.models));
+
+	function formatPrice(model: AiModelOption): string | null {
+		if (model.input_per_million == null || model.output_per_million == null) return null;
+		const fmt = (n: number) => (n < 1 ? `$${n.toFixed(2)}` : `$${n.toFixed(2).replace(/\.00$/, '')}`);
+		return `${fmt(model.input_per_million)} in / ${fmt(model.output_per_million)} out per M`;
+	}
+
+	function costTone(model: AiModelOption): string {
+		const f = model.cost_factor;
+		if (f == null) return 'text-text-muted';
+		if (f <= 0.5) return 'text-success';
+		if (f <= 1.5) return 'text-text-muted';
+		return 'text-primary';
+	}
+
+	function choose(model: AiModelOption) {
+		value = model.id;
+		open = false;
+		query = '';
+	}
+
+	function toggle() {
+		if (disabled) return;
+		open = !open;
+		if (open) {
+			query = '';
+			highlighted = Math.max(0, flatFiltered.findIndex((m) => m.id === value));
+			queueMicrotask(() => searchInput?.focus());
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (!open) {
+			if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown') {
+				event.preventDefault();
+				toggle();
+			}
+			return;
+		}
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			open = false;
+		} else if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			highlighted = Math.min(highlighted + 1, flatFiltered.length - 1);
+		} else if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			highlighted = Math.max(highlighted - 1, 0);
+		} else if (event.key === 'Enter') {
+			event.preventDefault();
+			const model = flatFiltered[highlighted];
+			if (model) choose(model);
+		}
+	}
+
+	function handleWindowClick(event: MouseEvent) {
+		if (!open || !container) return;
+		if (!container.contains(event.target as Node)) open = false;
+	}
+</script>
+
+<svelte:window onclick={handleWindowClick} />
+
+<div class="relative" bind:this={container}>
+	<button
+		{id}
+		type="button"
+		{disabled}
+		onclick={toggle}
+		onkeydown={handleKeydown}
+		aria-haspopup="listbox"
+		aria-expanded={open}
+		class="flex w-full items-center justify-between gap-3 border border-border bg-surface px-3 py-2 text-left text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+	>
+		<span class="min-w-0 flex-1 truncate font-mono text-text">{value}</span>
+		{#if selected?.cost_factor_label}
+			<span class="shrink-0 text-xs {costTone(selected)}">{selected.cost_factor_label}</span>
+		{/if}
+		<svg class="h-4 w-4 shrink-0 text-text-muted" viewBox="0 0 20 20" fill="currentColor">
+			<path
+				fill-rule="evenodd"
+				d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	</button>
+
+	{#if open}
+		<div
+			class="absolute z-30 mt-1 max-h-96 w-full overflow-y-auto border border-border bg-surface shadow-lg"
+			role="listbox"
+		>
+			<div class="sticky top-0 border-b border-border bg-surface p-2">
+				<input
+					bind:this={searchInput}
+					bind:value={query}
+					oninput={() => (highlighted = 0)}
+					onkeydown={handleKeydown}
+					type="text"
+					placeholder="Search models..."
+					class="w-full border border-border bg-bg px-2 py-1.5 text-sm focus:border-primary focus:outline-none"
+				/>
+			</div>
+
+			{#if flatFiltered.length === 0}
+				<div class="p-3 text-sm text-text-muted">No models match "{query}".</div>
+			{/if}
+
+			{#each filteredGroups as group}
+				<div class="border-b border-border/50 last:border-b-0">
+					<div
+						class="bg-bg px-3 py-1 text-xs font-semibold uppercase tracking-wide text-text-muted"
+					>
+						{group.label}
+					</div>
+					{#each group.models as model}
+						{@const index = flatFiltered.indexOf(model)}
+						<button
+							type="button"
+							role="option"
+							aria-selected={model.id === value}
+							onclick={() => choose(model)}
+							onmouseenter={() => (highlighted = index)}
+							class="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-bg
+								{index === highlighted ? 'bg-bg' : ''}"
+						>
+							<span class="min-w-0 flex-1">
+								<span class="block truncate font-mono text-sm text-text">
+									{#if model.id === value}<span class="text-primary">✓ </span>{/if}{model.id}
+								</span>
+								{#if formatPrice(model)}
+									<span class="block truncate text-xs text-text-muted">{formatPrice(model)}</span>
+								{/if}
+							</span>
+							{#if model.cost_factor_label}
+								<span class="shrink-0 text-xs font-medium {costTone(model)}">
+									{model.cost_factor_label}
+								</span>
+							{/if}
+						</button>
+					{/each}
+				</div>
+			{/each}
+
+			{#if baselineModel}
+				<div class="border-t border-border bg-bg px-3 py-2 text-xs text-text-muted">
+					Cost shown relative to <span class="font-mono">{baselineModel}</span> (blended
+					input/output price). Live from OpenRouter.
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/software/hive/frontend/src/lib/components/primitives/index.ts
+++ b/software/hive/frontend/src/lib/components/primitives/index.ts
@@ -1,3 +1,4 @@
 export { default as Button } from './Button.svelte';
 export { default as Alert } from './Alert.svelte';
 export { default as Tooltip } from './Tooltip.svelte';
+export { default as ModelSelect } from './ModelSelect.svelte';

--- a/software/hive/frontend/src/lib/components/profile/edit/chat-helpers.ts
+++ b/software/hive/frontend/src/lib/components/profile/edit/chat-helpers.ts
@@ -116,6 +116,7 @@ function aiMessagePerformance(message: SortingProfileAiMessage): {
 	toolMs: number | null;
 	roundCount: number | null;
 	toolCallCount: number | null;
+	cost: number | null;
 } | null {
 	const performance = message.usage?.performance;
 	if (!isRecord(performance)) return null;
@@ -124,8 +125,14 @@ function aiMessagePerformance(message: SortingProfileAiMessage): {
 	const toolMs = asNumber(performance.tool_ms);
 	const roundCount = asNumber(performance.round_count);
 	const toolCallCount = asNumber(performance.tool_call_count);
+	const cost = asNumber(performance.cost);
 	if (totalMs === null && llmMs === null && toolMs === null) return null;
-	return { totalMs, llmMs, toolMs, roundCount, toolCallCount };
+	return { totalMs, llmMs, toolMs, roundCount, toolCallCount, cost };
+}
+
+export function formatCost(cost: number): string {
+	if (cost < 0.01) return `$${cost.toFixed(4)}`;
+	return `$${cost.toFixed(2)}`;
 }
 
 export function aiMessagePerformanceLabel(message: SortingProfileAiMessage): string | null {
@@ -140,6 +147,7 @@ export function aiMessagePerformanceLabel(message: SortingProfileAiMessage): str
 	if (tool && perf.toolMs && perf.toolMs > 0) parts.push(`Tools ${tool}`);
 	if (typeof perf.roundCount === 'number' && perf.roundCount > 1) parts.push(`${perf.roundCount} rounds`);
 	if (typeof perf.toolCallCount === 'number' && perf.toolCallCount > 0) parts.push(`${perf.toolCallCount} tool calls`);
+	if (typeof perf.cost === 'number' && perf.cost > 0) parts.push(formatCost(perf.cost));
 	return parts.length > 0 ? parts.join(' · ') : null;
 }
 

--- a/software/hive/frontend/src/lib/uuid.ts
+++ b/software/hive/frontend/src/lib/uuid.ts
@@ -1,0 +1,20 @@
+// crypto.randomUUID only exists in secure contexts, so it is missing when Hive
+// is served over plain http (LAN / tailscale dev hosts). getRandomValues is not
+// gated that way, so fall back to building the v4 by hand.
+export function uuid(): string {
+	if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID();
+	}
+
+	const bytes = new Uint8Array(16);
+	if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+		crypto.getRandomValues(bytes);
+	} else {
+		for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+	}
+	bytes[6] = (bytes[6] & 0x0f) | 0x40;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+	return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}

--- a/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
@@ -37,6 +37,9 @@
 		type ToolResultListItem
 	} from '$lib/components/profile/edit/chat-helpers';
 	import { renderMarkdown } from '$lib/markdown';
+	import { uuid } from '$lib/uuid';
+	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
+	import Pencil from 'lucide-svelte/icons/pencil';
 
 	const ANY_COLOR_ID = -1;
 
@@ -248,6 +251,28 @@
 		}
 	});
 
+	let nameDraft = $state('');
+	let nameInput: HTMLInputElement | undefined = $state(undefined);
+
+	async function renameProfile() {
+		if (!profile) return;
+		const newName = nameDraft.trim();
+		if (!newName) {
+			nameDraft = profile.name;
+			return;
+		}
+		if (newName === profile.name) {
+			nameDraft = newName;
+			return;
+		}
+		try {
+			profile = await api.updateSortingProfile(profile.id, { name: newName });
+			nameDraft = profile.name;
+		} catch {
+			nameDraft = profile.name;
+		}
+	}
+
 	async function loadProfile() {
 		if (!profileId) return;
 		loading = true;
@@ -255,6 +280,7 @@
 		try {
 			const detail = await api.getSortingProfile(profileId);
 			profile = detail;
+			nameDraft = detail.name;
 			hydrateWorkingState(detail);
 			void ensureCatalogColorsLoaded();
 			if (detail.is_owner) {
@@ -471,7 +497,7 @@
 
 	function makeRule(name = 'New Category'): SortingProfileRule {
 		return {
-			id: crypto.randomUUID(),
+			id: uuid(),
 			name,
 			match_mode: 'all',
 			conditions: [],
@@ -482,7 +508,7 @@
 
 	function makeCustomSetRule(name = 'Custom Set'): SortingProfileRule {
 		const rule: SortingProfileRule = {
-			id: crypto.randomUUID(),
+			id: uuid(),
 			rule_type: 'set',
 			set_source: 'custom',
 			name,
@@ -525,7 +551,7 @@
 
 	function addSetRule(set: { set_num: string; name: string; year: number; num_parts: number; img_url: string | null }) {
 		const newRule: SortingProfileRule = {
-			id: crypto.randomUUID(),
+			id: uuid(),
 			rule_type: 'set',
 			set_source: 'rebrickable',
 			name: set.name,
@@ -728,7 +754,7 @@
 	function addCondition(ruleId: string) {
 		withRules((rules) => {
 			updateRuleList(rules, ruleId, (rule) => {
-				rule.conditions.push({ id: crypto.randomUUID(), field: 'part_num', op: 'eq', value: '' });
+				rule.conditions.push({ id: uuid(), field: 'part_num', op: 'eq', value: '' });
 			});
 		});
 	}
@@ -947,7 +973,7 @@
 
 		// Show user message immediately
 		const tempUserMsg: SortingProfileAiMessage = {
-			id: crypto.randomUUID(),
+			id: uuid(),
 			role: 'user',
 			content: userMsg,
 			model: null,
@@ -1084,27 +1110,34 @@
 	<div class="mb-4 flex items-center justify-between">
 		<div class="flex items-center gap-3">
 			<a href={`/profiles/${profile.id}`} class="text-text-muted hover:text-text" title="Back to profile">
-				<svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-					<path fill-rule="evenodd" d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z" clip-rule="evenodd" />
-				</svg>
+				<ArrowLeft size={20} />
 			</a>
 			<div>
-				<input
-					type="text"
-					value={profile.name}
-					onblur={async (e) => {
-						const newName = (e.currentTarget as HTMLInputElement).value.trim();
-						if (newName && newName !== profile!.name) {
-							try {
-								const updated = await api.updateSortingProfile(profile!.id, { name: newName });
-								profile = updated;
-							} catch { /* ignore */ }
-						}
-					}}
-					onkeydown={(e) => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur(); }}
-					class="border-0 bg-transparent text-xl font-bold text-text outline-none focus:border-b-2 focus:border-primary w-full"
-				/>
-				<span class="text-xs text-text-muted">v{profile.current_version.version_number}</span>
+				<div class="group flex items-center gap-1.5">
+					<!-- the hidden span sizes the grid cell so the input hugs the name and the pencil sits right after it -->
+					<div class="inline-grid items-center">
+						<span aria-hidden="true" class="invisible col-start-1 row-start-1 whitespace-pre border-b-2 border-transparent px-1 text-xl font-bold">{nameDraft || 'Untitled Profile'}</span>
+						<input
+							type="text"
+							bind:this={nameInput}
+							bind:value={nameDraft}
+							title="Click to rename"
+							onblur={renameProfile}
+							onkeydown={(e) => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur(); }}
+							class="col-start-1 row-start-1 w-full min-w-0 border-0 border-b-2 border-transparent bg-transparent px-1 text-xl font-bold text-text outline-none group-hover:border-border focus:border-primary"
+						/>
+					</div>
+					<button
+						type="button"
+						title="Rename profile"
+						aria-label="Rename profile"
+						class="text-text-muted opacity-50 transition hover:text-text group-hover:opacity-100"
+						onclick={() => { nameInput?.focus(); nameInput?.select(); }}
+					>
+						<Pencil size={16} />
+					</button>
+				</div>
+				<span class="ml-1 text-xs text-text-muted">v{profile.current_version.version_number}</span>
 			</div>
 		</div>
 		<div class="relative">

--- a/software/hive/frontend/src/routes/profiles/new/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/new/+page.svelte
@@ -3,6 +3,7 @@
 	import { auth } from '$lib/auth.svelte';
 	import { goto } from '$app/navigation';
 	import SetSearch from '$lib/components/profile/SetSearch.svelte';
+	import { uuid } from '$lib/uuid';
 
 	type SetResult = {
 		set_num: string;
@@ -34,7 +35,7 @@
 
 	function makeSetRule(set: SetResult): SortingProfileRule {
 		return {
-			id: crypto.randomUUID(),
+			id: uuid(),
 			rule_type: 'set',
 			name: set.name,
 			match_mode: 'all',

--- a/software/hive/frontend/src/routes/settings/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { auth } from '$lib/auth.svelte';
-	import { api } from '$lib/api';
+	import { api, type AiModelCatalog } from '$lib/api';
 	import { goto } from '$app/navigation';
 	import Modal from '$lib/components/Modal.svelte';
 	import Badge from '$lib/components/Badge.svelte';
+	import ModelSelect from '$lib/components/primitives/ModelSelect.svelte';
+	import AiUsagePanel from '$lib/components/AiUsagePanel.svelte';
 
 	let showDeleteModal = $state(false);
 	let deleteError = $state<string | null>(null);
@@ -89,10 +91,23 @@
 
 	// AI / OpenRouter
 	let openrouterApiKey = $state('');
-	let preferredAiModel = $state(auth.user?.preferred_ai_model ?? 'anthropic/claude-sonnet-4.6');
+	let preferredAiModel = $state(auth.user?.preferred_ai_model ?? '');
 	let aiError = $state<string | null>(null);
 	let aiSaved = $state(false);
 	let aiSaving = $state(false);
+	let aiCatalog = $state<AiModelCatalog | null>(null);
+
+	$effect(() => {
+		void (async () => {
+			try {
+				const catalog = await api.listAiModels();
+				aiCatalog = catalog;
+				if (!preferredAiModel) preferredAiModel = catalog.default_model;
+			} catch {
+				aiCatalog = null;
+			}
+		})();
+	});
 
 	// Perceptron (admin-only teacher path that bypasses OpenRouter)
 	let perceptronApiKey = $state('');
@@ -140,16 +155,6 @@
 			teacherSettingSaving = false;
 		}
 	}
-
-	const aiModelOptions = [
-		'anthropic/claude-haiku-4-5',
-		'anthropic/claude-sonnet-4.6',
-		'anthropic/claude-3.7-sonnet',
-		'openai/gpt-5.4',
-		'google/gemini-3.1-pro-preview',
-		'google/gemini-3-flash-preview',
-		'google/gemini-3.5-flash'
-	];
 
 	async function handleSaveName() {
 		nameError = null;
@@ -478,17 +483,31 @@
 				</div>
 
 				<div>
-					<label for="preferred-model" class="block text-sm text-text-muted">Preferred Model</label>
-					<select
-						id="preferred-model"
-						bind:value={preferredAiModel}
-						class="mt-1 w-full border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-					>
-						{#each aiModelOptions as model}
-							<option value={model}>{model}</option>
-						{/each}
-					</select>
+					<label for="preferred-model" class="mb-1 block text-sm text-text-muted">
+						Preferred Model
+					</label>
+					{#if aiCatalog}
+						<ModelSelect
+							id="preferred-model"
+							bind:value={preferredAiModel}
+							groups={aiCatalog.groups}
+							baselineModel={aiCatalog.baseline_model}
+						/>
+					{:else}
+						<input
+							id="preferred-model"
+							type="text"
+							bind:value={preferredAiModel}
+							placeholder="OpenRouter model id"
+							class="w-full border border-border px-3 py-2 font-mono text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+						/>
+						<p class="mt-1 text-xs text-text-muted">
+							Model list unavailable — enter an OpenRouter model id manually.
+						</p>
+					{/if}
 				</div>
+
+				<AiUsagePanel />
 
 				{#if aiError}
 					<div class="bg-primary/8 p-3 text-sm text-primary">{aiError}</div>

--- a/software/hive/frontend/vite.config.ts
+++ b/software/hive/frontend/vite.config.ts
@@ -5,6 +5,10 @@ import { defineConfig } from 'vite';
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 	server: {
+		// Reachable over Tailscale so the dev Hive can be used like a hosted
+		// instance (browse at http://flux.tailf1686d.ts.net:5174).
+		host: true,
+		allowedHosts: ['.ts.net'],
 		proxy: {
 			'/api': 'http://localhost:8002'
 		}

--- a/software/sorter/backend/supervisor.py
+++ b/software/sorter/backend/supervisor.py
@@ -244,6 +244,13 @@ class BackendSupervisor:
 
     def _clear_bytecode_caches(self) -> int:
         cleared = 0
+        cache_prefix = self._environment.get("PYTHONPYCACHEPREFIX")
+        if cache_prefix and Path(cache_prefix).is_dir():
+            try:
+                shutil.rmtree(cache_prefix)
+                cleared += 1
+            except OSError:
+                pass
         for root, dirs, _files in os.walk(self._cwd):
             dirs[:] = [d for d in dirs if d not in (".venv", "node_modules", ".git")]
             if "__pycache__" in dirs:

--- a/software/sorter/backend/supervisor.py
+++ b/software/sorter/backend/supervisor.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
 import threading
 import time
+from collections import deque
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -32,6 +34,10 @@ DEFAULT_HEALTH_INTERVAL_S = float(os.getenv("BACKEND_SUPERVISOR_HEALTH_INTERVAL_
 DEFAULT_HEALTH_TIMEOUT_S = float(os.getenv("BACKEND_SUPERVISOR_HEALTH_TIMEOUT_S", "1.5"))
 DEFAULT_RESTART_BACKOFF_S = float(os.getenv("BACKEND_SUPERVISOR_RESTART_BACKOFF_S", "0.2"))
 DEFAULT_STOP_TIMEOUT_S = float(os.getenv("BACKEND_SUPERVISOR_STOP_TIMEOUT_S", "5.0"))
+DEFAULT_FAST_CRASH_WINDOW_S = float(os.getenv("BACKEND_SUPERVISOR_FAST_CRASH_WINDOW_S", "30.0"))
+CACHE_CLEAR_CRASH_THRESHOLD = 3
+CRASH_OUTPUT_MAX_LINES = 60
+CRASH_OUTPUT_MAX_CHARS = 4000
 
 
 def _timestamp() -> float:
@@ -50,6 +56,7 @@ class BackendSupervisor:
         health_timeout_s: float,
         restart_backoff_s: float,
         stop_timeout_s: float,
+        fast_crash_window_s: float = DEFAULT_FAST_CRASH_WINDOW_S,
     ) -> None:
         self._command = list(command)
         self._cwd = cwd
@@ -59,6 +66,7 @@ class BackendSupervisor:
         self._health_timeout_s = health_timeout_s
         self._restart_backoff_s = restart_backoff_s
         self._stop_timeout_s = stop_timeout_s
+        self._fast_crash_window_s = fast_crash_window_s
 
         self._lock = threading.RLock()
         self._shutdown = threading.Event()
@@ -73,6 +81,10 @@ class BackendSupervisor:
         self._last_health_error: str | None = None
         self._last_health_ok_at: float | None = None
         self._health_failures = 0
+        self._consecutive_fast_crashes = 0
+        self._cache_cleared_for_streak = False
+        self._pycache_cleared_at: float | None = None
+        self._last_crash_output: str | None = None
         self._state = "stopped"
 
         self._health_thread = threading.Thread(
@@ -108,6 +120,10 @@ class BackendSupervisor:
                 "last_exit_at": self._last_exit_at,
                 "last_exit_reason": self._last_exit_reason,
                 "restart_requested": self._restart_requested,
+                "consecutive_fast_crashes": self._consecutive_fast_crashes,
+                "crash_looping": self._consecutive_fast_crashes >= CACHE_CLEAR_CRASH_THRESHOLD,
+                "last_crash_output": self._last_crash_output,
+                "pycache_cleared_at": self._pycache_cleared_at,
                 "command": list(self._command),
             }
 
@@ -163,6 +179,8 @@ class BackendSupervisor:
                     self._last_health_ok_at = _timestamp()
                     self._last_health_error = None
                     self._health_failures = 0
+                    self._consecutive_fast_crashes = 0
+                    self._cache_cleared_for_streak = False
             except Exception as exc:
                 with self._lock:
                     self._last_health_error = str(exc)
@@ -180,6 +198,7 @@ class BackendSupervisor:
                 cwd=str(self._cwd),
                 env=self._environment,
                 start_new_session=True,
+                stderr=subprocess.PIPE,
             )
             self._process = child
             self._process_group_pid = child.pid
@@ -191,17 +210,65 @@ class BackendSupervisor:
             self._health_failures = 0
             self._state = "running"
 
+        stderr_tail: deque[str] = deque(maxlen=CRASH_OUTPUT_MAX_LINES)
+        stderr_thread = threading.Thread(
+            target=self._pump_stderr,
+            args=(child, stderr_tail),
+            daemon=True,
+            name="supervisor-stderr",
+        )
+        stderr_thread.start()
+
         threading.Thread(
             target=self._watch_process,
-            args=(child,),
+            args=(child, stderr_tail, stderr_thread),
             daemon=True,
         ).start()
 
-    def _watch_process(self, child: subprocess.Popen[bytes]) -> None:
+    def _pump_stderr(self, child: subprocess.Popen[bytes], tail: deque[str]) -> None:
+        stream = child.stderr
+        if stream is None:
+            return
+        try:
+            for raw_line in iter(stream.readline, b""):
+                sys.stderr.buffer.write(raw_line)
+                sys.stderr.buffer.flush()
+                tail.append(raw_line.decode("utf-8", errors="replace"))
+        except (OSError, ValueError):
+            pass
+        finally:
+            try:
+                stream.close()
+            except OSError:
+                pass
+
+    def _clear_bytecode_caches(self) -> int:
+        cleared = 0
+        for root, dirs, _files in os.walk(self._cwd):
+            dirs[:] = [d for d in dirs if d not in (".venv", "node_modules", ".git")]
+            if "__pycache__" in dirs:
+                dirs.remove("__pycache__")
+                try:
+                    shutil.rmtree(Path(root) / "__pycache__")
+                    cleared += 1
+                except OSError:
+                    pass
+        return cleared
+
+    def _watch_process(
+        self,
+        child: subprocess.Popen[bytes],
+        stderr_tail: deque[str] | None = None,
+        stderr_thread: threading.Thread | None = None,
+    ) -> None:
         return_code = child.wait()
+        if stderr_thread is not None:
+            stderr_thread.join(timeout=2.0)
+        clear_cache = False
         with self._lock:
             if self._process is not child:
                 return
+            started_at = self._process_started_at
             self._process = None
             self._process_group_pid = None
             self._last_exit_code = return_code
@@ -221,6 +288,35 @@ class BackendSupervisor:
                 return
             self._state = "crashed"
             self._last_exit_reason = "backend exited unexpectedly"
+            if stderr_tail:
+                self._last_crash_output = "".join(stderr_tail)[-CRASH_OUTPUT_MAX_CHARS:]
+            fast = (
+                started_at is not None
+                and self._last_exit_at - started_at < self._fast_crash_window_s
+            )
+            if fast:
+                self._consecutive_fast_crashes += 1
+            else:
+                self._consecutive_fast_crashes = 0
+                self._cache_cleared_for_streak = False
+            clear_cache = (
+                self._consecutive_fast_crashes >= CACHE_CLEAR_CRASH_THRESHOLD
+                and not self._cache_cleared_for_streak
+            )
+
+        if clear_cache:
+            # A corrupt .pyc never self-heals: Python trusts the cache header while the
+            # body is garbage, so the backend crash-loops forever. Clearing the caches
+            # once per streak is free and lets the next start recompile from source.
+            cleared = self._clear_bytecode_caches()
+            with self._lock:
+                self._cache_cleared_for_streak = True
+                self._pycache_cleared_at = _timestamp()
+            print(
+                f"[supervisor] crash loop detected ({self._consecutive_fast_crashes} fast exits); "
+                f"cleared {cleared} __pycache__ dirs before restarting",
+                flush=True,
+            )
 
         time.sleep(self._restart_backoff_s)
         if not self._shutdown.is_set():

--- a/software/sorter/backend/tests/test_supervisor_crash_loop.py
+++ b/software/sorter/backend/tests/test_supervisor_crash_loop.py
@@ -1,0 +1,192 @@
+import sys
+import time
+from collections import deque
+from pathlib import Path
+
+from supervisor import BackendSupervisor
+
+
+class _FakeProcess:
+    pid = 12345
+    returncode = 1
+
+    def wait(self):
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def _supervisor(fast_crash_window_s: float = 30.0) -> BackendSupervisor:
+    return BackendSupervisor(
+        command=["backend"],
+        cwd=Path("."),
+        environment={},
+        backend_health_url="http://127.0.0.1:1/health",
+        health_interval_s=999.0,
+        health_timeout_s=0.01,
+        restart_backoff_s=0.0,
+        stop_timeout_s=0.01,
+        fast_crash_window_s=fast_crash_window_s,
+    )
+
+
+def _crash_once(
+    supervisor: BackendSupervisor,
+    *,
+    runtime_s: float,
+    stderr_tail: deque[str] | None = None,
+) -> None:
+    child = _FakeProcess()
+    supervisor._process = child
+    supervisor._process_group_pid = child.pid
+    supervisor._process_started_at = time.time() - runtime_s
+    supervisor._watch_process(child, stderr_tail=stderr_tail)
+
+
+def test_three_fast_crashes_clear_bytecode_caches(monkeypatch):
+    supervisor = _supervisor()
+    restarted: list[str] = []
+    cleared: list[int] = []
+    monkeypatch.setattr(
+        supervisor, "_start_backend", lambda *, reason: restarted.append(reason)
+    )
+    monkeypatch.setattr(
+        supervisor, "_clear_bytecode_caches", lambda: cleared.append(1) or 2
+    )
+
+    _crash_once(supervisor, runtime_s=1.0)
+    _crash_once(supervisor, runtime_s=1.0)
+    assert cleared == []
+    assert supervisor.status()["crash_looping"] is False
+
+    _crash_once(supervisor, runtime_s=1.0)
+    assert cleared == [1]
+    status = supervisor.status()
+    assert status["crash_looping"] is True
+    assert status["consecutive_fast_crashes"] == 3
+    assert status["pycache_cleared_at"] is not None
+    assert len(restarted) == 3
+
+
+def test_cache_cleared_once_per_streak(monkeypatch):
+    supervisor = _supervisor()
+    cleared: list[int] = []
+    monkeypatch.setattr(supervisor, "_start_backend", lambda *, reason: None)
+    monkeypatch.setattr(
+        supervisor, "_clear_bytecode_caches", lambda: cleared.append(1) or 0
+    )
+
+    for _ in range(5):
+        _crash_once(supervisor, runtime_s=1.0)
+
+    assert cleared == [1]
+    assert supervisor.status()["consecutive_fast_crashes"] == 5
+
+
+def test_slow_crash_resets_streak(monkeypatch):
+    supervisor = _supervisor()
+    cleared: list[int] = []
+    monkeypatch.setattr(supervisor, "_start_backend", lambda *, reason: None)
+    monkeypatch.setattr(
+        supervisor, "_clear_bytecode_caches", lambda: cleared.append(1) or 0
+    )
+
+    _crash_once(supervisor, runtime_s=1.0)
+    _crash_once(supervisor, runtime_s=1.0)
+    _crash_once(supervisor, runtime_s=300.0)
+
+    assert cleared == []
+    assert supervisor.status()["consecutive_fast_crashes"] == 0
+
+
+def test_crash_output_captured_in_status(monkeypatch):
+    supervisor = _supervisor()
+    monkeypatch.setattr(supervisor, "_start_backend", lambda *, reason: None)
+    tail = deque(
+        [
+            "Traceback (most recent call last):\n",
+            '  File "main.py", line 1, in <module>\n',
+            "ValueError: could not convert string to float: ''\n",
+        ]
+    )
+
+    _crash_once(supervisor, runtime_s=1.0, stderr_tail=tail)
+
+    output = supervisor.status()["last_crash_output"]
+    assert output is not None
+    assert "ValueError: could not convert string to float" in output
+
+
+def test_manual_stop_does_not_count_as_crash(monkeypatch):
+    supervisor = _supervisor()
+    monkeypatch.setattr(supervisor, "_start_backend", lambda *, reason: None)
+    child = _FakeProcess()
+    supervisor._process = child
+    supervisor._process_group_pid = child.pid
+    supervisor._process_started_at = time.time()
+    supervisor._manual_stop_requested = True
+
+    supervisor._watch_process(child)
+
+    status = supervisor.status()
+    assert status["consecutive_fast_crashes"] == 0
+    assert status["last_crash_output"] is None
+
+
+def test_real_crashing_subprocess_captures_stderr_and_clears_cache(tmp_path):
+    (tmp_path / "perception" / "__pycache__").mkdir(parents=True)
+    supervisor = BackendSupervisor(
+        command=[
+            sys.executable,
+            "-c",
+            "import sys; sys.stderr.write('ValueError: boom\\n'); sys.exit(1)",
+        ],
+        cwd=tmp_path,
+        environment={},
+        backend_health_url="http://127.0.0.1:1/health",
+        health_interval_s=999.0,
+        health_timeout_s=0.01,
+        restart_backoff_s=0.05,
+        stop_timeout_s=0.01,
+    )
+
+    supervisor._start_backend(reason="test")
+    deadline = time.time() + 30.0
+    while time.time() < deadline:
+        if supervisor.status()["crash_looping"]:
+            break
+        time.sleep(0.05)
+    supervisor.shutdown()
+
+    status = supervisor.status()
+    assert status["crash_looping"] is True
+    assert status["last_crash_output"] is not None
+    assert "ValueError: boom" in status["last_crash_output"]
+    assert status["pycache_cleared_at"] is not None
+    assert not (tmp_path / "perception" / "__pycache__").exists()
+
+
+def test_clear_bytecode_caches_skips_venv(tmp_path):
+    backend = tmp_path
+    (backend / "perception" / "__pycache__").mkdir(parents=True)
+    (backend / "perception" / "__pycache__" / "capture.cpython-312.pyc").write_bytes(
+        b"garbage"
+    )
+    (backend / ".venv" / "lib" / "__pycache__").mkdir(parents=True)
+    supervisor = BackendSupervisor(
+        command=["backend"],
+        cwd=backend,
+        environment={},
+        backend_health_url="http://127.0.0.1:1/health",
+        health_interval_s=999.0,
+        health_timeout_s=0.01,
+        restart_backoff_s=0.0,
+        stop_timeout_s=0.01,
+    )
+
+    cleared = supervisor._clear_bytecode_caches()
+
+    assert cleared == 1
+    assert not (backend / "perception" / "__pycache__").exists()
+    assert (backend / ".venv" / "lib" / "__pycache__").exists()

--- a/software/sorter/backend/tests/test_supervisor_crash_loop.py
+++ b/software/sorter/backend/tests/test_supervisor_crash_loop.py
@@ -168,16 +168,18 @@ def test_real_crashing_subprocess_captures_stderr_and_clears_cache(tmp_path):
 
 
 def test_clear_bytecode_caches_skips_venv(tmp_path):
-    backend = tmp_path
+    backend = tmp_path / "backend"
     (backend / "perception" / "__pycache__").mkdir(parents=True)
     (backend / "perception" / "__pycache__" / "capture.cpython-312.pyc").write_bytes(
         b"garbage"
     )
     (backend / ".venv" / "lib" / "__pycache__").mkdir(parents=True)
+    cache_prefix = tmp_path / "pycache-prefix"
+    (cache_prefix / "sub").mkdir(parents=True)
     supervisor = BackendSupervisor(
         command=["backend"],
         cwd=backend,
-        environment={},
+        environment={"PYTHONPYCACHEPREFIX": str(cache_prefix)},
         backend_health_url="http://127.0.0.1:1/health",
         health_interval_s=999.0,
         health_timeout_s=0.01,
@@ -187,6 +189,7 @@ def test_clear_bytecode_caches_skips_venv(tmp_path):
 
     cleared = supervisor._clear_bytecode_caches()
 
-    assert cleared == 1
+    assert cleared == 2
     assert not (backend / "perception" / "__pycache__").exists()
+    assert not cache_prefix.exists()
     assert (backend / ".venv" / "lib" / "__pycache__").exists()

--- a/software/sorter/frontend/src/lib/backend.ts
+++ b/software/sorter/frontend/src/lib/backend.ts
@@ -79,6 +79,8 @@ export type BackendConnectionProbeResult = {
 	backendRunning: boolean;
 	backendHealthy: boolean;
 	restartRequested: boolean;
+	crashLooping: boolean;
+	lastCrashOutput: string | null;
 };
 
 export async function requestBackendRestart(
@@ -136,7 +138,9 @@ export async function probeBackendConnection(
 				supervisorState: null,
 				backendRunning: true,
 				backendHealthy: true,
-				restartRequested: false
+				restartRequested: false,
+				crashLooping: false,
+				lastCrashOutput: null
 			};
 		}
 		console.warn(`[backend] /health probe returned non-ok status ${response.status} for ${backendBaseUrl}/health`);
@@ -160,7 +164,10 @@ export async function probeBackendConnection(
 						typeof data?.supervisor_state === 'string' ? data.supervisor_state : null,
 					backendRunning: Boolean(data?.backend_running),
 					backendHealthy: Boolean(data?.backend_healthy),
-					restartRequested: Boolean(data?.restart_requested)
+					restartRequested: Boolean(data?.restart_requested),
+					crashLooping: Boolean(data?.crash_looping),
+					lastCrashOutput:
+						typeof data?.last_crash_output === 'string' ? data.last_crash_output : null
 				};
 			}
 		} catch (err) {
@@ -175,7 +182,9 @@ export async function probeBackendConnection(
 		supervisorState: null,
 		backendRunning: false,
 		backendHealthy: false,
-		restartRequested: false
+		restartRequested: false,
+		crashLooping: false,
+		lastCrashOutput: null
 	};
 }
 

--- a/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
+++ b/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
@@ -27,6 +27,8 @@
 	let healthy = $state(true);
 	let checking = $state(false);
 	let restarting = $state(false);
+	let crashLooping = $state(false);
+	let lastCrashOutput = $state<string | null>(null);
 	let consecutiveFailures = $state(0);
 	let firstFailureAt = $state<number | null>(null);
 	let lastRecoveryRefreshAt = $state(0);
@@ -76,12 +78,18 @@
 			manager.ensureConnected(url);
 			firstFailureAt = null;
 			restarting = false;
+			crashLooping = false;
+			lastCrashOutput = null;
 			return { backendOk: true, showUnavailable: false };
 		}
 		if (selectedMachineLooksAlive()) {
 			firstFailureAt = null;
 			restarting = false;
 			return { backendOk: true, showUnavailable: false };
+		}
+		crashLooping = status.crashLooping;
+		if (status.lastCrashOutput) {
+			lastCrashOutput = status.lastCrashOutput;
 		}
 
 		consecutiveFailures++;
@@ -182,8 +190,17 @@
 			>
 				<WifiOff size={18} />
 			</div>
-			<div>
-				{#if restarting}
+			<div class="min-w-0 flex-1">
+				{#if crashLooping}
+					<div class="text-sm text-text">
+						The backend keeps crashing during startup. It is being restarted automatically, but it
+						has failed several times in a row.
+					</div>
+					{#if lastCrashOutput}
+						<pre
+							class="mt-3 max-h-48 overflow-auto whitespace-pre-wrap border border-border bg-bg p-2 font-mono text-xs text-text-muted">{lastCrashOutput}</pre>
+					{/if}
+				{:else if restarting}
 					<div class="text-sm text-text">
 						The backend is restarting. Waiting for it to come back online...
 					</div>
@@ -203,7 +220,7 @@
 			</div>
 		</div>
 
-		{#if !restarting}
+		{#if !restarting || crashLooping}
 			<div class="flex items-center justify-end gap-2 border-t border-border pt-3">
 				<button
 					type="button"

--- a/software/sorteros/build/overlay/etc/systemd/system/sorter-backend-dev.service
+++ b/software/sorteros/build/overlay/etc/systemd/system/sorter-backend-dev.service
@@ -3,13 +3,19 @@ Description=Sorter Backend (dev)
 After=network-online.target
 Wants=network-online.target
 Conflicts=sorter-backend.service
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/backend
+# Bytecode caches on tmpfs: a power cut once corrupted an on-disk .pyc whose
+# header still validated, crash-looping the backend forever (bbs-01,
+# 2026-08-01). /tmp is RAM-backed, so caches regenerate fresh every boot and
+# can never carry corruption across one.
+Environment=PYTHONPYCACHEPREFIX=/tmp/sorter-pycache
 # Dev mode notes:
 #   - Same supervisor + main.py as prod so hardware/coordinator behavior matches.
 #   - For fast iteration on a code edit, prefer a soft restart of main.py via the

--- a/software/sorteros/build/overlay/etc/systemd/system/sorter-backend.service
+++ b/software/sorteros/build/overlay/etc/systemd/system/sorter-backend.service
@@ -3,13 +3,17 @@ Description=Sorter Backend
 Documentation=https://basicallysource.github.io/sorter-v2/sorter/installation/
 After=network-online.target
 Wants=network-online.target
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/backend
+# Bytecode caches on tmpfs — power-cut corruption of an on-disk .pyc once
+# crash-looped the backend forever (bbs-01, 2026-08-01); see sorter-backend-dev.
+Environment=PYTHONPYCACHEPREFIX=/tmp/sorter-pycache
 # .env uses "export FOO=bar" syntax; systemd EnvironmentFile= doesn't handle
 # the export keyword — source through bash so both forms work correctly.
 ExecStart=/bin/bash -c "set -a; source __SOFTWARE_DIR__/.env; exec __UV_BIN__ run python supervisor.py"

--- a/software/sorteros/build/overlay/etc/systemd/system/sorter-ui-dev.service
+++ b/software/sorteros/build/overlay/etc/systemd/system/sorter-ui-dev.service
@@ -3,14 +3,21 @@ Description=Sorter UI (dev — Vite HMR)
 After=network-online.target sorter-backend-dev.service
 Wants=network-online.target
 Conflicts=sorter-ui.service
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: machines in the field get power-cut, and a corrupted
+# generated file used to make vite fail instantly 3x, after which systemd gave
+# up forever — leaving the UI dead until someone SSHed in (bbs-01, 2026-08-03).
+# Keep retrying; ExecStartPre wipes the poison so the next attempt succeeds.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/frontend
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# .svelte-kit and node_modules/.vite are generated caches rewritten by vite on
+# startup — exactly the files a power cut catches mid-write. Corrupt contents
+# make vite exit before binding the port, so never trust them across a start.
+ExecStartPre=/bin/rm -rf __SOFTWARE_DIR__/sorter/frontend/.svelte-kit __SOFTWARE_DIR__/sorter/frontend/node_modules/.vite
 # `vite dev` gives sub-second HMR for .svelte / .ts edits scp'd from the Mac.
 # `--host 0.0.0.0` makes it reachable on the LAN; `--strictPort` makes it fail
 # loudly if the port is busy instead of silently picking another port.
@@ -18,7 +25,7 @@ Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # binding is enabled via /etc/sysctl.d/99-sorter-unprivileged-ports.conf.
 ExecStart=__PNPM_BIN__ dev --host 0.0.0.0 --port 80 --strictPort
 Restart=on-failure
-RestartSec=2
+RestartSec=5
 StandardOutput=journal
 StandardError=journal
 

--- a/software/sorteros/build/overlay/etc/systemd/system/sorter-ui.service
+++ b/software/sorteros/build/overlay/etc/systemd/system/sorter-ui.service
@@ -3,8 +3,11 @@ Description=Sorter UI
 Documentation=https://basicallysource.github.io/sorter-v2/sorter/installation/
 After=network-online.target sorter-backend.service
 Wants=network-online.target
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+# (No cache wipe here: preview serves the built app from .svelte-kit/output,
+# which is NOT regenerable at startup — a corrupt build needs a rebuild.)
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple

--- a/software/systemd/sorter-backend-dev.service
+++ b/software/systemd/sorter-backend-dev.service
@@ -3,13 +3,19 @@ Description=Sorter Backend (dev)
 After=network-online.target
 Wants=network-online.target
 Conflicts=sorter-backend.service
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/backend
+# Bytecode caches on tmpfs: a power cut once corrupted an on-disk .pyc whose
+# header still validated, crash-looping the backend forever (bbs-01,
+# 2026-08-01). /tmp is RAM-backed, so caches regenerate fresh every boot and
+# can never carry corruption across one.
+Environment=PYTHONPYCACHEPREFIX=/tmp/sorter-pycache
 # Dev mode notes:
 #   - Same supervisor + main.py as prod so hardware/coordinator behavior matches.
 #   - For fast iteration on a code edit, prefer a soft restart of main.py via the

--- a/software/systemd/sorter-backend.service
+++ b/software/systemd/sorter-backend.service
@@ -3,13 +3,17 @@ Description=Sorter Backend
 Documentation=https://basicallysource.github.io/sorter-v2/sorter/installation/
 After=network-online.target
 Wants=network-online.target
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/backend
+# Bytecode caches on tmpfs — power-cut corruption of an on-disk .pyc once
+# crash-looped the backend forever (bbs-01, 2026-08-01); see sorter-backend-dev.
+Environment=PYTHONPYCACHEPREFIX=/tmp/sorter-pycache
 # .env uses "export FOO=bar" syntax; systemd EnvironmentFile= doesn't handle
 # the export keyword — source through bash so both forms work correctly.
 ExecStart=/bin/bash -c "set -a; source __SOFTWARE_DIR__/.env; exec __UV_BIN__ run python supervisor.py"

--- a/software/systemd/sorter-ui-dev.service
+++ b/software/systemd/sorter-ui-dev.service
@@ -3,14 +3,21 @@ Description=Sorter UI (dev — Vite HMR)
 After=network-online.target sorter-backend-dev.service
 Wants=network-online.target
 Conflicts=sorter-ui.service
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: machines in the field get power-cut, and a corrupted
+# generated file used to make vite fail instantly 3x, after which systemd gave
+# up forever — leaving the UI dead until someone SSHed in (bbs-01, 2026-08-03).
+# Keep retrying; ExecStartPre wipes the poison so the next attempt succeeds.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/frontend
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# .svelte-kit and node_modules/.vite are generated caches rewritten by vite on
+# startup — exactly the files a power cut catches mid-write. Corrupt contents
+# make vite exit before binding the port, so never trust them across a start.
+ExecStartPre=/bin/rm -rf __SOFTWARE_DIR__/sorter/frontend/.svelte-kit __SOFTWARE_DIR__/sorter/frontend/node_modules/.vite
 # `vite dev` gives sub-second HMR for .svelte / .ts edits scp'd from the Mac.
 # `--host 0.0.0.0` makes it reachable on the LAN; `--strictPort` makes it fail
 # loudly if the port is busy instead of silently picking another port.
@@ -18,7 +25,7 @@ Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # binding is enabled via /etc/sysctl.d/99-sorter-unprivileged-ports.conf.
 ExecStart=__PNPM_BIN__ dev --host 0.0.0.0 --port 80 --strictPort
 Restart=on-failure
-RestartSec=2
+RestartSec=5
 StandardOutput=journal
 StandardError=journal
 

--- a/software/systemd/sorter-ui.service
+++ b/software/systemd/sorter-ui.service
@@ -3,8 +3,11 @@ Description=Sorter UI
 Documentation=https://basicallysource.github.io/sorter-v2/sorter/installation/
 After=network-online.target sorter-backend.service
 Wants=network-online.target
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+# (No cache wipe here: preview serves the built app from .svelte-kit/output,
+# which is NOT regenerable at startup — a corrupt build needs a rebuild.)
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple


### PR DESCRIPTION
Branched off `settings-tuning-revert-and-info`, so it targets that rather than `main`.

**AI cost logging.** OpenRouter calls now ask for `usage: {include: true}` — token counts came back by default, price did not, so cost was never available before. Cost is summed across the tool-call rounds of a turn. New `ai_usage_events` table: one row per chat turn (or change-note call), keyed by user, profile, and assistant message, carrying model, generation ids, token counts, and `cost_usd`. Written from all four AI paths. `GET /api/ai/usage` aggregates per user over 7d / 30d / 1y / all time.

**AI Spend panel.** Below the model picker in settings: cost, request count, and tokens per period, plus "tracked since". Sub-cent turns format to 4 decimals. Per-turn cost also joins the chat performance line.

**Profile rename.** The name in the edit header was an unmarked text input that read as static text — now has a `Pencil` button beside it and underlines on hover/focus.

**Fix: chat was broken over plain http.** `crypto.randomUUID` only exists in secure contexts, so every rule id and chat request id threw on dev Hive over the tailnet. Replaced with a `getRandomValues` v4 in `lib/uuid.ts`.

Also included, because they share the settings page and api client: the model picker (`ModelSelect`, curated `/api/ai/models` catalog, GLM 5.2 default) and the vite config that makes dev Hive reachable over the tailnet. Hive frontend `CLAUDE.md` gained two rules — icons come from `lucide-svelte`, and Hive changes get verified in a signed-in browser.

Adds one migration (`a4d6f8b0c2e5_add_ai_usage_events`).
