### PR TITLE
LED assignment becomes a sidebar tab instead of a bottom card

### DIFF
--- a/software/sorter/frontend/src/lib/components/settings/ChannelLedSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/ChannelLedSection.svelte
@@ -91,9 +91,7 @@
 	{#if errorMsg}
 		<Alert variant="danger">{errorMsg}</Alert>
 	{:else if !loading && outputs.length === 0}
-		<Alert variant="info">
-			No control board on this machine exposes an LED output, so there is nothing to assign.
-		</Alert>
+		<Alert variant="info">No LED outputs are available to assign right now.</Alert>
 	{/if}
 
 	<SettingRow

--- a/software/sorter/frontend/src/lib/components/settings/ZoneSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/ZoneSection.svelte
@@ -2,6 +2,7 @@
 	import { getBackendHttpBase } from '$lib/backend';
 	import CameraSourcePreview from '$lib/components/CameraSourcePreview.svelte';
 	import Modal from '$lib/components/Modal.svelte';
+	import ChannelLedSection from '$lib/components/settings/ChannelLedSection.svelte';
 	import ClassificationBaselineSection from '$lib/components/settings/ClassificationBaselineSection.svelte';
 	import PictureSettingsSidebar from '$lib/components/settings/PictureSettingsSidebar.svelte';
 	import StepperSidebar from '$lib/components/settings/StepperSidebar.svelte';
@@ -17,6 +18,7 @@
 		Camera,
 		Check,
 		FlipHorizontal,
+		Lightbulb,
 		Pencil,
 		Plus,
 		RefreshCw,
@@ -155,7 +157,7 @@
 	};
 	type CalibrationHighlight = [number, number, number, number];
 	type DetectionHighlight = [number, number, number, number];
-	type SidePanel = 'picture' | 'zone' | 'classification' | null;
+	type SidePanel = 'picture' | 'zone' | 'classification' | 'led' | null;
 	type DragState =
 		| {
 				kind: 'polygon-shape';
@@ -238,6 +240,9 @@
 		'class_top',
 		'class_bottom'
 	];
+	// The channels with a lighting hood of their own; their camera role doubles as
+	// the backend LED channel key.
+	const LED_CHANNELS: Channel[] = ['second', 'third', 'classification_channel'];
 	const ALL_CHANNELS: Channel[] = [...TRANSPORT_CHANNELS, ...CLASSIFICATION_CHANNELS];
 	const HANDLE_HIT_RADIUS = 22;
 	const HANDLE_DRAW_RADIUS = 9;
@@ -582,6 +587,10 @@
 
 	function supportsDetectionSidebar(ch: Channel): ch is (typeof DETECTION_CHANNELS)[number] {
 		return DETECTION_CHANNELS.includes(ch as (typeof DETECTION_CHANNELS)[number]);
+	}
+
+	function supportsLedSidebar(ch: Channel): ch is (typeof LED_CHANNELS)[number] {
+		return LED_CHANNELS.includes(ch as (typeof LED_CHANNELS)[number]);
 	}
 
 	function detectionScopeForChannel(channel: Channel): 'classification' | 'feeder' | 'carousel' {
@@ -1104,11 +1113,30 @@
 		activeSidebar = 'classification';
 	}
 
