### PR TITLE
hive/frontend: unify all loading spinners on the canonical Sorter spinner scheme

### DIFF
--- a/software/hive/frontend/CLAUDE.md
+++ b/software/hive/frontend/CLAUDE.md
@@ -26,9 +26,40 @@ Hive is a public community product, so it is permitted to be friendlier than the
 
 - Cards, panels, buttons, inputs, alerts, modals: **flat corners** (no `rounded-*`).
 - Pill chips and avatar circles are OK (`rounded-full` on a small badge or avatar).
-- `Spinner` uses `rounded-full` because a circular spinner is the primitive.
 
 When in doubt, prefer flat. The divergence from the Sorter design language is intentional.
+
+## Loading — `Spinner` is the only loading animation
+
+`src/lib/components/Spinner.svelte` is a port of the canonical Sorter spinner
+(`software/sorter/frontend/src/lib/components/Spinner.svelte`): four **sharp-cornered**
+squares in a 2x2, one lit at a time, snapping clockwise every quarter cycle. The motion
+is discrete (`linear`, not eased), it inherits color via `currentColor`, and it scales
+via a `size` prop (a px number, default `16`). It deliberately keeps animating under
+`prefers-reduced-motion` — a frozen indicator reads as a hung process.
+
+This is the *one* exception to Hive's "friendlier than Sorter" license: spinners are
+sharp-cornered, same as Sorter. There is no `rounded-full` here.
+
+It is the **only** loading animation in the app. Import it and pass a `size`:
+
+```svelte
+import Spinner from '$lib/components/Spinner.svelte';
+…
+<Spinner size={32} />                       <!-- page/block loading -->
+<Spinner size={12} class="text-text-muted" /> <!-- inline, next to a label -->
+```
+
+Never hand-roll a loading indicator: no `animate-spin`, no `border-current
+border-t-transparent` ring, no spinning lucide `Loader2`, no inline `<svg
+class="animate-spin">`, no CSS `@keyframes` rotation. `rg "animate-spin" src/` should
+return nothing.
+
+`Spinner` renders only the indicator — it does **not** center or pad itself. Wrap it
+where you need layout (`<div class="flex justify-center p-8"><Spinner size={32} /></div>`).
+
+Genuine skeleton loaders (content-shaped placeholder blocks) are a different thing and
+are fine; this rule is about spinning/looping indicators.
 
 ## Primitives
 

--- a/software/hive/frontend/src/lib/components/AiUsagePanel.svelte
+++ b/software/hive/frontend/src/lib/components/AiUsagePanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { api, type AiUsageSummary, type AiUsageTotals } from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	let summary = $state<AiUsageSummary | null>(null);
 	let loading = $state(true);
