### PR TITLE
Add parts calculator links to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@
 [More details](https://basically.website/sorter-v2)
 
 [Documentation source](docs/index.md)
+
+[Parts calculator](https://parts-calculator.basically.website/)

--- a/mechanical/README.md
+++ b/mechanical/README.md
@@ -1,6 +1,8 @@
 # basically Sorter - Mechanical
 
-The CAD is not finished and nothing has been exported or committed to this repository yet.
+The CAD is not finished. The CAD exports live in [basicallysource/parts-calculator](https://github.com/basicallysource/parts-calculator/) right now, but will eventually get merged into this repository.
+
+[Parts calculator](https://parts-calculator.basically.website/)
 
 The CAD lives in OnShape. The top-level folder is private, and we're not even sure it's possible to make it public. If you'd like access, join the [Discord](https://discord.gg/6PZtqkwtaS).
 


### PR DESCRIPTION
Adds a link to the parts calculator on the root README (same bare-link style as the others) and on the mechanical README alongside the OnShape links.

Also notes on the mechanical README that CAD exports currently live in [basicallysource/parts-calculator](https://github.com/basicallysource/parts-calculator/) and will eventually be merged into this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)