+	function toggleLedSidebar() {
+		if (!supportsLedSidebar(currentChannel)) return;
+		if (activeSidebar === 'picture') {
+			clearPicturePreview(currentRole());
+			setCalibrationHighlight(currentRole(), null);
+		}
+		if (activeSidebar === 'classification') {
+			setDetectionHighlights(currentRole(), null);
+		}
+		if (activeSidebar === 'led') {
+			activeSidebar = null;
+			return;
+		}
+		activeSidebar = 'led';
+	}
+
 	function selectChannel(channel: Channel) {
 		if (activeSidebar === 'picture') {
 			clearPicturePreview(currentRole());
 		}
 		if (activeSidebar === 'classification' && !supportsDetectionSidebar(channel)) {
+			activeSidebar = null;
+		}
+		if (activeSidebar === 'led' && !supportsLedSidebar(channel)) {
 			activeSidebar = null;
 		}
 		currentChannel = channel;
@@ -4040,6 +4068,21 @@
 					</button>
 				{/if}
 
+				{#if supportsLedSidebar(currentChannel)}
+					<button
+						onclick={toggleLedSidebar}
+						disabled={editingZone}
+						class={`inline-flex cursor-pointer items-center gap-2 border px-3 py-1.5 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+							activeSidebar === 'led'
+								? 'border-sky-500 bg-sky-500/15 text-sky-700 hover:bg-sky-500/25 dark:text-sky-300'
+								: 'border-border bg-bg text-text hover:bg-bg/80'
+						}`}
+					>
+						<Lightbulb size={15} />
+						<span>{activeSidebar === 'led' ? 'Hide LED' : 'LED'}</span>
+					</button>
+				{/if}
+
 				{#if editingZone}
 					{#if isArcChannel(currentChannel)}
 						<button
@@ -4404,6 +4447,35 @@
 						}}
 					/>
 				{/key}
+			{/if}
+
+			{#if activeSidebar === 'led' && supportsLedSidebar(currentChannel)}
+				<aside class="flex h-full min-w-0 flex-col border border-border bg-bg xl:min-h-[32rem]">
+					<div class="border-b border-border bg-surface px-4 py-3">
+						<div class="flex items-start justify-between gap-3">
+							<div class="min-w-0">
+								<div class="flex items-center gap-2 text-sm font-semibold text-text">
+									<Lightbulb size={16} />
+									<span>LED</span>
+								</div>
+								<p class="mt-1 text-sm leading-5 text-text-muted">
+									The light in {CHANNEL_LABELS[currentChannel]}'s hood.
+								</p>
+							</div>
+							<button
+								onclick={() => (activeSidebar = null)}
+								class="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center text-text-muted transition-colors hover:text-text"
+								aria-label="Close LED settings"
+							>
+								<X size={15} />
+							</button>
+						</div>
+					</div>
+
+					<div class="flex flex-1 flex-col px-4 py-4">
+						<ChannelLedSection channelKey={currentRole()} />
+					</div>
+				</aside>
 			{/if}
 
 			{#if !wizardMode && !activeSidebar && hasStepper && stepperKey}

--- a/software/sorter/frontend/src/routes/settings/[station]/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/[station]/+page.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
 	import SectionCard from '$lib/components/settings/SectionCard.svelte';
 	import C4SectorOccupancyPanel from '$lib/components/settings/C4SectorOccupancyPanel.svelte';
-	import ChannelLedSection from '$lib/components/settings/ChannelLedSection.svelte';
 	import StepperSidebar from '$lib/components/settings/StepperSidebar.svelte';
 	import ZoneSection from '$lib/components/settings/ZoneSection.svelte';
 	import type { PageData } from './$types';
-
-	// The stations with a lighting hood of their own; the slug doubles as the
-	// backend channel key once dashes become underscores.
-	const LED_STATION_SLUGS = ['c-channel-2', 'c-channel-3', 'classification-channel'];
 
 	let { data }: { data: PageData } = $props();
 </script>
@@ -53,11 +48,5 @@
 				/>
 			{/each}
 		</div>
-	{/if}
-
-	{#if LED_STATION_SLUGS.includes(data.station.slug)}
-		<SectionCard title="LED" description="The light in this channel's hood.">
-			<ChannelLedSection channelKey={data.station.slug.replaceAll('-', '_')} />
-		</SectionCard>
 	{/if}
 </div>


### PR DESCRIPTION
The LED assignment control worked, but it rendered as a full-width `SectionCard` appended below the zone editor rather than living where every other per-station setting lives. This moves it into `ZoneSection`'s existing right-hand sidebar, so it behaves exactly like Picture Settings and Detection.

## What changed

- `ZoneSection.svelte`: `SidePanel` gains `'led'`; new `LED_CHANNELS` / `supportsLedSidebar()` following the `DETECTION_CHANNELS` idiom; `toggleLedSidebar()` with the same mutual-exclusion + cleanup as the existing toggles; a toggle button ("LED" / "Hide LED") matching the surrounding button styling; the panel renders in the sidebar column with the same `<aside>` chrome as its siblings.
- The LED channel key comes from `currentRole()` — the camera role for the three hooded channels is already exactly `c_channel_2` / `c_channel_3` / `classification_channel`, so nothing new is threaded down from the page.
- `[station]/+page.svelte`: `LED_STATION_SLUGS`, the `ChannelLedSection` import, and the trailing `SectionCard` block are gone.

Only `c-channel-2`, `c-channel-3`, and `classification-channel` render the button. Carousel and the classification chamber (`class_top` / `class_bottom`) do not, and the wizard path never did — the button sits in the non-wizard branch.

## Standby message

`GET /api/leds` returns `outputs: []` both when the board genuinely exposes no LED GPIOs and when hardware has not initialized yet — there is no field that separates the two, and adding one would mean new API state and new branching. So instead of adding a case, the one message is reworded from "No control board on this machine exposes an LED output, so there is nothing to assign" to "No LED outputs are available to assign right now." That is true in both states and stops asserting a hardware limitation that is not there.

## Verification

`svelte-check`: 5 errors, 20 warnings — identical to the base commit (all pre-existing, in `StepperChuteStressTest` and `jitter-test`). Zero new. Prettier-clean on the added code; two pre-existing unformatted hunks elsewhere in `ZoneSection.svelte` were left alone.

Not deployed or tested on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)