### PR TITLE
Supervisor: self-heal backend crash loops, show crash output in the UI

### DIFF
--- a/software/hive/frontend/src/lib/components/charts/AnalyticsDashboard.svelte
+++ b/software/hive/frontend/src/lib/components/charts/AnalyticsDashboard.svelte
@@ -83,16 +83,34 @@
 	}
 
 	const statusSegments = $derived<DonutSegment[]>(
-		(data?.distributions.by_status ?? []).map((s) => ({ label: s.label, value: s.value, color: statusColor(s.label) }))
+		(data?.distributions.by_status ?? []).map((s) => ({ key: s.label, label: s.label, value: s.value, color: statusColor(s.label) }))
 	);
-	const machineSegments = $derived<DonutSegment[]>(
-		(data?.distributions.by_machine ?? []).map((m, i) => ({ label: m.label, value: m.value, color: PALETTE[i % PALETTE.length] }))
-	);
+	const machineSegments = $derived.by<DonutSegment[]>(() => {
+		const rows = data?.distributions.by_machine ?? [];
+		// Machine names aren't unique across the fleet — tag the collisions so the
+		// legend doesn't show three identical rows.
+		const dupes = new Set(rows.map((m) => m.label).filter((l, i, all) => all.indexOf(l) !== i));
+		return rows.map((m, i) => ({
+			key: m.machine_id,
+			label: dupes.has(m.label) ? `${m.label} · ${m.machine_id.slice(0, 6)}` : m.label,
+			value: m.value,
+			color: PALETTE[i % PALETTE.length]
+		}));
+	});
 	const topParts = $derived<BarItem[]>(
-		(data?.distributions.top_parts ?? []).map((p) => ({ label: p.part_name || p.part_id || '—', sublabel: p.part_id, value: p.value }))
+		(data?.distributions.top_parts ?? []).map((p, i) => ({
+			key: p.part_id ?? `part-${i}`,
+			label: p.part_name || p.part_id || '—',
+			sublabel: p.part_id,
+			value: p.value
+		}))
 	);
 	const topColors = $derived<BarItem[]>(
-		(data?.distributions.top_colors ?? []).map((c) => ({ label: c.color_name || c.color_id || '—', value: c.value }))
+		(data?.distributions.top_colors ?? []).map((c, i) => ({
+			key: c.color_id ?? `color-${i}`,
+			label: c.color_name || c.color_id || '—',
+			value: c.value
+		}))
 	);
 
 	function num(n: number | null | undefined): string {

--- a/software/hive/frontend/src/lib/components/charts/BarList.svelte
+++ b/software/hive/frontend/src/lib/components/charts/BarList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	// Horizontal bar list for ranked categorical data (top parts, top colors).
-	export type BarItem = { label: string; sublabel?: string | null; value: number; swatch?: string | null };
+	// `key` must be unique — labels are not (two colors can share a name).
+	export type BarItem = { key: string; label: string; sublabel?: string | null; value: number; swatch?: string | null };
 
 	let {
 		items,
@@ -17,7 +18,7 @@
 	<div class="flex h-24 items-center justify-center text-sm text-text-muted">No data yet.</div>
 {:else}
 	<div class="flex flex-col gap-1.5">
-		{#each items as item (item.label + (item.sublabel ?? ''))}
+		{#each items as item (item.key)}
 			<div class="flex items-center gap-2 text-sm">
 				{#if item.swatch}
 					<span class="h-3 w-3 flex-shrink-0 border border-border" style:background-color={item.swatch}></span>

--- a/software/hive/frontend/src/lib/components/charts/DonutChart.svelte
+++ b/software/hive/frontend/src/lib/components/charts/DonutChart.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	// Hand-rolled SVG donut. Segments drawn with stroke-dasharray on a circle so
 	// there's no arc math; the legend carries the exact numbers.
-	export type DonutSegment = { label: string; value: number; color: string };
+	// `key` must be unique — labels are not (two machines can share a name).
+	export type DonutSegment = { key: string; label: string; value: number; color: string };
 
 	let {
 		segments,
@@ -39,7 +40,7 @@
 	<div class="flex flex-wrap items-center gap-4">
 		<svg viewBox="0 0 120 120" class="h-36 w-36 flex-shrink-0" role="img">
 			<circle cx="60" cy="60" r={R} fill="none" stroke="var(--color-border)" stroke-width={STROKE} />
-			{#each arcs as a (a.label)}
+			{#each arcs as a (a.key)}
 				<circle
 					cx="60"
 					cy="60"
@@ -64,7 +65,7 @@
 			{/if}
 		</svg>
 		<div class="flex min-w-0 flex-1 flex-col gap-1">
-			{#each arcs as a (a.label)}
+			{#each arcs as a (a.key)}
 				<div class="flex items-center gap-2 text-sm">
 					<span class="h-3 w-3 flex-shrink-0 border border-border" style:background-color={a.color}></span>
 					<span class="truncate text-text">{a.label}</span>

--- a/software/sorter/backend/supervisor.py
+++ b/software/sorter/backend/supervisor.py
@@ -244,6 +244,13 @@ class BackendSupervisor:
 
     def _clear_bytecode_caches(self) -> int:
         cleared = 0
+        cache_prefix = self._environment.get("PYTHONPYCACHEPREFIX")
+        if cache_prefix and Path(cache_prefix).is_dir():
+            try:
+                shutil.rmtree(cache_prefix)
+                cleared += 1
+            except OSError:
+                pass
         for root, dirs, _files in os.walk(self._cwd):
             dirs[:] = [d for d in dirs if d not in (".venv", "node_modules", ".git")]
             if "__pycache__" in dirs:

--- a/software/sorter/backend/supervisor.py
+++ b/software/sorter/backend/supervisor.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
 import threading
 import time
+from collections import deque
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -32,6 +34,10 @@ DEFAULT_HEALTH_INTERVAL_S = float(os.getenv("BACKEND_SUPERVISOR_HEALTH_INTERVAL_
 DEFAULT_HEALTH_TIMEOUT_S = float(os.getenv("BACKEND_SUPERVISOR_HEALTH_TIMEOUT_S", "1.5"))
 DEFAULT_RESTART_BACKOFF_S = float(os.getenv("BACKEND_SUPERVISOR_RESTART_BACKOFF_S", "0.2"))
 DEFAULT_STOP_TIMEOUT_S = float(os.getenv("BACKEND_SUPERVISOR_STOP_TIMEOUT_S", "5.0"))
+DEFAULT_FAST_CRASH_WINDOW_S = float(os.getenv("BACKEND_SUPERVISOR_FAST_CRASH_WINDOW_S", "30.0"))
+CACHE_CLEAR_CRASH_THRESHOLD = 3
+CRASH_OUTPUT_MAX_LINES = 60
+CRASH_OUTPUT_MAX_CHARS = 4000
 
 
 def _timestamp() -> float:
@@ -50,6 +56,7 @@ class BackendSupervisor:
         health_timeout_s: float,
         restart_backoff_s: float,
         stop_timeout_s: float,
+        fast_crash_window_s: float = DEFAULT_FAST_CRASH_WINDOW_S,
     ) -> None:
         self._command = list(command)
         self._cwd = cwd
@@ -59,6 +66,7 @@ class BackendSupervisor:
         self._health_timeout_s = health_timeout_s
         self._restart_backoff_s = restart_backoff_s
         self._stop_timeout_s = stop_timeout_s
+        self._fast_crash_window_s = fast_crash_window_s
 
         self._lock = threading.RLock()
         self._shutdown = threading.Event()
@@ -73,6 +81,10 @@ class BackendSupervisor:
         self._last_health_error: str | None = None
         self._last_health_ok_at: float | None = None
         self._health_failures = 0
+        self._consecutive_fast_crashes = 0
+        self._cache_cleared_for_streak = False
+        self._pycache_cleared_at: float | None = None
+        self._last_crash_output: str | None = None
         self._state = "stopped"
 
         self._health_thread = threading.Thread(
@@ -108,6 +120,10 @@ class BackendSupervisor:
                 "last_exit_at": self._last_exit_at,
                 "last_exit_reason": self._last_exit_reason,
                 "restart_requested": self._restart_requested,
+                "consecutive_fast_crashes": self._consecutive_fast_crashes,
+                "crash_looping": self._consecutive_fast_crashes >= CACHE_CLEAR_CRASH_THRESHOLD,
+                "last_crash_output": self._last_crash_output,
+                "pycache_cleared_at": self._pycache_cleared_at,
                 "command": list(self._command),
             }
 
@@ -163,6 +179,8 @@ class BackendSupervisor:
                     self._last_health_ok_at = _timestamp()
                     self._last_health_error = None
                     self._health_failures = 0
+                    self._consecutive_fast_crashes = 0
+                    self._cache_cleared_for_streak = False
             except Exception as exc:
                 with self._lock:
                     self._last_health_error = str(exc)
@@ -180,6 +198,7 @@ class BackendSupervisor:
                 cwd=str(self._cwd),
                 env=self._environment,
                 start_new_session=True,
+                stderr=subprocess.PIPE,
             )
             self._process = child
             self._process_group_pid = child.pid
@@ -191,17 +210,65 @@ class BackendSupervisor:
             self._health_failures = 0
             self._state = "running"
 
+        stderr_tail: deque[str] = deque(maxlen=CRASH_OUTPUT_MAX_LINES)
+        stderr_thread = threading.Thread(
+            target=self._pump_stderr,
+            args=(child, stderr_tail),
+            daemon=True,
+            name="supervisor-stderr",
+        )
+        stderr_thread.start()
+
         threading.Thread(
             target=self._watch_process,
-            args=(child,),
+            args=(child, stderr_tail, stderr_thread),
             daemon=True,
         ).start()
 
-    def _watch_process(self, child: subprocess.Popen[bytes]) -> None:
+    def _pump_stderr(self, child: subprocess.Popen[bytes], tail: deque[str]) -> None:
+        stream = child.stderr
+        if stream is None:
+            return
+        try:
+            for raw_line in iter(stream.readline, b""):
+                sys.stderr.buffer.write(raw_line)
+                sys.stderr.buffer.flush()
+                tail.append(raw_line.decode("utf-8", errors="replace"))
+        except (OSError, ValueError):
+            pass
+        finally:
+            try:
+                stream.close()
+            except OSError:
+                pass
+
+    def _clear_bytecode_caches(self) -> int:
+        cleared = 0
+        for root, dirs, _files in os.walk(self._cwd):
+            dirs[:] = [d for d in dirs if d not in (".venv", "node_modules", ".git")]
+            if "__pycache__" in dirs:
+                dirs.remove("__pycache__")
+                try:
+                    shutil.rmtree(Path(root) / "__pycache__")
+                    cleared += 1
+                except OSError:
+                    pass
+        return cleared
+
+    def _watch_process(
+        self,
+        child: subprocess.Popen[bytes],
+        stderr_tail: deque[str] | None = None,
+        stderr_thread: threading.Thread | None = None,
+    ) -> None:
         return_code = child.wait()
+        if stderr_thread is not None:
+            stderr_thread.join(timeout=2.0)
+        clear_cache = False
         with self._lock:
             if self._process is not child:
                 return
+            started_at = self._process_started_at
             self._process = None
             self._process_group_pid = None
             self._last_exit_code = return_code
@@ -221,6 +288,35 @@ class BackendSupervisor:
                 return
             self._state = "crashed"
             self._last_exit_reason = "backend exited unexpectedly"
+            if stderr_tail:
+                self._last_crash_output = "".join(stderr_tail)[-CRASH_OUTPUT_MAX_CHARS:]
+            fast = (
+                started_at is not None
+                and self._last_exit_at - started_at < self._fast_crash_window_s
+            )
+            if fast:
+                self._consecutive_fast_crashes += 1
+            else:
+                self._consecutive_fast_crashes = 0
+                self._cache_cleared_for_streak = False
+            clear_cache = (
+                self._consecutive_fast_crashes >= CACHE_CLEAR_CRASH_THRESHOLD
+                and not self._cache_cleared_for_streak
+            )
+
+        if clear_cache:
+            # A corrupt .pyc never self-heals: Python trusts the cache header while the
+            # body is garbage, so the backend crash-loops forever. Clearing the caches
+            # once per streak is free and lets the next start recompile from source.
+            cleared = self._clear_bytecode_caches()
+            with self._lock:
+                self._cache_cleared_for_streak = True
+                self._pycache_cleared_at = _timestamp()
+            print(
+                f"[supervisor] crash loop detected ({self._consecutive_fast_crashes} fast exits); "
+                f"cleared {cleared} __pycache__ dirs before restarting",
+                flush=True,
+            )
 
         time.sleep(self._restart_backoff_s)
         if not self._shutdown.is_set():

--- a/software/sorter/backend/tests/test_supervisor_crash_loop.py
+++ b/software/sorter/backend/tests/test_supervisor_crash_loop.py
@@ -1,0 +1,192 @@
+import sys
+import time
+from collections import deque
+from pathlib import Path
+
+from supervisor import BackendSupervisor
+
+
+class _FakeProcess:
+    pid = 12345
+    returncode = 1
+
+    def wait(self):
+        return self.returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def _supervisor(fast_crash_window_s: float = 30.0) -> BackendSupervisor:
+    return BackendSupervisor(
+        command=["backend"],
+        cwd=Path("."),
+        environment={},
+        backend_health_url="http://127.0.0.1:1/health",
+        health_interval_s=999.0,
+        health_timeout_s=0.01,
+        restart_backoff_s=0.0,
+        stop_timeout_s=0.01,
+        fast_crash_window_s=fast_crash_window_s,
+    )
+
+
+def _crash_once(
+    supervisor: BackendSupervisor,
+    *,
+    runtime_s: float,
+    stderr_tail: deque[str] | None = None,
+) -> None:
+    child = _FakeProcess()
+    supervisor._process = child
+    supervisor._process_group_pid = child.pid
+    supervisor._process_started_at = time.time() - runtime_s
+    supervisor._watch_process(child, stderr_tail=stderr_tail)
+
+
+def test_three_fast_crashes_clear_bytecode_caches(monkeypatch):
+    supervisor = _supervisor()
+    restarted: list[str] = []
+    cleared: list[int] = []
+    monkeypatch.setattr(
+        supervisor, "_start_backend", lambda *, reason: restarted.append(reason)
+    )
+    monkeypatch.setattr(
+        supervisor, "_clear_bytecode_caches", lambda: cleared.append(1) or 2
+    )
+
+    _crash_once(supervisor, runtime_s=1.0)
+    _crash_once(supervisor, runtime_s=1.0)
+    assert cleared == []
+    assert supervisor.status()["crash_looping"] is False
+
+    _crash_once(supervisor, runtime_s=1.0)
+    assert cleared == [1]
+    status = supervisor.status()
+    assert status["crash_looping"] is True
+    assert status["consecutive_fast_crashes"] == 3
+    assert status["pycache_cleared_at"] is not None
+    assert len(restarted) == 3
+
+
+def test_cache_cleared_once_per_streak(monkeypatch):
+    supervisor = _supervisor()
+    cleared: list[int] = []
+    monkeypatch.setattr(supervisor, "_start_backend", lambda *, reason: None)
+    monkeypatch.setattr(
+        supervisor, "_clear_bytecode_caches", lambda: cleared.append(1) or 0
+    )
+
+    for _ in range(5):
+        _crash_once(supervisor, runtime_s=1.0)
+
+    assert cleared == [1]
+    assert supervisor.status()["consecutive_fast_crashes"] == 5
+
+
+def test_slow_crash_resets_streak(monkeypatch):
+    supervisor = _supervisor()
+    cleared: list[int] = []
+    monkeypatch.setattr(supervisor, "_start_backend", lambda *, reason: None)
+    monkeypatch.setattr(
+        supervisor, "_clear_bytecode_caches", lambda: cleared.append(1) or 0
+    )
+
+    _crash_once(supervisor, runtime_s=1.0)
+    _crash_once(supervisor, runtime_s=1.0)
+    _crash_once(supervisor, runtime_s=300.0)
+
+    assert cleared == []
+    assert supervisor.status()["consecutive_fast_crashes"] == 0
+
+
+def test_crash_output_captured_in_status(monkeypatch):
+    supervisor = _supervisor()
+    monkeypatch.setattr(supervisor, "_start_backend", lambda *, reason: None)
+    tail = deque(
+        [
+            "Traceback (most recent call last):\n",
+            '  File "main.py", line 1, in <module>\n',
+            "ValueError: could not convert string to float: ''\n",
+        ]
+    )
+
+    _crash_once(supervisor, runtime_s=1.0, stderr_tail=tail)
+
+    output = supervisor.status()["last_crash_output"]
+    assert output is not None
+    assert "ValueError: could not convert string to float" in output
+
+
+def test_manual_stop_does_not_count_as_crash(monkeypatch):
+    supervisor = _supervisor()
+    monkeypatch.setattr(supervisor, "_start_backend", lambda *, reason: None)
+    child = _FakeProcess()
+    supervisor._process = child
+    supervisor._process_group_pid = child.pid
+    supervisor._process_started_at = time.time()
+    supervisor._manual_stop_requested = True
+
+    supervisor._watch_process(child)
+
+    status = supervisor.status()
+    assert status["consecutive_fast_crashes"] == 0
+    assert status["last_crash_output"] is None
+
+
+def test_real_crashing_subprocess_captures_stderr_and_clears_cache(tmp_path):
+    (tmp_path / "perception" / "__pycache__").mkdir(parents=True)
+    supervisor = BackendSupervisor(
+        command=[
+            sys.executable,
+            "-c",
+            "import sys; sys.stderr.write('ValueError: boom\\n'); sys.exit(1)",
+        ],
+        cwd=tmp_path,
+        environment={},
+        backend_health_url="http://127.0.0.1:1/health",
+        health_interval_s=999.0,
+        health_timeout_s=0.01,
+        restart_backoff_s=0.05,
+        stop_timeout_s=0.01,
+    )
+
+    supervisor._start_backend(reason="test")
+    deadline = time.time() + 30.0
+    while time.time() < deadline:
+        if supervisor.status()["crash_looping"]:
+            break
+        time.sleep(0.05)
+    supervisor.shutdown()
+
+    status = supervisor.status()
+    assert status["crash_looping"] is True
+    assert status["last_crash_output"] is not None
+    assert "ValueError: boom" in status["last_crash_output"]
+    assert status["pycache_cleared_at"] is not None
+    assert not (tmp_path / "perception" / "__pycache__").exists()
+
+
+def test_clear_bytecode_caches_skips_venv(tmp_path):
+    backend = tmp_path
+    (backend / "perception" / "__pycache__").mkdir(parents=True)
+    (backend / "perception" / "__pycache__" / "capture.cpython-312.pyc").write_bytes(
+        b"garbage"
+    )
+    (backend / ".venv" / "lib" / "__pycache__").mkdir(parents=True)
+    supervisor = BackendSupervisor(
+        command=["backend"],
+        cwd=backend,
+        environment={},
+        backend_health_url="http://127.0.0.1:1/health",
+        health_interval_s=999.0,
+        health_timeout_s=0.01,
+        restart_backoff_s=0.0,
+        stop_timeout_s=0.01,
+    )
+
+    cleared = supervisor._clear_bytecode_caches()
+
+    assert cleared == 1
+    assert not (backend / "perception" / "__pycache__").exists()
+    assert (backend / ".venv" / "lib" / "__pycache__").exists()

--- a/software/sorter/backend/tests/test_supervisor_crash_loop.py
+++ b/software/sorter/backend/tests/test_supervisor_crash_loop.py
@@ -168,16 +168,18 @@ def test_real_crashing_subprocess_captures_stderr_and_clears_cache(tmp_path):
 
 
 def test_clear_bytecode_caches_skips_venv(tmp_path):
-    backend = tmp_path
+    backend = tmp_path / "backend"
     (backend / "perception" / "__pycache__").mkdir(parents=True)
     (backend / "perception" / "__pycache__" / "capture.cpython-312.pyc").write_bytes(
         b"garbage"
     )
     (backend / ".venv" / "lib" / "__pycache__").mkdir(parents=True)
+    cache_prefix = tmp_path / "pycache-prefix"
+    (cache_prefix / "sub").mkdir(parents=True)
     supervisor = BackendSupervisor(
         command=["backend"],
         cwd=backend,
-        environment={},
+        environment={"PYTHONPYCACHEPREFIX": str(cache_prefix)},
         backend_health_url="http://127.0.0.1:1/health",
         health_interval_s=999.0,
         health_timeout_s=0.01,
@@ -187,6 +189,7 @@ def test_clear_bytecode_caches_skips_venv(tmp_path):
 
     cleared = supervisor._clear_bytecode_caches()
 
-    assert cleared == 1
+    assert cleared == 2
     assert not (backend / "perception" / "__pycache__").exists()
+    assert not cache_prefix.exists()
     assert (backend / ".venv" / "lib" / "__pycache__").exists()

--- a/software/sorter/frontend/src/lib/backend.ts
+++ b/software/sorter/frontend/src/lib/backend.ts
@@ -79,6 +79,8 @@ export type BackendConnectionProbeResult = {
 	backendRunning: boolean;
 	backendHealthy: boolean;
 	restartRequested: boolean;
+	crashLooping: boolean;
+	lastCrashOutput: string | null;
 };
 
 export async function requestBackendRestart(
@@ -136,7 +138,9 @@ export async function probeBackendConnection(
 				supervisorState: null,
 				backendRunning: true,
 				backendHealthy: true,
-				restartRequested: false
+				restartRequested: false,
+				crashLooping: false,
+				lastCrashOutput: null
 			};
 		}
 		console.warn(`[backend] /health probe returned non-ok status ${response.status} for ${backendBaseUrl}/health`);
@@ -160,7 +164,10 @@ export async function probeBackendConnection(
 						typeof data?.supervisor_state === 'string' ? data.supervisor_state : null,
 					backendRunning: Boolean(data?.backend_running),
 					backendHealthy: Boolean(data?.backend_healthy),
-					restartRequested: Boolean(data?.restart_requested)
+					restartRequested: Boolean(data?.restart_requested),
+					crashLooping: Boolean(data?.crash_looping),
+					lastCrashOutput:
+						typeof data?.last_crash_output === 'string' ? data.last_crash_output : null
 				};
 			}
 		} catch (err) {
@@ -175,7 +182,9 @@ export async function probeBackendConnection(
 		supervisorState: null,
 		backendRunning: false,
 		backendHealthy: false,
-		restartRequested: false
+		restartRequested: false,
+		crashLooping: false,
+		lastCrashOutput: null
 	};
 }
 

--- a/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
+++ b/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
@@ -27,6 +27,8 @@
 	let healthy = $state(true);
 	let checking = $state(false);
 	let restarting = $state(false);
+	let crashLooping = $state(false);
+	let lastCrashOutput = $state<string | null>(null);
 	let consecutiveFailures = $state(0);
 	let firstFailureAt = $state<number | null>(null);
 	let lastRecoveryRefreshAt = $state(0);
@@ -76,12 +78,18 @@
 			manager.ensureConnected(url);
 			firstFailureAt = null;
 			restarting = false;
+			crashLooping = false;
+			lastCrashOutput = null;
 			return { backendOk: true, showUnavailable: false };
 		}
 		if (selectedMachineLooksAlive()) {
 			firstFailureAt = null;
 			restarting = false;
 			return { backendOk: true, showUnavailable: false };
+		}
+		crashLooping = status.crashLooping;
+		if (status.lastCrashOutput) {
+			lastCrashOutput = status.lastCrashOutput;
 		}
 
 		consecutiveFailures++;
@@ -182,8 +190,17 @@
 			>
 				<WifiOff size={18} />
 			</div>
-			<div>
-				{#if restarting}
+			<div class="min-w-0 flex-1">
+				{#if crashLooping}
+					<div class="text-sm text-text">
+						The backend keeps crashing during startup. It is being restarted automatically, but it
+						has failed several times in a row.
+					</div>
+					{#if lastCrashOutput}
+						<pre
+							class="mt-3 max-h-48 overflow-auto whitespace-pre-wrap border border-border bg-bg p-2 font-mono text-xs text-text-muted">{lastCrashOutput}</pre>
+					{/if}
+				{:else if restarting}
 					<div class="text-sm text-text">
 						The backend is restarting. Waiting for it to come back online...
 					</div>
@@ -203,7 +220,7 @@
 			</div>
 		</div>
 
-		{#if !restarting}
+		{#if !restarting || crashLooping}
 			<div class="flex items-center justify-end gap-2 border-t border-border pt-3">
 				<button
 					type="button"

--- a/software/sorteros/build/overlay/etc/systemd/system/sorter-backend-dev.service
+++ b/software/sorteros/build/overlay/etc/systemd/system/sorter-backend-dev.service
@@ -3,13 +3,19 @@ Description=Sorter Backend (dev)
 After=network-online.target
 Wants=network-online.target
 Conflicts=sorter-backend.service
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/backend
+# Bytecode caches on tmpfs: a power cut once corrupted an on-disk .pyc whose
+# header still validated, crash-looping the backend forever (bbs-01,
+# 2026-08-01). /tmp is RAM-backed, so caches regenerate fresh every boot and
+# can never carry corruption across one.
+Environment=PYTHONPYCACHEPREFIX=/tmp/sorter-pycache
 # Dev mode notes:
 #   - Same supervisor + main.py as prod so hardware/coordinator behavior matches.
 #   - For fast iteration on a code edit, prefer a soft restart of main.py via the

--- a/software/sorteros/build/overlay/etc/systemd/system/sorter-backend.service
+++ b/software/sorteros/build/overlay/etc/systemd/system/sorter-backend.service
@@ -3,13 +3,17 @@ Description=Sorter Backend
 Documentation=https://basicallysource.github.io/sorter-v2/sorter/installation/
 After=network-online.target
 Wants=network-online.target
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/backend
+# Bytecode caches on tmpfs — power-cut corruption of an on-disk .pyc once
+# crash-looped the backend forever (bbs-01, 2026-08-01); see sorter-backend-dev.
+Environment=PYTHONPYCACHEPREFIX=/tmp/sorter-pycache
 # .env uses "export FOO=bar" syntax; systemd EnvironmentFile= doesn't handle
 # the export keyword — source through bash so both forms work correctly.
 ExecStart=/bin/bash -c "set -a; source __SOFTWARE_DIR__/.env; exec __UV_BIN__ run python supervisor.py"

--- a/software/sorteros/build/overlay/etc/systemd/system/sorter-ui-dev.service
+++ b/software/sorteros/build/overlay/etc/systemd/system/sorter-ui-dev.service
@@ -3,14 +3,21 @@ Description=Sorter UI (dev — Vite HMR)
 After=network-online.target sorter-backend-dev.service
 Wants=network-online.target
 Conflicts=sorter-ui.service
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: machines in the field get power-cut, and a corrupted
+# generated file used to make vite fail instantly 3x, after which systemd gave
+# up forever — leaving the UI dead until someone SSHed in (bbs-01, 2026-08-03).
+# Keep retrying; ExecStartPre wipes the poison so the next attempt succeeds.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/frontend
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# .svelte-kit and node_modules/.vite are generated caches rewritten by vite on
+# startup — exactly the files a power cut catches mid-write. Corrupt contents
+# make vite exit before binding the port, so never trust them across a start.
+ExecStartPre=/bin/rm -rf __SOFTWARE_DIR__/sorter/frontend/.svelte-kit __SOFTWARE_DIR__/sorter/frontend/node_modules/.vite
 # `vite dev` gives sub-second HMR for .svelte / .ts edits scp'd from the Mac.
 # `--host 0.0.0.0` makes it reachable on the LAN; `--strictPort` makes it fail
 # loudly if the port is busy instead of silently picking another port.
@@ -18,7 +25,7 @@ Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # binding is enabled via /etc/sysctl.d/99-sorter-unprivileged-ports.conf.
 ExecStart=__PNPM_BIN__ dev --host 0.0.0.0 --port 80 --strictPort
 Restart=on-failure
-RestartSec=2
+RestartSec=5
 StandardOutput=journal
 StandardError=journal
 

--- a/software/sorteros/build/overlay/etc/systemd/system/sorter-ui.service
+++ b/software/sorteros/build/overlay/etc/systemd/system/sorter-ui.service
@@ -3,8 +3,11 @@ Description=Sorter UI
 Documentation=https://basicallysource.github.io/sorter-v2/sorter/installation/
 After=network-online.target sorter-backend.service
 Wants=network-online.target
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+# (No cache wipe here: preview serves the built app from .svelte-kit/output,
+# which is NOT regenerable at startup — a corrupt build needs a rebuild.)
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple

--- a/software/systemd/sorter-backend-dev.service
+++ b/software/systemd/sorter-backend-dev.service
@@ -3,13 +3,19 @@ Description=Sorter Backend (dev)
 After=network-online.target
 Wants=network-online.target
 Conflicts=sorter-backend.service
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/backend
+# Bytecode caches on tmpfs: a power cut once corrupted an on-disk .pyc whose
+# header still validated, crash-looping the backend forever (bbs-01,
+# 2026-08-01). /tmp is RAM-backed, so caches regenerate fresh every boot and
+# can never carry corruption across one.
+Environment=PYTHONPYCACHEPREFIX=/tmp/sorter-pycache
 # Dev mode notes:
 #   - Same supervisor + main.py as prod so hardware/coordinator behavior matches.
 #   - For fast iteration on a code edit, prefer a soft restart of main.py via the

--- a/software/systemd/sorter-backend.service
+++ b/software/systemd/sorter-backend.service
@@ -3,13 +3,17 @@ Description=Sorter Backend
 Documentation=https://basicallysource.github.io/sorter-v2/sorter/installation/
 After=network-online.target
 Wants=network-online.target
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/backend
+# Bytecode caches on tmpfs — power-cut corruption of an on-disk .pyc once
+# crash-looped the backend forever (bbs-01, 2026-08-01); see sorter-backend-dev.
+Environment=PYTHONPYCACHEPREFIX=/tmp/sorter-pycache
 # .env uses "export FOO=bar" syntax; systemd EnvironmentFile= doesn't handle
 # the export keyword — source through bash so both forms work correctly.
 ExecStart=/bin/bash -c "set -a; source __SOFTWARE_DIR__/.env; exec __UV_BIN__ run python supervisor.py"

--- a/software/systemd/sorter-ui-dev.service
+++ b/software/systemd/sorter-ui-dev.service
@@ -3,14 +3,21 @@ Description=Sorter UI (dev — Vite HMR)
 After=network-online.target sorter-backend-dev.service
 Wants=network-online.target
 Conflicts=sorter-ui.service
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: machines in the field get power-cut, and a corrupted
+# generated file used to make vite fail instantly 3x, after which systemd gave
+# up forever — leaving the UI dead until someone SSHed in (bbs-01, 2026-08-03).
+# Keep retrying; ExecStartPre wipes the poison so the next attempt succeeds.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 User=__USER__
 WorkingDirectory=__SOFTWARE_DIR__/sorter/frontend
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# .svelte-kit and node_modules/.vite are generated caches rewritten by vite on
+# startup — exactly the files a power cut catches mid-write. Corrupt contents
+# make vite exit before binding the port, so never trust them across a start.
+ExecStartPre=/bin/rm -rf __SOFTWARE_DIR__/sorter/frontend/.svelte-kit __SOFTWARE_DIR__/sorter/frontend/node_modules/.vite
 # `vite dev` gives sub-second HMR for .svelte / .ts edits scp'd from the Mac.
 # `--host 0.0.0.0` makes it reachable on the LAN; `--strictPort` makes it fail
 # loudly if the port is busy instead of silently picking another port.
@@ -18,7 +25,7 @@ Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # binding is enabled via /etc/sysctl.d/99-sorter-unprivileged-ports.conf.
 ExecStart=__PNPM_BIN__ dev --host 0.0.0.0 --port 80 --strictPort
 Restart=on-failure
-RestartSec=2
+RestartSec=5
 StandardOutput=journal
 StandardError=journal
 

--- a/software/systemd/sorter-ui.service
+++ b/software/systemd/sorter-ui.service
@@ -3,8 +3,11 @@ Description=Sorter UI
 Documentation=https://basicallysource.github.io/sorter-v2/sorter/installation/
 After=network-online.target sorter-backend.service
 Wants=network-online.target
-StartLimitBurst=3
-StartLimitIntervalSec=60
+# No start-rate limit: field machines get power-cut and must keep retrying
+# instead of giving up forever after 3 fast failures (see sorter-ui-dev).
+# (No cache wipe here: preview serves the built app from .svelte-kit/output,
+# which is NOT regenerable at startup — a corrupt build needs a rebuild.)
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple


### PR DESCRIPTION
Prompted by the bbs-01 outage on 2026-08-01, where a power loss corrupted `perception/__pycache__/capture.cpython-312.pyc` and the backend crash-looped for ~18h — invisible to systemd (the service wraps the supervisor, which stayed "active") and opaque in the UI (generic "Backend Unavailable").

**Crash-loop self-heal.** The supervisor counts consecutive fast exits (process dies <30s after launch; window configurable via `BACKEND_SUPERVISOR_FAST_CRASH_WINDOW_S`). After 3 in a row it clears the backend tree's `__pycache__` dirs (skipping `.venv`) before the next restart, once per streak. A corrupt `.pyc` passes Python's cache-header check (magic + source mtime + size) while its body is garbage, so a crash loop caused by one never recovers on its own. A healthy run or a slow crash resets the streak.

**Crash visibility.** `main.py`'s stderr is teed — lines still reach journald, and the last 60 are kept in a ring buffer. On an unexpected exit the tail is exposed on `/api/supervisor/status` as `last_crash_output`, alongside `crash_looping`, `consecutive_fast_crashes`, and `pycache_cleared_at`. The Backend Unavailable dialog shows the actual traceback instead of "check that the machine is powered on".

**Systemd units.** Same failure mode one layer down: the backend and UI units (dev + prod, plus the sorteros overlay copies) now survive power-cut corruption of their generated caches rather than failing to start.

**Hive fleet analytics.** Also carries a fix for `/admin/machines` — three machines named "Lego Sorter" made the by-machine donut throw `each_key_duplicate` and blank the whole analytics section. Charts key on ids now, and colliding machine names get a short id suffix. Already deployed to hive prod.

Stacked on #230.
