### PR TITLE
hive: send backups to object storage (boto3), and fail the run if they don't land

### DIFF
--- a/software/hive/scripts/CUTOVER.md
+++ b/software/hive/scripts/CUTOVER.md
@@ -168,12 +168,27 @@ EOF
 chmod 600 /etc/hive-release.env
 ```
 
-Optional off-box backup copies — set this only if you have an S3 target and the
-`aws` CLI is installed and credentialed; the agent treats the upload as
-best-effort and never fails a deploy on it:
+Off-box backup copies. Uses boto3 (already present on the box) against any
+S3-compatible endpoint — DigitalOcean Spaces here. Give the key access to the
+backup bucket **only**: if the key that writes backups can also be used to
+delete them, a single leaked credential takes your data and your recovery path
+together.
+
+Setting `HIVE_BACKUP_S3_BUCKET` makes the upload **required** — a backup run
+whose upload fails exits non-zero rather than warning. That is deliberate:
+local retention is short because the off-box copy is the durable one, so an
+upload that silently fails is how you end up with no backups and no signal.
 
 ```bash
-# echo 'HIVE_BACKUP_S3_PREFIX=s3://<bucket>/hive-db' >> /etc/hive-release.env
+cat >> /etc/hive-release.env <<'EOF'
+HIVE_BACKUP_S3_BUCKET=sorter-hive-backups
+HIVE_BACKUP_S3_ENDPOINT=https://nyc3.digitaloceanspaces.com
+HIVE_BACKUP_S3_REGION=nyc3
+HIVE_BACKUP_S3_ACCESS_KEY_ID=<spaces key scoped to that bucket>
+HIVE_BACKUP_S3_SECRET_ACCESS_KEY=<its secret>
+HIVE_BACKUP_KEEP_DAYS=3
+HIVE_BACKUP_KEEP_MIN=3
+EOF
 ```
 
 ### 2.6 Install the systemd units

--- a/software/hive/scripts/README.md
+++ b/software/hive/scripts/README.md
@@ -60,7 +60,7 @@ wrote — see CUTOVER.md → "Restoring the database".
 |-------|------|-------|---------|
 | Pre-deploy | agent dumps + verifies before migrating; deploy aborts if it fails | `/basically/backups/hive-db/db-*-predeploy.dump` | every deploy |
 | Nightly | `hive-backup.timer` → same verified dump | `/basically/backups/hive-db/db-*-nightly.dump` | 03:15 daily |
-| Off-box (opt) | same dump uploaded | `$HIVE_BACKUP_S3_PREFIX` | with each dump |
+| Off-box | same dump uploaded; run fails if it does not land | `$HIVE_BACKUP_S3_BUCKET` | with each dump |
 | Off-box (manual) | `backup.sh` pulls DB + parts.db to your Mac | `./backups/` | on demand |
 | Images | app writes originals | S3 bucket | continuous |
 

--- a/software/hive/scripts/hive_release_agent.py
+++ b/software/hive/scripts/hive_release_agent.py
@@ -26,7 +26,12 @@ DEPLOY_DIR = Path(os.environ.get("HIVE_DEPLOY_DIR", "/basically/hive"))
 BACKUP_DIR = Path(os.environ.get("HIVE_BACKUP_DIR", "/basically/backups/hive-db"))
 BACKUP_KEEP_DAYS = int(os.environ.get("HIVE_BACKUP_KEEP_DAYS", "30"))
 BACKUP_KEEP_MIN = int(os.environ.get("HIVE_BACKUP_KEEP_MIN", "7"))
+BACKUP_S3_BUCKET = os.environ.get("HIVE_BACKUP_S3_BUCKET", "")
 BACKUP_S3_PREFIX = os.environ.get("HIVE_BACKUP_S3_PREFIX", "")
+BACKUP_S3_ENDPOINT = os.environ.get("HIVE_BACKUP_S3_ENDPOINT", "")
+BACKUP_S3_REGION = os.environ.get("HIVE_BACKUP_S3_REGION", "")
+BACKUP_S3_ACCESS_KEY_ID = os.environ.get("HIVE_BACKUP_S3_ACCESS_KEY_ID", "")
+BACKUP_S3_SECRET_ACCESS_KEY = os.environ.get("HIVE_BACKUP_S3_SECRET_ACCESS_KEY", "")
 RELEASES_KEEP = int(os.environ.get("HIVE_RELEASES_KEEP", "5"))
 HEALTH_URL = os.environ.get("HIVE_HEALTH_URL", "https://hive.basically.website/api/health")
 PG_CONTAINER = os.environ.get("HIVE_PG_CONTAINER", "hive-postgres")
@@ -224,17 +229,23 @@ def verifyBackup(path: Path) -> None:
 
 
 def uploadBackup(path: Path) -> None:
-    if not BACKUP_S3_PREFIX or shutil.which("aws") is None:
+    if not BACKUP_S3_BUCKET:
         return
-    result = subprocess.run(
-        ["aws", "s3", "cp", str(path), f"{BACKUP_S3_PREFIX}/{path.name}"],
-        capture_output=True,
-        text=True,
+    # Raises rather than warns. Local retention is short precisely because the
+    # off-box copy is meant to be the durable one, so an upload that quietly
+    # fails is how you arrive back at having no backups without being told.
+    import boto3
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=BACKUP_S3_ENDPOINT,
+        region_name=BACKUP_S3_REGION,
+        aws_access_key_id=BACKUP_S3_ACCESS_KEY_ID,
+        aws_secret_access_key=BACKUP_S3_SECRET_ACCESS_KEY,
     )
-    if result.returncode == 0:
-        log(f"  ✓ off-box copy → {BACKUP_S3_PREFIX}/{path.name}")
-    else:
-        log(f"  ! off-box copy failed (non-fatal): {result.stderr.strip()}")
+    key = f"{BACKUP_S3_PREFIX}{path.name}" if BACKUP_S3_PREFIX else path.name
+    client.upload_file(str(path), BACKUP_S3_BUCKET, key)
+    log(f"  ✓ off-box copy → s3://{BACKUP_S3_BUCKET}/{key}")
 
 
 def pruneBackups(cfg: AgentConfig) -> None:


### PR DESCRIPTION
Follow-up to #241, from actually installing the backup half on prod.

**The off-box upload could never have worked.** `uploadBackup` shelled out to `aws s3 cp` — but `aws` is not installed on the box, so the function returned early and silently did nothing. Even with the CLI present it passed no `--endpoint-url`, so it would have addressed real AWS rather than DigitalOcean Spaces. boto3 is already installed there, so this uses it directly.

**Upload is now required, not best-effort.** With short local retention the object-storage copy is the durable one, so a warn-and-continue upload failure reproduces the exact situation #241 was written to fix: no backups, no signal. A failed upload now exits non-zero and systemd records the failure.

Config (`/etc/hive-release.env`, documented in CUTOVER.md): `HIVE_BACKUP_S3_BUCKET`, `_ENDPOINT`, `_REGION`, `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY`. Empty bucket keeps the previous no-op behaviour for anyone without a target.

Deployed and verified on prod as part of this change.