### PR TITLE
Fix 3 stale hive backend tests

### DIFF
--- a/software/hive/backend/tests/test_model_download_filename.py
+++ b/software/hive/backend/tests/test_model_download_filename.py
@@ -44,6 +44,6 @@ def test_date_uses_published_at_in_iso_format() -> None:
     assert name == "lego-detect_v3_2026-01-09_hailo.hef"
 
 
-def test_preserves_compound_extension_first_segment_only() -> None:
+def test_preserves_full_compound_tar_gz_extension() -> None:
     name = build_download_filename(_model(), _variant("pytorch", "weights.tar.gz"))
-    assert name == "lego-detect_v3_2026-04-28_pytorch.gz"
+    assert name == "lego-detect_v3_2026-04-28_pytorch.tar.gz"

--- a/software/hive/backend/tests/test_profiles.py
+++ b/software/hive/backend/tests/test_profiles.py
@@ -314,12 +314,35 @@ class TestProfileCatalogPermissions:
         assert response.status_code == 403
         assert service.started is None
 
-    def test_reviewer_can_start_catalog_sync(
+    def test_reviewer_cannot_start_catalog_sync(
         self,
         client: TestClient,
         test_reviewer: dict,
         monkeypatch,
     ) -> None:
+        # Catalog sync routes are admin-only (locked down in #148 along with
+        # the admin-gated /settings/catalog-sync page).
+        service = _CatalogRouteService()
+        monkeypatch.setattr(profiles_router, "get_profile_catalog_service", lambda: service)
+
+        response = client.post(
+            "/api/profile-catalog/sync/categories",
+            headers=_auth_headers(client),
+        )
+        assert response.status_code == 403
+        assert service.started is None
+
+    def test_admin_can_start_catalog_sync(
+        self,
+        client: TestClient,
+        db: Session,
+        test_user: dict,
+        monkeypatch,
+    ) -> None:
+        user = db.query(User).filter(User.email == test_user["email"]).first()
+        user.role = "admin"
+        db.commit()
+
         service = _CatalogRouteService()
         monkeypatch.setattr(profiles_router, "get_profile_catalog_service", lambda: service)
 

--- a/software/hive/backend/tests/test_samples.py
+++ b/software/hive/backend/tests/test_samples.py
@@ -336,7 +336,7 @@ class TestSampleAssets:
 
 
 class TestSampleAuthorization:
-    def test_member_sees_other_users_samples_by_default(
+    def test_member_cannot_see_other_users_samples(
         self,
         client: TestClient,
         test_user: dict,
@@ -344,10 +344,9 @@ class TestSampleAuthorization:
         machine_token: str,
         upload_dir: str,
     ) -> None:
-        """Default scope is public — any signed-in member can read any sample.
-
-        Writes (annotations, deletes) still require ownership or reviewer/admin role; that
-        constraint is asserted further down.
+        """Members only ever see their own machines' samples — other owners'
+        data is invisible to them (reads 404 so they can't probe existence).
+        Reviewers/admins see everything; that's asserted in the next test.
         """
         sample = _upload_sample(client, machine_token, "sess-auth", "s1")
         sample_id = sample["id"]
@@ -356,21 +355,17 @@ class TestSampleAuthorization:
         _login_user(client, "other@test.com", "Password123!")
         other_headers = _auth_headers(client)
 
-        listing = client.get("/api/samples", headers=other_headers)
+        # annotated=all opts out of the default teacher-pass filter so the
+        # exclusion below is down to ownership, not annotation state.
+        listing = client.get("/api/samples?annotated=all", headers=other_headers)
         assert listing.status_code == 200
-        items = listing.json().get("items", [])
-        assert any(item["id"] == sample_id for item in items)
-
-        mine_only = client.get("/api/samples?scope=mine", headers=other_headers)
-        assert mine_only.status_code == 200
-        assert all(item["id"] != sample_id for item in mine_only.json().get("items", []))
+        assert all(item["id"] != sample_id for item in listing.json().get("items", []))
 
         detail = client.get(f"/api/samples/{sample_id}", headers=other_headers)
-        assert detail.status_code == 200
-        assert detail.json()["id"] == sample_id
+        assert detail.status_code == 404
 
         asset = client.get(f"/api/samples/{sample_id}/assets/image", headers=other_headers)
-        assert asset.status_code == 200
+        assert asset.status_code == 404
 
         annotations = client.put(
             f"/api/samples/{sample_id}/annotations",
@@ -378,6 +373,25 @@ class TestSampleAuthorization:
             json={"annotations": []},
         )
         assert annotations.status_code == 403
+
+    def test_member_sees_own_samples(
+        self,
+        client: TestClient,
+        test_user: dict,
+        auth_headers: dict,
+        machine_token: str,
+        upload_dir: str,
+    ) -> None:
+        sample = _upload_sample(client, machine_token, "sess-own", "s1")
+        sample_id = sample["id"]
+
+        listing = client.get("/api/samples?annotated=all", headers=auth_headers)
+        assert listing.status_code == 200
+        assert any(item["id"] == sample_id for item in listing.json().get("items", []))
+
+        detail = client.get(f"/api/samples/{sample_id}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["id"] == sample_id
 
     def test_reviewer_can_access_other_users_samples(
         self,


### PR DESCRIPTION
Three tests in `software/hive/backend` were failing on main. All three turned out to be stale tests predating intentional code changes — no code regressions:

- **test_model_download_filename** — now expects the full `.tar.gz` compound suffix. Preserving it was intentional (c012cdf0, mirrored in the frontend variant dropdown).
- **test_profiles catalog sync** — the `/profile-catalog` sync/status/stop routes were deliberately locked to admin in #148 (with the admin-gated `/settings/catalog-sync` page). The reviewer test now asserts 403, and a new `test_admin_can_start_catalog_sync` keeps the positive path covered.
- **test_samples authorization** — the old test asserted any member can read any sample, which is exactly what the role-based access control in 1b812935 removed (members only see their own machines' samples; other owners' reads 404 to prevent existence-probing). Rewritten as `test_member_cannot_see_other_users_samples`, plus a new `test_member_sees_own_samples`.

Suite after: **216 passed, 0 failed** (was 211 passed / 3 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)