### PR TITLE
docs: add external distribution-frame bracket assembly page

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -94,11 +94,27 @@ yourself:
    The script generates the web version (long side ≤ 1600px, **opaque →
    `.jpg`**, **transparent → `.png`**), uploads the full-res original to
    `originals/<path>` and the web version to `web/<path>`, and prints both URLs.
-   Credentials: `~/.config/basically/do-spaces.env`.
+   Credentials: `SPACES_KEY`/`SPACES_SECRET`, either as environment variables
+   or in `~/.config/basically/do-spaces.env` (the script checks env first).
+   If neither is set, say so and use `img-placeholder` divs (below) instead
+   of guessing or embedding the image data directly in the page.
 3. **Reference the printed web URL** in the page:
    `https://img.basically.website/web/<path>.<jpg|png>`. Plain URL, no Liquid.
 4. Nothing image-related gets committed. The URL works identically on PR
    previews and production, since the bucket is branch-independent.
+
+**A contributor's file sometimes carries images embedded as base64 data URIs**
+(e.g. `![alt](data:image/jpeg;base64,...)`) instead of as separate
+attachments. Same workflow applies, decode first: extract each data URI to
+its own file, then upload that file with `upload_image.py` like any other
+original. Don't leave the base64 inline in the page, it defeats "images are
+not in git" and bloats the repo.
+
+**A printed part's catalog image (`_data/parts.yml`'s `image:` field) can
+often be pulled from `parts-calculator`'s own renders** instead of asking for
+a fresh photo: that repo's `static/renders/<part-id>.png` is a real OrcaSlicer
+thumbnail for every printed part in its catalog. Upload it the same way,
+under `parts/<page>/<part-id>`.
 
 **Names are immutable.** The CDN caches for 30 days, so if an image's content
 changes, upload under a new name and update the reference — never reuse a name

--- a/docs/_data/authors.yml
+++ b/docs/_data/authors.yml
@@ -10,3 +10,6 @@ spencer:
 
 zed0:
   name: zed0
+
+christoph:
+  name: Christoph

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -36,6 +36,8 @@ sections:
                     url: /hardware/assembly/distribution/bin-frame/bottom-two-layers/
                   - title: Regular layers
                     url: /hardware/assembly/distribution/bin-frame/regular-layers/
+              - title: External bracket
+                url: /hardware/assembly/distribution/external-bracket/
               - title: Top interface
                 url: /hardware/assembly/distribution/top-interface/
               - title: Chute

--- a/docs/_data/parts.yml
+++ b/docs/_data/parts.yml
@@ -50,16 +50,19 @@ m4-12mm-countersunk:
 ext-bracket-left:
   name: External bracket — side
   category: Printed parts
+  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-left.png
   page: /hardware/assembly/distribution/external-bracket/
 
 ext-bracket-bottom-vertical:
   name: External bracket — bottom vertical
   category: Printed parts
+  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-bottom-vertical.png
   page: /hardware/assembly/distribution/external-bracket/
 
 ext-bracket-cover:
   name: External bracket — cover
   category: Printed parts
+  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-cover.png
   page: /hardware/assembly/distribution/external-bracket/
 
 scr-m5-16-shcs:

--- a/docs/_data/parts.yml
+++ b/docs/_data/parts.yml
@@ -46,3 +46,22 @@ m4-12mm-countersunk:
   name: M4 × 12 mm countersunk screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/m4-12mm-countersunk.jpg
+
+ext-bracket-left:
+  name: External bracket — side
+  category: Printed parts
+  page: /hardware/assembly/distribution/external-bracket/
+
+ext-bracket-bottom-vertical:
+  name: External bracket — bottom vertical
+  category: Printed parts
+  page: /hardware/assembly/distribution/external-bracket/
+
+ext-bracket-cover:
+  name: External bracket — cover
+  category: Printed parts
+  page: /hardware/assembly/distribution/external-bracket/
+
+scr-m5-16-shcs:
+  name: M5 × 16 mm socket head cap screw
+  category: Screws

