### PR TITLE
Hive frontend: mobile responsiveness — collapsible nav + overflow sweep

### DIFF
--- a/software/hive/frontend/src/lib/components/Modal.svelte
+++ b/software/hive/frontend/src/lib/components/Modal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import X from 'lucide-svelte/icons/x';
 
 	interface Props {
 		open: boolean;
@@ -28,27 +29,21 @@
 	>
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
-			class="mx-4 w-full max-w-lg bg-surface p-6"
+			class="mx-4 max-h-[90vh] w-full max-w-lg overflow-y-auto bg-surface p-4 sm:p-6"
 			role="dialog"
 			aria-modal="true"
 			tabindex="-1"
 			onkeydown={(e) => e.stopPropagation()}
 			onclick={(e) => e.stopPropagation()}
 		>
-			<div class="mb-4 flex items-center justify-between">
-				<h2 class="text-lg font-semibold text-text">{title}</h2>
+			<div class="mb-4 flex items-start justify-between gap-3">
+				<h2 class="min-w-0 text-lg font-semibold text-text">{title}</h2>
 				<button
 					onclick={onclose}
 					aria-label="Close"
-					class="text-text-muted hover:text-text"
+					class="shrink-0 text-text-muted hover:text-text"
 				>
-					<svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-						<path
-							fill-rule="evenodd"
-							d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-							clip-rule="evenodd"
-						/>
-					</svg>
+					<X size={20} />
 				</button>
 			</div>
 			{@render children()}

--- a/software/hive/frontend/src/lib/components/ModelCard.svelte
+++ b/software/hive/frontend/src/lib/components/ModelCard.svelte
@@ -137,9 +137,9 @@
 	<!-- Body — 3 columns matching the metric grid above: Model · Samples · Rigs -->
 	{#if arch || imgsz || samples !== null || machineCount !== null}
 		<div class="grid grid-cols-3 gap-px bg-[var(--color-border)]">
-			<div class="bg-[var(--color-surface)] px-3 py-2">
+			<div class="min-w-0 bg-[var(--color-surface)] px-3 py-2">
 				<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Model</div>
-				<div class="font-mono text-sm font-semibold text-[var(--color-text)]">
+				<div class="truncate font-mono text-xs font-semibold text-[var(--color-text)] sm:text-sm">
 					{#if arch && imgsz}{arch} @ {imgsz}
 					{:else if arch}{arch}
 					{:else if imgsz}{imgsz}×{imgsz}

--- a/software/hive/frontend/src/lib/components/ModelTrainingReport.svelte
+++ b/software/hive/frontend/src/lib/components/ModelTrainingReport.svelte
@@ -400,7 +400,7 @@
 				<div class="space-y-2">
 					{#each spectrumPrimary as row}
 						{@const accuracy = clampPct(row.within_1_count_rate)}
-						<div class="grid grid-cols-[5rem_1fr_4.5rem_5rem] items-center gap-3 text-sm">
+						<div class="grid grid-cols-[3.5rem_1fr_3.5rem_4rem] items-center gap-2 text-sm sm:grid-cols-[5rem_1fr_4.5rem_5rem] sm:gap-3">
 							<div class="font-mono text-xs text-[var(--color-text-muted)]">{textValue(row.gt_count_bin)} pc</div>
 							<div class="h-3 bg-[var(--color-bg)]">
 								<div class="h-3" style={`width: ${accuracy}%; background: ${gaugeColor(accuracy)};`}></div>
@@ -421,18 +421,20 @@
 				<span class="text-xs text-[var(--color-text-muted)]">ONNX Runtime · imgsz {textValue(model.imgsz)}</span>
 			</div>
 			<div class="border border-[var(--color-border)] bg-[var(--color-surface)]">
-				<div class="grid grid-cols-[6rem_1fr_5rem_5rem_5rem] items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-2 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">
+				<!-- The throughput bar is the first thing to go at mobile: five tracks
+				     need ~416px and the bar is decoration next to the numbers. -->
+				<div class="grid grid-cols-[1fr_3.5rem_3.5rem_3rem] items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-2 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] sm:grid-cols-[6rem_1fr_5rem_5rem_5rem] sm:gap-3">
 					<div>Provider</div>
-					<div>Throughput</div>
+					<div class="hidden sm:block">Throughput</div>
 					<div class="text-right">Mean</div>
 					<div class="text-right">P95</div>
 					<div class="text-right">FPS</div>
 				</div>
 				{#each perfRows as row, i (row.name)}
 					{@const widthPct = ((row.fps ?? 0) / perfFpsMax) * 100}
-					<div class={`grid grid-cols-[6rem_1fr_5rem_5rem_5rem] items-center gap-3 px-4 py-2.5 ${i > 0 ? 'border-t border-[var(--color-border)]' : ''}`}>
+					<div class={`grid grid-cols-[1fr_3.5rem_3.5rem_3rem] items-center gap-2 px-4 py-2.5 sm:grid-cols-[6rem_1fr_5rem_5rem_5rem] sm:gap-3 ${i > 0 ? 'border-t border-[var(--color-border)]' : ''}`}>
 						<div class="font-mono text-xs uppercase tracking-wide text-[var(--color-text)]">{row.name}</div>
-						<div class="h-2 bg-[var(--color-bg)]">
+						<div class="hidden h-2 bg-[var(--color-bg)] sm:block">
 							<div class="h-2" style={`width: ${widthPct}%; background: ${softInfo};`}></div>
 						</div>
 						<div class="text-right text-sm tabular-nums">{num(row.mean, 1)} ms</div>

--- a/software/hive/frontend/src/lib/components/PieceLabelPanel.svelte
+++ b/software/hive/frontend/src/lib/components/PieceLabelPanel.svelte
@@ -693,7 +693,11 @@
 			return;
 		}
 		const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
-		qualityMenuPos = { top: r.bottom + 4, left: r.left };
+		// The menu is 14rem wide and position:fixed, so on a phone a trigger past
+		// ~x:166 would hang it off the right edge. Clamp it into the viewport.
+		const MENU_WIDTH = 224;
+		const maxLeft = Math.max(8, window.innerWidth - MENU_WIDTH - 8);
+		qualityMenuPos = { top: r.bottom + 4, left: Math.min(r.left, maxLeft) };
 		qualityMenuOpenFor = key;
 	}
 
@@ -874,7 +878,7 @@
 				</span>
 			{/each}
 		</div>
-		<div class="ml-auto flex items-center gap-2">
+		<div class="flex flex-wrap items-center gap-2 sm:ml-auto">
 			<span class="hidden text-xs text-text-muted xl:inline">Enter accept · →/Space skip · ← back</span>
 			<!-- Reject this bbox sample (with reason(s)) — left of the skip/continue CTA -->
 			<div class="relative">

--- a/software/hive/frontend/src/lib/components/charts/BarList.svelte
+++ b/software/hive/frontend/src/lib/components/charts/BarList.svelte
@@ -24,13 +24,13 @@
 					<span class="h-3 w-3 flex-shrink-0 border border-border" style:background-color={item.swatch}></span>
 				{/if}
 				{#if item.sublabel}
-					<span class="w-14 flex-shrink-0 truncate font-mono text-xs text-text-muted">{item.sublabel}</span>
+					<span class="w-10 flex-shrink-0 truncate font-mono text-xs text-text-muted sm:w-14">{item.sublabel}</span>
 				{/if}
-				<span class="w-28 flex-shrink-0 truncate text-text" title={item.label}>{item.label}</span>
+				<span class="w-20 flex-shrink-0 truncate text-text sm:w-28" title={item.label}>{item.label}</span>
 				<div class="h-4 flex-1 bg-bg">
 					<div class="h-full" style="width: {(item.value / max) * 100}%; background: {color}"></div>
 				</div>
-				<span class="w-16 flex-shrink-0 text-right tabular-nums text-text-muted">{item.value.toLocaleString()}</span>
+				<span class="w-12 flex-shrink-0 text-right tabular-nums text-text-muted sm:w-16">{item.value.toLocaleString()}</span>
 			</div>
 		{/each}
 	</div>

--- a/software/hive/frontend/src/lib/components/primitives/Alert.svelte
+++ b/software/hive/frontend/src/lib/components/primitives/Alert.svelte
@@ -19,7 +19,9 @@
 	};
 </script>
 
-<div class="border px-3 py-2 text-sm {VARIANTS[variant]}">
+<!-- break-words: alerts routinely carry raw API errors with a URL in them, and an
+     unbreakable URL is enough to make the whole page scroll sideways. -->
+<div class="border px-3 py-2 text-sm break-words {VARIANTS[variant]}">
 	{#if title}
 		<div class="font-semibold">{title}</div>
 	{/if}

--- a/software/hive/frontend/src/lib/components/primitives/Tooltip.svelte
+++ b/software/hive/frontend/src/lib/components/primitives/Tooltip.svelte
@@ -40,7 +40,7 @@
 	{#if visible}
 		<span
 			role="tooltip"
-			class="pointer-events-none absolute z-50 whitespace-nowrap bg-text px-2 py-1 text-xs text-surface shadow-md {PLACEMENTS[placement]}"
+			class="pointer-events-none absolute z-50 w-max max-w-[min(16rem,80vw)] bg-text px-2 py-1 text-xs text-surface shadow-md {PLACEMENTS[placement]}"
 		>
 			{text}
 		</span>

--- a/software/hive/frontend/src/lib/components/profile/edit/RuleAccordionNode.svelte
+++ b/software/hive/frontend/src/lib/components/profile/edit/RuleAccordionNode.svelte
@@ -112,7 +112,9 @@
 	const hasChildren = $derived(rule.children.length > 0);
 </script>
 
-<div class="{depth > 0 ? 'ml-4 border-l border-border' : ''}">
+<!-- Nesting indent is halved on phones: at 16px per level a depth-4 rule would
+     eat a quarter of the screen before its controls start. -->
+<div class="min-w-0 {depth > 0 ? 'ml-2 border-l border-border sm:ml-4' : ''}">
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div onclick={() => { onToggleNode(rule.id); onSelectRule(rule.id); }}
 		onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { onToggleNode(rule.id); onSelectRule(rule.id); } }}
@@ -359,7 +361,7 @@
 				{#if rule.conditions.length > 0}
 					<div class="mb-2 space-y-1.5">
 						{#each rule.conditions as cond (cond.id)}
-							<div class="flex items-center gap-1.5">
+							<div class="flex flex-wrap items-center gap-1.5">
 								<select value={cond.field}
 									onchange={(e) => {
 										const field = (e.currentTarget as HTMLSelectElement).value;

--- a/software/hive/frontend/src/lib/components/review/ReviewActionPad.svelte
+++ b/software/hive/frontend/src/lib/components/review/ReviewActionPad.svelte
@@ -31,7 +31,7 @@
 <div class="border border-border bg-surface p-4">
 	<div class="space-y-2 text-xs">
 		{#if FEATURES.ANNOTATION_EDITING}
-			<div class="flex items-center justify-center gap-2">
+			<div class="flex flex-wrap items-center justify-center gap-2">
 				<button
 					type="button"
 					onclick={onToggleAnnotate}

--- a/software/hive/frontend/src/routes/+layout.svelte
+++ b/software/hive/frontend/src/routes/+layout.svelte
@@ -8,6 +8,23 @@
 	import { theme } from '$lib/stores/theme';
 	import type { Snippet } from 'svelte';
 	import { onMount } from 'svelte';
+	import { fade, fly } from 'svelte/transition';
+	import ChartColumn from 'lucide-svelte/icons/chart-column';
+	import ChevronDown from 'lucide-svelte/icons/chevron-down';
+	import Database from 'lucide-svelte/icons/database';
+	import KeyRound from 'lucide-svelte/icons/key-round';
+	import Link from 'lucide-svelte/icons/link';
+	import List from 'lucide-svelte/icons/list';
+	import Lock from 'lucide-svelte/icons/lock';
+	import LogOut from 'lucide-svelte/icons/log-out';
+	import Menu from 'lucide-svelte/icons/menu';
+	import Palette from 'lucide-svelte/icons/palette';
+	import RefreshCw from 'lucide-svelte/icons/refresh-cw';
+	import Server from 'lucide-svelte/icons/server';
+	import Sparkles from 'lucide-svelte/icons/sparkles';
+	import User from 'lucide-svelte/icons/user';
+	import Users from 'lucide-svelte/icons/users';
+	import X from 'lucide-svelte/icons/x';
 
 	interface Props {
 		children: Snippet;
@@ -16,10 +33,23 @@
 	let { children }: Props = $props();
 
 	let dropdownOpen = $state(false);
+	let menuOpen = $state(false);
 
 	// /machine-ip-lookup is an unlisted, login-free rendezvous page used by the
 	// SorterOS onboarding flow — a fresh sorter has no Hive account yet.
 	const publicRoutes = ['/login', '/register', '/machine-ip-lookup', '/forget'];
+
+	// The seven primary destinations. Kept as data so the desktop bar and the
+	// mobile drawer can't drift apart.
+	const navLinks: { href: string; label: string; match: (path: string) => boolean }[] = [
+		{ href: '/', label: 'Dashboard', match: (p) => p === '/' },
+		{ href: '/machines', label: 'My Machines', match: (p) => p === '/machines' || p.startsWith('/machines/') },
+		{ href: '/profiles', label: 'Profiles', match: (p) => p.startsWith('/profiles') },
+		{ href: '/samples', label: 'Channel Samples', match: (p) => p.startsWith('/samples') || p === '/review' },
+		{ href: '/piece-bboxes', label: 'Piece Samples', match: (p) => p.startsWith('/piece-bboxes') },
+		{ href: '/models', label: 'Models', match: (p) => p.startsWith('/models') },
+		{ href: '/leaderboard', label: 'Leaderboard', match: (p) => p.startsWith('/leaderboard') }
+	];
 
 	function currentPathWithSearch(): string {
 		return `${page.url.pathname}${page.url.search}`;
@@ -27,8 +57,15 @@
 
 	async function handleLogout() {
 		dropdownOpen = false;
+		menuOpen = false;
 		await auth.logout();
 		goto('/login');
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key !== 'Escape') return;
+		menuOpen = false;
+		dropdownOpen = false;
 	}
 
 	onMount(() => {
@@ -46,7 +83,28 @@
 		if (typeof document === 'undefined') return;
 		document.documentElement.classList.toggle('dark', $theme === 'dark');
 	});
+
+	// Any navigation (link click, back button, redirect) dismisses the overlays.
+	$effect(() => {
+		page.url.pathname;
+		menuOpen = false;
+		dropdownOpen = false;
+	});
+
+	// The drawer is a full-viewport overlay; letting the page behind it scroll
+	// under your finger is the classic mobile-drawer bug.
+	$effect(() => {
+		if (typeof document === 'undefined') return;
+		if (!menuOpen) return;
+		const previous = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = previous;
+		};
+	});
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 {#if auth.loading && !auth.initialized}
 	<div class="flex min-h-screen items-center justify-center">
@@ -54,66 +112,40 @@
 	</div>
 {:else}
 	{#if auth.isAuthenticated}
-		<nav class="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-			<div class="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
-				<div class="flex items-center gap-6">
-					<a href="/" class="text-xl font-bold font-mono uppercase tracking-tight text-[var(--color-text)]">Hive</a>
-					<div class="flex gap-1">
-						<a
-							href="/"
-							class="px-3 py-1.5 text-sm font-medium {page.url.pathname === '/' ? 'border-b-2 border-primary text-primary' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)]'}"
-						>
-							Dashboard
-						</a>
-						<a
-							href="/machines"
-							class="px-3 py-1.5 text-sm font-medium {page.url.pathname === '/machines' || page.url.pathname.startsWith('/machines/') ? 'border-b-2 border-primary text-primary' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)]'}"
-						>
-							My Machines
-						</a>
-						<a
-							href="/profiles"
-							class="px-3 py-1.5 text-sm font-medium {page.url.pathname.startsWith('/profiles') ? 'border-b-2 border-primary text-primary' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)]'}"
-						>
-							Profiles
-						</a>
-						<a
-							href="/samples"
-							class="px-3 py-1.5 text-sm font-medium {page.url.pathname.startsWith('/samples') || page.url.pathname === '/review' ? 'border-b-2 border-primary text-primary' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)]'}"
-						>
-							Channel Samples
-						</a>
-						<a
-							href="/piece-bboxes"
-							class="px-3 py-1.5 text-sm font-medium {page.url.pathname.startsWith('/piece-bboxes') ? 'border-b-2 border-primary text-primary' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)]'}"
-						>
-							Piece Samples
-						</a>
-						<a
-							href="/models"
-							class="px-3 py-1.5 text-sm font-medium {page.url.pathname.startsWith('/models') ? 'border-b-2 border-primary text-primary' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)]'}"
-						>
-							Models
-						</a>
-						<a
-							href="/leaderboard"
-							class="px-3 py-1.5 text-sm font-medium {page.url.pathname.startsWith('/leaderboard') ? 'border-b-2 border-primary text-primary' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)]'}"
-						>
-							Leaderboard
-						</a>
+		<nav class="border-b border-border bg-surface">
+			<div class="mx-auto flex max-w-7xl items-center justify-between gap-2 px-4 py-3">
+				<div class="flex min-w-0 items-center gap-3 lg:gap-6">
+					<!-- The seven nav links don't fit beside the wordmark and the user
+					     menu until ~1024px, so the drawer covers phones and tablets. -->
+					<button
+						onclick={() => { menuOpen = true; }}
+						class="-ml-1 p-1 text-text-muted hover:text-text lg:hidden"
+						aria-label="Open navigation menu"
+						aria-expanded={menuOpen}
+					>
+						<Menu size={22} />
+					</button>
+					<a href="/" class="text-xl font-bold font-mono uppercase tracking-tight text-text">Hive</a>
+					<div class="hidden gap-1 lg:flex">
+						{#each navLinks as link (link.href)}
+							<a
+								href={link.href}
+								class="px-3 py-1.5 text-sm font-medium whitespace-nowrap {link.match(page.url.pathname) ? 'border-b-2 border-primary text-primary' : 'text-text-muted hover:text-text hover:bg-bg'}"
+							>
+								{link.label}
+							</a>
+						{/each}
 					</div>
 				</div>
-				<div class="flex items-center gap-3">
+				<div class="flex shrink-0 items-center gap-1 sm:gap-3">
 					<ThemeToggle />
 					<div class="relative">
 						<button
 							onclick={() => { dropdownOpen = !dropdownOpen; }}
-							class="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+							class="flex max-w-[9rem] items-center gap-1 px-2 py-1.5 text-sm font-medium text-text hover:bg-bg sm:max-w-[16rem] sm:gap-2 sm:px-3"
 						>
-							<span>{auth.user?.display_name ?? auth.user?.email}</span>
-							<svg class="h-4 w-4 transition-transform {dropdownOpen ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-							</svg>
+							<span class="truncate">{auth.user?.display_name ?? auth.user?.email}</span>
+							<ChevronDown size={16} class="shrink-0 transition-transform {dropdownOpen ? 'rotate-180' : ''}" />
 						</button>
 
 						{#if dropdownOpen}
@@ -123,148 +155,122 @@
 								onclick={() => { dropdownOpen = false; }}
 								onkeydown={() => {}}
 							></div>
-							<div class="absolute right-0 z-50 mt-1 w-56 border border-[var(--color-border)] bg-[var(--color-surface)] py-1 shadow-lg">
-								<div class="border-b border-[var(--color-border)] px-4 py-2">
-									<p class="text-sm font-medium text-[var(--color-text)]">{auth.user?.display_name}</p>
-									<p class="text-xs text-[var(--color-text-muted)]">{auth.user?.email}</p>
+							<div class="absolute right-0 z-50 mt-1 max-h-[80vh] w-56 max-w-[calc(100vw-2rem)] overflow-y-auto border border-border bg-surface py-1 shadow-lg">
+								<div class="border-b border-border px-4 py-2">
+									<p class="truncate text-sm font-medium text-text">{auth.user?.display_name}</p>
+									<p class="truncate text-xs text-text-muted">{auth.user?.email}</p>
 								</div>
 
 								<a
 									href="/settings"
-									class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+									class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 									onclick={() => { dropdownOpen = false; }}
 								>
-									<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-									</svg>
-									Profile & Settings
+									<User size={16} class="shrink-0 text-text-muted" />
+									Profile &amp; Settings
 								</a>
 								<a
 									href="/settings#password"
-									class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+									class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 									onclick={() => { dropdownOpen = false; }}
 								>
-									<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
-									</svg>
+									<KeyRound size={16} class="shrink-0 text-text-muted" />
 									Change Password
 								</a>
 
 								{#if auth.isAdmin}
-									<div class="border-t border-[var(--color-border)] my-1"></div>
+									<div class="my-1 border-t border-border"></div>
 									<div class="px-4 py-1">
-										<p class="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">Admin</p>
+										<p class="text-xs font-semibold uppercase tracking-wider text-text-muted">Admin</p>
 									</div>
 									<a
 										href="/admin/users"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
-										</svg>
+										<Users size={16} class="shrink-0 text-text-muted" />
 										Manage Users
 									</a>
 									<a
 										href="/admin/machines"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 0h.008v.008h-.008v-.008Zm-3 0h.008v.008h-.008v-.008Z" />
-										</svg>
+										<Server size={16} class="shrink-0 text-text-muted" />
 										All Machines
 									</a>
 									<a
 										href="/admin/control-data"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 5.625c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
-										</svg>
+										<Database size={16} class="shrink-0 text-text-muted" />
 										Control Data
 									</a>
 									<a
 										href="/admin/server-health"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
-										</svg>
+										<ChartColumn size={16} class="shrink-0 text-text-muted" />
 										Server Health
 									</a>
 									<a
 										href="/admin/teacher-jobs"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
-										</svg>
+										<Sparkles size={16} class="shrink-0 text-text-muted" />
 										Teacher Jobs
 									</a>
 									<a
 										href="/admin/color-models"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M4.098 19.902a3.75 3.75 0 0 0 5.304 0l6.401-6.402M6.75 21A3.75 3.75 0 0 1 3 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 0 0 3.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008Z" />
-										</svg>
+										<Palette size={16} class="shrink-0 text-text-muted" />
 										Color Models
 									</a>
 									<a
 										href="/admin/link-models"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
-										</svg>
+										<Link size={16} class="shrink-0 text-text-muted" />
 										Link Models
 									</a>
 									<a
 										href="/admin/parts"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
-										</svg>
+										<List size={16} class="shrink-0 text-text-muted" />
 										Parts Database
 									</a>
 									<a
 										href="/admin/access-windows"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
-										</svg>
+										<Lock size={16} class="shrink-0 text-text-muted" />
 										Access Windows
 									</a>
 									<a
 										href="/settings/catalog-sync"
-										class="flex items-center gap-2 px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+										class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg"
 										onclick={() => { dropdownOpen = false; }}
 									>
-										<svg class="h-4 w-4 text-[var(--color-text-muted)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-											<path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
-										</svg>
+										<RefreshCw size={16} class="shrink-0 text-text-muted" />
 										Catalog Sync
 									</a>
 								{/if}
 
-								<div class="border-t border-[var(--color-border)] my-1"></div>
+								<div class="my-1 border-t border-border"></div>
 								<button
 									onclick={handleLogout}
 									class="flex w-full items-center gap-2 px-4 py-2 text-sm text-primary hover:bg-primary-light"
 								>
-									<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-									</svg>
+									<LogOut size={16} class="shrink-0" />
 									Logout
 								</button>
 							</div>
@@ -273,6 +279,43 @@
 				</div>
 			</div>
 		</nav>
+
+		{#if menuOpen}
+			<div class="fixed inset-0 z-50 lg:hidden">
+				<button
+					class="absolute inset-0 bg-black/50"
+					aria-label="Close navigation menu"
+					onclick={() => { menuOpen = false; }}
+					transition:fade={{ duration: 120 }}
+				></button>
+				<div
+					class="absolute inset-y-0 left-0 flex w-72 max-w-[85vw] flex-col border-r border-border bg-surface shadow-xl"
+					transition:fly={{ x: -288, duration: 180 }}
+				>
+					<div class="flex items-center justify-between border-b border-border px-4 py-3">
+						<span class="text-xl font-bold font-mono uppercase tracking-tight text-text">Hive</span>
+						<button
+							onclick={() => { menuOpen = false; }}
+							class="-mr-1 p-1 text-text-muted hover:text-text"
+							aria-label="Close navigation menu"
+						>
+							<X size={22} />
+						</button>
+					</div>
+					<div class="flex-1 overflow-y-auto py-1">
+						{#each navLinks as link (link.href)}
+							<a
+								href={link.href}
+								onclick={() => { menuOpen = false; }}
+								class="block border-l-2 px-4 py-3 text-sm font-medium {link.match(page.url.pathname) ? 'border-primary bg-primary-light/30 text-primary' : 'border-transparent text-text-muted hover:bg-bg hover:text-text'}"
+							>
+								{link.label}
+							</a>
+						{/each}
+					</div>
+				</div>
+			</div>
+		{/if}
 	{/if}
 
 	<!-- Piece labeling carries a reference column, the piece, and the color picker

--- a/software/hive/frontend/src/routes/+page.svelte
+++ b/software/hive/frontend/src/routes/+page.svelte
@@ -82,7 +82,7 @@
 		</div>
 	</div>
 
-	<div class="flex gap-4">
+	<div class="flex flex-wrap gap-3 sm:gap-4">
 		<a
 			href="/profiles"
 			class="bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-hover"

--- a/software/hive/frontend/src/routes/admin/color-models/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/color-models/+page.svelte
@@ -92,7 +92,7 @@
 
 	{#if modelDir}
 		<p class="text-xs text-text-muted">
-			Scan directory: <code class="bg-bg px-1.5 py-0.5 text-text">{modelDir}</code>
+			Scan directory: <code class="break-all bg-bg px-1.5 py-0.5 text-text">{modelDir}</code>
 		</p>
 	{/if}
 
@@ -108,7 +108,7 @@
 		</div>
 	{:else}
 		<div class="border border-border bg-surface">
-			<div class="flex items-center justify-between border-b border-border bg-bg px-4 py-2">
+			<div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-border bg-bg px-4 py-2">
 				<span class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
 					{models.length} model{models.length === 1 ? '' : 's'} on disk
 				</span>
@@ -133,7 +133,7 @@
 						{#if m.description}
 							<p class="mt-0.5 truncate text-xs text-text-muted">{m.description}</p>
 						{/if}
-						<p class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-text-muted">
+						<p class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 break-all text-[11px] text-text-muted">
 							<span><code class="text-text-muted">{m.filename}</code></span>
 							<span>{m.class_count} colors</span>
 							<span>{m.input_size}×{m.input_size}</span>

--- a/software/hive/frontend/src/routes/admin/control-data/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/control-data/+page.svelte
@@ -185,7 +185,9 @@
 		<h2 class="mb-3 text-lg font-semibold text-text">By dimension</h2>
 		<div class="grid gap-6 lg:grid-cols-2">
 			{#each dimensionEntries as dim (dim.key)}
-				<div>
+				<!-- min-w-0: without it the grid track sizes to the widest table cell
+				     and the overflow-x-auto wrapper below never gets to scroll. -->
+				<div class="min-w-0">
 					<h3 class="mb-2 text-sm font-semibold text-text">{dim.label}</h3>
 					<div class="overflow-x-auto border border-border bg-surface">
 						<table class="min-w-full divide-y divide-border">

--- a/software/hive/frontend/src/routes/admin/link-models/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/link-models/+page.svelte
@@ -94,7 +94,7 @@
 
 	{#if modelDir}
 		<p class="text-xs text-text-muted">
-			Scan directory: <code class="bg-bg px-1.5 py-0.5 text-text">{modelDir}</code>
+			Scan directory: <code class="break-all bg-bg px-1.5 py-0.5 text-text">{modelDir}</code>
 		</p>
 	{/if}
 
@@ -111,7 +111,7 @@
 		</div>
 	{:else}
 		<div class="border border-border bg-surface">
-			<div class="flex items-center justify-between border-b border-border bg-bg px-4 py-2">
+			<div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b border-border bg-bg px-4 py-2">
 				<span class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
 					{models.length} model{models.length === 1 ? '' : 's'} on disk
 				</span>
@@ -136,7 +136,7 @@
 						{#if m.description}
 							<p class="mt-0.5 truncate text-xs text-text-muted">{m.description}</p>
 						{/if}
-						<p class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-text-muted">
+						<p class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 break-all text-[11px] text-text-muted">
 							<span><code class="text-text-muted">{m.encoder_filename}</code> + <code class="text-text-muted">{m.head_filename}</code></span>
 							<span>{m.input_size}×{m.input_size}</span>
 							<span>{m.embed_dim}-d embed</span>

--- a/software/hive/frontend/src/routes/admin/parts/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/parts/+page.svelte
@@ -227,11 +227,13 @@
 		bind:value={query}
 		onkeydown={(e) => e.key === 'Enter' && applyFilters()}
 		placeholder="Search part #, name, or BrickLink ID…"
-		class="min-w-64 flex-1 border border-border bg-surface px-3 py-2 text-sm text-text"
+		class="w-full flex-1 border border-border bg-surface px-3 py-2 text-sm text-text sm:min-w-64"
 	/>
+	<!-- A <select> sizes to its widest option; the category names are long enough
+	     to push the row past a phone screen without an explicit cap. -->
 	<select
 		bind:value={catId}
-		class="border border-border bg-surface px-3 py-2 text-sm text-text"
+		class="max-w-full min-w-0 border border-border bg-surface px-3 py-2 text-sm text-text"
 	>
 		<option value={null}>All categories</option>
 		{#each categories as cat}
@@ -240,7 +242,7 @@
 	</select>
 	<select
 		bind:value={missing}
-		class="border border-border bg-surface px-3 py-2 text-sm text-text"
+		class="max-w-full min-w-0 border border-border bg-surface px-3 py-2 text-sm text-text"
 	>
 		<option value="">Any connection</option>
 		<option value="bricklink_id">Missing BrickLink ID</option>
@@ -326,7 +328,7 @@
 				{#if detail.part.part_img_url}
 					<img src={detail.part.part_img_url} alt="" class="h-20 w-20 object-contain border border-border" />
 				{/if}
-				<dl class="grid flex-1 grid-cols-2 gap-x-3 gap-y-1 text-sm">
+				<dl class="grid min-w-0 flex-1 grid-cols-2 gap-x-3 gap-y-1 text-sm">
 					<dt class="text-text-muted">Category</dt>
 					<dd class="text-text">{detail.part._category_name}</dd>
 					<dt class="text-text-muted">Years</dt>
@@ -385,9 +387,9 @@
 				{:else}
 					<div class="space-y-1 text-sm">
 						{#each Object.entries(detail.part.external_ids) as [source, ids]}
-							<div class="flex gap-2">
+							<div class="flex min-w-0 gap-2">
 								<span class="w-24 shrink-0 text-text-muted">{source}</span>
-								<span class="font-mono text-text">{ids.join(', ')}</span>
+								<span class="min-w-0 break-all font-mono text-text">{ids.join(', ')}</span>
 							</div>
 						{/each}
 					</div>
@@ -438,7 +440,7 @@
 				{#if detail.prices.length === 0}
 					<p class="text-sm text-text-muted">No price data yet — run the price sync.</p>
 				{:else}
-					<div class="max-h-64 overflow-y-auto border border-border">
+					<div class="max-h-64 overflow-auto border border-border">
 						<table class="min-w-full divide-y divide-border text-sm">
 							<thead class="sticky top-0 bg-bg">
 								<tr>

--- a/software/hive/frontend/src/routes/admin/teacher-jobs/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/teacher-jobs/[id]/+page.svelte
@@ -277,13 +277,13 @@
 
 		{#if job.items_pages > 1}
 			{@const j = job}
-			<div class="mt-4 flex items-center justify-between border border-border bg-surface px-4 py-2.5 text-xs">
+			<div class="mt-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border border-border bg-surface px-4 py-2.5 text-xs">
 				<span class="text-text-muted">
 					Page {j.items_page} of {j.items_pages} · showing
 					{(j.items_page - 1) * j.items_page_size + 1}–{Math.min(j.items_page * j.items_page_size, j.items_total)}
 					of {j.items_total.toLocaleString()}
 				</span>
-				<div class="flex items-center gap-1">
+				<div class="flex flex-wrap items-center gap-1">
 					<button
 						type="button"
 						onclick={() => goToPage(j.items_page - 1)}

--- a/software/hive/frontend/src/routes/admin/users/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/users/+page.svelte
@@ -88,7 +88,7 @@
 	<title>Manage Users - Hive</title>
 </svelte:head>
 
-<div class="mb-6 flex items-center justify-between">
+<div class="mb-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
 	<h1 class="text-2xl font-bold text-text">Manage Users</h1>
 	<span class="text-sm text-text-muted">{users.length} users total</span>
 </div>
@@ -102,7 +102,7 @@
 		<Spinner size={32} />
 	</div>
 {:else}
-	<div class="overflow-hidden border border-border bg-surface">
+	<div class="overflow-x-auto border border-border bg-surface">
 		<table class="min-w-full divide-y divide-border">
 			<thead class="bg-bg">
 				<tr>

--- a/software/hive/frontend/src/routes/leaderboard/+page.svelte
+++ b/software/hive/frontend/src/routes/leaderboard/+page.svelte
@@ -100,7 +100,7 @@
 				Ranked by total contributions — sample reviews plus piece labels (color + same-piece). Period switches the ranking; clicks open full stats + achievements.
 			</p>
 		</div>
-		<div class="flex border border-border bg-surface text-xs">
+		<div class="flex flex-wrap border border-border bg-surface text-xs">
 			{#each PERIOD_OPTIONS as opt}
 				<button
 					type="button"
@@ -123,19 +123,21 @@
 		</div>
 	{:else}
 		<div class="border border-border bg-surface">
-			<div class="grid grid-cols-[40px_1fr_90px_150px_120px] items-center gap-3 border-b border-border bg-bg px-4 py-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+			<!-- Mobile keeps rank/name/total on one line and drops the two detail
+			     columns onto a second grid row; the 5-track layout needs ~480px. -->
+			<div class="grid grid-cols-[32px_minmax(0,1fr)_auto] items-center gap-3 border-b border-border bg-bg px-4 py-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted sm:grid-cols-[40px_1fr_90px_150px_120px]">
 				<span>Rank</span>
 				<span>Contributor</span>
 				<span class="text-right">Total</span>
-				<span class="text-right">Samples · Pieces</span>
-				<span class="text-right">Last activity</span>
+				<span class="hidden text-right sm:block">Samples · Pieces</span>
+				<span class="hidden text-right sm:block">Last activity</span>
 			</div>
 			{#each data.entries as entry, idx (entry.user_id)}
 				{@const isMe = auth.user?.id === entry.user_id}
 				{@const medal = medalFor(idx)}
 				<a
 					href={profileHref(entry)}
-					class="grid grid-cols-[40px_1fr_90px_150px_120px] items-center gap-3 border-b border-border px-4 py-2.5 text-sm transition-colors hover:bg-bg {isMe ? 'bg-primary-light/30' : ''} last:border-b-0"
+					class="grid grid-cols-[32px_minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 border-b border-border px-4 py-2.5 text-sm transition-colors hover:bg-bg sm:grid-cols-[40px_1fr_90px_150px_120px] {isMe ? 'bg-primary-light/30' : ''} last:border-b-0"
 				>
 					<span class="text-center text-base font-semibold tabular-nums text-text">
 						{medal ?? idx + 1}
@@ -159,13 +161,13 @@
 					<span class="text-right text-base font-bold tabular-nums text-text">
 						{entry.total_contributions.toLocaleString()}
 					</span>
-					<span class="text-right text-xs tabular-nums text-text-muted">
+					<span class="col-start-2 row-start-2 text-xs tabular-nums text-text-muted sm:col-start-auto sm:row-start-auto sm:text-right">
 						<span title="sample reviews">{entry.total_reviews.toLocaleString()}</span>
 						· <span class="text-primary" title="piece color labels + same-piece links">
 							{(entry.piece_color_labels + entry.piece_crop_links).toLocaleString()}
 						</span>
 					</span>
-					<span class="text-right text-xs text-text-muted">{relativeTime(entry.last_review_at)}</span>
+					<span class="col-start-3 row-start-2 text-right text-xs text-text-muted sm:col-start-auto sm:row-start-auto">{relativeTime(entry.last_review_at)}</span>
 				</a>
 			{/each}
 		</div>

--- a/software/hive/frontend/src/routes/link-machine/+page.svelte
+++ b/software/hive/frontend/src/routes/link-machine/+page.svelte
@@ -225,12 +225,12 @@
 				</div>
 				<div class="grid gap-1">
 					<span class="text-xs font-semibold tracking-wider text-text-muted uppercase">Return target</span>
-					<span class="font-mono text-text">{destinationLabel()}</span>
+					<span class="break-all font-mono text-text">{destinationLabel()}</span>
 				</div>
 				{#if sorterOrigin()}
 					<div class="grid gap-1">
 						<span class="text-xs font-semibold tracking-wider text-text-muted uppercase">Started from</span>
-						<span class="font-mono text-text">{sorterOrigin()}</span>
+						<span class="break-all font-mono text-text">{sorterOrigin()}</span>
 					</div>
 				{/if}
 			</div>
@@ -339,7 +339,7 @@
 
 				<div class="flex flex-wrap items-center justify-between gap-3">
 					<p class="text-xs leading-relaxed text-text-muted">
-						Only confirm this if you trust <span class="font-mono text-text">{destinationLabel()}</span>.
+						Only confirm this if you trust <span class="break-all font-mono text-text">{destinationLabel()}</span>.
 					</p>
 					<button
 						type="submit"

--- a/software/hive/frontend/src/routes/machines/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/+page.svelte
@@ -360,8 +360,8 @@ async function loadAssignmentProfile(profileId: string) {
 	<title>Machines - Hive</title>
 </svelte:head>
 
-<div class="mb-6 flex items-center justify-between">
-	<div>
+<div class="mb-6 flex flex-wrap items-center justify-between gap-3">
+	<div class="min-w-0">
 		<h1 class="text-2xl font-bold text-text">Machines</h1>
 		<p class="mt-1 text-sm text-text-muted">
 			Manage machine tokens and decide which sorting profile version each machine should pull.
@@ -369,7 +369,7 @@ async function loadAssignmentProfile(profileId: string) {
 	</div>
 	<button
 		onclick={() => { showAddModal = true; }}
-		class="bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-hover"
+		class="shrink-0 bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-hover"
 	>
 		Add Machine
 	</button>
@@ -509,7 +509,7 @@ async function loadAssignmentProfile(profileId: string) {
 
 				<!-- Footer -->
 				<div class="mt-auto border-t border-border bg-bg px-4 py-2">
-					<div class="flex items-center justify-between text-[10px] text-text-muted">
+					<div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 text-[10px] text-text-muted">
 						<span>Registered {formatUptime(machine.created_at)} ago</span>
 						{#if machine.last_seen_at}
 							<span>{isOnline ? 'Online now' : `Last seen ${new Date(machine.last_seen_at).toLocaleString()}`}</span>

--- a/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
@@ -197,7 +197,9 @@
 	<title>{machine ? `${machine.name} — Overview` : 'Machine'} · Hive</title>
 </svelte:head>
 
-<div class="mx-auto max-w-5xl px-4 py-8">
+<!-- No horizontal padding at mobile: the app shell already pads by 4, and a
+     second px-4 here costs 64px of a 390px screen. -->
+<div class="mx-auto max-w-5xl py-8 sm:px-4">
 	<a href={backLink.href} class="text-sm text-text-muted hover:text-primary hover:underline">{backLink.label}</a>
 
 	{#if loading}
@@ -268,9 +270,9 @@
 
 		<!-- Piece stats -->
 		<section class="mt-6">
-			<div class="flex items-baseline justify-between">
+			<div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
 				<h2 class="text-lg font-semibold text-text">Sorting</h2>
-				<div class="flex items-baseline gap-4">
+				<div class="flex flex-wrap items-baseline gap-4">
 					<a
 						href={`/machines/${machine.id}/channel-crops`}
 						class="text-sm text-primary hover:underline">Channel crops →</a
@@ -379,11 +381,11 @@
 								<button
 									type="button"
 									onclick={() => toggle(backup.version)}
-									class="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-bg"
+									class="flex w-full flex-wrap items-center gap-x-3 gap-y-1 px-4 py-3 text-left hover:bg-bg"
 								>
 									<span class="font-mono text-sm font-semibold text-text">v{backup.version}</span>
 									<Badge text={backup.trigger} variant={triggerVariant(backup.trigger)} />
-									<span class="text-sm text-text-muted">{formatDate(backup.created_at)}</span>
+									<span class="min-w-0 truncate text-sm text-text-muted">{formatDate(backup.created_at)}</span>
 									<span class="ml-auto font-mono text-xs text-text-muted">{backup.content_hash.slice(0, 12)}</span>
 									<span class="text-text-muted">{expanded === backup.version ? '▾' : '▸'}</span>
 								</button>

--- a/software/hive/frontend/src/routes/machines/[machine_id]/channel-crops/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/channel-crops/+page.svelte
@@ -139,8 +139,8 @@
 	<a href={`/machines/${machineId}`} class="text-sm text-text-muted hover:text-text">← Machine overview</a>
 </div>
 
-<div class="mb-4 flex items-end justify-between">
-	<div>
+<div class="mb-4 flex flex-wrap items-end justify-between gap-x-4 gap-y-1">
+	<div class="min-w-0">
 		<h1 class="text-2xl font-bold text-text">{machineName || 'Machine'}</h1>
 		<p class="text-sm text-text-muted">
 			Unlabeled C2/C3 bbox crops synced from this machine — tagged with the piece's

--- a/software/hive/frontend/src/routes/machines/[machine_id]/pieces/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/pieces/+page.svelte
@@ -119,13 +119,13 @@
 	<a href={`/machines/${machineId}`} class="text-sm text-text-muted hover:text-text">← Machine overview</a>
 </div>
 
-<div class="mb-6 flex items-end justify-between">
-	<div>
+<div class="mb-6 flex flex-wrap items-end justify-between gap-x-4 gap-y-1">
+	<div class="min-w-0">
 		<h1 class="text-2xl font-bold text-text">{machineName || 'Machine'}</h1>
 		<p class="text-sm text-text-muted">Pieces synced from this machine</p>
 	</div>
 	{#if !loading}
-		<span class="text-sm text-text-muted">
+		<span class="shrink-0 text-sm text-text-muted">
 			{pieces.length.toLocaleString()} of {total.toLocaleString()} loaded
 		</span>
 	{/if}
@@ -147,9 +147,10 @@
 	<div class="flex flex-col gap-2">
 		{#each pieces as piece (piece.piece_uuid)}
 			{@const bin = binLabel(piece.bin)}
-			<div class="flex gap-4 border border-border bg-surface p-3">
-				<!-- Left: crops from the machine -->
-				<div class="flex shrink-0 flex-wrap items-start gap-1.5" style="max-width: 15rem">
+			<div class="flex flex-col gap-4 border border-border bg-surface p-3 sm:flex-row">
+				<!-- Left: crops from the machine. The 15rem cap only applies once
+				     there is a second column beside it. -->
+				<div class="flex flex-wrap items-start gap-1.5 sm:max-w-60 sm:shrink-0">
 					{#if piece.images.length === 0}
 						<div class="flex h-16 w-16 items-center justify-center border border-border bg-bg text-[10px] text-text-muted">
 							no images
@@ -205,7 +206,7 @@
 							<span>Bin: <span class="text-text tabular-nums">{bin}</span></span>
 						{/if}
 						{#if piece.run_id}
-							<span class="truncate">Run: <span class="text-text">{piece.run_id}</span></span>
+							<span class="min-w-0 truncate">Run: <span class="text-text">{piece.run_id}</span></span>
 						{/if}
 					</div>
 

--- a/software/hive/frontend/src/routes/models/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/models/[id]/+page.svelte
@@ -163,7 +163,7 @@
 			<!-- items-stretch + aspect-square on the swatch makes its height auto-match the
 				 text block's natural height (codename H1 + slug + name = ~3 lines) so the
 				 dot reads as a hero element proportional to its label. -->
-			<div class="flex items-stretch gap-4 border-b border-[var(--color-border)] px-5 py-4">
+			<div class="flex flex-wrap items-stretch gap-4 border-b border-[var(--color-border)] px-4 py-4 sm:flex-nowrap sm:px-5">
 				{#if model.codename_color}
 					<div class="flex shrink-0 items-center">
 						<span
@@ -200,7 +200,7 @@
 
 			<!-- Metric pills — 4 columns including Precision, since the detail page has room -->
 			{#if map50 !== null || map50_95 !== null || precision !== null || recall !== null}
-				<div class="grid grid-cols-4 gap-px border-b border-[var(--color-border)] bg-[var(--color-border)]">
+				<div class="grid grid-cols-2 gap-px border-b border-[var(--color-border)] bg-[var(--color-border)] sm:grid-cols-4">
 					<div class="bg-[var(--color-surface)] px-4 py-3">
 						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">mAP50</div>
 						<div class="font-mono text-lg font-semibold text-[var(--color-text)]">{formatPct(map50)}</div>
@@ -222,7 +222,7 @@
 
 			<!-- Spec pills: Model / Samples / Diversity -->
 			{#if arch || imgsz || samples !== null || diversityScore !== null}
-				<div class="grid grid-cols-3 gap-px bg-[var(--color-border)]">
+				<div class="grid grid-cols-2 gap-px bg-[var(--color-border)] sm:grid-cols-3">
 					<div class="bg-[var(--color-surface)] px-4 py-3">
 						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Model</div>
 						<div class="font-mono text-base font-semibold text-[var(--color-text)]">

--- a/software/hive/frontend/src/routes/profiles/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/+page.svelte
@@ -200,7 +200,7 @@
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onkeydown={(e) => { if (e.key === 'Escape') deleteTarget = null; }} onclick={() => deleteTarget = null}>
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
-			class="w-full max-w-md bg-surface p-6"
+			class="mx-4 w-full max-w-md bg-surface p-4 sm:p-6"
 			role="dialog"
 			aria-modal="true"
 			tabindex="-1"

--- a/software/hive/frontend/src/routes/profiles/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/[id]/+page.svelte
@@ -224,9 +224,9 @@
 				<div class="space-y-2">
 					{#each sortedCategories as cat}
 						<div class="flex items-center gap-3">
-							<div class="w-40 truncate text-sm text-text">{cat.name}{#if cat.isFallback} <span class="text-xs text-text-muted">(fallback)</span>{/if}</div>
+							<div class="w-24 truncate text-sm text-text sm:w-40">{cat.name}{#if cat.isFallback} <span class="text-xs text-text-muted">(fallback)</span>{/if}</div>
 							<div class="flex-1"><div class="h-5 bg-primary-light" style="width: {cat.pct}%"><div class="h-full bg-info" style="width: 100%"></div></div></div>
-							<div class="w-20 text-right text-sm text-text-muted">{cat.parts} parts</div>
+							<div class="w-16 shrink-0 text-right text-sm text-text-muted sm:w-20">{cat.parts} parts</div>
 						</div>
 					{/each}
 				</div>

--- a/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
@@ -1107,15 +1107,15 @@
 	<Alert variant="danger">No version available.</Alert>
 {:else}
 	<!-- Header -->
-	<div class="mb-4 flex items-center justify-between">
-		<div class="flex items-center gap-3">
-			<a href={`/profiles/${profile.id}`} class="text-text-muted hover:text-text" title="Back to profile">
+	<div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+		<div class="flex min-w-0 items-center gap-3">
+			<a href={`/profiles/${profile.id}`} class="shrink-0 text-text-muted hover:text-text" title="Back to profile">
 				<ArrowLeft size={20} />
 			</a>
-			<div>
-				<div class="group flex items-center gap-1.5">
+			<div class="min-w-0">
+				<div class="group flex min-w-0 items-center gap-1.5">
 					<!-- the hidden span sizes the grid cell so the input hugs the name and the pencil sits right after it -->
-					<div class="inline-grid items-center">
+					<div class="inline-grid min-w-0 max-w-full items-center overflow-hidden">
 						<span aria-hidden="true" class="invisible col-start-1 row-start-1 whitespace-pre border-b-2 border-transparent px-1 text-xl font-bold">{nameDraft || 'Untitled Profile'}</span>
 						<input
 							type="text"
@@ -1184,14 +1184,16 @@
 	{/if}
 
 	<!-- Main 2-column layout: Rules (left, wider) | Chat (right) -->
-	<div class="grid min-h-0 grid-cols-1 gap-4 overflow-hidden xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]" style="height: calc(100vh - 200px);">
+	<!-- The viewport-locked height only makes sense once the two panels sit side
+	     by side; stacked, it would split one screen between them. -->
+	<div class="grid min-h-0 grid-cols-1 gap-4 xl:h-[calc(100vh-200px)] xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] xl:overflow-hidden">
 
 		<!-- LEFT: Rules (accordion) -->
-		<div class="flex min-h-0 min-w-0 flex-col border border-border bg-surface">
-			<div class="flex items-center justify-between border-b border-border px-4 py-2">
+		<div class="flex min-h-[60vh] min-w-0 flex-col border border-border bg-surface xl:min-h-0">
+			<div class="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-2">
 				<h2 class="text-sm font-semibold text-text">Rules</h2>
 				{#if !isPreview}
-					<div class="flex items-center gap-1.5">
+					<div class="flex flex-wrap items-center gap-1.5">
 						<button onclick={() => addRule()}
 							class="border border-border bg-surface px-2.5 py-1 text-[11px] font-medium text-text-muted hover:bg-bg hover:text-text">
 							+ Rule
@@ -1208,8 +1210,8 @@
 				{/if}
 			</div>
 			{#if isPreview}
-				<div class="flex items-center justify-between border-b border-warning/30 bg-warning/[0.1] px-4 py-2">
-					<span class="text-xs font-medium text-warning-strong">
+				<div class="flex flex-wrap items-center justify-between gap-2 border-b border-warning/30 bg-warning/[0.1] px-4 py-2">
+					<span class="min-w-0 text-xs font-medium text-warning-strong">
 						Viewing v{previewVersion?.version_number}
 						{#if previewVersion?.change_note}
 							— {previewVersion.change_note}
@@ -1342,7 +1344,7 @@
 	<!-- Sticky bottom bar -->
 	{#if hasUnsavedChanges}
 		<div class="fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-surface px-4 py-3">
-			<div class="mx-auto flex max-w-7xl items-center justify-between">
+			<div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-2">
 				<div class="flex items-center gap-2 text-sm text-text-muted">
 					<span class="inline-block h-2 w-2 bg-warning"></span>
 					Unsaved changes

--- a/software/hive/frontend/src/routes/profiles/new/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/new/+page.svelte
@@ -117,7 +117,7 @@
 		<!-- Profile Type Toggle -->
 		<div>
 			<div class="mb-2 text-sm font-medium text-text">Profile Type</div>
-			<div class="flex gap-2">
+			<div class="flex flex-col gap-2 sm:flex-row">
 				<button
 					type="button"
 					class="flex-1 border px-4 py-3 text-sm font-medium transition-colors {profileType === 'rule'

--- a/software/hive/frontend/src/routes/review/+page.svelte
+++ b/software/hive/frontend/src/routes/review/+page.svelte
@@ -487,7 +487,7 @@
 			Arrow up accepts, arrow down rejects, arrow right skips, arrow left goes back{#if FEATURES.ANNOTATION_EDITING}, and <kbd class="border border-border bg-bg px-1.5 py-0.5 text-[11px] font-semibold text-text">D</kbd> toggles annotation{/if}.
 		</p>
 		{#if activeFilterChips.length > 0}
-			<div class="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
+			<div class="mt-2 flex flex-wrap items-center gap-2 break-all text-[11px]">
 				<span class="text-text-muted">Scoped to:</span>
 				{#each activeFilterChips as [key, value] (key)}
 					<span class="border border-border bg-bg px-1.5 py-0.5 text-text-muted">
@@ -500,7 +500,7 @@
 	</div>
 	<!-- Kind switcher — flips the queue between regular detection samples and
 	     piece-condition crops without leaving the review page. -->
-	<div class="flex border border-border bg-surface text-xs">
+	<div class="flex flex-wrap border border-border bg-surface text-xs">
 		{#each [
 			{ value: '', label: 'All' },
 			{ value: 'regular', label: 'Regular' },

--- a/software/hive/frontend/src/routes/samples/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/+page.svelte
@@ -634,14 +634,14 @@
 	<title>Samples - Hive</title>
 </svelte:head>
 
-<div class="mb-6 flex items-center justify-between">
-	<div>
+<div class="mb-6 flex flex-wrap items-center justify-between gap-3">
+	<div class="min-w-0">
 		<h1 class="text-2xl font-bold text-text">Samples</h1>
 		<p class="mt-1 text-sm text-text-muted">
 			Browse and review training samples captured by your machines.
 		</p>
 	</div>
-	<div class="flex items-center gap-2">
+	<div class="flex flex-wrap items-center gap-2">
 		<a
 			href="/samples/diversity"
 			class="inline-flex items-center gap-2 border border-border bg-surface px-4 py-2 text-sm font-medium text-text hover:bg-bg"
@@ -754,8 +754,8 @@
 	{@const pct = job.total > 0 ? Math.round((job.processed / job.total) * 100) : 0}
 	{@const eta = computeEta(job)}
 	<div class="mb-4 border border-border bg-surface">
-		<div class="flex items-center justify-between gap-3 border-b border-border px-4 py-2.5">
-			<div class="flex items-center gap-2 text-xs">
+		<div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-b border-border px-4 py-2.5">
+			<div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
 				<span class="font-semibold text-text">Teacher job</span>
 				<span class="text-text-muted">{job.openrouter_model}</span>
 				<span class="tabular-nums text-text">{job.processed}/{job.total}</span>
@@ -782,7 +782,7 @@
 					</span>
 				{/if}
 			</div>
-			<div class="flex items-center gap-3">
+			<div class="flex flex-wrap items-center gap-3">
 				<a href={`/admin/teacher-jobs/${job.id}`} class="text-xs text-primary hover:underline">
 					Open details →
 				</a>
@@ -859,7 +859,7 @@
 			{#if hasActiveFilters}
 				<div class="border border-border bg-bg px-3 py-2 text-xs">
 					<div class="mb-1 font-semibold text-text-muted">Active filter</div>
-					<div class="flex flex-wrap gap-1.5">
+					<div class="flex flex-wrap gap-1.5 break-all">
 						{#if filterScope === 'mine'}<span class="border border-border px-1.5 py-0.5 text-text">scope=mine</span>{/if}
 						{#if filterMachine}<span class="border border-border px-1.5 py-0.5 text-text">machine={filterMachine}</span>{/if}
 						{#if filterSourceRole}<span class="border border-border px-1.5 py-0.5 text-text">source_role={filterSourceRole}</span>{/if}
@@ -936,7 +936,7 @@
 			{#if hasActiveFilters}
 				<div class="border border-border bg-bg px-3 py-2 text-xs">
 					<div class="mb-1 font-semibold text-text-muted">Active filter</div>
-					<div class="flex flex-wrap gap-1.5">
+					<div class="flex flex-wrap gap-1.5 break-all">
 						{#if filterMachine}<span class="border border-border px-1.5 py-0.5 text-text">machine={filterMachine}</span>{/if}
 						{#if filterSourceRole}<span class="border border-border px-1.5 py-0.5 text-text">source_role={filterSourceRole}</span>{/if}
 						{#if filterCaptureReason}<span class="border border-border px-1.5 py-0.5 text-text">capture_reason={filterCaptureReason}</span>{/if}
@@ -1048,10 +1048,11 @@
 	</div>
 {/if}
 
-<div class="flex gap-5">
-	<!-- Sidebar filters -->
-	<aside class="w-48 shrink-0">
-		<div class="sticky top-20 space-y-1">
+<div class="flex flex-col gap-5 lg:flex-row">
+	<!-- Sidebar filters. Below lg the rail becomes a full-width block stacked
+	     above the grid — a 192px column leaves ~150px for the samples. -->
+	<aside class="w-full shrink-0 lg:w-48">
+		<div class="space-y-1 lg:sticky lg:top-20">
 			{#if hasActiveFilters}
 				<button onclick={clearFilters} class="flex items-center gap-1 text-xs text-primary hover:underline">
 					<svg class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
@@ -1366,8 +1367,8 @@
 
 			<!-- Pagination -->
 			{#if data.pages > 1}
-				<div class="mt-6 flex items-center justify-between border border-border bg-surface px-4 py-2.5">
-					<div class="flex items-center gap-3">
+				<div class="mt-6 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border border-border bg-surface px-4 py-2.5">
+					<div class="flex flex-wrap items-center gap-3">
 						<span class="text-xs text-text-muted">{(data.page - 1) * pageSize + 1}–{Math.min(data.page * pageSize, data.total)} of {data.total.toLocaleString()}</span>
 						<select
 							value={pageSize}
@@ -1381,7 +1382,7 @@
 							<option value={100}>100 / page</option>
 						</select>
 					</div>
-					<div class="flex items-center gap-1">
+					<div class="flex flex-wrap items-center gap-1">
 						<button
 							onclick={() => goToPage(currentPage - 1)}
 							disabled={currentPage <= 1}

--- a/software/hive/frontend/src/routes/samples/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/[id]/+page.svelte
@@ -487,7 +487,7 @@
 	<p class="text-text-muted">Sample not found.</p>
 {:else}
 	<!-- Header bar -->
-	<div class="mb-5 flex items-center justify-between gap-3">
+	<div class="mb-5 flex flex-wrap items-center justify-between gap-3">
 		<div class="flex items-center gap-3">
 			<a href={listBackHref} class="flex items-center gap-1 text-sm text-text-muted hover:text-text transition-colors">
 				<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
@@ -496,7 +496,7 @@
 			<span class="text-border">/</span>
 			<span class="text-sm font-medium text-text" title={sample.local_sample_id}>{shortId(sample.local_sample_id)}</span>
 		</div>
-		<div class="flex items-center gap-2">
+		<div class="flex flex-wrap items-center gap-2">
 			<div class="flex items-center gap-1" title="Use ← / → to navigate samples">
 				<button
 					type="button"
@@ -524,7 +524,7 @@
 			{#if sample.review_count > 0}
 				<span class="text-xs text-text-muted">{sample.review_count} review{sample.review_count !== 1 ? 's' : ''}</span>
 			{/if}
-			<div class="ml-1 flex items-center gap-1.5">
+			<div class="flex flex-wrap items-center gap-1.5 sm:ml-1">
 				<a
 					href={`/samples/${sample.id}/similar`}
 					class="inline-flex items-center gap-1 border border-border bg-surface px-3 py-1 text-xs font-medium text-text hover:bg-bg"
@@ -552,7 +552,7 @@
 		<!-- Left: Image area -->
 		<div class="min-w-0 space-y-3">
 			<!-- View toggle toolbar (above image) -->
-			<div class="flex items-center gap-1 bg-bg p-1">
+			<div class="flex flex-wrap items-center gap-1 bg-bg p-1">
 				<button
 					onclick={() => setView('image')}
 					class="px-3 py-1.5 text-xs font-medium transition-colors {activeView === 'image' ? 'bg-surface text-text' : 'text-text-muted hover:text-text'}"

--- a/software/hive/frontend/src/routes/samples/[id]/compare/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/[id]/compare/+page.svelte
@@ -136,8 +136,8 @@
 	<title>Compare models · Sample · Hive</title>
 </svelte:head>
 
-<div class="mb-5 flex items-end justify-between gap-3">
-	<div>
+<div class="mb-5 flex flex-wrap items-end justify-between gap-3">
+	<div class="min-w-0">
 		<div class="mb-1 text-xs text-text-muted">
 			<a href="/samples" class="hover:underline">Samples</a>
 			<span class="mx-1">/</span>
@@ -152,7 +152,7 @@
 			One image tile per model. Non-destructive — the sample's stored detection is not touched.
 		</p>
 	</div>
-	<div class="flex items-center gap-2">
+	<div class="flex shrink-0 items-center gap-2">
 		<Button variant="primary" size="sm" onclick={runAll}>Run all models</Button>
 	</div>
 </div>

--- a/software/hive/frontend/src/routes/samples/[id]/similar/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/[id]/similar/+page.svelte
@@ -72,7 +72,7 @@
 
 	<div class="flex flex-wrap items-center gap-2 border border-border bg-surface px-3 py-2">
 		<span class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">Max distance</span>
-		<div class="inline-flex border border-border">
+		<div class="flex flex-wrap border border-border">
 			{#each DISTANCE_OPTIONS as opt}
 				<button
 					type="button"

--- a/software/hive/frontend/src/routes/samples/diversity/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/diversity/+page.svelte
@@ -86,8 +86,8 @@
 	<title>Diversity - Hive</title>
 </svelte:head>
 
-<div class="mb-6 flex items-center justify-between gap-4">
-	<div>
+<div class="mb-6 flex flex-wrap items-center justify-between gap-4">
+	<div class="min-w-0">
 		<div class="mb-1 text-xs text-text-muted">
 			<a href="/samples" class="hover:underline">Samples</a>
 			<span class="mx-1">/</span>
@@ -164,7 +164,7 @@
 					</div>
 					<Sparkline values={group.coverage_trend} height={72} />
 				</div>
-				<div class="mt-2 flex items-center justify-between gap-2 text-[11px] text-text-muted">
+				<div class="mt-2 flex flex-wrap items-center justify-between gap-x-2 gap-y-0.5 text-[11px] text-text-muted">
 					<span>
 						{group.by_source_role.length} source{group.by_source_role.length === 1 ? '' : 's'}
 					</span>

--- a/software/hive/frontend/src/routes/samples/diversity/[reason]/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/diversity/[reason]/+page.svelte
@@ -106,8 +106,8 @@
 	<title>{prettifyToken(captureReason)} - Diversity - Hive</title>
 </svelte:head>
 
-<div class="mb-6 flex items-center justify-between">
-	<div>
+<div class="mb-6 flex flex-wrap items-center justify-between gap-4">
+	<div class="min-w-0">
 		<div class="mb-1 text-xs text-text-muted">
 			<a href="/samples" class="hover:underline">Samples</a>
 			<span class="mx-1">/</span>
@@ -143,7 +143,7 @@
 {:else}
 	<section class="mb-4 border border-border bg-surface p-4">
 		<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-			<div class="flex items-center gap-4">
+			<div class="flex flex-wrap items-center gap-4">
 				<DiversityDonut
 					bucketFills={group.bucket_fills}
 					bucketKeys={data.bucket_keys}
@@ -202,7 +202,7 @@
 					</div>
 					<Sparkline values={role.coverage_trend} height={72} />
 				</div>
-				<div class="mt-2 flex items-center justify-between gap-2 text-[11px] text-text-muted">
+				<div class="mt-2 flex flex-wrap items-center justify-between gap-x-2 gap-y-0.5 text-[11px] text-text-muted">
 					<span class={role.machine_factor < 1 ? 'text-warning-strong' : ''} title={`coverage × ${role.machine_factor.toFixed(2)}`}>
 						{role.machine_count}/{role.machine_target} machines
 					</span>

--- a/software/hive/frontend/src/routes/settings/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/+page.svelte
@@ -473,7 +473,7 @@
 				</div>
 				<div>
 					<dt class="text-text-muted">Email</dt>
-					<dd class="font-medium text-text">{auth.user.email}</dd>
+					<dd class="break-all font-medium text-text">{auth.user.email}</dd>
 				</div>
 				<div>
 					<dt class="text-text-muted">GitHub</dt>
@@ -912,8 +912,8 @@
 				{#if apiKeys.length === 0}
 					<p class="text-sm text-text-muted">No tokens yet.</p>
 				{:else}
-					<div class="border border-border">
-						<table class="w-full text-sm">
+					<div class="overflow-x-auto border border-border">
+						<table class="w-full min-w-[52rem] text-sm">
 							<thead class="border-b border-border bg-bg text-left text-xs uppercase tracking-wide text-text-muted">
 								<tr>
 									<th class="px-3 py-2">Name</th>

--- a/software/hive/frontend/src/routes/settings/catalog-sync/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/catalog-sync/+page.svelte
@@ -223,7 +223,7 @@
 					{/if}
 
 					{#if state.last_message}
-						<p class="mt-3 text-sm text-text">{state.last_message}</p>
+						<p class="mt-3 break-words text-sm text-text">{state.last_message}</p>
 					{/if}
 
 					{#if state.error && state.status !== 'running'}

--- a/software/hive/frontend/src/routes/styleguide/+page.svelte
+++ b/software/hive/frontend/src/routes/styleguide/+page.svelte
@@ -168,7 +168,7 @@
 	<section class="space-y-4">
 		<h2 class="text-lg font-semibold tracking-tight">Stat Cards</h2>
 		<p class="text-sm text-text-muted">Colored label + dot indicator. The label text and dot carry the semantic color.</p>
-		<div class="grid grid-cols-4 gap-4">
+		<div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
 			<div class="border border-border bg-surface p-4">
 				<p class="flex items-center gap-2 text-xs font-medium text-info"><span class="inline-block h-2.5 w-2.5 bg-info"></span>In Review</p>
 				<p class="font-mono text-2xl font-bold">9</p>
@@ -192,7 +192,7 @@
 	<!-- ─── Profile Cards ─── -->
 	<section class="space-y-4">
 		<h2 class="text-lg font-semibold tracking-tight">Profile Cards</h2>
-		<div class="grid grid-cols-3 gap-4">
+		<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
 			<a href="#" class="border border-border bg-surface p-4 transition-colors hover:border-text-muted">
 				<p class="font-semibold">My Star Wars Collection</p>
 				<p class="text-xs text-text-muted">Set-based profile</p>
@@ -274,7 +274,7 @@
 	<section class="space-y-4">
 		<h2 class="text-lg font-semibold tracking-tight">Tab Navigation</h2>
 		<div class="border border-border bg-surface p-6">
-			<div class="inline-flex border border-border p-1">
+			<div class="flex flex-wrap border border-border p-1">
 				<button class="px-3 py-1.5 text-sm font-medium text-text-muted hover:text-text hover:bg-bg">Discover</button>
 				<button class="px-3 py-1.5 text-sm font-medium text-text-muted hover:text-text hover:bg-bg">My Library</button>
 				<button class="bg-primary-light px-3 py-1.5 text-sm font-medium text-primary">My Profiles</button>
@@ -311,7 +311,7 @@
 	<section class="space-y-4">
 		<h2 class="text-lg font-semibold tracking-tight">Dropdown Menu</h2>
 		<div class="border border-border bg-surface p-6">
-			<div class="flex gap-8">
+			<div class="flex flex-wrap gap-8">
 				<div class="relative">
 					<button class="flex items-center gap-2 border border-border px-3 py-1.5 text-sm font-medium text-text hover:bg-bg">
 						User Menu
@@ -319,7 +319,7 @@
 							<path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
 						</svg>
 					</button>
-					<div class="absolute left-0 z-50 mt-1 w-56 border border-border bg-surface py-1">
+					<div class="absolute left-0 z-50 mt-1 w-56 max-w-[calc(100vw-3rem)] border border-border bg-surface py-1">
 						<div class="px-4 py-2 text-xs font-medium uppercase tracking-wider text-text-muted">Account</div>
 						<a href="#" class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg">Settings</a>
 						<a href="#" class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg">Profile</a>
@@ -333,7 +333,7 @@
 							<path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
 						</svg>
 					</button>
-					<div class="absolute left-0 z-50 mt-1 w-48 border border-border bg-surface py-1">
+					<div class="absolute left-0 z-50 mt-1 w-48 max-w-[calc(100vw-3rem)] border border-border bg-surface py-1">
 						<a href="#" class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg">Edit</a>
 						<a href="#" class="flex items-center gap-2 px-4 py-2 text-sm text-text hover:bg-bg">Duplicate</a>
 						<div class="my-1 border-b border-border"></div>
@@ -350,7 +350,7 @@
 		<h2 class="text-lg font-semibold tracking-tight">Icon Buttons</h2>
 		<div class="border border-border bg-surface p-6">
 			<div class="flex flex-wrap items-center gap-4">
-				<div class="flex items-center gap-1">
+				<div class="flex flex-wrap items-center gap-1">
 					<button class="p-1 text-text-muted hover:text-text" title="Move up">
 						<svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
 							<path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd" />
@@ -514,7 +514,7 @@
 				<code class="bg-bg px-1">size</code> (px); never hand-roll an <code class="bg-bg px-1">animate-spin</code> ring. It inherits its color from
 				<code class="bg-bg px-1">currentColor</code>.
 			</p>
-			<div class="flex items-end gap-8">
+			<div class="flex flex-wrap items-end gap-8">
 				<div class="flex flex-col items-center gap-2">
 					<Spinner size={32} class="text-primary" />
 					<span class="text-xs text-text-muted">Page — size={32}</span>
@@ -578,7 +578,7 @@
 	<!-- ─── Data Table ─── -->
 	<section class="space-y-4">
 		<h2 class="text-lg font-semibold tracking-tight">Data Table</h2>
-		<div class="border border-border bg-surface">
+		<div class="overflow-x-auto border border-border bg-surface">
 			<table class="min-w-full divide-y divide-border">
 				<thead class="bg-bg">
 					<tr>
@@ -611,7 +611,7 @@
 	<section class="space-y-4">
 		<h2 class="text-lg font-semibold tracking-tight">Pagination</h2>
 		<div class="border border-border bg-surface p-6">
-			<div class="flex items-center gap-1">
+			<div class="flex flex-wrap items-center gap-1">
 				<button class="border border-border px-3 py-1.5 text-sm font-medium text-text hover:bg-bg disabled:opacity-50" disabled>Previous</button>
 				<button class="border border-border px-3 py-1.5 text-sm font-medium bg-primary text-white">1</button>
 				<button class="border border-border px-3 py-1.5 text-sm font-medium text-text hover:bg-bg">2</button>
@@ -693,7 +693,7 @@
 		<div class="border border-border bg-surface p-6">
 			<div class="relative inline-block">
 				<button class="bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-hover">Save Version</button>
-				<div class="absolute left-0 top-full z-50 mt-2 w-72 border border-border bg-surface p-4">
+				<div class="absolute left-0 top-full z-50 mt-2 w-72 max-w-[calc(100vw-3rem)] border border-border bg-surface p-4">
 					<h3 class="mb-2 text-sm font-semibold">Save New Version</h3>
 					<input type="text" placeholder="Change note (optional)" class="mb-3 w-full border border-border px-2 py-1 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary" />
 					<div class="flex justify-end gap-2">
@@ -754,7 +754,7 @@
 	<!-- ─── Card Grid ─── -->
 	<section class="space-y-4">
 		<h2 class="text-lg font-semibold tracking-tight">Card Grid</h2>
-		<div class="grid grid-cols-3 gap-4">
+		<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
 			<div class="border border-border border-t-2 border-t-success bg-surface text-left">
 				<div class="aspect-square overflow-hidden bg-bg">
 					<div class="flex h-full items-center justify-center text-sm text-text-muted">Image</div>


### PR DESCRIPTION
Hive was built desktop-first and had never been looked at on a phone. On an iPhone (~390px) the nav bar ran off-screen, the dashboard action row overflowed, and most pages scrolled sideways. This is an additive `sm:`/`lg:` pass — no desktop restyling.

## Root causes

Four shapes, repeated everywhere:

1. **Fixed-width columns that never collapse.** `w-48` filter rails, `w-40`/`w-28` label tracks, `max-width: 15rem` crop columns. On the samples page the 192px rail left ~146px for the sample grid.
2. **`flex … justify-between` header rows with no `flex-wrap`.** A title plus 3–6 action buttons is 500–900px wide and simply hangs off the right edge.
3. **Multi-track grids with no responsive prefix.** The leaderboard's `grid-cols-[40px_1fr_90px_150px_120px]` needs 480px of fixed tracks and gutters before the name column gets a single pixel, against 358px of usable width.
4. **Unbreakable strings and unwrapped tables.** UUIDs, `.onnx` filenames, filesystem paths, callback URLs and raw API errors with a URL in them; plus wide tables rendered without an `overflow-x-auto` container, so the *page* scrolled instead of the table.

One subtler cause worth calling out: `admin/control-data` already wrapped its table in `overflow-x-auto`, but the wrapper sat in a grid item, and grid items default to `min-width: auto` — so the track sized to the widest cell and the scroller never engaged. `min-w-0` on the item was the whole fix.

## Nav

The seven links plus wordmark, theme toggle and user menu need ~860px on one line, so the breakpoint is `lg` (1024px), not `md`. Below that they collapse into a slide-in drawer behind a hamburger (`lucide-svelte/icons/menu` / `icons/x`), with a `bg-black/50` scrim. The wordmark, theme toggle and user menu stay in the bar.

- Link list is data (`navLinks`), so the desktop bar and the drawer can't drift apart.
- Closes on link click, Escape, scrim click, and any navigation — the last via an `$effect` keyed on the pathname, which also covers the back button.
- Body scroll is locked while it's open.
- The user-menu trigger truncates a long display name rather than widening the bar; its dropdown is capped to the viewport and scrolls when the admin section makes it tall.
- The layout's legacy inline SVGs were replaced with lucide icons, per the frontend `CLAUDE.md` rule about replacing them when you touch that markup.

## What changed, by area

**Nav / shell** — `+layout.svelte`: hamburger drawer, truncating user menu, lucide icons.

**Shared components** — `Alert` (`break-words`; a catalog-sync 404 carrying a URL was widening the page), `Tooltip` (`whitespace-nowrap` → `w-max max-w-[min(16rem,80vw)]`), `Modal` (90vh cap + own scroll, lighter mobile padding, lucide close icon), `ModelTrainingReport` (the 5-track inference table needed 416px; drops the decorative throughput bar below `sm`), `BarList`, `ModelCard`, `PieceLabelPanel` (its fixed-position quality menu is placed at a JS-computed `left` and hung off-screen — now clamped), `ReviewActionPad`, `RuleAccordionNode` (indent halved below `sm`; it compounded per nesting level with no cap).

**Dashboard** — quick-action row wraps.

**Leaderboard** — below `sm`, rank / name / total stay on line one and the breakdown + last-activity move to a second grid row, so nothing is hidden rather than columns being dropped.

**Samples** — filter rail becomes a full-width block above the grid below `lg` (and is only `sticky` at `lg`); header actions, teacher-job banner and pagination wrap; UUID chips break.

**Sample detail / similar / compare / diversity** — header clusters, view-toggle toolbar and the distance segmented control wrap; the 180px donut no longer collides with its text.

**Machines** — list + detail headers wrap; the detail page dropped its doubled `px-4` (64px of a 390px screen); config-backup rows wrap; the piece list stacks its crop column above the details instead of starving it to zero.

**Models** — detail page's 4-up metric strip and 3-up spec strip go 2-up below `sm`.

**Admin / settings / profiles** — token table and users table get real scrollers; `control-data` grid `min-w-0`; parts `<select>` capped; teacher-job pagination wraps; paths and filenames break. The profile editor's `height: calc(100vh - 200px)` was splitting a single screen between the stacked rules and chat panels — the viewport lock is now `xl`-only, where the panels actually sit side by side.

**Styleguide** — table scroller, wrapping pagination/tabs/dropdown demos, stacking card grids.

## Verification

`pnpm check` → **0 errors** (18 pre-existing warnings, unchanged). `pnpm build` → green.

Browsed the real app against a dev server, in a same-origin harness that renders the app in an iframe at an exact CSS width (the Chrome window here is maximized and can't be resized, and media queries resolve against the iframe viewport). Measured `document.documentElement.scrollWidth` vs `innerWidth` on every route, plus every element extending past the right edge.

At **390px**, `scrollWidth === 390` (no horizontal body scroll) on: `/`, `/machines`, `/samples`, `/piece-bboxes`, `/models`, `/profiles`, `/profiles/new`, `/leaderboard`, `/settings`, `/settings/catalog-sync`, `/review`, `/samples/diversity`, `/styleguide`, `/login`, `/register`, `/forget`, `/machine-ip-lookup`, `/admin/users`, `/admin/machines`, `/admin/control-data`, `/admin/server-health`, `/admin/parts`, `/admin/teacher-jobs`, `/admin/color-models`, `/admin/link-models`, `/admin/access-windows`. The only elements still wider than the viewport are the admin data tables, which now live inside their own `overflow-x-auto` scrollers — that is the intended behavior.

Nav breakpoint checked at 360 / 390 / 768 / 900 / 1024 / 1280: hamburger below `lg`, full bar at 1280, and the drawer opens and closes correctly. Desktop spot-checks at 1280 on `/`, `/samples`, `/leaderboard`, `/settings`, `/models`, `/machines` — `scrollWidth === 1280`, layout visually identical to before.

The dev backend has no sample/model/machine/profile rows, so the data-bearing detail routes could only be exercised in their empty states. The leaderboard row rewrite was verified by measuring the real markup injected into the live page at 390px: 357px wide, two rows, nothing clipped.

## Found but deliberately not fixed

- **`/piece-bboxes` at mobile** puts the labeling pane below the entire card list, so opening a piece scrolls you past N cards to reach it. Nothing overflows; fixing it properly means a mobile-specific flow, not a breakpoint.
- **Admin tables stay wide** and scroll horizontally inside their containers rather than being re-cut as mobile cards. `/admin/access-windows` in particular is ~900px of editable cells; a card layout would be a redesign.
- **`/models/+page.svelte`** uses raw `text-[var(--color-text)]` / `bg-[var(--color-surface)]` instead of the `text-text` / `bg-surface` token utilities the design system prefers. Cosmetic and out of scope here.
- **A 1024px-wide browser window gets the mobile nav**, because the classic scrollbar takes the media-query width to ~1009px. Harmless, and widening the breakpoint would let the bar overflow again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)