### PR TITLE
leds: fix LED toggle silently doing nothing when hardware is up

### DIFF
--- a/software/sorter/backend/server/routers/leds.py
+++ b/software/sorter/backend/server/routers/leds.py
@@ -23,8 +23,11 @@ class LedSettingsPayload(BaseModel):
 
 
 def _ledController() -> Any | None:
-    controller = shared_state.controller_ref
-    irl = getattr(controller, "irl", None) if controller is not None else None
+    # getActiveIRL() falls back to the runtime IRL when the controller has no
+    # .irl of its own. Reading controller_ref directly misses that case, and the
+    # miss is silent: the endpoint takes the offline path and reports success
+    # while the LEDs keep whatever duty hardware init left them at.
+    irl = shared_state.getActiveIRL()
     return getattr(irl, "led_controller", None) if irl is not None else None
 
 

--- a/software/sorter/backend/tests/test_led_control.py
+++ b/software/sorter/backend/tests/test_led_control.py
@@ -263,5 +263,38 @@ class LedControllerTests(unittest.TestCase):
         self.assertEqual(controller.state["brightness_percent"], 100)
 
 
+class LedRouterLookupTest(unittest.TestCase):
+    # The router reaching for shared_state.controller_ref.irl directly shipped a
+    # silent failure: with hardware up but the controller carrying no .irl, the
+    # lookup returned None, so every write took the offline path and reported
+    # success while the LEDs stayed at whatever duty hardware init set.
+    def setUp(self) -> None:
+        from server import shared_state
+
+        self.shared_state = shared_state
+        self.prior_controller = shared_state.controller_ref
+        self.prior_irl = shared_state.hardware_runtime_irl
+
+    def tearDown(self) -> None:
+        self.shared_state.controller_ref = self.prior_controller
+        self.shared_state.hardware_runtime_irl = self.prior_irl
+
+    def test_controller_found_via_runtime_irl_when_controller_has_no_irl(self) -> None:
+        from server.routers import leds as leds_router
+
+        sentinel = object()
+
+        class IrlWithLeds:
+            led_controller = sentinel
+
+        class ControllerWithoutIrl:
+            pass
+
+        self.shared_state.controller_ref = ControllerWithoutIrl()
+        self.shared_state.setHardwareRuntimeIRL(IrlWithLeds())
+
+        self.assertIs(leds_router._ledController(), sentinel)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`_ledController()` read `shared_state.controller_ref.irl` directly instead of calling `shared_state.getActiveIRL()`, which falls back to `hardware_runtime_irl` when the controller has no `.irl` of its own.

Consequence on kitbash: hardware init bound both LEDs and lit them (`DigitalOutput ch0/ch1: set duty=65535`), but every subsequent `POST /api/leds` found no controller, took the offline path, persisted the new value and returned 200 — without writing to hardware. Toggling the LEDs off in the UI changed the stored state to `enabled: false` while the LEDs stayed on. `GET /api/leds` also reported `leds: [], hardware_ready: false` with hardware up.

Found by testing #242 on kitbash.

Adds a regression test covering the lookup; verified it fails against the previous implementation and passes with the fix. Full LED suite: 17 passed.