@@ -48,7 +49,7 @@
 	</div>
 
 	{#if loading}
-		<p class="text-xs text-text-muted">Loading…</p>
+		<p class="flex items-center gap-1.5 text-xs text-text-muted"><Spinner size={12} /> Loading…</p>
 	{:else if error}
 		<p class="text-xs text-text-muted">{error}</p>
 	{:else if summary}

--- a/software/hive/frontend/src/lib/components/MachineLabeledPieces.svelte
+++ b/software/hive/frontend/src/lib/components/MachineLabeledPieces.svelte
@@ -66,7 +66,7 @@
 	</div>
 
 	{#if loading}
-		<div class="flex justify-center py-8"><Spinner /></div>
+		<div class="flex justify-center py-8"><Spinner size={32} /></div>
 	{:else if error}
 		<div class="p-3 text-sm text-primary">{error}</div>
 	{:else if items.length === 0}

--- a/software/hive/frontend/src/lib/components/PaletteCoverage.svelte
+++ b/software/hive/frontend/src/lib/components/PaletteCoverage.svelte
@@ -123,7 +123,7 @@
 	{#if open}
 		<div class="border-t border-border p-4">
 			{#if loading}
-				<div class="flex justify-center py-8"><Spinner /></div>
+				<div class="flex justify-center py-8"><Spinner size={32} /></div>
 			{:else if error}
 				<div class="bg-primary/8 p-3 text-sm text-primary">{error}</div>
 			{:else}

--- a/software/hive/frontend/src/lib/components/PartBrickLinkColors.svelte
+++ b/software/hive/frontend/src/lib/components/PartBrickLinkColors.svelte
@@ -71,7 +71,7 @@
 	</div>
 
 	{#if loading}
-		<div class="flex justify-center py-8"><Spinner /></div>
+		<div class="flex justify-center py-8"><Spinner size={32} /></div>
 	{:else if error}
 		<div class="p-3 text-sm text-primary">{error}</div>
 	{:else if items.length === 0}

--- a/software/hive/frontend/src/lib/components/PieceLabelPanel.svelte
+++ b/software/hive/frontend/src/lib/components/PieceLabelPanel.svelte
@@ -1102,7 +1102,7 @@
 		</p>
 
 		{#if cropLoading}
-			<div class="flex justify-center py-8"><Spinner /></div>
+			<div class="flex justify-center py-8"><Spinner size={32} /></div>
 		{:else if cropError}
 			<div class="bg-primary/8 p-3 text-sm text-primary">{cropError}</div>
 		{:else if cropCandidates.length === 0}
@@ -1424,7 +1424,7 @@
 {/if}
 
 {#if loading}
-	<div class="flex justify-center py-16"><Spinner /></div>
+	<div class="flex justify-center py-16"><Spinner size={32} /></div>
 {:else if !detail}
 	<div class="border border-border bg-surface p-10 text-center">
 		<p class="text-sm text-text-muted">Piece not found.</p>

--- a/software/hive/frontend/src/lib/components/PiecePartPicker.svelte
+++ b/software/hive/frontend/src/lib/components/PiecePartPicker.svelte
@@ -207,7 +207,7 @@
 	</div>
 
 	{#if searching}
-		<div class="flex justify-center py-3"><Spinner /></div>
+		<div class="flex justify-center py-3"><Spinner size={24} /></div>
 	{:else if searched && results.length === 0}
 		<p class="py-3 text-center text-xs text-text-muted">No parts match.</p>
 	{:else if results.length > 0}

--- a/software/hive/frontend/src/lib/components/Spinner.svelte
+++ b/software/hive/frontend/src/lib/components/Spinner.svelte
@@ -1,3 +1,40 @@
-<div class="flex items-center justify-center p-8">
-	<div class="h-8 w-8 animate-spin border-4 border-border border-t-primary"></div>
+<script lang="ts">
+	let { size = 16, class: className = '' }: { size?: number; class?: string } = $props();
+</script>
+
+<div class="spinner {className}" style={`--spinner-size:${size}px`} role="status" aria-label="Loading">
+	<i></i><i></i><i></i><i></i>
 </div>
+
+<style>
+	/* Canonical loading indicator, ported from the Sorter UI
+	   (software/sorter/frontend/src/lib/components/Spinner.svelte): four squares,
+	   one lit at a time, snapping clockwise every quarter cycle. Discrete (not
+	   eased) and sharp-cornered. Inherits color via currentColor and scales via
+	   the size prop. Deliberately keeps animating under prefers-reduced-motion —
+	   a frozen loading indicator reads as a hung process. */
+	.spinner {
+		position: relative;
+		display: inline-block;
+		flex: none;
+		width: var(--spinner-size);
+		height: var(--spinner-size);
+		vertical-align: middle;
+	}
+	.spinner i {
+		position: absolute;
+		width: 42%;
+		height: 42%;
+		background: currentColor;
+		opacity: 0.2;
+		animation: spinner-quarter 0.667s linear infinite;
+	}
+	.spinner i:nth-child(1) { top: 0; left: 0; animation-delay: 0s; }
+	.spinner i:nth-child(2) { top: 0; right: 0; animation-delay: 0.1667s; }
+	.spinner i:nth-child(3) { bottom: 0; right: 0; animation-delay: 0.3333s; }
+	.spinner i:nth-child(4) { bottom: 0; left: 0; animation-delay: 0.5s; }
+	@keyframes spinner-quarter {
+		0%, 24% { opacity: 1; }
+		25%, 100% { opacity: 0.2; }
+	}
+</style>

--- a/software/hive/frontend/src/lib/components/charts/AnalyticsDashboard.svelte
+++ b/software/hive/frontend/src/lib/components/charts/AnalyticsDashboard.svelte
@@ -142,7 +142,7 @@
 </script>
 
 {#if loading}
-	<div class="flex justify-center py-10"><Spinner /></div>
+	<div class="flex justify-center py-10"><Spinner size={32} /></div>
 {:else if error}
 	<div class="bg-primary/8 p-3 text-sm text-primary">{error}</div>
 {:else if data}

--- a/software/hive/frontend/src/lib/components/primitives/Button.svelte
+++ b/software/hive/frontend/src/lib/components/primitives/Button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	type Variant = 'primary' | 'secondary' | 'danger' | 'ghost';
 	type Size = 'sm' | 'md';
@@ -48,7 +49,7 @@
 	class="inline-flex items-center justify-center gap-2 font-medium transition-colors disabled:cursor-not-allowed {VARIANTS[variant]} {SIZES[size]} {extra}"
 >
 	{#if loading}
-		<span class="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent"></span>
+		<Spinner size={12} />
 	{/if}
 	{@render children()}
 </button>

--- a/software/hive/frontend/src/lib/components/profile/PartSearch.svelte
+++ b/software/hive/frontend/src/lib/components/profile/PartSearch.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { api, type ProfileCatalogSearchResult } from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	let {
 		onSelect,
@@ -60,7 +61,7 @@
 	/>
 
 	{#if loading}
-		<div class="py-4 text-center text-xs text-text-muted">Searching...</div>
+		<div class="flex items-center justify-center gap-1.5 py-4 text-xs text-text-muted"><Spinner size={12} /> Searching...</div>
 	{:else if searched && results.length === 0}
 		<div class="py-4 text-center text-xs text-text-muted">No parts found</div>
 	{:else if results.length > 0}

--- a/software/hive/frontend/src/lib/components/profile/SetSearch.svelte
+++ b/software/hive/frontend/src/lib/components/profile/SetSearch.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { api } from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	type SetResult = {
 		set_num: string;
@@ -72,7 +73,7 @@
 	</div>
 
 	{#if loading}
-		<div class="py-4 text-center text-xs text-text-muted">Searching...</div>
+		<div class="flex items-center justify-center gap-1.5 py-4 text-xs text-text-muted"><Spinner size={12} /> Searching...</div>
 	{:else if searched && results.length === 0}
 		<div class="py-4 text-center text-xs text-text-muted">No sets found</div>
 	{:else if results.length > 0}

--- a/software/hive/frontend/src/lib/components/profile/edit/ProfileChatPanel.svelte
+++ b/software/hive/frontend/src/lib/components/profile/edit/ProfileChatPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { renderMarkdown } from '$lib/markdown';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import type { SortingProfileAiMessage, SortingProfileDetail, SortingProfileVersion, AiToolTraceItem } from '$lib/api';
 
 	type ToolResultListItem = {
@@ -323,10 +324,7 @@
 										<div class="flex items-start gap-2">
 											<div class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center {card.status === 'active' ? 'text-[#8A6D1F]' : 'text-success'}">
 												{#if card.status === 'active'}
-													<svg class="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
-														<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-														<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-													</svg>
+													<Spinner size={14} />
 												{:else}
 													<svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
 														<path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />

--- a/software/hive/frontend/src/lib/components/teacher/TeacherRerunButtons.svelte
+++ b/software/hive/frontend/src/lib/components/teacher/TeacherRerunButtons.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { api, type SampleDetail, type TeacherModelInfo } from '$lib/api';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	interface Props {
 		sampleId: string;
@@ -125,7 +126,7 @@
 				class="flex items-center gap-2 border px-2 py-1.5 text-left text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-60 {isPreferred ? 'border-primary bg-primary-light text-primary' : 'border-border bg-surface text-text hover:bg-bg'}"
 			>
 				{#if running}
-					<span class="inline-block h-3 w-3 shrink-0 animate-spin border-2 border-current border-t-transparent rounded-full"></span>
+					<Spinner size={12} />
 				{:else}
 					<svg class="h-3 w-3 shrink-0 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3" />

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -50,7 +50,7 @@
 
 {#if auth.loading && !auth.initialized}
 	<div class="flex min-h-screen items-center justify-center">
-		<Spinner />
+		<Spinner size={32} />
 	</div>
 {:else}
 	{#if auth.isAuthenticated}

--- a/software/hive/frontend/src/routes/+page.svelte
+++ b/software/hive/frontend/src/routes/+page.svelte
@@ -49,7 +49,7 @@
 </div>
 
 {#if loading}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if stats}
 	<div class="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
 		<div class="border border-border bg-surface p-4">

--- a/software/hive/frontend/src/routes/admin/access-windows/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/access-windows/+page.svelte
@@ -89,7 +89,7 @@
 
 {#if loading}
 	<div class="flex justify-center py-12">
-		<Spinner />
+		<Spinner size={32} />
 	</div>
 {:else}
 	<div class="overflow-x-auto border border-border bg-surface">

--- a/software/hive/frontend/src/routes/admin/color-models/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/color-models/+page.svelte
@@ -101,7 +101,7 @@
 	{/if}
 
 	{#if loading}
-		<div class="flex justify-center py-16"><Spinner /></div>
+		<div class="flex justify-center py-16"><Spinner size={32} /></div>
 	{:else if models.length === 0}
 		<div class="border border-border bg-surface px-4 py-10 text-center text-sm text-text-muted">
 			No color models found in the scan directory. Upload an <code>.onnx</code> file there and hit Rescan.

--- a/software/hive/frontend/src/routes/admin/control-data/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/control-data/+page.svelte
@@ -97,7 +97,7 @@
 
 {#if loading}
 	<div class="flex justify-center py-12">
-		<Spinner />
+		<Spinner size={32} />
 	</div>
 {:else if summary && summary.totals.segments === 0}
 	<div class="border border-border bg-surface p-8 text-center text-sm text-text-muted">

--- a/software/hive/frontend/src/routes/admin/link-models/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/link-models/+page.svelte
@@ -103,7 +103,7 @@
 	{/if}
 
 	{#if loading}
-		<div class="flex justify-center py-16"><Spinner /></div>
+		<div class="flex justify-center py-16"><Spinner size={32} /></div>
 	{:else if models.length === 0}
 		<div class="border border-border bg-surface px-4 py-10 text-center text-sm text-text-muted">
 			No link models found in the scan directory. Upload an encoder+head <code>.onnx</code> pair there

--- a/software/hive/frontend/src/routes/admin/machines/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/machines/+page.svelte
@@ -86,7 +86,7 @@
 
 {#if loading}
 	<div class="flex justify-center py-12">
-		<Spinner />
+		<Spinner size={32} />
 	</div>
 {:else if machines.length === 0}
 	<div class="border border-border bg-surface p-8 text-center text-sm text-text-muted">

--- a/software/hive/frontend/src/routes/admin/parts/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/parts/+page.svelte
@@ -251,7 +251,7 @@
 
 <!-- Results -->
 {#if loading}
-	<div class="flex justify-center py-12"><Spinner /></div>
+	<div class="flex justify-center py-12"><Spinner size={32} /></div>
 {:else}
 	<div class="mb-2 flex items-center justify-between text-sm text-text-muted">
 		<span>{fmt(total)} parts</span>
@@ -319,7 +319,7 @@
 <!-- Detail modal -->
 <Modal open={detailOpen} title={detail ? `${detail.part.part_num} — ${detail.part.name}` : 'Part detail'} onclose={() => (detailOpen = false)}>
 	{#if detailLoading}
-		<div class="flex justify-center py-8"><Spinner /></div>
+		<div class="flex justify-center py-8"><Spinner size={32} /></div>
 	{:else if detail}
 		<div class="space-y-4">
 			<div class="flex gap-3">

--- a/software/hive/frontend/src/routes/admin/server-health/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/server-health/+page.svelte
@@ -93,7 +93,7 @@
 {/if}
 
 {#if loading}
-	<div class="flex justify-center py-12"><Spinner /></div>
+	<div class="flex justify-center py-12"><Spinner size={32} /></div>
 {:else if health}
 	<!-- Storage -->
 	<section class="border border-border bg-surface p-5">

--- a/software/hive/frontend/src/routes/admin/teacher-jobs/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/teacher-jobs/+page.svelte
@@ -133,7 +133,7 @@
 </div>
 
 {#if loading && jobs.length === 0}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if error && jobs.length === 0}
 	<div class="border border-border bg-surface px-6 py-12 text-center text-sm text-text-muted">
 		{error}

--- a/software/hive/frontend/src/routes/admin/teacher-jobs/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/teacher-jobs/[id]/+page.svelte
@@ -184,7 +184,7 @@
 </div>
 
 {#if loading && !job}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if error && !job}
 	<div class="border border-border bg-surface px-6 py-12 text-center text-sm text-text-muted">
 		{error}

--- a/software/hive/frontend/src/routes/admin/users/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/users/+page.svelte
@@ -99,7 +99,7 @@
 
 {#if loading}
 	<div class="flex justify-center py-12">
-		<Spinner />
+		<Spinner size={32} />
 	</div>
 {:else}
 	<div class="overflow-hidden border border-border bg-surface">

--- a/software/hive/frontend/src/routes/leaderboard/+page.svelte
+++ b/software/hive/frontend/src/routes/leaderboard/+page.svelte
@@ -114,7 +114,7 @@
 	</div>
 
 	{#if loading}
-		<Spinner />
+		<div class="flex justify-center p-8"><Spinner size={32} /></div>
 	{:else if error}
 		<div class="border border-danger bg-danger/10 px-3 py-2 text-sm text-danger">{error}</div>
 	{:else if !data || data.entries.length === 0}

--- a/software/hive/frontend/src/routes/leaderboard/[user_id]/+page.svelte
+++ b/software/hive/frontend/src/routes/leaderboard/[user_id]/+page.svelte
@@ -66,7 +66,7 @@
 	</div>
 
 	{#if loading}
-		<Spinner />
+		<div class="flex justify-center p-8"><Spinner size={32} /></div>
 	{:else if error}
 		<div class="border border-danger bg-danger/10 px-3 py-2 text-sm text-danger">{error}</div>
 	{:else if profile}

--- a/software/hive/frontend/src/routes/link-machine/+page.svelte
+++ b/software/hive/frontend/src/routes/link-machine/+page.svelte
@@ -10,6 +10,7 @@
 		type MachineWithToken
 	} from '$lib/api';
 	import { auth } from '$lib/auth.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 
 	type LinkMode = 'existing' | 'new';
 
@@ -346,7 +347,7 @@
 						class="inline-flex min-h-10 items-center justify-center gap-2 bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
 					>
 						{#if submitting}
-							<span class="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white"></span>
+							<Spinner size={14} />
 							Linking...
 						{:else}
 							<svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/software/hive/frontend/src/routes/machine-ip-lookup/+page.svelte
+++ b/software/hive/frontend/src/routes/machine-ip-lookup/+page.svelte
@@ -179,7 +179,7 @@
 		<div
 			class="flex flex-col items-center gap-4 border border-[var(--color-border)] bg-[var(--color-surface)] px-6 py-10 text-center"
 		>
-			<Spinner />
+			<Spinner size={32} />
 			<div class="text-[var(--color-text)]">Waiting for your sorter to come online…</div>
 			<p class="max-w-sm text-sm text-[var(--color-text-muted)]">
 				Make sure you've rejoined your normal Wi-Fi. As soon as the sorter connects to the same

--- a/software/hive/frontend/src/routes/machines/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/+page.svelte
@@ -380,7 +380,7 @@ async function loadAssignmentProfile(profileId: string) {
 {/if}
 
 {#if loading}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if machines.length === 0}
 	<p class="text-text-muted">No machines yet. Add one to get started.</p>
 {:else}
@@ -663,7 +663,7 @@ async function loadAssignmentProfile(profileId: string) {
 >
 	<div class="space-y-4">
 		{#if assignmentLoading}
-			<Spinner />
+			<div class="flex justify-center p-8"><Spinner size={32} /></div>
 		{:else if accessibleProfiles.length === 0}
 			<p class="text-sm text-text-muted">
 				No profiles are available yet. Create one or save a public profile to your library first.

--- a/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
@@ -201,7 +201,7 @@
 	<a href={backLink.href} class="text-sm text-text-muted hover:text-primary hover:underline">{backLink.label}</a>
 
 	{#if loading}
-		<div class="mt-8 flex justify-center"><Spinner /></div>
+		<div class="mt-8 flex justify-center"><Spinner size={32} /></div>
 	{:else if error}
 		<div class="mt-6"><Alert variant="danger">{error}</Alert></div>
 	{:else if overview && machine}
@@ -390,7 +390,7 @@
 								{#if expanded === backup.version}
 									<div class="border-t border-border bg-bg px-4 py-3">
 										{#if detailLoading}
-											<div class="flex justify-center py-4"><Spinner /></div>
+											<div class="flex justify-center py-4"><Spinner size={24} /></div>
 										{:else if detail}
 											<div class="mb-2 text-xs font-semibold tracking-wider text-text-muted uppercase">
 												local_state

--- a/software/hive/frontend/src/routes/machines/[machine_id]/channel-crops/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/channel-crops/+page.svelte
@@ -181,7 +181,7 @@
 
 {#if loading}
 	<div class="flex justify-center py-12">
-		<Spinner />
+		<Spinner size={32} />
 	</div>
 {:else if crops.length === 0}
 	<div class="border border-border bg-surface p-8 text-center text-sm text-text-muted">
@@ -221,7 +221,7 @@
 
 	<div class="flex justify-center py-6">
 		{#if loadingMore}
-			<Spinner />
+			<Spinner size={24} />
 		{:else if nextCursor != null}
 			<Button variant="secondary" size="sm" onclick={loadMore}>Load more</Button>
 		{:else}

--- a/software/hive/frontend/src/routes/machines/[machine_id]/pieces/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/pieces/+page.svelte
@@ -137,7 +137,7 @@
 
 {#if loading}
 	<div class="flex justify-center py-12">
-		<Spinner />
+		<Spinner size={32} />
 	</div>
 {:else if pieces.length === 0}
 	<div class="border border-border bg-surface p-8 text-center text-sm text-text-muted">
@@ -235,7 +235,7 @@
 
 	<div class="flex justify-center py-6">
 		{#if loadingMore}
-			<Spinner />
+			<Spinner size={24} />
 		{:else if nextCursor != null}
 			<Button variant="secondary" size="sm" onclick={loadMore}>Load more</Button>
 		{:else}

--- a/software/hive/frontend/src/routes/models/+page.svelte
+++ b/software/hive/frontend/src/routes/models/+page.svelte
@@ -127,7 +127,7 @@
 	{/if}
 
 	{#if loading && !data}
-		<div class="flex justify-center py-12"><Spinner /></div>
+		<div class="flex justify-center py-12"><Spinner size={32} /></div>
 	{:else if data && data.items.length === 0}
 		<div class="border border-dashed border-[var(--color-border)] p-8 text-center text-sm text-[var(--color-text-muted)]">
 			No models match the current filters.

--- a/software/hive/frontend/src/routes/models/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/models/[id]/+page.svelte
@@ -154,7 +154,7 @@
 	<a href="/models" class="inline-flex items-center gap-1 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)]">← Back to models</a>
 
 	{#if loading}
-		<div class="flex justify-center py-12"><Spinner /></div>
+		<div class="flex justify-center py-12"><Spinner size={32} /></div>
 	{:else if error}
 		<div class="border border-primary bg-primary-light p-3 text-sm text-primary">{error}</div>
 	{:else if model}

--- a/software/hive/frontend/src/routes/piece-bboxes/+page.svelte
+++ b/software/hive/frontend/src/routes/piece-bboxes/+page.svelte
@@ -431,7 +431,7 @@
 			</div>
 
 			{#if loading}
-				<div class="flex justify-center py-16"><Spinner /></div>
+				<div class="flex justify-center py-16"><Spinner size={32} /></div>
 			{:else if items.length === 0}
 				<div class="border border-border bg-surface p-10 text-center">
 					<p class="text-sm text-text-muted">No labelable pieces match these filters.</p>

--- a/software/hive/frontend/src/routes/profiles/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/+page.svelte
@@ -83,7 +83,7 @@
 {/if}
 
 {#if loading}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if profiles.length === 0}
 	<div class="border border-border bg-surface p-6 text-sm text-text-muted">You have not created any profiles yet.</div>
 {:else}

--- a/software/hive/frontend/src/routes/profiles/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/[id]/+page.svelte
@@ -161,7 +161,7 @@
 <svelte:head><title>{profile ? `${profile.name} - Hive` : 'Sorting Profile - Hive'}</title></svelte:head>
 
 {#if loading}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if !profile}
 	<div class="border border-primary/20 bg-primary-light p-4 text-sm text-primary">{error ?? 'Profile not found.'}</div>
 {:else}

--- a/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
@@ -1100,7 +1100,7 @@
 </svelte:head>
 
 {#if loading}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if !profile}
 	<Alert variant="danger">Profile not found.</Alert>
 {:else if !profile.current_version}
@@ -1154,7 +1154,7 @@
 							onkeydown={(e) => { if (e.key === 'Enter') void saveVersion(); }} />
 						{#if suggestingNote}
 							<div class="absolute right-2.5 top-1/2 -translate-y-1/2">
-								<div class="h-3.5 w-3.5 animate-spin border-2 border-border border-t-[#7A7770]" style="border-radius: 50%"></div>
+								<Spinner size={14} class="text-text-muted" />
 							</div>
 						{/if}
 					</div>
@@ -1230,7 +1230,7 @@
 			{/if}
 			<div class="flex-1 overflow-y-auto">
 				{#if previewLoading}
-					<div class="flex items-center justify-center p-8"><Spinner /></div>
+					<div class="flex items-center justify-center p-8"><Spinner size={32} /></div>
 				{:else if displayRules.length === 0}
 					<div class="p-4 text-center text-sm text-text-muted">
 						No rules yet. Use chat to generate categories, or add one manually.

--- a/software/hive/frontend/src/routes/profiles/new/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/new/+page.svelte
@@ -3,6 +3,7 @@
 	import { auth } from '$lib/auth.svelte';
 	import { goto } from '$app/navigation';
 	import SetSearch from '$lib/components/profile/SetSearch.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import { uuid } from '$lib/uuid';
 
 	type SetResult = {
@@ -218,10 +219,7 @@
 		>
 			{#if creating}
 				<span class="flex items-center justify-center gap-2">
-					<svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-					</svg>
+					<Spinner size={16} />
 					Creating...
 				</span>
 			{:else if profileType === 'set'}

--- a/software/hive/frontend/src/routes/review/+page.svelte
+++ b/software/hive/frontend/src/routes/review/+page.svelte
@@ -518,7 +518,7 @@
 </div>
 
 {#if loading}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if empty}
 	<div class="border border-border bg-surface p-10 text-center">
 		<p class="text-lg font-medium text-text">No more samples to review.</p>

--- a/software/hive/frontend/src/routes/samples/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/+page.svelte
@@ -1340,7 +1340,7 @@
 	<!-- Main content -->
 	<div class="min-w-0 flex-1">
 		{#if loading}
-			<Spinner />
+			<div class="flex justify-center p-8"><Spinner size={32} /></div>
 		{:else if !data || data.items.length === 0}
 			<div class="border border-border bg-surface px-6 py-12 text-center">
 				<svg class="mx-auto mb-3 h-10 w-10 text-border" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">

--- a/software/hive/frontend/src/routes/samples/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/[id]/+page.svelte
@@ -482,7 +482,7 @@
 <svelte:window onkeydown={onWindowKeyDown} />
 
 {#if loading}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if !sample}
 	<p class="text-text-muted">Sample not found.</p>
 {:else}

--- a/software/hive/frontend/src/routes/samples/[id]/compare/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/[id]/compare/+page.svelte
@@ -158,7 +158,7 @@
 </div>
 
 {#if loading}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if loadError}
 	<div class="border border-border bg-surface px-6 py-10 text-center text-sm text-text-muted">
 		{loadError}

--- a/software/hive/frontend/src/routes/samples/[id]/similar/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/[id]/similar/+page.svelte
@@ -87,7 +87,7 @@
 	</div>
 
 	{#if loading}
-		<Spinner />
+		<div class="flex justify-center p-8"><Spinner size={32} /></div>
 	{:else if loadError}
 		<div class="border border-danger bg-danger/10 px-3 py-2 text-sm text-danger">{loadError}</div>
 	{:else if target === null}

--- a/software/hive/frontend/src/routes/samples/diversity/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/diversity/+page.svelte
@@ -127,7 +127,7 @@
 </div>
 
 {#if loading && !data}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if error && !data}
 	<div class="border border-border bg-surface px-6 py-12 text-center text-sm text-text-muted">
 		{error}

--- a/software/hive/frontend/src/routes/samples/diversity/[reason]/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/diversity/[reason]/+page.svelte
@@ -131,7 +131,7 @@
 </div>
 
 {#if loading && !data}
-	<Spinner />
+	<div class="flex justify-center p-8"><Spinner size={32} /></div>
 {:else if error && !data}
 	<div class="border border-border bg-surface px-6 py-12 text-center text-sm text-text-muted">
 		{error}

--- a/software/hive/frontend/src/routes/settings/catalog-sync/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/catalog-sync/+page.svelte
@@ -154,7 +154,7 @@
 	{/if}
 
 	{#if loading && !status}
-		<Spinner />
+		<div class="flex justify-center p-8"><Spinner size={32} /></div>
 	{:else if status}
 		<div class="mb-6 border border-border bg-bg p-4 text-sm text-text-muted">
 			<div class="flex flex-wrap gap-x-6 gap-y-1">

--- a/software/hive/frontend/src/routes/styleguide/+page.svelte
+++ b/software/hive/frontend/src/routes/styleguide/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button, Alert, Tooltip } from '$lib/components/primitives';
+	import Spinner from '$lib/components/Spinner.svelte';
 </script>
 
 <svelte:head>
@@ -508,18 +509,27 @@
 	<section class="space-y-4">
 		<h2 class="text-lg font-semibold tracking-tight">Loading States</h2>
 		<div class="border border-[#E2E0DB] bg-surface p-6">
-			<div class="flex items-center gap-8">
+			<p class="mb-4 text-sm text-[#7A7770]">
+				<code class="bg-bg px-1">Spinner</code> is the <strong>only</strong> loading animation in Hive — four sharp squares, one lit at a time, snapping clockwise. Import it and pass a
+				<code class="bg-bg px-1">size</code> (px); never hand-roll an <code class="bg-bg px-1">animate-spin</code> ring. It inherits its color from
+				<code class="bg-bg px-1">currentColor</code>.
+			</p>
+			<div class="flex items-end gap-8">
 				<div class="flex flex-col items-center gap-2">
-					<div class="h-8 w-8 animate-spin border-4 border-[#E2E0DB] border-t-[#D01012]" style="border-radius: 50%"></div>
-					<span class="text-xs text-[#7A7770]">Page Spinner</span>
+					<Spinner size={32} class="text-primary" />
+					<span class="text-xs text-[#7A7770]">Page — size={32}</span>
 				</div>
 				<div class="flex flex-col items-center gap-2">
-					<div class="h-4 w-4 animate-spin border-2 border-[#E2E0DB] border-t-[#7A7770]" style="border-radius: 50%"></div>
-					<span class="text-xs text-[#7A7770]">Inline Spinner</span>
+					<Spinner size={16} />
+					<span class="text-xs text-[#7A7770]">Inline — size={16}</span>
 				</div>
 				<div class="flex flex-col items-center gap-2">
-					<div class="py-4 text-center text-xs text-[#7A7770]">Searching...</div>
-					<span class="text-xs text-[#7A7770]">Text Loading</span>
+					<Spinner size={12} class="text-[#7A7770]" />
+					<span class="text-xs text-[#7A7770]">Compact — size={12}</span>
+				</div>
+				<div class="flex flex-col items-center gap-2">
+					<div class="flex items-center gap-1.5 py-4 text-xs text-[#7A7770]"><Spinner size={12} /> Searching...</div>
+					<span class="text-xs text-[#7A7770]">Inline with label</span>
 				</div>
 			</div>
 		</div>
@@ -667,7 +677,7 @@
 				<div class="mr-8">
 					<div class="border border-[#00852B]/15 bg-[#00852B]/5 px-3 py-2 text-xs">
 						<div class="flex items-center gap-1.5 text-[#00852B]/60">
-							<div class="h-3 w-3 shrink-0 animate-spin border-2 border-[#00852B]/20 border-t-[#00852B]" style="border-radius: 50%"></div>
+							<Spinner size={12} />
 							Searching sets for "Minecraft"...
 						</div>
 					</div>


### PR DESCRIPTION
Every loading spinner in the Hive frontend now uses the canonical Sorter spinner. `Spinner` is the only loading animation in the app.

## The scheme ported

From `software/sorter/frontend/src/lib/components/Spinner.svelte`:

- Four **sharp-cornered** squares in a 2x2, one lit at a time (opacity 1 vs 0.2), snapping clockwise every quarter of a 0.667s cycle.
- `linear` timing — discrete snap, not eased rotation.
- Color inherits via `currentColor`.
- Scales via a `size` prop (px number, default `16`); `class` passes through.
- Deliberately keeps animating under `prefers-reduced-motion` — a frozen indicator reads as a hung process.

Hive's old `Spinner` was `h-8 w-8 animate-spin border-4 border-border border-t-primary` inside a hardcoded `flex items-center justify-center p-8` wrapper, and took **no props**.

### API change

Converged on the Sorter's `size` / `class` API (both optional, so no call site broke on props). The one behavioral change: **`Spinner` no longer centers or pads itself.** The built-in `p-8` wrapper was a layout concern leaking into the component; layout is now the call site's job. That's why 18 call sites gained a wrapper div below.

## Call sites converted

### `Spinner` component
- `src/lib/components/Spinner.svelte` — rewritten.

### 46 existing `<Spinner />` call sites — sizes made explicit

28 were already inside a centering wrapper, so they only needed a `size`:

| File | Size |
|---|---|
| `lib/components/MachineLabeledPieces.svelte` | 32 |
| `lib/components/PaletteCoverage.svelte` | 32 |
| `lib/components/PartBrickLinkColors.svelte` | 32 |
| `lib/components/PieceLabelPanel.svelte` (×2) | 32 |
| `lib/components/PiecePartPicker.svelte` | 24 |
| `lib/components/charts/AnalyticsDashboard.svelte` | 32 |
| `routes/+layout.svelte` | 32 |
| `routes/admin/link-models/+page.svelte` | 32 |
| `routes/admin/control-data/+page.svelte` | 32 |
| `routes/admin/color-models/+page.svelte` | 32 |
| `routes/admin/machines/+page.svelte` | 32 |
| `routes/admin/users/+page.svelte` | 32 |
| `routes/admin/parts/+page.svelte` (×2) | 32 |
| `routes/admin/server-health/+page.svelte` | 32 |
| `routes/admin/access-windows/+page.svelte` | 32 |
| `routes/models/+page.svelte` | 32 |
| `routes/models/[id]/+page.svelte` | 32 |
| `routes/machines/[machine_id]/+page.svelte` | 32, 24 |
| `routes/machines/[machine_id]/pieces/+page.svelte` | 32, 24 |
| `routes/machines/[machine_id]/channel-crops/+page.svelte` | 32, 24 |
| `routes/piece-bboxes/+page.svelte` | 32 |
| `routes/profiles/[id]/edit/+page.svelte` | 32 |
| `routes/machine-ip-lookup/+page.svelte` | 32 |

18 relied on the removed built-in `p-8` wrapper, so they got `<div class="flex justify-center p-8"><Spinner size={32} /></div>` — preserving the previous visual box exactly:

`routes/+page.svelte` · `routes/settings/catalog-sync/+page.svelte` · `routes/admin/teacher-jobs/+page.svelte` · `routes/admin/teacher-jobs/[id]/+page.svelte` · `routes/leaderboard/+page.svelte` · `routes/leaderboard/[user_id]/+page.svelte` · `routes/samples/+page.svelte` · `routes/samples/diversity/+page.svelte` · `routes/samples/diversity/[reason]/+page.svelte` · `routes/samples/[id]/+page.svelte` · `routes/samples/[id]/similar/+page.svelte` · `routes/samples/[id]/compare/+page.svelte` · `routes/machines/+page.svelte` (×2) · `routes/review/+page.svelte` · `routes/profiles/+page.svelte` · `routes/profiles/[id]/+page.svelte` · `routes/profiles/[id]/edit/+page.svelte`

### 9 hand-rolled indicators routed through `Spinner`

| File | Was | Now |
|---|---|---|
| `lib/components/primitives/Button.svelte` | `h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent` | `<Spinner size={12} />` |
| `lib/components/teacher/TeacherRerunButtons.svelte` | same ring, `h-3 w-3` | `<Spinner size={12} />` |
| `lib/components/profile/edit/ProfileChatPanel.svelte` | inline `<svg class="animate-spin">` (4 lines of path data) | `<Spinner size={14} />` |
| `routes/link-machine/+page.svelte` | `h-3.5 w-3.5 animate-spin rounded-full border-white/40` | `<Spinner size={14} />` |
| `routes/profiles/new/+page.svelte` | inline `<svg class="animate-spin">` | `<Spinner size={16} />` |
| `routes/profiles/[id]/edit/+page.svelte` | `h-3.5 w-3.5 animate-spin` ring w/ raw hex `border-t-[#7A7770]` | `<Spinner size={14} class="text-text-muted" />` (also removes a raw hex) |
| `routes/styleguide/+page.svelte` | 3 showcase rings | real `<Spinner>` at 32/16/12 |

The three inline `<svg>` spinners also clear the "never paste inline SVG" rule in `CLAUDE.md`.

### 3 text-only loading states given the indicator

`lib/components/profile/PartSearch.svelte`, `lib/components/profile/SetSearch.svelte`, and `lib/components/AiUsagePanel.svelte` rendered a bare `Searching...` / `Loading…` string with no indicator. They now render `<Spinner size={12} />` inline next to the label — which is exactly the pattern the styleguide's own "Search with Results" mockup already depicted. Flagging this as an *addition* rather than a conversion, in case you'd rather they stay text-only.

**Total: 58 loading indicators now on the canonical scheme** (46 existing `Spinner` sites + 9 hand-rolled + 3 text-only).

## Deliberately left alone

- **Skeleton loaders** — none found. Hive has zero `animate-pulse`, so there were no skeleton-as-spinner hacks to untangle.
- **No lucide `Loader2` / `LoaderCircle`** existed anywhere in the tree.
- **No CSS `@keyframes` spinners** existed either — the sweep (`animate-`, `@keyframes`, `animation:`, `<animate`) found exactly the 10 `animate-spin` sites handled above and nothing else.
- **`software/hive/frontend` only.** No backend, no scripts, no Dockerfiles, no sorter/firmware.
- **Spinner color left as plain `currentColor`.** The old Hive spinner was always brand red (`border-t-primary`); the new one inherits body text color at most call sites, matching the Sorter's own default. If you'd rather page-level loads stay LEGO red, adding `class="text-primary"` to the `size={32}` sites is a one-line-each follow-up — say the word.
- Existing a11y / raw-hex warnings unrelated to spinners were not touched.

## `CLAUDE.md` correction

The "Sharp edges" section claimed:

> `Spinner` uses `rounded-full` because a circular spinner is the primitive.

That is now wrong — the spinner is sharp-cornered like everything else. Removed that bullet and added a **"Loading — `Spinner` is the only loading animation"** section describing the scheme, the `size`/`class` API, the "never hand-roll `animate-spin`" rule with an `rg` check, the fact that `Spinner` no longer self-centers, and a note that genuine skeleton loaders are a different thing and remain fine.

The rest of Hive's intentional divergence from the Sorter design language (flat corners, pill chips, friendlier tone) is untouched — the doc now explicitly calls spinners out as the *one* exception where Hive matches Sorter exactly.

## Verification

```
pnpm --dir software/hive/frontend install   ✅
pnpm --dir software/hive/frontend check     ✅ 426 files, 0 errors, 18 warnings (all pre-existing a11y/state warnings, none in changed lines)
pnpm --dir software/hive/frontend build     ✅ built in 4.48s
rg "animate-spin" src/                      only the prose in the styleguide copy
rg "<Spinner" src/ | rg -v "size="          empty
```

Not deployed or synced anywhere — PR only.

Based on `integration/batch-01`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
