### PR TITLE
LED control: PWM brightness, on/off, and boot behavior from the UI

### DIFF
--- a/docs/sorter/machine-toml-reference.md
+++ b/docs/sorter/machine-toml-reference.md
@@ -134,7 +134,9 @@ Per-camera image transform settings applied after capture.
 
 ## `[[gpio_leds]]`
 
-Digital output pins that are driven HIGH on boot and LOW on shutdown. One entry per pin. Useful for status LEDs wired to the basically or SKR Pico boards.
+Wiring only: which digital output channels have LEDs on them. One entry per pin.
+
+Whether those LEDs are on, how bright they are, and whether they light up at startup are **not** configured here — they are set from Settings → LEDs in the UI and stored in the machine's local state database.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/software/firmware/sorter_interface_firmware/CMakeLists.txt
+++ b/software/firmware/sorter_interface_firmware/CMakeLists.txt
@@ -151,6 +151,7 @@ target_link_libraries(sorter_interface_firmware
         pico_time
         hardware_i2c
         hardware_timer
+        hardware_pwm
         )
 
 pico_add_extra_outputs(sorter_interface_firmware)

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -21,6 +21,7 @@
  * SOFTWARE.
  */
 
+#include "hardware/pwm.h"
 #include "hardware/timer.h"
 #include "pico/multicore.h"
 #include "pico/stdlib.h"
