### PR TITLE
Hive: stats:read scope — retire the shared-secret stats key

### DIFF
--- a/software/hive/agent-docs/auth.md
+++ b/software/hive/agent-docs/auth.md
@@ -27,7 +27,11 @@ Design philosophy: **a key grants exactly what its scopes say, nothing more.**
   grants nothing.
 - Scope vocabulary lives in `deps.py` (`VALID_API_KEY_SCOPES`): currently
   `models:read`, `models:write`, `samples:read`, `samples:write`,
-  `keys:manage`.
+  `keys:manage`, `stats:read`.
+- `stats:read` (admin-owned, non-machine-constrained keys only) grants the
+  aggregate stats endpoint (`routers/public_stats.py`) — the replacement for
+  the legacy `PUBLIC_STATS_API_KEY` shared secret, which stays accepted only
+  until consumers cut over; then delete the env var and the legacy branch.
 - Keys may carry an optional `expires_at`; expired keys 401.
 - Revocation is a tombstone (`revoked_at`), not a delete, so the UI can show
   history.

--- a/software/hive/backend/app/deps.py
+++ b/software/hive/backend/app/deps.py
@@ -19,6 +19,7 @@ API_KEY_SCOPE_MODELS_WRITE = "models:write"
 API_KEY_SCOPE_SAMPLES_READ = "samples:read"
 API_KEY_SCOPE_SAMPLES_WRITE = "samples:write"
 API_KEY_SCOPE_KEYS_MANAGE = "keys:manage"
