### PR TITLE
Hive frontend: fix white-on-white inverted controls in dark mode

### DIFF
--- a/software/hive/frontend/src/lib/components/SampleAnnotator.svelte
+++ b/software/hive/frontend/src/lib/components/SampleAnnotator.svelte
@@ -619,10 +619,10 @@
 		<div class="flex flex-wrap items-center gap-2">
 			<div class="inline-flex border border-border bg-bg p-1">
 				<button type="button" onclick={() => { activeTool = 'rectangle'; }}
-					class="px-3 py-1.5 text-xs font-medium transition-colors {activeTool === 'rectangle' ? 'bg-text text-white' : 'text-text-muted hover:bg-surface'}"
+					class="px-3 py-1.5 text-xs font-medium transition-colors {activeTool === 'rectangle' ? 'bg-text text-surface' : 'text-text-muted hover:bg-surface'}"
 				>Rectangle</button>
 				<button type="button" onclick={() => { activeTool = 'polygon'; }}
-					class="px-3 py-1.5 text-xs font-medium transition-colors {activeTool === 'polygon' ? 'bg-text text-white' : 'text-text-muted hover:bg-surface'}"
+					class="px-3 py-1.5 text-xs font-medium transition-colors {activeTool === 'polygon' ? 'bg-text text-surface' : 'text-text-muted hover:bg-surface'}"
 				>Polygon</button>
 			</div>
 			<button type="button" onclick={() => { void saveAnnotations(); }} disabled={saving || !isDirty}

--- a/software/hive/frontend/src/lib/components/review/ReviewAnnotatorPanel.svelte
+++ b/software/hive/frontend/src/lib/components/review/ReviewAnnotatorPanel.svelte
@@ -44,14 +44,14 @@
 		<button
 			type="button"
 			onclick={() => { annotatorApi.activeTool = 'rectangle'; }}
-			class="px-3 py-1.5 text-xs font-medium transition-colors {annotatorApi.activeTool === 'rectangle' ? 'bg-text text-white' : 'text-text-muted hover:bg-surface'}"
+			class="px-3 py-1.5 text-xs font-medium transition-colors {annotatorApi.activeTool === 'rectangle' ? 'bg-text text-surface' : 'text-text-muted hover:bg-surface'}"
 		>
 			Rectangle
 		</button>
 		<button
 			type="button"
 			onclick={() => { annotatorApi.activeTool = 'polygon'; }}
-			class="px-3 py-1.5 text-xs font-medium transition-colors {annotatorApi.activeTool === 'polygon' ? 'bg-text text-white' : 'text-text-muted hover:bg-surface'}"
+			class="px-3 py-1.5 text-xs font-medium transition-colors {annotatorApi.activeTool === 'polygon' ? 'bg-text text-surface' : 'text-text-muted hover:bg-surface'}"
 		>
 			Polygon
 		</button>

--- a/software/hive/frontend/src/lib/components/sample/SampleConditionTagger.svelte
+++ b/software/hive/frontend/src/lib/components/sample/SampleConditionTagger.svelte
@@ -188,7 +188,7 @@
 					<button
 						type="button"
 						class="border px-2.5 py-1 text-[11px] font-medium {flags[chip.value]
-							? 'border-text bg-text text-white'
+							? 'border-text bg-text text-surface'
 							: 'border-border bg-surface text-text-muted hover:border-text'}"
 						onclick={() => toggleFlag(chip.value)}
 					>

--- a/software/hive/frontend/src/routes/link-machine/+page.svelte
+++ b/software/hive/frontend/src/routes/link-machine/+page.svelte
@@ -188,7 +188,7 @@
 </svelte:head>
 
 <div class="mx-auto grid min-h-[70vh] max-w-2xl place-items-center">
-	<div class="w-full border border-border bg-surface p-6 shadow-sm dark:bg-[var(--color-surface)]">
+	<div class="w-full border border-border bg-surface p-6 shadow-sm">
 		<div class="flex items-start gap-3">
 			<div class="flex h-10 w-10 shrink-0 items-center justify-center bg-primary-light text-primary">
 				<svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
@@ -291,7 +291,7 @@
 								<select
 									bind:value={selectedMachineId}
 									disabled={submitting}