@@ -112,6 +113,7 @@ const struct CommandTable stepperDrvCmdTable = {
 
 void CMDH_digital_read(const BusMessage *msg, BusMessage *resp);
 void CMDH_digital_write(const BusMessage *msg, BusMessage *resp);
+void CMDH_digital_write_pwm(const BusMessage *msg, BusMessage *resp);
 bool VAL_digital_out_channel(uint8_t channel);
 bool VAL_digital_in_channel(uint8_t channel);
 
@@ -120,6 +122,7 @@ const struct CommandTable digitalIoCmdTable = { //
     .commands = {{
         {"READ", "", "?", 0, VAL_digital_in_channel, CMDH_digital_read},
         {"WRITE", "?", "", 1, VAL_digital_out_channel, CMDH_digital_write},
+        {"WRITE_PWM", "H", "", 2, VAL_digital_out_channel, CMDH_digital_write_pwm},
     }}};
 
 void CMDH_servo_move_to(const BusMessage *msg, BusMessage *resp);
@@ -318,7 +321,7 @@ int dump_observability(char *buf, size_t buf_size) {
     int n_bytes = snprintf(
         buf,
         buf_size,
-        "{\"hw\":\"%s\",\"diag_pins\":%s}",
+        "{\"hw\":\"%s\",\"diag_pins\":%s,\"digital_output_pwm\":true}",
         HW_ID,
         diag_pins_len > 0 ? diag_pins_buf : "[]");
 
@@ -583,10 +586,50 @@ void CMDH_digital_read(const BusMessage *msg, BusMessage *resp) {
     resp->payload_length = 1;
 }
 
+// Counter wraps at 65534, so it takes 65535 values (0..65534) and a duty of
+// 65535 is genuinely always-high rather than 65535/65536 of the time. Duty 0 is
+// likewise always-low, so the full u16 range maps to real 0%..100%.
+static const uint16_t PWM_OUTPUT_WRAP = 65534;
+
+static bool digital_output_pwm_active[DIGITAL_OUTPUT_COUNT];
+static bool pwm_slice_configured[NUM_PWM_SLICES];
+
+static void digital_output_set_plain(int pin, uint8_t channel, bool value) {
+    if (digital_output_pwm_active[channel]) {
+        // Hand the pad back to SIO. Never disable the slice: on some boards two
+        // outputs share one slice, and disabling it would freeze the other pin.
+        gpio_set_function(pin, GPIO_FUNC_SIO);
+        gpio_set_dir(pin, GPIO_OUT);
+        digital_output_pwm_active[channel] = false;
+    }
+    gpio_put(pin, value ? 1 : 0);
+}
+
 void CMDH_digital_write(const BusMessage *msg, BusMessage *resp) {
     int pin = digital_output_pins[msg->channel];
     bool value = msg->payload[0] != 0;
-    gpio_put(pin, value ? 1 : 0);
+    digital_output_set_plain(pin, msg->channel, value);
+    resp->payload_length = 0;
+}
+
+void CMDH_digital_write_pwm(const BusMessage *msg, BusMessage *resp) {
+    uint16_t duty;
+    memcpy(&duty, msg->payload, sizeof(duty));
+    int pin = digital_output_pins[msg->channel];
+
+    uint slice = pwm_gpio_to_slice_num(pin);
+    if (!pwm_slice_configured[slice]) {
+        pwm_config config = pwm_get_default_config();
+        pwm_config_set_wrap(&config, PWM_OUTPUT_WRAP);
+        pwm_init(slice, &config, false);
+        pwm_slice_configured[slice] = true;
+    }
+    pwm_set_chan_level(slice, pwm_gpio_to_channel(pin), duty);
+    pwm_set_enabled(slice, true);
+    if (!digital_output_pwm_active[msg->channel]) {
+        gpio_set_function(pin, GPIO_FUNC_PWM);
+        digital_output_pwm_active[msg->channel] = true;
+    }
     resp->payload_length = 0;
 }
 

--- a/software/machine.example.toml
+++ b/software/machine.example.toml
@@ -155,7 +155,9 @@ c_channel_3 = 4
 carousel = true
 
 # --- GPIO LED pins ---
-# Pins that should be driven HIGH on boot and LOW on shutdown.
+# Wiring only: which digital output channels have LEDs on them.
+# On/off, brightness, and whether they light up at startup are set from
+# Settings -> LEDs in the UI, not here.
 # board = "feeder" | "distribution" | "any"
 #   "any" applies to every connected board that has the pin.
 # pin = digital output channel index (0-based)

--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -8,6 +8,7 @@
 import os
 import time
 import json
+from typing import Protocol
 from .bus import MCUDevice, BaseCommandCode, MCUBusError
 import struct
 from global_config import GlobalConfig
@@ -77,8 +78,18 @@ class DigitalInputPin:
 DIGITAL_OUTPUT_DUTY_MAX = 65535
 
 
+class DigitalOutputDevice(Protocol):
+    # The whole surface a digital output needs from its board. Narrower than
+    # MCUDevice because writes never inspect the response, and it keeps the
+    # PWM capability flag typed instead of getattr-probed.
+    @property
+    def supports_digital_output_pwm(self) -> bool: ...
+
+    def send_command(self, command: int, channel: int, payload: bytes) -> object: ...
+
+
 class DigitalOutputPin:
-    def __init__(self, device: MCUDevice, channel: int, gc: GlobalConfig):
+    def __init__(self, device: DigitalOutputDevice, channel: int, gc: GlobalConfig):
         self._dev = device
         self._channel = channel
         self._value = False
@@ -105,9 +116,11 @@ class DigitalOutputPin:
 
     @property
     def pwm_supported(self) -> bool:
-        if self._pwm_supported is None:
-            self._pwm_supported = self._dev.supports_digital_output_pwm
-        return self._pwm_supported
+        cached = self._pwm_supported
+        if cached is None:
+            cached = self._dev.supports_digital_output_pwm
+            self._pwm_supported = cached
+        return cached
 
     def setDuty(self, duty: int) -> None:
         clamped = max(0, min(DIGITAL_OUTPUT_DUTY_MAX, int(duty)))
@@ -958,18 +971,21 @@ class SorterInterface(MCUDevice):
 
     @property
     def supports_digital_output_pwm(self) -> bool:
-        if self._digital_output_pwm is None:
-            try:
-                info = self.get_observability_info()
-            except Exception as exc:
-                self._gc.logger.warning(
-                    f"Could not read observability from {self._name} to check PWM "
-                    f"support ({exc}). Assuming on/off only."
-                )
-                self._digital_output_pwm = False
-            else:
-                self._digital_output_pwm = bool(info.get("digital_output_pwm", False))
-        return self._digital_output_pwm
+        cached = self._digital_output_pwm
+        if cached is not None:
+            return cached
+        try:
+            info = self.get_observability_info()
+        except Exception as exc:
+            self._gc.logger.warning(
+                f"Could not read observability from {self._name} to check PWM "
+                f"support ({exc}). Assuming on/off only."
+            )
+            supported = False
+        else:
+            supported = bool(info.get("digital_output_pwm", False))
+        self._digital_output_pwm = supported
+        return supported
 
     def get_observability_info(self, *, force_refresh: bool = False) -> dict:
         if self._observability_info is not None and not force_refresh:

--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -8,7 +8,7 @@
 import os
 import time
 import json
-from .bus import MCUDevice, BaseCommandCode
+from .bus import MCUDevice, BaseCommandCode, MCUBusError
 import struct
 from global_config import GlobalConfig
 
@@ -44,6 +44,7 @@ class InterfaceCommandCode(BaseCommandCode):
     # Digital I/O commands
     DIGITAL_READ = 0x30
     DIGITAL_WRITE = 0x31
+    DIGITAL_WRITE_PWM = 0x32  # payload: uint16 duty (0 = off, 65535 = full on)
     # Servo commands
     SERVO_MOVE_TO = 0x40
     SERVO_SET_SPEED_LIMITS = 0x41
@@ -71,25 +72,68 @@ class DigitalInputPin:
     def channel(self):
         return self._channel
     
+# Duty is a uint16 on the wire. The firmware wraps its PWM counter at 65534 so
+# that 0 is genuinely always-low and DIGITAL_OUTPUT_DUTY_MAX always-high.
+DIGITAL_OUTPUT_DUTY_MAX = 65535
+
+
 class DigitalOutputPin:
     def __init__(self, device: MCUDevice, channel: int, gc: GlobalConfig):
         self._dev = device
         self._channel = channel
         self._value = False
+        self._duty = 0
         self._enabled = True
+        self._pwm_supported: bool | None = None
         self._gc = gc
 
     @property
     def value(self):
         return self._value
-    
+
     @value.setter
     def value(self, value: bool):
         self._value = bool(value)
+        self._duty = DIGITAL_OUTPUT_DUTY_MAX if self._value else 0
         self._gc.logger.info(f"DigitalOutput ch{self._channel}: set value={self._value}")
         payload = struct.pack("<?", self._value) # 1 byte, boolean
         self._dev.send_command(InterfaceCommandCode.DIGITAL_WRITE, self._channel, payload)
-    
+
+    @property
+    def duty(self) -> int:
+        return self._duty
+
+    @property
+    def pwm_supported(self) -> bool:
+        if self._pwm_supported is None:
+            self._pwm_supported = self._dev.supports_digital_output_pwm
+        return self._pwm_supported
+
+    def setDuty(self, duty: int) -> None:
+        clamped = max(0, min(DIGITAL_OUTPUT_DUTY_MAX, int(duty)))
+        if not self.pwm_supported:
+            self.value = clamped > 0
+            return
+        payload = struct.pack("<H", clamped)
+        try:
+            self._dev.send_command(
+                InterfaceCommandCode.DIGITAL_WRITE_PWM, self._channel, payload
+            )
+        except MCUBusError as exc:
+            # Firmware predating DIGITAL_IO/WRITE_PWM (0x32) answers with an
+            # error frame instead of acting, so a board that was never reflashed
+            # degrades to plain on/off for the rest of this process.
+            self._pwm_supported = False
+            self._gc.logger.warning(
+                f"DigitalOutput ch{self._channel}: firmware rejected PWM write ({exc}). "
+                "Falling back to on/off for this output."
+            )
+            self.value = clamped > 0
+            return
+        self._duty = clamped
+        self._value = clamped > 0
+        self._gc.logger.info(f"DigitalOutput ch{self._channel}: set duty={clamped}")
+
     @property
     def channel(self):
         return self._channel
@@ -865,6 +909,7 @@ class SorterInterface(MCUDevice):
         super().__init__(bus, address)
         self._gc = gc
         self._observability_info: dict | None = None
+        self._digital_output_pwm: bool | None = None
         # Obtain the device information to populate the internal objects
         retries = 5
         while retries > 0:
@@ -910,6 +955,21 @@ class SorterInterface(MCUDevice):
             return 0
         res = self.send_command(InterfaceCommandCode.STEPPER_GET_STALL_STATUS, 0, b"")
         return res.payload[0] if res.payload else 0
+
+    @property
+    def supports_digital_output_pwm(self) -> bool:
+        if self._digital_output_pwm is None:
+            try:
+                info = self.get_observability_info()
+            except Exception as exc:
+                self._gc.logger.warning(
+                    f"Could not read observability from {self._name} to check PWM "
+                    f"support ({exc}). Assuming on/off only."
+                )
+                self._digital_output_pwm = False
+            else:
+                self._digital_output_pwm = bool(info.get("digital_output_pwm", False))
+        return self._digital_output_pwm
 
     def get_observability_info(self, *, force_refresh: bool = False) -> dict:
         if self._observability_info is not None and not force_refresh:

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     from machine_platform.control_board import ControlBoard
     from machine_platform.machine_profile import MachineProfile
     from machine_platform.servo_controller import ServoController
-    from hardware.sorter_interface import StepperMotor, ServoMotor, DigitalInputPin, DigitalOutputPin
+    from hardware.sorter_interface import StepperMotor, ServoMotor, DigitalInputPin
     from subsystems.classification.carousel_hardware import CarouselHardware
     from subsystems.distribution.chute import Chute
 
@@ -91,6 +91,7 @@ from .parse_user_toml import (
     applyStepperCurrentOverride,
     applyStepperStallguard,
 )
+from .leds import LedController, bindGpioLeds
 from blob_manager import getBinCategories
 from local_state import get_servo_states, set_servo_states
 
@@ -634,14 +635,14 @@ class IRLInterface:
     control_boards: dict[str, "ControlBoard"]
     servo_controller: "ServoController | None"
     machine_profile: "MachineProfile | None"
-    gpio_led_pins: "list[DigitalOutputPin]"
+    led_controller: "LedController | None"
 
     def __init__(self):
         self.interfaces: dict[str, SorterInterface] = {}
         self.control_boards = {}
         self.servo_controller = None
         self.machine_profile = None
-        self.gpio_led_pins = []
+        self.led_controller = None
 
     def enableSteppers(self) -> None:
         for stepper_name in [
@@ -678,11 +679,8 @@ class IRLInterface:
                 stepper.enabled = False
 
     def shutdown(self) -> None:
-        for pin in self.gpio_led_pins:
-            try:
-                pin.value = False
-            except Exception:
-                pass
+        if self.led_controller is not None:
+            self.led_controller.allOff()
         if self.servo_controller is not None and hasattr(self.servo_controller, "shutdown"):
             try:
                 self.servo_controller.shutdown()
@@ -1278,44 +1276,6 @@ HARDWARE_DISCOVERY_ATTEMPTS = 8
 HARDWARE_DISCOVERY_RETRY_DELAY_S = 0.75
 
 
-def _applyGpioLeds(
-    control_boards: list,
-    led_configs: list,
-    gc: GlobalConfig,
-) -> list:
-    from hardware.sorter_interface import DigitalOutputPin
-    from .parse_user_toml import GpioLedConfig
-
-    active: list[DigitalOutputPin] = []
-    for cfg in led_configs:
-        cfg: GpioLedConfig
-        matched = [
-            b for b in control_boards
-            if cfg.board == "any" or b.identity.role == cfg.board
-        ]
-        for board in matched:
-            outputs = board.interface.digital_outputs
-            if cfg.pin >= len(outputs):
-                gc.logger.warning(
-                    f"gpio_leds: board {board.identity.role} ({board.identity.device_name}) "
-                    f"has no digital output at pin {cfg.pin} (only {len(outputs)} outputs). Skipping."
-                )
-                continue
-            pin = outputs[cfg.pin]
-            try:
-                pin.value = True
-                gc.logger.info(
-                    f"gpio_leds: turned on pin {cfg.pin} on {board.identity.role} board "
-                    f"({board.identity.device_name})"
-                )
-                active.append(pin)
-            except Exception as exc:
-                gc.logger.warning(
-                    f"gpio_leds: failed to set pin {cfg.pin} on {board.identity.role} board: {exc}"
-                )
-    return active
-
-
 def _requiredCanonicalStepperNames(
     machine_setup: MachineSetupDefinition,
     stepper_binding_overrides: dict[str, str],
@@ -1387,7 +1347,10 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
     }
 
     gpio_led_configs = loadGpioLedsConfig(gc, machine_specific_params)
-    irl_interface.gpio_led_pins = _applyGpioLeds(control_boards, gpio_led_configs, gc)
+    irl_interface.led_controller = LedController(
+        gc, bindGpioLeds(gc, control_boards, gpio_led_configs)
+    )
+    irl_interface.led_controller.applyBootState()
 
     stepper_entries: list[tuple[str, str, "StepperMotor", "ControlBoard"]] = []
     feeder_board: "ControlBoard | None" = None

--- a/software/sorter/backend/irl/leds.py
+++ b/software/sorter/backend/irl/leds.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from global_config import GlobalConfig
 from hardware.sorter_interface import DIGITAL_OUTPUT_DUTY_MAX
@@ -8,12 +9,27 @@ from local_state import (
     get_led_control_state,
     set_led_control_state,
 )
+from machine_platform.control_board import BoardIdentity
 
 if TYPE_CHECKING:
     from hardware.sorter_interface import DigitalOutputPin
-    from machine_platform.control_board import ControlBoard
 
     from .parse_user_toml import GpioLedConfig
+
+
+class DigitalOutputHost(Protocol):
+    @property
+    def digital_outputs(self) -> "Sequence[DigitalOutputPin]": ...
+
+
+class LedCapableBoard(Protocol):
+    # Structural rather than the ControlBoard ABC: binding LEDs only ever reads
+    # the board's name/role and its digital outputs.
+    @property
+    def identity(self) -> BoardIdentity: ...
+
+    @property
+    def interface(self) -> DigitalOutputHost: ...
 
 
 def brightnessPercentToDuty(brightness_percent: int) -> int:
@@ -30,7 +46,7 @@ class BoundLed:
 
 
 class LedController:
-    def __init__(self, gc: GlobalConfig, leds: list[BoundLed]) -> None:
+    def __init__(self, gc: GlobalConfig, leds: Sequence[BoundLed]) -> None:
         self._gc = gc
         self._leds = leds
         self._state = get_led_control_state()
@@ -112,8 +128,8 @@ class LedController:
 
 def bindGpioLeds(
     gc: GlobalConfig,
-    control_boards: "list[ControlBoard]",
-    led_configs: "list[GpioLedConfig]",
+    control_boards: Sequence[LedCapableBoard],
+    led_configs: "Sequence[GpioLedConfig]",
 ) -> list[BoundLed]:
     bound: list[BoundLed] = []
     for cfg in led_configs:

--- a/software/sorter/backend/irl/leds.py
+++ b/software/sorter/backend/irl/leds.py
@@ -1,0 +1,140 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from global_config import GlobalConfig
+from hardware.sorter_interface import DIGITAL_OUTPUT_DUTY_MAX
+from local_state import (
+    LED_CONTROL_DEFAULTS,
+    get_led_control_state,
+    set_led_control_state,
+)
+
+if TYPE_CHECKING:
+    from hardware.sorter_interface import DigitalOutputPin
+    from machine_platform.control_board import ControlBoard
+
+    from .parse_user_toml import GpioLedConfig
+
+
+def brightnessPercentToDuty(brightness_percent: int) -> int:
+    clamped = max(0, min(100, int(brightness_percent)))
+    return round(clamped * DIGITAL_OUTPUT_DUTY_MAX / 100)
+
+
+@dataclass
+class BoundLed:
+    board_role: str
+    board_name: str
+    channel: int
+    pin: "DigitalOutputPin"
+
+
+class LedController:
+    def __init__(self, gc: GlobalConfig, leds: list[BoundLed]) -> None:
+        self._gc = gc
+        self._leds = leds
+        self._state = get_led_control_state()
+
+    @property
+    def state(self) -> dict[str, Any]:
+        return dict(self._state)
+
+    def applyBootState(self) -> dict[str, Any]:
+        # Probe PWM support here so the first bus round-trip happens during
+        # hardware init rather than inside whichever request thread polls
+        # /api/leds first.
+        self._pwmSupported()
+        # "Come on at boot" is the only thing that decides whether the LEDs are
+        # lit after a restart — the persisted on/off is overwritten to match it
+        # so the two settings can never disagree about what just happened.
+        self._state["enabled"] = bool(self._state["on_at_boot"])
+        self._state = set_led_control_state(self._state)
+        self._drive()
+        return self.state
+
+    def update(self, updates: dict[str, Any]) -> dict[str, Any]:
+        # Merge onto what is on disk, not onto the cached copy: the API also
+        # writes settings straight to local state while hardware is down.
+        self._state = set_led_control_state({**get_led_control_state(), **updates})
+        self._drive()
+        return self.state
+
+    def allOff(self) -> None:
+        for led in self._leds:
+            try:
+                led.pin.value = False
+            except Exception as exc:
+                self._gc.logger.warning(
+                    f"LED {led.board_role} ch{led.channel}: failed to turn off: {exc}"
+                )
+
+    def status(self) -> dict[str, Any]:
+        return {
+            **self.state,
+            "defaults": dict(LED_CONTROL_DEFAULTS),
+            "configured": len(self._leds) > 0,
+            "pwm_supported": self._pwmSupported(),
+            "leds": [
+                {
+                    "board_role": led.board_role,
+                    "board_name": led.board_name,
+                    "channel": led.channel,
+                    "duty": led.pin.duty,
+                }
+                for led in self._leds
+            ],
+        }
+
+    def _pwmSupported(self) -> bool:
+        if not self._leds:
+            return False
+        return all(led.pin.pwm_supported for led in self._leds)
+
+    def _drive(self) -> None:
+        duty = (
+            brightnessPercentToDuty(int(self._state["brightness_percent"]))
+            if self._state["enabled"]
+            else 0
+        )
+        for led in self._leds:
+            try:
+                led.pin.setDuty(duty)
+            except Exception as exc:
+                self._gc.logger.warning(
+                    f"LED {led.board_role} ch{led.channel}: failed to set duty {duty}: {exc}"
+                )
+        self._gc.logger.info(
+            f"LEDs: enabled={self._state['enabled']} "
+            f"brightness={self._state['brightness_percent']}% duty={duty} "
+            f"across {len(self._leds)} output(s)"
+        )
+
+
+def bindGpioLeds(
+    gc: GlobalConfig,
+    control_boards: "list[ControlBoard]",
+    led_configs: "list[GpioLedConfig]",
+) -> list[BoundLed]:
+    bound: list[BoundLed] = []
+    for cfg in led_configs:
+        matched = [
+            b for b in control_boards
+            if cfg.board == "any" or b.identity.role == cfg.board
+        ]
+        for board in matched:
+            outputs = board.interface.digital_outputs
+            if cfg.pin >= len(outputs):
+                gc.logger.warning(
+                    f"gpio_leds: board {board.identity.role} ({board.identity.device_name}) "
+                    f"has no digital output at pin {cfg.pin} (only {len(outputs)} outputs). Skipping."
+                )
+                continue
+            bound.append(
+                BoundLed(
+                    board_role=board.identity.role,
+                    board_name=board.identity.device_name,
+                    channel=cfg.pin,
+                    pin=outputs[cfg.pin],
+                )
+            )
+    return bound

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -1036,6 +1036,9 @@ def applyStepperStallguard(
     )
 
 
+# Wiring only — which board/channel an LED is soldered to. The runtime values an
+# operator changes (on/off, brightness, light-up-at-startup) live in
+# local_state.sqlite under the "led_control" key, not in machine.toml.
 VALID_GPIO_LED_BOARDS = {"feeder", "distribution", "any"}
 
 

--- a/software/sorter/backend/local_state.py
+++ b/software/sorter/backend/local_state.py
@@ -66,6 +66,10 @@ _STATE_KEY_SERVO_CHANNEL_CALIBRATION = "servo_channel_calibration"
 _STATE_KEY_TAILSCALE_HOSTNAME = "tailscale_hostname"
 _STATE_KEY_SAMPLE_COLLECTION = "sample_collection"
 _STATE_KEY_TELEMETRY_INSTALL = "telemetry_install"
+# Runtime LED control (on/off, brightness, boot behavior). The *wiring* — which
+# board and which digital-output channel is an LED — stays in machine.toml under
+# [[gpio_leds]]; only the values an operator changes from the UI live here.
+_STATE_KEY_LED_CONTROL = "led_control"
 _STATE_KEY_BASICALLY_SERVICES = "basically_services"
 
 _META_KEY_ACTIVE_SORTING_SESSION_ID = "active_sorting_session_id"
@@ -1060,6 +1064,37 @@ def get_set_progress_state() -> dict[str, Any] | None:
 def set_set_progress_state(state: dict[str, Any] | None) -> None:
     normalized = dict(state) if isinstance(state, dict) else None
     _write_state(_STATE_KEY_SET_PROGRESS, normalized)
+
+
+LED_CONTROL_DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "brightness_percent": 100,
+    "on_at_boot": True,
+}
+
+
+def _normalize_led_control(raw: Any) -> dict[str, Any]:
+    merged = dict(LED_CONTROL_DEFAULTS)
+    if not isinstance(raw, dict):
+        return merged
+    if isinstance(raw.get("enabled"), bool):
+        merged["enabled"] = raw["enabled"]
+    if isinstance(raw.get("on_at_boot"), bool):
+        merged["on_at_boot"] = raw["on_at_boot"]
+    brightness = raw.get("brightness_percent")
+    if isinstance(brightness, (int, float)) and not isinstance(brightness, bool):
+        merged["brightness_percent"] = max(0, min(100, int(round(brightness))))
+    return merged
+
+
+def get_led_control_state() -> dict[str, Any]:
+    return _normalize_led_control(_read_state(_STATE_KEY_LED_CONTROL))
+
+
+def set_led_control_state(state: dict[str, Any]) -> dict[str, Any]:
+    normalized = _normalize_led_control(state)
+    _write_state(_STATE_KEY_LED_CONTROL, normalized)
+    return normalized
 
 
 def get_ui_theme_color_id() -> str | None:

--- a/software/sorter/backend/server/api.py
+++ b/software/sorter/backend/server/api.py
@@ -140,6 +140,7 @@ from server.routers.wifi import router as wifi_router
 from server.routers.firmware import router as firmware_router
 from server.routers.versions import router as versions_router
 from server.routers.status_ping import router as status_ping_router
+from server.routers.leds import router as leds_router
 
 app.include_router(hardware_router)
 app.include_router(steppers_router)
@@ -163,6 +164,7 @@ app.include_router(wifi_router)
 app.include_router(firmware_router)
 app.include_router(versions_router)
 app.include_router(status_ping_router)
+app.include_router(leds_router)
 
 # ---------------------------------------------------------------------------
 # Lifecycle

--- a/software/sorter/backend/server/routers/leds.py
+++ b/software/sorter/backend/server/routers/leds.py
@@ -1,0 +1,72 @@
+"""LED endpoints: on/off, brightness, and whether the LEDs light up at boot."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from local_state import (
+    LED_CONTROL_DEFAULTS,
+    get_led_control_state,
+    set_led_control_state,
+)
+from server import shared_state
+
+router = APIRouter()
+
+
+class LedSettingsPayload(BaseModel):
+    enabled: bool | None = None
+    brightness_percent: int | None = None
+    on_at_boot: bool | None = None
+
+
+def _ledController() -> Any | None:
+    controller = shared_state.controller_ref
+    irl = getattr(controller, "irl", None) if controller is not None else None
+    return getattr(irl, "led_controller", None) if irl is not None else None
+
+
+def _offlineStatus() -> dict[str, Any]:
+    # Hardware is not up (standby, or a machine with no boards discovered yet).
+    # Still report the persisted settings so the UI renders the real values.
+    return {
+        **get_led_control_state(),
+        "defaults": dict(LED_CONTROL_DEFAULTS),
+        "configured": False,
+        "pwm_supported": False,
+        "leds": [],
+        "hardware_ready": False,
+    }
+
+
+@router.get("/api/leds")
+def get_leds() -> dict[str, Any]:
+    led_controller = _ledController()
+    if led_controller is None:
+        return _offlineStatus()
+    return {**led_controller.status(), "hardware_ready": True}
+
+
+@router.post("/api/leds")
+def set_leds(payload: LedSettingsPayload) -> dict[str, Any]:
+    updates = payload.model_dump(exclude_none=True)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No LED settings supplied")
+
+    brightness = updates.get("brightness_percent")
+    if brightness is not None and not 0 <= brightness <= 100:
+        raise HTTPException(
+            status_code=400, detail="brightness_percent must be between 0 and 100"
+        )
+
+    led_controller = _ledController()
+    if led_controller is None:
+        # Standby, or hardware not discovered yet. Persist anyway so the choice
+        # survives to the next hardware init instead of silently failing.
+        set_led_control_state({**get_led_control_state(), **updates})
+        return _offlineStatus()
+
+    led_controller.update(updates)
+    return {**led_controller.status(), "hardware_ready": True}

--- a/software/sorter/backend/tests/test_led_control.py
+++ b/software/sorter/backend/tests/test_led_control.py
@@ -1,0 +1,256 @@
+import importlib
+import os
+import tempfile
+import unittest
+from typing import Any
+
+from hardware.bus import MCUBusError
+from hardware.sorter_interface import DIGITAL_OUTPUT_DUTY_MAX, DigitalOutputPin
+from irl.leds import BoundLed, LedController, bindGpioLeds, brightnessPercentToDuty
+from irl.parse_user_toml import GpioLedConfig
+
+
+class FakeDevice:
+    def __init__(self, pwm_supported: bool = True, reject_pwm: bool = False) -> None:
+        self.supports_digital_output_pwm = pwm_supported
+        self.reject_pwm = reject_pwm
+        self.commands: list[tuple[int, int, bytes]] = []
+
+    def send_command(self, command: int, channel: int, payload: bytes) -> Any:
+        if int(command) == 0x32 and self.reject_pwm:
+            raise MCUBusError("Unknown command")
+        self.commands.append((int(command), channel, payload))
+        return None
+
+
+class FakeBoardIdentity:
+    def __init__(self, role: str, device_name: str) -> None:
+        self.role = role
+        self.device_name = device_name
+
+
+class FakeBoardInterface:
+    def __init__(self, digital_outputs: tuple) -> None:
+        self.digital_outputs = digital_outputs
+
+
+class FakeBoard:
+    def __init__(self, role: str, device_name: str, digital_outputs: tuple) -> None:
+        self.identity = FakeBoardIdentity(role, device_name)
+        self.interface = FakeBoardInterface(digital_outputs)
+
+
+class FakeLogger:
+    def info(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def warning(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class FakeGlobalConfig:
+    def __init__(self) -> None:
+        self.logger = FakeLogger()
+
+
+def mkGc() -> Any:
+    return FakeGlobalConfig()
+
+
+class BrightnessMappingTests(unittest.TestCase):
+    def test_percent_maps_to_full_duty_range(self) -> None:
+        self.assertEqual(brightnessPercentToDuty(0), 0)
+        self.assertEqual(brightnessPercentToDuty(100), DIGITAL_OUTPUT_DUTY_MAX)
+        self.assertEqual(brightnessPercentToDuty(50), round(DIGITAL_OUTPUT_DUTY_MAX / 2))
+
+    def test_percent_is_clamped(self) -> None:
+        self.assertEqual(brightnessPercentToDuty(-20), 0)
+        self.assertEqual(brightnessPercentToDuty(500), DIGITAL_OUTPUT_DUTY_MAX)
+
+
+class DigitalOutputPwmTests(unittest.TestCase):
+    def test_set_duty_sends_pwm_command(self) -> None:
+        gc = mkGc()
+        device = FakeDevice(pwm_supported=True)
+        pin = DigitalOutputPin(device, 0, gc)
+
+        pin.setDuty(30000)
+
+        self.assertEqual(len(device.commands), 1)
+        command, channel, payload = device.commands[0]
+        self.assertEqual(command, 0x32)
+        self.assertEqual(channel, 0)
+        self.assertEqual(payload, (30000).to_bytes(2, "little"))
+        self.assertEqual(pin.duty, 30000)
+        self.assertTrue(pin.value)
+
+    def test_set_duty_zero_reports_off(self) -> None:
+        gc = mkGc()
+        pin = DigitalOutputPin(FakeDevice(pwm_supported=True), 1, gc)
+
+        pin.setDuty(0)
+
+        self.assertEqual(pin.duty, 0)
+        self.assertFalse(pin.value)
+
+    def test_boolean_write_still_tracks_duty(self) -> None:
+        gc = mkGc()
+        device = FakeDevice(pwm_supported=True)
+        pin = DigitalOutputPin(device, 0, gc)
+
+        pin.value = True
+
+        self.assertEqual(device.commands[0][0], 0x31)
+        self.assertEqual(pin.duty, DIGITAL_OUTPUT_DUTY_MAX)
+
+    def test_old_firmware_degrades_to_on_off(self) -> None:
+        gc = mkGc()
+        # Board claims support via observability but rejects the opcode — what a
+        # board flashed with firmware predating WRITE_PWM would actually do if
+        # the capability flag were ever wrong.
+        device = FakeDevice(pwm_supported=True, reject_pwm=True)
+        pin = DigitalOutputPin(device, 0, gc)
+
+        pin.setDuty(20000)
+
+        self.assertFalse(pin.pwm_supported)
+        self.assertEqual([c[0] for c in device.commands], [0x31])
+        self.assertTrue(pin.value)
+
+        pin.setDuty(0)
+        self.assertEqual([c[0] for c in device.commands], [0x31, 0x31])
+        self.assertFalse(pin.value)
+
+    def test_board_without_pwm_never_sends_pwm_command(self) -> None:
+        gc = mkGc()
+        device = FakeDevice(pwm_supported=False)
+        pin = DigitalOutputPin(device, 0, gc)
+
+        pin.setDuty(40000)
+
+        self.assertEqual([c[0] for c in device.commands], [0x31])
+
+
+class BindGpioLedsTests(unittest.TestCase):
+    def test_binds_matching_boards_and_skips_missing_channels(self) -> None:
+        gc = mkGc()
+        outputs = (
+            DigitalOutputPin(FakeDevice(), 0, gc),
+            DigitalOutputPin(FakeDevice(), 1, gc),
+        )
+        boards = [
+            FakeBoard("feeder", "feeder-board", outputs),
+            FakeBoard("distribution", "dist-board", outputs),
+        ]
+
+        bound = bindGpioLeds(
+            gc,
+            boards,
+            [
+                GpioLedConfig(board="any", pin=0),
+                GpioLedConfig(board="feeder", pin=1),
+                GpioLedConfig(board="feeder", pin=9),
+            ],
+        )
+
+        self.assertEqual(
+            [(b.board_role, b.channel) for b in bound],
+            [("feeder", 0), ("distribution", 0), ("feeder", 1)],
+        )
+
+
+class LedControllerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_db = os.environ.get("LOCAL_STATE_DB_PATH")
+        os.environ["LOCAL_STATE_DB_PATH"] = os.path.join(self._tmp.name, "state.sqlite")
+        import local_state
+
+        importlib.reload(local_state)
+        self.local_state = local_state
+        importlib.reload(importlib.import_module("irl.leds"))
+
+        self.gc = mkGc()
+        self.device = FakeDevice(pwm_supported=True)
+        self.pin = DigitalOutputPin(self.device, 0, self.gc)
+        self.leds = [
+            BoundLed(board_role="feeder", board_name="feeder-board", channel=0, pin=self.pin)
+        ]
+
+    def tearDown(self) -> None:
+        if self._old_db is None:
+            os.environ.pop("LOCAL_STATE_DB_PATH", None)
+        else:
+            os.environ["LOCAL_STATE_DB_PATH"] = self._old_db
+        self._tmp.cleanup()
+        import local_state
+
+        importlib.reload(local_state)
+        importlib.reload(importlib.import_module("irl.leds"))
+
+    def test_boot_turns_leds_on_by_default(self) -> None:
+        controller = LedController(self.gc, self.leds)
+
+        state = controller.applyBootState()
+
+        self.assertTrue(state["enabled"])
+        self.assertEqual(self.pin.duty, DIGITAL_OUTPUT_DUTY_MAX)
+
+    def test_boot_leaves_leds_dark_when_on_at_boot_is_off(self) -> None:
+        LedController(self.gc, self.leds).update({"on_at_boot": False})
+
+        state = LedController(self.gc, self.leds).applyBootState()
+
+        self.assertFalse(state["enabled"])
+        self.assertEqual(self.pin.duty, 0)
+
+    def test_brightness_persists_across_controllers(self) -> None:
+        LedController(self.gc, self.leds).update({"brightness_percent": 40})
+
+        state = LedController(self.gc, self.leds).state
+
+        self.assertEqual(state["brightness_percent"], 40)
+
+    def test_enabling_drives_configured_brightness(self) -> None:
+        controller = LedController(self.gc, self.leds)
+
+        controller.update({"brightness_percent": 25, "enabled": True})
+
+        self.assertEqual(self.pin.duty, brightnessPercentToDuty(25))
+
+    def test_disabling_drives_zero_without_losing_brightness(self) -> None:
+        controller = LedController(self.gc, self.leds)
+        controller.update({"brightness_percent": 25})
+
+        controller.update({"enabled": False})
+
+        self.assertEqual(self.pin.duty, 0)
+        self.assertEqual(controller.state["brightness_percent"], 25)
+
+    def test_status_reports_wiring_and_capability(self) -> None:
+        controller = LedController(self.gc, self.leds)
+
+        status = controller.status()
+
+        self.assertTrue(status["configured"])
+        self.assertTrue(status["pwm_supported"])
+        self.assertEqual(status["leds"][0]["board_role"], "feeder")
+        self.assertEqual(status["defaults"], dict(self.local_state.LED_CONTROL_DEFAULTS))
+
+    def test_status_without_wiring_is_not_configured(self) -> None:
+        status = LedController(self.gc, []).status()
+
+        self.assertFalse(status["configured"])
+        self.assertFalse(status["pwm_supported"])
+        self.assertEqual(status["leds"], [])
+
+    def test_brightness_is_clamped_on_write(self) -> None:
+        controller = LedController(self.gc, self.leds)
+
+        controller.update({"brightness_percent": 480})
+
+        self.assertEqual(controller.state["brightness_percent"], 100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/sorter/backend/tests/test_led_control.py
+++ b/software/sorter/backend/tests/test_led_control.py
@@ -2,49 +2,60 @@ import importlib
 import os
 import tempfile
 import unittest
+from collections.abc import Sequence
 from typing import Any
 
 from hardware.bus import MCUBusError
 from hardware.sorter_interface import DIGITAL_OUTPUT_DUTY_MAX, DigitalOutputPin
 from irl.leds import BoundLed, LedController, bindGpioLeds, brightnessPercentToDuty
 from irl.parse_user_toml import GpioLedConfig
+from machine_platform.control_board import BoardIdentity
 
 
 class FakeDevice:
+    # Structurally a sorter_interface.DigitalOutputDevice.
     def __init__(self, pwm_supported: bool = True, reject_pwm: bool = False) -> None:
-        self.supports_digital_output_pwm = pwm_supported
+        self._pwm_supported = pwm_supported
         self.reject_pwm = reject_pwm
         self.commands: list[tuple[int, int, bytes]] = []
 
-    def send_command(self, command: int, channel: int, payload: bytes) -> Any:
+    @property
+    def supports_digital_output_pwm(self) -> bool:
+        return self._pwm_supported
+
+    def send_command(self, command: int, channel: int, payload: bytes) -> object:
         if int(command) == 0x32 and self.reject_pwm:
             raise MCUBusError("Unknown command")
         self.commands.append((int(command), channel, payload))
         return None
 
 
-class FakeBoardIdentity:
-    def __init__(self, role: str, device_name: str) -> None:
-        self.role = role
-        self.device_name = device_name
-
-
 class FakeBoardInterface:
-    def __init__(self, digital_outputs: tuple) -> None:
+    def __init__(self, digital_outputs: Sequence[DigitalOutputPin]) -> None:
         self.digital_outputs = digital_outputs
 
 
 class FakeBoard:
-    def __init__(self, role: str, device_name: str, digital_outputs: tuple) -> None:
-        self.identity = FakeBoardIdentity(role, device_name)
+    # Structurally a leds.LedCapableBoard — the real ControlBoard ABC demands a
+    # whole SorterInterface, which these tests have no use for.
+    def __init__(
+        self, role: str, device_name: str, digital_outputs: Sequence[DigitalOutputPin]
+    ) -> None:
+        self.identity = BoardIdentity(
+            family="basically",
+            role=role,
+            device_name=device_name,
+            port="/dev/null",
+            address=0,
+        )
         self.interface = FakeBoardInterface(digital_outputs)
 
 
 class FakeLogger:
-    def info(self, *args: Any, **kwargs: Any) -> None:
+    def info(self, message: str) -> None:
         pass
 
-    def warning(self, *args: Any, **kwargs: Any) -> None:
+    def warning(self, message: str) -> None:
         pass
 
 

--- a/software/sorter/frontend/src/lib/components/settings/LedsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/LedsSection.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { getBackendHttpBase, machineHttpBaseUrlFromWsUrl } from '$lib/backend';
+	import { getMachineContext } from '$lib/machines/context';
+	import { ToggleSwitch, Alert } from '$lib/components/primitives';
+	import SettingRow from '$lib/components/settings/SettingRow.svelte';
+
+	const machine = getMachineContext();
+
+	const STATUS_POLL_MS = 5000;
+	// Applied while dragging the brightness slider so we don't POST per pixel.
+	const BRIGHTNESS_DEBOUNCE_MS = 200;
+
+	type LedInfo = {
+		board_role: string;
+		board_name: string;
+		channel: number;
+		duty: number;
+	};
+
+	let enabled = $state(true);
+	let brightnessPercent = $state(100);
+	let onAtBoot = $state(true);
+	let defaults = $state({ enabled: true, brightness_percent: 100, on_at_boot: true });
+	let configured = $state(false);
+	let pwmSupported = $state(false);
+	let hardwareReady = $state(false);
+	let leds = $state<LedInfo[]>([]);
+
+	let loading = $state(true);
+	let saving = $state(false);
+	let errorMsg = $state<string | null>(null);
+
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+	let brightnessTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function currentBackendBaseUrl(): string {
+		return machineHttpBaseUrlFromWsUrl(machine.machine?.url) ?? getBackendHttpBase();
+	}
+
+	function applyStatus(payload: any) {
+		enabled = Boolean(payload?.enabled);
+		onAtBoot = Boolean(payload?.on_at_boot);
+		const pct = Number(payload?.brightness_percent);
+		if (Number.isFinite(pct)) brightnessPercent = Math.max(0, Math.min(100, Math.round(pct)));
+		if (payload?.defaults) defaults = payload.defaults;
+		configured = Boolean(payload?.configured);
+		pwmSupported = Boolean(payload?.pwm_supported);
+		hardwareReady = Boolean(payload?.hardware_ready);
+		leds = Array.isArray(payload?.leds) ? payload.leds : [];
+	}
+
+	async function loadStatus(showLoading = true) {
+		if (showLoading) loading = true;
+		try {
+			const res = await fetch(`${currentBackendBaseUrl()}/api/leds`);
+			if (!res.ok) throw new Error(await res.text());
+			applyStatus(await res.json());
+			errorMsg = null;
+		} catch (e: any) {
+			errorMsg = e?.message ?? 'Failed to load LED settings.';
+		} finally {
+			if (showLoading) loading = false;
+		}
+	}
+
+	async function post(body: Record<string, unknown>) {
+		saving = true;
+		errorMsg = null;
+		try {
+			const res = await fetch(`${currentBackendBaseUrl()}/api/leds`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body)
+			});
+			if (!res.ok) throw new Error(await res.text());
+			applyStatus(await res.json());
+		} catch (e: any) {
+			errorMsg = e?.message ?? 'Failed to update LEDs.';
+		} finally {
+			saving = false;
+		}
+	}
+
+	function saveEnabled(next: boolean) {
+		enabled = next;
+		void post({ enabled: next });
+	}
+
+	function saveOnAtBoot(next: boolean) {
+		onAtBoot = next;
+		void post({ on_at_boot: next });
+	}
+
+	function saveBrightness(next: number) {
+		if (!Number.isFinite(next)) return;
+		const clamped = Math.max(0, Math.min(100, Math.round(next)));
+		brightnessPercent = clamped;
+		if (brightnessTimer) clearTimeout(brightnessTimer);
+		brightnessTimer = setTimeout(() => {
+			void post({ brightness_percent: clamped });
+		}, BRIGHTNESS_DEBOUNCE_MS);
+	}
+
+	onMount(() => {
+		void loadStatus();
+		pollTimer = setInterval(() => void loadStatus(false), STATUS_POLL_MS);
+	});
+
+	onDestroy(() => {
+		if (pollTimer) clearInterval(pollTimer);
+		if (brightnessTimer) clearTimeout(brightnessTimer);
+	});
+</script>
+
+<div class="flex flex-col gap-2">
+	{#if errorMsg}
+		<Alert variant="danger">{errorMsg}</Alert>
+	{/if}
+
+	{#if !loading && !configured && hardwareReady}
+		<Alert variant="info">
+			No LEDs are wired up on this machine. Declare them in <code>machine.toml</code> with a
+			<code>[[gpio_leds]]</code> entry per LED (board plus digital-output channel), then restart the backend.
+		</Alert>
+	{:else if !loading && !hardwareReady}
+		<Alert variant="info">
+			Machine hardware is not initialized, so the LEDs cannot be driven right now. Changes are saved
+			and applied the next time the machine starts up.
+		</Alert>
+	{:else if !loading && configured && !pwmSupported}
+		<Alert variant="warning">
+			The control board firmware does not support PWM output, so brightness has no effect — the LEDs
+			are either fully on or fully off. Reflash the board from Settings → Versions to enable
+			dimming.
+		</Alert>
+	{/if}
+
+	<SettingRow
+		label="LEDs on"
+		description="Turns the machine's LED lighting on or off right now. On drives the LEDs at the brightness set below."
+		changed={enabled !== defaults.enabled}
+		defaultLabel={defaults.enabled ? 'on' : 'off'}
+		onRevert={() => saveEnabled(defaults.enabled)}
+	>
+		<ToggleSwitch
+			checked={enabled}
+			label="LEDs on"
+			disabled={loading || saving}
+			onToggle={() => saveEnabled(!enabled)}
+		/>
+	</SettingRow>
+
+	<SettingRow
+		label="Turn LEDs on at startup"
+		description="When on, the LEDs light up automatically as soon as the machine finishes initializing its hardware. When off, they stay dark until you switch them on here."
+		changed={onAtBoot !== defaults.on_at_boot}
+		defaultLabel={defaults.on_at_boot ? 'on' : 'off'}
+		onRevert={() => saveOnAtBoot(defaults.on_at_boot)}
+	>
+		<ToggleSwitch
+			checked={onAtBoot}
+			label="Turn LEDs on at startup"
+			disabled={loading || saving}
+			onToggle={() => saveOnAtBoot(!onAtBoot)}
+		/>
+	</SettingRow>
+
+	<SettingRow
+		label="Brightness"
+		description="PWM duty cycle driven onto every configured LED output. 100% is full brightness; the LEDs still go fully dark when the toggle above is off."
+		changed={brightnessPercent !== defaults.brightness_percent}
+		defaultLabel={`${defaults.brightness_percent}%`}
+		onRevert={() => saveBrightness(defaults.brightness_percent)}
+	>
+		<div class="flex items-center gap-3">
+			<input
+				type="range"
+				min="0"
+				max="100"
+				step="1"
+				value={brightnessPercent}
+				disabled={loading || !pwmSupported}
+				aria-label="LED brightness percent"
+				oninput={(e) => saveBrightness(Number(e.currentTarget.value))}
+				class="w-40"
+			/>
+			<span class="w-12 shrink-0 text-right text-sm text-text tabular-nums">
+				{brightnessPercent}%
+			</span>
+		</div>
+	</SettingRow>
+
+	{#if leds.length > 0}
+		<div class="border border-border bg-bg px-3 py-2.5 text-sm text-text-muted">
+			Driving {leds.length} output{leds.length === 1 ? '' : 's'}:
+			{#each leds as led, i}
+				<span class="text-text">
+					{led.board_role} ch{led.channel}{i < leds.length - 1 ? ',' : ''}
+				</span>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/software/sorter/frontend/src/routes/settings/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/+page.svelte
@@ -4,6 +4,7 @@ import ApiKeysSection from '$lib/components/settings/ApiKeysSection.svelte';
 import SampleCaptureSection from '$lib/components/settings/SampleCaptureSection.svelte';
 import SampleStorageSection from '$lib/components/settings/SampleStorageSection.svelte';
 import TailscaleSection from '$lib/components/settings/TailscaleSection.svelte';
+import LedsSection from '$lib/components/settings/LedsSection.svelte';
 import WifiSection from '$lib/components/settings/WifiSection.svelte';
 import SectionCard from '$lib/components/settings/SectionCard.svelte';
 import LegoColorPicker from '$lib/components/LegoColorPicker.svelte';
@@ -44,6 +45,13 @@ import LegoColorPicker from '$lib/components/LegoColorPicker.svelte';
 				</a>
 			</div>
 		</div>
+	</SectionCard>
+
+	<SectionCard
+		title="LEDs"
+		description="Control the machine's LED lighting: on/off, brightness, and whether it comes on at startup."
+	>
+		<LedsSection />
 	</SectionCard>
 
 	<SectionCard


### PR DESCRIPTION
Annihilates the `gpio_leds` machine.toml hack and replaces it with a real LED subsystem controlled from the UI: on/off, PWM brightness, and a light-up-at-startup toggle.

## What was there before

`gpio_leds = [{board = "any", pin = 0}, ...]` in machine.toml, read by `loadGpioLedsConfig`, applied once by `_applyGpioLeds` during hardware init — pins latched HIGH, and that was it. No way to dim, turn off, or stop them coming on.

## Design

### The single-brightness model

Per Spencer's note ("if it is PWM, maybe the simpler method is to just have on map to like the full value"), there is one brightness number, not two parallel concepts. Effective duty = `enabled ? brightness_percent : 0`. The boolean on/off affordance sits on top of that in the UI, and turning the LEDs off never loses the brightness you had set.

### The config split

| Lives in | What | Why |
|---|---|---|
| `machine.toml` `[[gpio_leds]]` | board + digital-output channel | Genuinely machine-specific wiring. Doesn't change unless someone resolders. |
| `local_state.sqlite`, key `led_control` | `enabled`, `brightness_percent`, `on_at_boot` | Values an operator changes from the UI. |

This follows the split `toml_config.py` already documents — declarative machine config in the toml, mutable local state in sqlite — and mirrors the UI-theme setting (`get_ui_theme_color_id` / `set_ui_theme_color_id`) exactly. No new persistence mechanism.

**How `enabled` and `on_at_boot` interact:** at hardware init, `enabled` is forced to match `on_at_boot` and persisted. So the two can never disagree about what just happened, and "turn LEDs on at startup" means exactly what it says.

### Firmware PWM

New `DIGITAL_IO/WRITE_PWM` command at the free slot in the digital-io table — **opcode 0x32**, payload `uint16` duty. RP2040 hardware PWM, ~1.9 kHz.

The counter wraps at **65534** (not 65535) deliberately: it then takes 65535 values (0..65534), so duty 0 is genuinely always-low and duty 65535 is genuinely always-high, rather than 65535/65536 of the time. The full u16 range maps to a real 0%..100%.

Two details worth reviewing:
- **Slices are never disabled**, only levelled to 0. On basically v1-1, GPIO14/15 are PWM7A/7B — the *same slice*. Disabling it to turn one LED off would freeze the other.
- The existing on/off `WRITE` (0x31) still works and now hands the pad back to `GPIO_FUNC_SIO` first if that channel had been put into PWM mode, so `shutdown()` and `motor_test.py` behave exactly as before.

### Graceful degradation on old firmware

Two layers, because a board that was never reflashed must not error:

1. `GET_OBSERVABILITY` now reports `"digital_output_pwm": true`. The host reads it once (`SorterInterface.supports_digital_output_pwm`) and won't send 0x32 to a board that doesn't advertise it. This is the same detect-JSON mechanism `control_board.py` already uses; it avoids `dump_configuration()`, which is already fighting the 246-byte frame limit.
2. Belt and braces: if the flag is somehow wrong, `DigitalOutputPin.setDuty` catches the `MCUBusError` from the unknown opcode, marks the pin on/off-only for the rest of the process, and falls back. Covered by a test.

The UI reads `pwm_supported` and shows a warning telling you to reflash, with the brightness slider disabled, rather than silently doing nothing.

## Structural changes

- **New `irl/leds.py`** — `LedController` (owns state, drives pins, reports status), `BoundLed`, `bindGpioLeds`. Replaces `_applyGpioLeds`, which was inlined in `config.py`.
- **`IRLInterface.gpio_led_pins: list[DigitalOutputPin]` → `IRLInterface.led_controller: LedController | None`.** `shutdown()` calls `allOff()`.
- **New `server/routers/leds.py`** — `GET`/`POST /api/leds`. Kept out of `hardware.py`, which is already 3679 lines. REST-only, polled like `SampleCaptureSection` — **no `defs/events.py` change, so `events.ts` needs no regeneration.**
- **New `LedsSection.svelte`** on the root settings page, using the existing `SettingRow` / `ToggleSwitch` / `Alert` primitives and the established changed-from-default + revert affordance.

Product detail: changing settings while the machine is in standby (no `irl`) **persists** rather than 400-ing, and the UI says so — it applies at the next hardware init.

## machine.toml migration

**None required.** kitbash's existing `gpio_leds = [{board = "any", pin = 0}, {board = "any", pin = 1}]` keeps working as-is — it is now interpreted purely as wiring. Nothing to add or remove by hand. If you ever want the LEDs *not* to come on at startup, that is now the UI toggle, not a toml edit.

## Firmware flashing required

Brightness only works after **reflashing both Picos** (feeder and distribution) with this firmware. Until then the machine runs fine — the host detects the missing capability and the LEDs behave exactly as they do today (on/off), with the UI showing a reflash prompt.

## Verification

- **Firmware compiles clean, zero warnings**, across all three hwcfgs: `distribution-v1-2`, `feeder-v1-2`, `feeder-v1-1`, `feeder-skr`.
- **Backend suite: 618 passed.** 20 failures are pre-existing on `origin/main` — verified by stashing this branch and re-running (602 passed / same 20 failed). This PR adds 16 tests (`tests/test_led_control.py`) and breaks nothing.
- **`svelte-check`: zero errors or warnings in the new/changed frontend files.** The 5 repo-wide errors are pre-existing in `ServoLayerCalibrator.svelte` and `jitter-test/+page.svelte`, both untouched here.
- Route registration and `irl.config` import verified by loading the FastAPI app.
- **Pyright: zero errors in the three new files** (`irl/leds.py`, `server/routers/leds.py`, `tests/test_led_control.py`). The four shared files I edited (`hardware/sorter_interface.py`, `irl/config.py`, `local_state.py`, `server/api.py`) carry exactly their `origin/main` baseline errors, line-shifted by my additions — verified against a scratch worktree at `origin/main`.

### Typing notes

Three things the first revision got wrong, now fixed with no `# type: ignore` and no `Any`:

- `bindGpioLeds` / `LedController.__init__` took **invariant `list` parameters**, so `list[SorterInterfaceControlBoard]` wouldn't bind to `list[ControlBoard]`. These parameters are read-only, so they're now `Sequence`.
- `bindGpioLeds` no longer names the `ControlBoard` ABC at all. It reads only `identity` and `interface.digital_outputs`, so it takes a small `LedCapableBoard` / `DigitalOutputHost` protocol pair. The ABC would have forced the tests to conjure a whole `SorterInterface` just to bind two pins.
- `DigitalOutputPin` now takes a **`DigitalOutputDevice` protocol** instead of `MCUDevice`. That's what actually types `supports_digital_output_pwm` (previously an unknown attribute on `MCUDevice`), and it's the honest narrow surface: writes never inspect the response, hence `send_command(...) -> object`. This also resolved the test-double structural-typing complaints without a `Protocol` bolted on purely for tests. The cached `bool | None` in both capability properties no longer leaks `None` into a `bool` return.

### Not verifiable without hardware

Everything below needs a reflashed board on kitbash:

1. **That the pins are actually PWM-capable on basically v1-2.** Spencer was told they are but hasn't confirmed. On v1-2 the outputs are GPIO1 (PWM0B) and GPIO6 (PWM3A) — different slices, so independent duty is fine *if* the pads are wired to something dimmable. If the LED driver circuit doesn't like ~1.9 kHz switching, the frequency is a one-constant change (`PWM_OUTPUT_WRAP`).
2. That brightness visibly tracks the slider, and that 0% is fully dark / 100% is as bright as today's always-on behavior.
3. The SIO↔PWM handoff on a live board — that plain on/off after a PWM write still drives the pin, and that `shutdown()` leaves the LEDs dark.
4. The shared-slice case on **v1-1** specifically (GPIO14/15 on slice 7): two LEDs at different brightnesses simultaneously.
5. The old-firmware degradation path against a genuinely un-reflashed Pico.
6. That `on_at_boot = false` really leaves the LEDs dark through a full hardware init.

## Collisions with the other agent

None expected. Nothing here touches `software/hive/` or `.github/workflows/`. The only broadly-shared files are `server/api.py` (two added lines, router import + include) and `local_state.py` (a new state key and its getter/setter, appended).