+API_KEY_SCOPE_STATS_READ = "stats:read"
 VALID_API_KEY_SCOPES = frozenset(
     {
         API_KEY_SCOPE_MODELS_READ,
@@ -26,6 +27,7 @@ VALID_API_KEY_SCOPES = frozenset(
         API_KEY_SCOPE_SAMPLES_READ,
         API_KEY_SCOPE_SAMPLES_WRITE,
         API_KEY_SCOPE_KEYS_MANAGE,
+        API_KEY_SCOPE_STATS_READ,
     }
 )
 

--- a/software/hive/backend/app/routers/public_stats.py
+++ b/software/hive/backend/app/routers/public_stats.py
@@ -1,13 +1,17 @@
 """Service-to-service aggregate stats.
 
-A single shared-secret endpoint that exposes the same aggregate analytics an admin
-sees on the all-machines page (totals + daily time-series + distributions across
-every non-archived machine). Meant for other basically services (e.g. the public
-website) to pull headline numbers without a user session — regular Hive users
-cannot reach these aggregate stats through the normal analytics API.
+Exposes the same aggregate analytics an admin sees on the all-machines page
+(totals + daily time-series + distributions across every non-archived machine).
+Meant for other basically services (e.g. the public website) to pull headline
+numbers without a user session — regular Hive users cannot reach these
+aggregate stats through the normal analytics API.
 
-Auth is a static key in `settings.PUBLIC_STATS_API_KEY`, presented as either
-`Authorization: Bearer <key>` or an `X-Stats-Key: <key>` header.
+Auth, preferred: an `hv_*` API key carrying the `stats:read` scope, owned by an
+admin and not machine-constrained (a machine-limited key must not read
+fleet-wide aggregates). Legacy: the `settings.PUBLIC_STATS_API_KEY` shared
+secret, presented as `Authorization: Bearer <key>` or `X-Stats-Key: <key>` —
+kept only until every consumer holds a scoped key; delete the env var (and the
+legacy branch below) after cutover.
 """
 
 import hmac
@@ -18,7 +22,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.config import settings
-from app.deps import get_db
+from app.deps import API_KEY_PREFIX, API_KEY_SCOPE_STATS_READ, _resolve_api_key, get_db
 from app.models.machine import Machine
 from app.models.machine_daily_stats import MachineDailyStats
 from app.models.machine_piece import MachinePiece
@@ -35,16 +39,33 @@ PUBLIC_STATS_LOCAL_TZ = "America/Los_Angeles"
 
 
 def require_stats_key(
+    db: Session = Depends(get_db),
     authorization: str | None = Header(default=None),
     x_stats_key: str | None = Header(default=None),
 ) -> None:
-    configured = (settings.PUBLIC_STATS_API_KEY or "").strip()
-    if not configured:
-        raise HTTPException(status_code=503, detail="Public stats API is not configured")
     presented = x_stats_key
     if not presented and authorization and authorization.startswith("Bearer "):
         presented = authorization[7:]
-    if not presented or not hmac.compare_digest(presented.strip(), configured):
+    presented = (presented or "").strip()
+
+    # Preferred: a user API key with the stats:read scope.
+    if presented.startswith(API_KEY_PREFIX):
+        user, scopes, machine_ids = _resolve_api_key(db, presented)
+        if API_KEY_SCOPE_STATS_READ not in scopes:
+            raise HTTPException(status_code=403, detail="API key is missing required scopes: stats:read")
+        if user.role != "admin":
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        if machine_ids is not None:
+            raise HTTPException(
+                status_code=403, detail="Machine-scoped API keys cannot read fleet-wide stats"
+            )
+        return
+
+    # Legacy shared secret — delete once every consumer holds a scoped key.
+    configured = (settings.PUBLIC_STATS_API_KEY or "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Public stats API is not configured")
+    if not presented or not hmac.compare_digest(presented, configured):
         raise HTTPException(status_code=401, detail="Invalid stats API key")
 
 

--- a/software/hive/backend/tests/test_public_stats.py
+++ b/software/hive/backend/tests/test_public_stats.py
@@ -46,3 +46,61 @@ def test_last_24h_is_a_rolling_window(client, monkeypatch, machine_token):
     body = r.json()
     assert body["last_24h_pieces"] == 2
     assert body["totals"]["pieces_seen"] == 4
+
+
+class TestStatsScopeKeys:
+    """hv_* API keys with stats:read replace the shared secret (kept for legacy)."""
+
+    def _admin_headers(self, client, db):
+        from app.models.user import User
+        from tests.conftest import _auth_headers, _login_user, _register_user
+
+        _register_user(client, "stats-admin@test.com", "Password123!", "Stats Admin")
+        _login_user(client, "stats-admin@test.com", "Password123!")
+        user = db.query(User).filter(User.email == "stats-admin@test.com").first()
+        user.role = "admin"
+        db.commit()
+        _login_user(client, "stats-admin@test.com", "Password123!")
+        return _auth_headers(client)
+
+    def _mint(self, client, headers, scopes, machine_ids=None):
+        payload = {"name": "stats-key", "scopes": scopes}
+        if machine_ids is not None:
+            payload["machine_ids"] = machine_ids
+        r = client.post("/api/auth/api-keys", json=payload, headers=headers)
+        assert r.status_code == 200, r.text
+        return r.json()["raw_token"]
+
+    def test_stats_read_key_accepted_without_env_secret(self, client, db, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        token = self._mint(client, headers, ["stats:read"])
+        r = client.get("/api/public/stats", headers=_bearer(token))
+        assert r.status_code == 200, r.text
+        assert "last_24h_pieces" in r.json()
+
+    def test_key_without_stats_scope_403s(self, client, db, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        token = self._mint(client, headers, ["models:read"])
+        r = client.get("/api/public/stats", headers=_bearer(token))
+        assert r.status_code == 403
+        assert "stats:read" in r.json()["error"]
+
+    def test_machine_scoped_key_cannot_read_fleet_stats(self, client, db, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        m = client.post(
+            "/api/machines",
+            json={"name": "Stats Sorter", "description": "d"},
+            headers=headers,
+        )
+        assert m.status_code in (200, 201)
+        token = self._mint(client, headers, ["stats:read"], machine_ids=[m.json()["id"]])
+        r = client.get("/api/public/stats", headers=_bearer(token))
+        assert r.status_code == 403
+
+    def test_legacy_secret_still_accepted(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", STATS_KEY)
+        r = client.get("/api/public/stats", headers={"X-Stats-Key": STATS_KEY})
+        assert r.status_code == 200

--- a/software/hive/frontend/src/routes/settings/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/+page.svelte
@@ -88,7 +88,8 @@
 		{ scope: 'models:write', label: 'Write models' },
 		{ scope: 'samples:read', label: 'Read samples' },
 		{ scope: 'samples:write', label: 'Write samples' },
-		{ scope: 'keys:manage', label: 'Manage API keys' }
+		{ scope: 'keys:manage', label: 'Manage API keys' },
+		{ scope: 'stats:read', label: 'Read aggregate stats' }
 	];
 	let apiKeySelectedScopes = $state<string[]>([]);
 	let apiKeyExpiresInDays = $state('');


### PR DESCRIPTION
Stacked on #257 (which stacks on #256). Intended to merge after both.

The point of the whole auth overhaul: the aggregate stats endpoint (`/api/public/stats`) now takes a **user-tied, scoped, revocable `hv_*` API key** with the new `stats:read` scope instead of the `PUBLIC_STATS_API_KEY` env-var shared secret.

- Key must be admin-owned and **not** machine-constrained (a machine-limited key shouldn't read fleet-wide aggregates).
- The legacy shared secret is still accepted during cutover — sequence: deploy → mint a `stats:read` key in Settings → point consumers at it → delete `PUBLIC_STATS_API_KEY` from `.env.prod` and remove the legacy branch in `require_stats_key`.
- `stats:read` appears in the Settings scope picker.

Tests: 4 new (scoped key accepted with no env secret set, missing scope 403, machine-scoped key 403, legacy secret still works); 37 auth-related tests green; frontend check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)