--- a/docs/_data/parts.yml
+++ b/docs/_data/parts.yml
@@ -68,3 +68,4 @@ ext-bracket-cover:
 scr-m5-16-shcs:
   name: M5 × 16 mm socket head cap screw
   category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/m5-16mm-shcs.jpg

--- a/docs/_data/parts.yml
+++ b/docs/_data/parts.yml
@@ -68,4 +68,3 @@ ext-bracket-cover:
 scr-m5-16-shcs:
   name: M5 × 16 mm socket head cap screw
   category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/m5-16mm-shcs.jpg

--- a/docs/hardware/assembly/distribution/external-bracket.md
+++ b/docs/hardware/assembly/distribution/external-bracket.md
@@ -1,0 +1,103 @@
+---
+layout: default
+title: External bracket
+type: how-to
+section: hardware
+slug: assembly-external-bracket
+kicker: Distribution — External bracket
+lede: The bracket that mounts a distribution-frame vertical extrusion to the frame and gives it a mounting point.
+permalink: /hardware/assembly/distribution/external-bracket/
+author: christoph
+last_verified: 2026-08-03
+parts_needed:
+  - part: ext-bracket-left
+  - part: ext-bracket-bottom-vertical
+  - part: ext-bracket-cover
+  - part: scr-m5-16-shcs
+    qty: 4
+---
+
+Three printed parts that bolt together into one external bracket. **6 per distribution frame (per layer), plus one set per interface.**
+
+| Part | Qty per bracket | Qty per machine (6 brackets/layer) | Weight | STL |
+|---|---|---|---|---|
+| External bracket — side | 1 | 6 | 48.5 g | [Download STL](https://sorter-v2-parts.nyc3.cdn.digitaloceanspaces.com/stl/da4b3abd3db72070484178ef5aa1d0906397c6a310bdf0e22f724940bd62dba2.stl) |
+| External bracket — bottom vertical | 1 | 6 | 50.6 g | [Download STL](https://sorter-v2-parts.nyc3.cdn.digitaloceanspaces.com/stl/313397afb08fc1943f045905b96131f73f1dc70c05d59fd2583c77da38318c36.stl) |
+| External bracket — cover | 1 | 6 | 12.4 g | [Download STL](https://sorter-v2-parts.nyc3.cdn.digitaloceanspaces.com/stl/f99e33cea11551b8222feac91c28015488ff2c239e632f5098322e7ea10fc96c.stl) |
+
+**Other parts**
+
+| Part | Qty per bracket | Notes |
+|---|---|---|
+| C-Layer vertical support (extrusion) | 1 | The vertical aluminum extrusion the bracket clamps onto. |
+
+- No heat inserts are used on this assembly. Joining is **self-tap**: the M5 × 16 mm screws thread directly into the printed plastic.
+- The most-used M5 in the machine, the same screw used on every external bracket, every bin bracket, every interface rib, and every lazy Susan extrusion mount.
+- Of the four M5 × 16 mm screws: **2** join the bottom-vertical part to the side bracket, and **2** clamp the side bracket against the C-Layer vertical support to hold it in place. The **cover clips on**, it takes no screws.
+- Matching parts from the same print run are embossed with a shared set code (e.g. **"b2"**) on both the side bracket and the bottom-vertical part, keep marked pairs together so brackets don't get mixed across sets.
+
+<div class="img-placeholder">Photo coming: parts for one bracket laid out before assembly</div>
+
+*Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four M5 × 16 mm screws. The cover is fitted last, in Step 4.*
+
+<div class="img-row">
+  <figure>
+    <div class="img-placeholder">Photo coming: side bracket</div>
+    <figcaption>The side bracket on its own: the U-shaped opening clamps around the extrusion, and each of the two wings carries a pair of mounting holes.</figcaption>
+  </figure>
+  <figure>
+    <div class="img-placeholder">Photo coming: bottom-vertical top flange</div>
+    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two M5 × 16 mm screws in Step 1 go into.</figcaption>
+  </figure>
+</div>
+
+{% include step.html n="1" title="Mount the bottom-vertical leg to the side bracket" %}
+
+Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two M5 × 16 mm socket head screws down through the flange into the side bracket.
+
+<div class="img-placeholder">Photo coming: bottom-vertical leg screwed into the side bracket, viewed from above through the socket</div>
+
+*Two M5 × 16 mm screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.*
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Drive these tight. As self-tapping screws into printed plastic, they hold best if seated firmly the first time, repeated removal and reinsertion strips the plastic threads.</p>
+</div>
+
+{% include step.html n="2" title="Insert the C-Layer vertical support" %}
+
+Slide the C-Layer vertical support (the vertical aluminum extrusion) down through the side bracket's U-shaped clamp and into the square socket in the bottom-vertical leg below. The socket is sized to the extrusion's profile, so it can only seat in the correct orientation.
+
+<div class="img-placeholder">Photo coming: C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket</div>
+
+*C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3.*
+
+{% include step.html n="3" title="Screw the bracket down onto the extrusion" %}
+
+Two more M5 × 16 mm screws clamp the side bracket against the C-Layer vertical support to hold it firmly in place.
+
+<div class="img-row">
+  <figure>
+    <div class="img-placeholder">Photo coming: retention screw hole, empty</div>
+    <figcaption>Before: retention-screw hole empty.</figcaption>
+  </figure>
+  <figure>
+    <div class="img-placeholder">Photo coming: retention screw driven in</div>
+    <figcaption>After: M5 × 16 mm screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
+  </figure>
+</div>
+
+{% include step.html n="4" title="Clip on the cover" %}
+
+Clip the cover onto the side bracket to close it off. The cover takes no screws, it's a snap fit.
+
+<div class="img-row">
+  <figure>
+    <div class="img-placeholder">Photo coming: cover unattached, next to the assembled bracket</div>
+    <figcaption>The cover (left), not yet attached, next to the face of the assembly it clips onto.</figcaption>
+  </figure>
+  <figure>
+    <div class="img-placeholder">Photo coming: finished bracket with the cover clipped on</div>
+    <figcaption>Cover clipped into place. It sits flush against the side bracket, which is why the seam is subtle in photos.</figcaption>
+  </figure>
+</div>

--- a/docs/hardware/assembly/distribution/external-bracket.md
+++ b/docs/hardware/assembly/distribution/external-bracket.md
@@ -36,17 +36,18 @@ Three printed parts that bolt together into one external bracket. **6 per distri
 - Of the four M5 × 16 mm screws: **2** join the bottom-vertical part to the side bracket, and **2** clamp the side bracket against the C-Layer vertical support to hold it in place. The **cover clips on**, it takes no screws.
 - Matching parts from the same print run are embossed with a shared set code (e.g. **"b2"**) on both the side bracket and the bottom-vertical part, keep marked pairs together so brackets don't get mixed across sets.
 
-<div class="img-placeholder">Photo coming: parts for one bracket laid out before assembly</div>
-
-*Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four M5 × 16 mm screws. The cover is fitted last, in Step 4.*
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/parts-laid-out.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
+  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four M5 × 16 mm screws. The cover is fitted last, in Step 4.</figcaption>
+</figure>
 
 <div class="img-row">
   <figure>
-    <div class="img-placeholder">Photo coming: side bracket</div>
+    <img src="https://img.basically.website/web/assembly/external-bracket/side-bracket.jpg" alt="Close-up of the side bracket alone, showing the U-shaped extrusion clamp and the two mounting-hole wings">
     <figcaption>The side bracket on its own: the U-shaped opening clamps around the extrusion, and each of the two wings carries a pair of mounting holes.</figcaption>
   </figure>
   <figure>
-    <div class="img-placeholder">Photo coming: bottom-vertical top flange</div>
+    <img src="https://img.basically.website/web/assembly/external-bracket/bottom-vertical-flange.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
     <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two M5 × 16 mm screws in Step 1 go into.</figcaption>
   </figure>
 </div>
@@ -55,9 +56,10 @@ Three printed parts that bolt together into one external bracket. **6 per distri
 
 Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two M5 × 16 mm socket head screws down through the flange into the side bracket.
 
-<div class="img-placeholder">Photo coming: bottom-vertical leg screwed into the side bracket, viewed from above through the socket</div>
-
-*Two M5 × 16 mm screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.*
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step1-screwed-underside.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
+  <figcaption>Two M5 × 16 mm screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.</figcaption>
+</figure>
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -68,9 +70,10 @@ Set the bottom-vertical leg's flanged top into the U-shaped opening of the side 
 
 Slide the C-Layer vertical support (the vertical aluminum extrusion) down through the side bracket's U-shaped clamp and into the square socket in the bottom-vertical leg below. The socket is sized to the extrusion's profile, so it can only seat in the correct orientation.
 
-<div class="img-placeholder">Photo coming: C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket</div>
-
-*C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3.*
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step2-extrusion-inserted.jpg" alt="C-Layer vertical support extrusion inserted down through the side bracket and into the square socket of the bottom-vertical leg">
+  <figcaption>C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3.</figcaption>
+</figure>
 
 {% include step.html n="3" title="Screw the bracket down onto the extrusion" %}
 
@@ -78,11 +81,11 @@ Two more M5 × 16 mm screws clamp the side bracket against the C-Layer vertical 
 
 <div class="img-row">
   <figure>
-    <div class="img-placeholder">Photo coming: retention screw hole, empty</div>
+    <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-hole-empty.jpg" alt="Retention screw hole empty, before the screw is driven in">
     <figcaption>Before: retention-screw hole empty.</figcaption>
   </figure>
   <figure>
-    <div class="img-placeholder">Photo coming: retention screw driven in</div>
+    <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-driven-in.jpg" alt="Retention screw driven in, seated flush in the hex socket">
     <figcaption>After: M5 × 16 mm screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
   </figure>
 </div>
@@ -93,11 +96,11 @@ Clip the cover onto the side bracket to close it off. The cover takes no screws,
 
 <div class="img-row">
   <figure>
-    <div class="img-placeholder">Photo coming: cover unattached, next to the assembled bracket</div>
+    <img src="https://img.basically.website/web/assembly/external-bracket/step4-cover-unattached.jpg" alt="The unattached cover sitting next to the assembled bracket, at the face where it clips on">
     <figcaption>The cover (left), not yet attached, next to the face of the assembly it clips onto.</figcaption>
   </figure>
   <figure>
-    <div class="img-placeholder">Photo coming: finished bracket with the cover clipped on</div>
+    <img src="https://img.basically.website/web/assembly/external-bracket/step4-cover-clipped-on.jpg" alt="Finished bracket with the cover clipped into place">
     <figcaption>Cover clipped into place. It sits flush against the side bracket, which is why the seam is subtle in photos.</figcaption>
   </figure>
 </div>


### PR DESCRIPTION
Christoph shared a step-by-step assembly writeup for the external bracket in #assembly-docs ("Since i documented it anyway for me i thought I'd share my step-by-step assembly for the \"External distribution-frame bracke\"") [here](https://discord.com/channels/1430279849171222682/1525928562971115601/1533939316361789580). Spencer asked to get it onto the docs site.

- New page: `hardware/assembly/distribution/external-bracket.md` (steps, parts table with STL links, screw/set-code notes, warning callout)
- Added `ext-bracket-left`, `ext-bracket-bottom-vertical`, `ext-bracket-cover`, `scr-m5-16-shcs` to the parts catalog (ids mirror `parts-calculator`'s `slicer/parts.json`)
- Added Christoph as an author, added the page to nav

**Photos are not uploaded.** I don't have DO Spaces credentials in this environment, so the 9 photos from Christoph's original writeup are marked as placeholders with their original captions kept alongside, so someone with bucket access can drop them in via `docs/scripts/upload_image.py`.

`scripts/validate_frontmatter.py` passes (pre-existing unrelated failures on 3 other pages, untouched by this PR).