-									class="border border-border bg-surface px-3 py-2 text-sm text-text focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none disabled:opacity-60 dark:bg-[var(--color-bg)]"
+									class="border border-border bg-surface px-3 py-2 text-sm text-text focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none disabled:opacity-60 dark:bg-bg"
 								>
 									{#each machines as machine}
 										<option value={machine.id}>
@@ -315,7 +315,7 @@
 							type="text"
 							required
 							disabled={submitting}
-							class="border border-border bg-surface px-3 py-2 text-sm text-text focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none disabled:opacity-60 dark:bg-[var(--color-bg)]"
+							class="border border-border bg-surface px-3 py-2 text-sm text-text focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none disabled:opacity-60 dark:bg-bg"
 						/>
 					</label>
 
@@ -326,7 +326,7 @@
 							rows="3"
 							disabled={submitting}
 							placeholder="Where this sorter lives, who maintains it, or what it is used for."
-							class="resize-y border border-border bg-surface px-3 py-2 text-sm text-text focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none disabled:opacity-60 dark:bg-[var(--color-bg)]"
+							class="resize-y border border-border bg-surface px-3 py-2 text-sm text-text focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none disabled:opacity-60 dark:bg-bg"
 						></textarea>
 					</label>
 				{/if}

--- a/software/hive/frontend/src/routes/samples/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/+page.svelte
@@ -680,7 +680,7 @@
 			<button
 				type="button"
 				onclick={() => openArchiveModal(filterArchived === 'archived' ? 'unarchive' : 'archive')}
-				class="inline-flex items-center gap-2 border border-border px-4 py-2 text-sm font-medium text-text hover:border-text hover:bg-text hover:text-white"
+				class="inline-flex items-center gap-2 border border-border px-4 py-2 text-sm font-medium text-text hover:border-text hover:bg-text hover:text-surface"
 				title={hasActiveFilters
 					? (filterArchived === 'archived'
 						? 'Unarchive every sample matching the current filter'


### PR DESCRIPTION
## What

The 2026-08-08 dark-mode sweep validated with `rg "bg-\[#"`, which only catches frozen **hex literals**. It cannot catch the other way a control breaks in dark mode: pairing a **flipping** token background with a **fixed** foreground.

`bg-text` flips (`#1A1A1A` light → `#f3efe8` dark). Six call sites paired it with `text-white`, so in dark mode they render white ink on a near-white surface — contrast ~1.05:1, effectively invisible:

| File | Control |
|---|---|
| `SampleAnnotator.svelte:622,625` | Rectangle / Polygon tool toggle (active state) |
| `review/ReviewAnnotatorPanel.svelte:47,54` | same toggle in the review panel |
| `sample/SampleConditionTagger.svelte:191` | condition chips (selected state) |
| `routes/samples/+page.svelte:683` | "Archive filtered" button (hover state) |

## Fix

`text-white` → `text-surface` on those `bg-text` surfaces. That is the pairing `Tooltip.svelte:43` already uses, so it is the codebase's established convention rather than a new one.

**Light mode is byte-identical** — `--color-surface` is `#FFFFFF` in light, exactly what `text-white` resolved to. Dark mode goes from ~1.05:1 to ~15:1.

Verified against the live dev Hive in dark mode, forcing both states on the real page with the real tokens:

- before (`text-white`): `fg=rgb(255,255,255)` on `bg=rgb(243,239,232)`
- after (`text-surface`): `fg=rgb(31,27,24)` on `bg=rgb(243,239,232)`

## Also

Dropped a no-op `dark:bg-[var(--color-surface)]` on `link-machine` (identical to the `bg-surface` already on the element) and rewrote its three `dark:bg-[var(--color-bg)]` inputs as `dark:bg-bg`. Same rendering, token utilities instead of arbitrary values.

## Not changed

- Every remaining `text-white` sits on a **fixed** brand color (`bg-primary`, `bg-danger`, `bg-success`, `bg-info`, `bg-canvas/85`) or a photo chip — correct in both themes.
- The hex literals still in `src/` are all in the exemptions `CLAUDE.md` names: styleguide palette swatches, data-viz palettes over photos (`bbox-helpers.ts`, annotator boxes, model-compare, the Sparkline/DiversityDonut ramp midpoints), and `bg-black/50` scrims.
- `rg "-\[#" src/` outside the styleguide swatches is clean.

## Validation

`pnpm check` — 0 errors (18 pre-existing a11y warnings, all in the styleguide). `pnpm build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)