### PR TITLE
Hive frontend: use token utilities instead of arbitrary var() classes

### DIFF
--- a/software/hive/frontend/src/lib/components/ModelCard.svelte
+++ b/software/hive/frontend/src/lib/components/ModelCard.svelte
@@ -81,14 +81,14 @@
 
 <a
 	href="/models/{model.id}"
-	class="block border border-[var(--color-border)] bg-[var(--color-surface)] transition-colors hover:border-primary"
+	class="block border border-border bg-surface transition-colors hover:border-primary"
 >
 	<!-- Header — codename swatch sized to the codename+subtitle stack height -->
-	<div class="flex items-stretch gap-3 border-b border-[var(--color-border)] px-4 py-3">
+	<div class="flex items-stretch gap-3 border-b border-border px-4 py-3">
 		{#if model.codename_color}
 			<div class="flex shrink-0 items-center">
 				<span
-					class="block aspect-square w-12 rounded-full border border-[var(--color-border)]"
+					class="block aspect-square w-12 rounded-full border border-border"
 					style="background-color: {model.codename_color}"
 					aria-hidden="true"
 				></span>
@@ -96,11 +96,11 @@
 		{/if}
 		<div class="min-w-0 flex-1 self-center">
 			{#if model.codename}
-				<h3 class="truncate text-xl font-bold leading-tight text-[var(--color-text)]">{model.codename}</h3>
+				<h3 class="truncate text-xl font-bold leading-tight text-text">{model.codename}</h3>
 			{:else}
-				<h3 class="truncate text-base font-semibold text-[var(--color-text)]">{model.name}</h3>
+				<h3 class="truncate text-base font-semibold text-text">{model.name}</h3>
 			{/if}
-			<p class="truncate font-mono text-[11px] text-[var(--color-text-muted)]">
+			<p class="truncate font-mono text-[11px] text-text-muted">
 				{model.slug} · v{model.version} · {relativeTime(model.published_at)}
 			</p>
 		</div>
@@ -111,60 +111,60 @@
 				<Badge text="Stable" variant="success" />
 			{/if}
 			{#if !model.is_public}
-				<span class="border border-[var(--color-border)] bg-[var(--color-bg)] px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Private</span>
+				<span class="border border-border bg-bg px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-text-muted">Private</span>
 			{/if}
 		</div>
 	</div>
 
 	<!-- Metric pills — three columns: mAP50, mAP50_95, Recall -->
 	{#if map50 !== null || map50_95 !== null}
-		<div class="grid grid-cols-3 gap-px border-b border-[var(--color-border)] bg-[var(--color-border)]">
-			<div class="bg-[var(--color-surface)] px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">mAP50</div>
-				<div class="font-mono text-sm font-semibold text-[var(--color-text)]">{formatPct(map50)}</div>
+		<div class="grid grid-cols-3 gap-px border-b border-border bg-border">
+			<div class="bg-surface px-3 py-2">
+				<div class="text-[10px] uppercase tracking-wider text-text-muted">mAP50</div>
+				<div class="font-mono text-sm font-semibold text-text">{formatPct(map50)}</div>
 			</div>
-			<div class="bg-[var(--color-surface)] px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">mAP50_95</div>
-				<div class="font-mono text-sm font-semibold text-[var(--color-text)]">{formatPct(map50_95)}</div>
+			<div class="bg-surface px-3 py-2">
+				<div class="text-[10px] uppercase tracking-wider text-text-muted">mAP50_95</div>
+				<div class="font-mono text-sm font-semibold text-text">{formatPct(map50_95)}</div>
 			</div>
-			<div class="bg-[var(--color-surface)] px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Recall</div>
-				<div class="font-mono text-sm font-semibold text-[var(--color-text)]">{formatPct(recall)}</div>
+			<div class="bg-surface px-3 py-2">
+				<div class="text-[10px] uppercase tracking-wider text-text-muted">Recall</div>
+				<div class="font-mono text-sm font-semibold text-text">{formatPct(recall)}</div>
 			</div>
 		</div>
 	{/if}
 
 	<!-- Body — 3 columns matching the metric grid above: Model · Samples · Rigs -->
 	{#if arch || imgsz || samples !== null || machineCount !== null}
-		<div class="grid grid-cols-3 gap-px bg-[var(--color-border)]">
-			<div class="min-w-0 bg-[var(--color-surface)] px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Model</div>
-				<div class="truncate font-mono text-xs font-semibold text-[var(--color-text)] sm:text-sm">
+		<div class="grid grid-cols-3 gap-px bg-border">
+			<div class="min-w-0 bg-surface px-3 py-2">
+				<div class="text-[10px] uppercase tracking-wider text-text-muted">Model</div>
+				<div class="truncate font-mono text-xs font-semibold text-text sm:text-sm">
 					{#if arch && imgsz}{arch} @ {imgsz}
 					{:else if arch}{arch}
 					{:else if imgsz}{imgsz}×{imgsz}
 					{:else}—{/if}
 				</div>
 			</div>
-			<div class="bg-[var(--color-surface)] px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Samples</div>
-				<div class="font-mono text-sm font-semibold text-[var(--color-text)]">
+			<div class="bg-surface px-3 py-2">
+				<div class="text-[10px] uppercase tracking-wider text-text-muted">Samples</div>
+				<div class="font-mono text-sm font-semibold text-text">
 					{samples !== null ? samples.toLocaleString() : '—'}
 				</div>
 			</div>
 			<div
-				class="bg-[var(--color-surface)] px-3 py-2"
+				class="bg-surface px-3 py-2"
 				title={machineCount !== null
 					? `Normalized Shannon entropy of per-machine sample shares across ${machineCount} rigs. 0 = single rig, 1.0 = perfect even split.`
 					: 'Normalized Shannon entropy of per-machine sample shares. 0 = single rig, 1.0 = perfect even split.'}
 			>
-				<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Diversity</div>
-				<div class="font-mono text-sm font-semibold text-[var(--color-text)]">
+				<div class="text-[10px] uppercase tracking-wider text-text-muted">Diversity</div>
+				<div class="font-mono text-sm font-semibold text-text">
 					{diversityScore !== null ? diversityScore.toFixed(3) : '—'}
 				</div>
 			</div>
 		</div>
 	{:else if model.description}
-		<p class="line-clamp-2 px-4 py-3 text-xs text-[var(--color-text-muted)]">{model.description}</p>
+		<p class="line-clamp-2 px-4 py-3 text-xs text-text-muted">{model.description}</p>
 	{/if}
 </a>

--- a/software/hive/frontend/src/lib/components/ModelTrainingReport.svelte
+++ b/software/hive/frontend/src/lib/components/ModelTrainingReport.svelte
@@ -311,11 +311,11 @@
 		<section>
 			<div class={heroGridClass}>
 				{#each heroMetrics as metric (metric.label)}
-					<div class="relative overflow-hidden border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
-						<div class="text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">{metric.label}</div>
-						<div class="mt-2 text-3xl font-semibold tabular-nums text-[var(--color-text)]">{metric.value}</div>
-						<div class="mt-1 text-xs text-[var(--color-text-muted)]">{metric.caption}</div>
-						<div class="mt-3 h-1.5 w-full bg-[var(--color-bg)]">
+					<div class="relative overflow-hidden border border-border bg-surface p-4">
+						<div class="text-[11px] font-medium uppercase tracking-wider text-text-muted">{metric.label}</div>
+						<div class="mt-2 text-3xl font-semibold tabular-nums text-text">{metric.value}</div>
+						<div class="mt-1 text-xs text-text-muted">{metric.caption}</div>
+						<div class="mt-3 h-1.5 w-full bg-bg">
 							<div class="h-1.5" style={`width: ${metric.percent}%; background: ${metric.accent};`}></div>
 						</div>
 					</div>
@@ -326,12 +326,12 @@
 
 	{#if setupChips.length > 0}
 		<section>
-			<div class="border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3">
+			<div class="border border-border bg-surface px-4 py-3">
 				<div class="flex flex-wrap gap-x-5 gap-y-2">
 					{#each setupChips as chip (chip.label)}
 						<div class="flex items-baseline gap-1.5">
-							<span class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">{chip.label}</span>
-							<span class={`text-sm text-[var(--color-text)] ${chip.mono ? 'font-mono' : ''}`}>{chip.value}</span>
+							<span class="text-[10px] uppercase tracking-wider text-text-muted">{chip.label}</span>
+							<span class={`text-sm text-text ${chip.mono ? 'font-mono' : ''}`}>{chip.value}</span>
 						</div>
 					{/each}
 				</div>
@@ -342,13 +342,13 @@
 	{#if showAudit}
 		<section>
 			<div class="mb-3 flex items-baseline justify-between gap-3">
-				<h2 class="text-sm font-semibold uppercase tracking-wide text-[var(--color-text)]">Detection Quality</h2>
-				<span class="text-xs text-[var(--color-text-muted)]">
+				<h2 class="text-sm font-semibold uppercase tracking-wide text-text">Detection Quality</h2>
+				<span class="text-xs text-text-muted">
 					{int(auditManifest.sample_count)} images · {int(auditManifest.positive_holdout_count)} pos · {int(auditManifest.empty_holdout_count)} empty
 				</span>
 			</div>
-			<div class="border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
-				<div class="mb-3 flex flex-wrap items-center gap-4 text-xs text-[var(--color-text-muted)]">
+			<div class="border border-border bg-surface p-4">
+				<div class="mb-3 flex flex-wrap items-center gap-4 text-xs text-text-muted">
 					<span class="flex items-center gap-1.5"><span class="inline-block h-2 w-4" style={`background: ${softInfo}`}></span>Precision</span>
 					<span class="flex items-center gap-1.5"><span class="inline-block h-2 w-4" style={`background: ${softSuccess}`}></span>Recall</span>
 					<span class="flex items-center gap-1.5"><span class="inline-block h-2 w-4" style={`background: ${softPrimary}`}></span>F1</span>
@@ -357,28 +357,28 @@
 					{#each auditRows as row (row.threshold)}
 						<div>
 							<div class="mb-1.5 flex items-baseline justify-between gap-3">
-								<div class="text-xs font-mono text-[var(--color-text-muted)]">conf ≥ {num(row.threshold, 2)}</div>
-								<div class="text-xs text-[var(--color-text-muted)]">
+								<div class="text-xs font-mono text-text-muted">conf ≥ {num(row.threshold, 2)}</div>
+								<div class="text-xs text-text-muted">
 									Empty FP {int(row.empty_false_positive_samples)}/{int(row.empty_samples)} · IoU {num(row.matched_mean_iou, 3)}
 								</div>
 							</div>
 							<div class="grid grid-cols-[7rem_1fr_4rem] items-center gap-3">
-								<div class="text-xs text-[var(--color-text-muted)]">Precision</div>
-								<div class="h-2.5 bg-[var(--color-bg)]">
+								<div class="text-xs text-text-muted">Precision</div>
+								<div class="h-2.5 bg-bg">
 									<div class="h-2.5" style={`width: ${((numberValue(row.precision_iou50) ?? 0) / auditMax) * 100}%; background: ${softInfo};`}></div>
 								</div>
 								<div class="text-right text-xs tabular-nums">{pct(row.precision_iou50)}</div>
 							</div>
 							<div class="mt-1 grid grid-cols-[7rem_1fr_4rem] items-center gap-3">
-								<div class="text-xs text-[var(--color-text-muted)]">Recall</div>
-								<div class="h-2.5 bg-[var(--color-bg)]">
+								<div class="text-xs text-text-muted">Recall</div>
+								<div class="h-2.5 bg-bg">
 									<div class="h-2.5" style={`width: ${((numberValue(row.recall_iou50) ?? 0) / auditMax) * 100}%; background: ${softSuccess};`}></div>
 								</div>
 								<div class="text-right text-xs tabular-nums">{pct(row.recall_iou50)}</div>
 							</div>
 							<div class="mt-1 grid grid-cols-[7rem_1fr_4rem] items-center gap-3">
-								<div class="text-xs text-[var(--color-text-muted)]">F1</div>
-								<div class="h-2.5 bg-[var(--color-bg)]">
+								<div class="text-xs text-text-muted">F1</div>
+								<div class="h-2.5 bg-bg">
 									<div class="h-2.5" style={`width: ${((numberValue(row.f1_iou50) ?? 0) / auditMax) * 100}%; background: ${softPrimary};`}></div>
 								</div>
 								<div class="text-right text-xs tabular-nums">{num(row.f1_iou50)}</div>
@@ -393,20 +393,20 @@
 	{#if showSpectrum}
 		<section>
 			<div class="mb-3 flex items-baseline justify-between gap-3">
-				<h2 class="text-sm font-semibold uppercase tracking-wide text-[var(--color-text)]">Count Accuracy by Piece Count</h2>
-				<span class="text-xs text-[var(--color-text-muted)]">Within ±1 count · conf 0.25</span>
+				<h2 class="text-sm font-semibold uppercase tracking-wide text-text">Count Accuracy by Piece Count</h2>
+				<span class="text-xs text-text-muted">Within ±1 count · conf 0.25</span>
 			</div>
-			<div class="border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+			<div class="border border-border bg-surface p-4">
 				<div class="space-y-2">
 					{#each spectrumPrimary as row}
 						{@const accuracy = clampPct(row.within_1_count_rate)}
 						<div class="grid grid-cols-[3.5rem_1fr_3.5rem_4rem] items-center gap-2 text-sm sm:grid-cols-[5rem_1fr_4.5rem_5rem] sm:gap-3">
-							<div class="font-mono text-xs text-[var(--color-text-muted)]">{textValue(row.gt_count_bin)} pc</div>
-							<div class="h-3 bg-[var(--color-bg)]">
+							<div class="font-mono text-xs text-text-muted">{textValue(row.gt_count_bin)} pc</div>
+							<div class="h-3 bg-bg">
 								<div class="h-3" style={`width: ${accuracy}%; background: ${gaugeColor(accuracy)};`}></div>
 							</div>
 							<div class="text-right tabular-nums font-medium">{pct(row.within_1_count_rate)}</div>
-							<div class="text-right text-xs text-[var(--color-text-muted)]">MAE {num(row.count_mae, 2)}</div>
+							<div class="text-right text-xs text-text-muted">MAE {num(row.count_mae, 2)}</div>
 						</div>
 					{/each}
 				</div>
@@ -417,13 +417,13 @@
 	{#if showInference}
 		<section>
 			<div class="mb-3 flex items-baseline justify-between gap-3">
-				<h2 class="text-sm font-semibold uppercase tracking-wide text-[var(--color-text)]">Inference Performance</h2>
-				<span class="text-xs text-[var(--color-text-muted)]">ONNX Runtime · imgsz {textValue(model.imgsz)}</span>
+				<h2 class="text-sm font-semibold uppercase tracking-wide text-text">Inference Performance</h2>
+				<span class="text-xs text-text-muted">ONNX Runtime · imgsz {textValue(model.imgsz)}</span>
 			</div>
-			<div class="border border-[var(--color-border)] bg-[var(--color-surface)]">
+			<div class="border border-border bg-surface">
 				<!-- The throughput bar is the first thing to go at mobile: five tracks
 				     need ~416px and the bar is decoration next to the numbers. -->
-				<div class="grid grid-cols-[1fr_3.5rem_3.5rem_3rem] items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-2 text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] sm:grid-cols-[6rem_1fr_5rem_5rem_5rem] sm:gap-3">
+				<div class="grid grid-cols-[1fr_3.5rem_3.5rem_3rem] items-center gap-2 border-b border-border bg-bg px-4 py-2 text-[10px] uppercase tracking-wider text-text-muted sm:grid-cols-[6rem_1fr_5rem_5rem_5rem] sm:gap-3">
 					<div>Provider</div>
 					<div class="hidden sm:block">Throughput</div>
 					<div class="text-right">Mean</div>
@@ -432,13 +432,13 @@
 				</div>
 				{#each perfRows as row, i (row.name)}
 					{@const widthPct = ((row.fps ?? 0) / perfFpsMax) * 100}
-					<div class={`grid grid-cols-[1fr_3.5rem_3.5rem_3rem] items-center gap-2 px-4 py-2.5 sm:grid-cols-[6rem_1fr_5rem_5rem_5rem] sm:gap-3 ${i > 0 ? 'border-t border-[var(--color-border)]' : ''}`}>
-						<div class="font-mono text-xs uppercase tracking-wide text-[var(--color-text)]">{row.name}</div>
-						<div class="hidden h-2 bg-[var(--color-bg)] sm:block">
+					<div class={`grid grid-cols-[1fr_3.5rem_3.5rem_3rem] items-center gap-2 px-4 py-2.5 sm:grid-cols-[6rem_1fr_5rem_5rem_5rem] sm:gap-3 ${i > 0 ? 'border-t border-border' : ''}`}>
+						<div class="font-mono text-xs uppercase tracking-wide text-text">{row.name}</div>
+						<div class="hidden h-2 bg-bg sm:block">
 							<div class="h-2" style={`width: ${widthPct}%; background: ${softInfo};`}></div>
 						</div>
 						<div class="text-right text-sm tabular-nums">{num(row.mean, 1)} ms</div>
-						<div class="text-right text-xs tabular-nums text-[var(--color-text-muted)]">{num(row.p95, 1)} ms</div>
+						<div class="text-right text-xs tabular-nums text-text-muted">{num(row.p95, 1)} ms</div>
 						<div class="text-right text-sm font-medium tabular-nums">{int(row.fps)}</div>
 					</div>
 				{/each}
@@ -449,17 +449,17 @@
 	{#if sourceData.length > 0 || pieceData.length > 0}
 		<section>
 			<div class="mb-3 flex items-baseline justify-between gap-3">
-				<h2 class="text-sm font-semibold uppercase tracking-wide text-[var(--color-text)]">Dataset Composition</h2>
+				<h2 class="text-sm font-semibold uppercase tracking-wide text-text">Dataset Composition</h2>
 				{#if totalSelected > 0}
-					<span class="text-xs text-[var(--color-text-muted)]">{int(totalSelected)} selected samples</span>
+					<span class="text-xs text-text-muted">{int(totalSelected)} selected samples</span>
 				{/if}
 			</div>
 			<div class="grid gap-4 lg:grid-cols-2">
 				{#if sourceData.length > 0}
-					<div class="border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+					<div class="border border-border bg-surface p-4">
 						<div class="mb-3 flex items-baseline justify-between gap-3">
-							<h3 class="text-sm font-semibold text-[var(--color-text)]">Source Roles</h3>
-							<span class="text-xs text-[var(--color-text-muted)]">{sourceData.length} {sourceData.length === 1 ? 'source' : 'sources'}</span>
+							<h3 class="text-sm font-semibold text-text">Source Roles</h3>
+							<span class="text-xs text-text-muted">{sourceData.length} {sourceData.length === 1 ? 'source' : 'sources'}</span>
 						</div>
 						<div class="space-y-2.5">
 							{#each sourceData as row}
@@ -468,10 +468,10 @@
 								{@const share = totalSelected > 0 ? (selected / totalSelected) * 100 : 0}
 								<div>
 									<div class="mb-0.5 flex items-baseline justify-between gap-2">
-										<span class="font-mono text-xs text-[var(--color-text)]">{textValue(row.role)}</span>
-										<span class="text-xs tabular-nums text-[var(--color-text-muted)]">{int(row.selected)} · {share.toFixed(0)}%</span>
+										<span class="font-mono text-xs text-text">{textValue(row.role)}</span>
+										<span class="text-xs tabular-nums text-text-muted">{int(row.selected)} · {share.toFixed(0)}%</span>
 									</div>
-									<div class="h-3 bg-[var(--color-bg)]">
+									<div class="h-3 bg-bg">
 										<div class="h-3" style={`width: ${width}%; background: ${softInfo};`}></div>
 									</div>
 								</div>
@@ -481,24 +481,24 @@
 				{/if}
 
 				{#if pieceData.length > 0}
-					<div class="border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+					<div class="border border-border bg-surface p-4">
 						<div class="mb-3 flex items-baseline justify-between gap-3">
-							<h3 class="text-sm font-semibold text-[var(--color-text)]">Piece Count Buckets</h3>
-							<span class="text-xs text-[var(--color-text-muted)]">per image</span>
+							<h3 class="text-sm font-semibold text-text">Piece Count Buckets</h3>
+							<span class="text-xs text-text-muted">per image</span>
 						</div>
 						<div class="flex h-40 items-end gap-1">
 							{#each pieceData as row}
 								{@const selected = numberValue(row.selected) ?? 0}
 								{@const h = Math.max(2, (selected / pieceMax) * 100)}
 								<div class="flex flex-1 flex-col items-center gap-1">
-									<div class="text-[10px] tabular-nums text-[var(--color-text-muted)]">{int(row.selected)}</div>
+									<div class="text-[10px] tabular-nums text-text-muted">{int(row.selected)}</div>
 									<div class="w-full" style={`height: ${h}%; background: ${softInfo};`} title={`${row.bucket}: ${selected} samples`}></div>
 								</div>
 							{/each}
 						</div>
 						<div class="mt-1 flex gap-1">
 							{#each pieceData as row}
-								<div class="flex-1 text-center font-mono text-[10px] text-[var(--color-text-muted)]">{textValue(row.bucket)}</div>
+								<div class="flex-1 text-center font-mono text-[10px] text-text-muted">{textValue(row.bucket)}</div>
 							{/each}
 						</div>
 					</div>
@@ -510,23 +510,23 @@
 	{#if showCoverage}
 		<section>
 			<div class="mb-3 flex items-baseline justify-between gap-3">
-				<h2 class="text-sm font-semibold uppercase tracking-wide text-[var(--color-text)]">Precheck Coverage</h2>
-				<span class="text-xs text-[var(--color-text-muted)]">
+				<h2 class="text-sm font-semibold uppercase tracking-wide text-text">Precheck Coverage</h2>
+				<span class="text-xs text-text-muted">
 					Accepted {int(precheckTotals.accepted_evaluated_roles)} · pos {int(precheckTotals.accepted_positive_evaluated_roles)} · empty {int(precheckTotals.accepted_empty_evaluated_roles)}
 				</span>
 			</div>
 			<div class="grid gap-3 md:grid-cols-3">
 				{#each coverageRows as row}
 					{@const score = clampPct(row.score_percent)}
-					<div class="border border-[var(--color-border)] bg-[var(--color-surface)] p-3">
+					<div class="border border-border bg-surface p-3">
 						<div class="mb-2 flex items-center justify-between gap-2">
-							<span class="font-mono text-xs text-[var(--color-text)]">{textValue(row.role)}</span>
+							<span class="font-mono text-xs text-text">{textValue(row.role)}</span>
 							<span class="text-sm font-semibold tabular-nums" style={`color: ${gaugeText(score)};`}>{num(row.score_percent, 1)}%</span>
 						</div>
-						<div class="h-2 bg-[var(--color-bg)]">
+						<div class="h-2 bg-bg">
 							<div class="h-2" style={`width: ${score}%; background: ${gaugeColor(score)};`}></div>
 						</div>
-						<div class="mt-2 text-xs text-[var(--color-text-muted)]">Target {int(row.bucket_target_samples)} per bucket</div>
+						<div class="mt-2 text-xs text-text-muted">Target {int(row.bucket_target_samples)} per bucket</div>
 					</div>
 				{/each}
 			</div>
@@ -535,14 +535,14 @@
 
 	{#if showAudit || sourceData.length > 0 || pieceData.length > 0 || showSpectrum}
 		<section>
-			<h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--color-text)]">Detail Tables</h2>
+			<h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-text">Detail Tables</h2>
 			<div class="space-y-2">
 				{#if showAudit}
-					<details class="border border-[var(--color-border)] bg-[var(--color-surface)]">
-						<summary class="cursor-pointer px-4 py-2.5 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)]">Audit summary — precision / recall by threshold</summary>
-						<div class="overflow-x-auto border-t border-[var(--color-border)]">
+					<details class="border border-border bg-surface">
+						<summary class="cursor-pointer px-4 py-2.5 text-sm font-medium text-text hover:bg-bg">Audit summary — precision / recall by threshold</summary>
+						<div class="overflow-x-auto border-t border-border">
 							<table class="w-full text-sm">
-								<thead class="bg-[var(--color-bg)] text-left text-xs uppercase tracking-wide text-[var(--color-text-muted)]">
+								<thead class="bg-bg text-left text-xs uppercase tracking-wide text-text-muted">
 									<tr>
 										<th class="px-3 py-2">Conf</th>
 										<th class="px-3 py-2">Precision</th>
@@ -555,7 +555,7 @@
 								</thead>
 								<tbody>
 									{#each auditRows as row}
-										<tr class="border-t border-[var(--color-border)]">
+										<tr class="border-t border-border">
 											<td class="px-3 py-2 font-mono text-xs">{num(row.threshold, 2)}</td>
 											<td class="px-3 py-2 tabular-nums">{pct(row.precision_iou50)}</td>
 											<td class="px-3 py-2 tabular-nums">{pct(row.recall_iou50)}</td>
@@ -572,16 +572,16 @@
 				{/if}
 
 				{#if sourceData.length > 0}
-					<details class="border border-[var(--color-border)] bg-[var(--color-surface)]">
-						<summary class="cursor-pointer px-4 py-2.5 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)]">Dataset balance — source roles & splits</summary>
-						<div class="overflow-x-auto border-t border-[var(--color-border)]">
+					<details class="border border-border bg-surface">
+						<summary class="cursor-pointer px-4 py-2.5 text-sm font-medium text-text hover:bg-bg">Dataset balance — source roles & splits</summary>
+						<div class="overflow-x-auto border-t border-border">
 							<table class="w-full text-sm">
-								<thead class="bg-[var(--color-bg)] text-left text-xs uppercase tracking-wide text-[var(--color-text-muted)]">
+								<thead class="bg-bg text-left text-xs uppercase tracking-wide text-text-muted">
 									<tr><th class="px-3 py-2">Source</th><th class="px-3 py-2">Selected</th><th class="px-3 py-2">Train</th><th class="px-3 py-2">Val</th></tr>
 								</thead>
 								<tbody>
 									{#each sourceData as row}
-										<tr class="border-t border-[var(--color-border)]">
+										<tr class="border-t border-border">
 											<td class="px-3 py-2 font-mono text-xs">{textValue(row.role)}</td>
 											<td class="px-3 py-2 tabular-nums">{int(row.selected)}</td>
 											<td class="px-3 py-2 tabular-nums">{int(row.train)}</td>
@@ -595,16 +595,16 @@
 				{/if}
 
 				{#if pieceData.length > 0}
-					<details class="border border-[var(--color-border)] bg-[var(--color-surface)]">
-						<summary class="cursor-pointer px-4 py-2.5 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)]">Piece count buckets — splits</summary>
-						<div class="overflow-x-auto border-t border-[var(--color-border)]">
+					<details class="border border-border bg-surface">
+						<summary class="cursor-pointer px-4 py-2.5 text-sm font-medium text-text hover:bg-bg">Piece count buckets — splits</summary>
+						<div class="overflow-x-auto border-t border-border">
 							<table class="w-full text-sm">
-								<thead class="bg-[var(--color-bg)] text-left text-xs uppercase tracking-wide text-[var(--color-text-muted)]">
+								<thead class="bg-bg text-left text-xs uppercase tracking-wide text-text-muted">
 									<tr><th class="px-3 py-2">Bucket</th><th class="px-3 py-2">Selected</th><th class="px-3 py-2">Train</th><th class="px-3 py-2">Val</th></tr>
 								</thead>
 								<tbody>
 									{#each pieceData as row}
-										<tr class="border-t border-[var(--color-border)]">
+										<tr class="border-t border-border">
 											<td class="px-3 py-2 font-mono text-xs">{textValue(row.bucket)}</td>
 											<td class="px-3 py-2 tabular-nums">{int(row.selected)}</td>
 											<td class="px-3 py-2 tabular-nums">{int(row.train)}</td>
@@ -618,16 +618,16 @@
 				{/if}
 
 				{#if showSpectrum}
-					<details class="border border-[var(--color-border)] bg-[var(--color-surface)]">
-						<summary class="cursor-pointer px-4 py-2.5 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)]">Count spectrum — within ±1 & MAE</summary>
-						<div class="overflow-x-auto border-t border-[var(--color-border)]">
+					<details class="border border-border bg-surface">
+						<summary class="cursor-pointer px-4 py-2.5 text-sm font-medium text-text hover:bg-bg">Count spectrum — within ±1 & MAE</summary>
+						<div class="overflow-x-auto border-t border-border">
 							<table class="w-full text-sm">
-								<thead class="bg-[var(--color-bg)] text-left text-xs uppercase tracking-wide text-[var(--color-text-muted)]">
+								<thead class="bg-bg text-left text-xs uppercase tracking-wide text-text-muted">
 									<tr><th class="px-3 py-2">GT count</th><th class="px-3 py-2">Within ±1</th><th class="px-3 py-2">MAE</th><th class="px-3 py-2">Samples</th></tr>
 								</thead>
 								<tbody>
 									{#each spectrumPrimary as row}
-										<tr class="border-t border-[var(--color-border)]">
+										<tr class="border-t border-border">
 											<td class="px-3 py-2 font-mono text-xs">{textValue(row.gt_count_bin)}</td>
 											<td class="px-3 py-2 tabular-nums">{pct(row.within_1_count_rate)}</td>
 											<td class="px-3 py-2 tabular-nums">{num(row.count_mae, 2)}</td>

--- a/software/hive/frontend/src/lib/components/ThemeToggle.svelte
+++ b/software/hive/frontend/src/lib/components/ThemeToggle.svelte
@@ -4,7 +4,7 @@
 
 <button
 	type="button"
-	class="inline-flex items-center gap-2 border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-bg)]"
+	class="inline-flex items-center gap-2 border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text hover:bg-bg"
 	aria-label={$theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
 	title={$theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
 	onclick={() => theme.toggle($theme)}
@@ -16,7 +16,7 @@
 		</svg>
 		<span>Light</span>
 	{:else}
-		<svg class="h-4 w-4 text-[var(--color-text-muted)]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+		<svg class="h-4 w-4 text-text-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
 			<path stroke-linecap="round" stroke-linejoin="round" d="M21 12.8A9 9 0 1111.2 3 7 7 0 0021 12.8z" />
 		</svg>
 		<span>Dark</span>

--- a/software/hive/frontend/src/routes/machine-ip-lookup/+page.svelte
+++ b/software/hive/frontend/src/routes/machine-ip-lookup/+page.svelte
@@ -164,10 +164,10 @@
 
 <div class="mx-auto flex min-h-screen w-full max-w-xl flex-col justify-center gap-6 px-5 py-10">
 	<div class="text-center">
-		<div class="font-mono text-sm tracking-wider text-[var(--color-text-muted)] uppercase">
+		<div class="font-mono text-sm tracking-wider text-text-muted uppercase">
 			SorterOS onboarding
 		</div>
-		<h1 class="mt-1 text-2xl font-bold text-[var(--color-text)]">Find your sorter</h1>
+		<h1 class="mt-1 text-2xl font-bold text-text">Find your sorter</h1>
 	</div>
 
 	{#if phase === 'invalid'}
@@ -177,32 +177,32 @@
 		</Alert>
 	{:else if phase === 'waiting'}
 		<div
-			class="flex flex-col items-center gap-4 border border-[var(--color-border)] bg-[var(--color-surface)] px-6 py-10 text-center"
+			class="flex flex-col items-center gap-4 border border-border bg-surface px-6 py-10 text-center"
 		>
 			<Spinner size={32} />
-			<div class="text-[var(--color-text)]">Waiting for your sorter to come online…</div>
-			<p class="max-w-sm text-sm text-[var(--color-text-muted)]">
+			<div class="text-text">Waiting for your sorter to come online…</div>
+			<p class="max-w-sm text-sm text-text-muted">
 				Make sure you've rejoined your normal Wi-Fi. As soon as the sorter connects to the same
 				network it will report its address here — this stays private, the address is encrypted end
 				to end and only your browser can read it.
 			</p>
-			<div class="font-mono text-xs text-[var(--color-text-muted)]">
+			<div class="font-mono text-xs text-text-muted">
 				{Math.floor(elapsed / 60)}:{String(elapsed % 60).padStart(2, '0')} elapsed
 			</div>
 		</div>
 	{:else if phase === 'found' && info}
 		<div
-			class="flex flex-col items-center gap-5 border border-[var(--color-success)]/40 bg-[var(--color-success)]/[0.06] px-6 py-10 text-center"
+			class="flex flex-col items-center gap-5 border border-success/40 bg-success/[0.06] px-6 py-10 text-center"
 		>
-			<div class="text-lg font-semibold text-[var(--color-text)]">Your sorter is online! 🎉</div>
+			<div class="text-lg font-semibold text-text">Your sorter is online! 🎉</div>
 			{#if info.hostname}
-				<div class="font-mono text-sm text-[var(--color-text-muted)]">{info.hostname}</div>
+				<div class="font-mono text-sm text-text-muted">{info.hostname}</div>
 			{/if}
-			<div class="font-mono text-base break-all text-[var(--color-text)]">{sorterUrl()}</div>
+			<div class="font-mono text-base break-all text-text">{sorterUrl()}</div>
 			<a href={sorterUrl()} class="w-full max-w-xs">
 				<Button variant="primary">Open the sorter →</Button>
 			</a>
-			<p class="max-w-sm text-xs text-[var(--color-text-muted)]">
+			<p class="max-w-sm text-xs text-text-muted">
 				Bookmark this address — it's your sorter's dashboard on your local network.
 			</p>
 		</div>

--- a/software/hive/frontend/src/routes/models/+page.svelte
+++ b/software/hive/frontend/src/routes/models/+page.svelte
@@ -68,54 +68,54 @@
 
 <div class="space-y-6">
 	<div>
-		<h1 class="text-2xl font-bold text-[var(--color-text)]">Detection Models</h1>
-		<p class="text-sm text-[var(--color-text-muted)]">Published model catalog — browse and download model variants.</p>
+		<h1 class="text-2xl font-bold text-text">Detection Models</h1>
+		<p class="text-sm text-text-muted">Published model catalog — browse and download model variants.</p>
 	</div>
 
-	<div class="flex flex-wrap items-end gap-3 border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
-		<label class="flex flex-col gap-1 text-xs text-[var(--color-text-muted)]">
+	<div class="flex flex-wrap items-end gap-3 border border-border bg-surface p-4">
+		<label class="flex flex-col gap-1 text-xs text-text-muted">
 			<span>Search</span>
 			<input
 				type="text"
 				bind:value={query}
 				placeholder="slug or name"
-				class="border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm text-[var(--color-text)]"
+				class="border border-border bg-bg px-2 py-1 text-sm text-text"
 			/>
 		</label>
-		<label class="flex flex-col gap-1 text-xs text-[var(--color-text-muted)]">
+		<label class="flex flex-col gap-1 text-xs text-text-muted">
 			<span>Scope</span>
 			<select
 				bind:value={filterScope}
-				class="border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm text-[var(--color-text)]"
+				class="border border-border bg-bg px-2 py-1 text-sm text-text"
 			>
 				{#each scopeOptions as opt (opt)}
 					<option value={opt}>{opt || 'Any scope'}</option>
 				{/each}
 			</select>
 		</label>
-		<label class="flex flex-col gap-1 text-xs text-[var(--color-text-muted)]">
+		<label class="flex flex-col gap-1 text-xs text-text-muted">
 			<span>Runtime</span>
 			<select
 				bind:value={filterRuntime}
-				class="border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm text-[var(--color-text)]"
+				class="border border-border bg-bg px-2 py-1 text-sm text-text"
 			>
 				{#each runtimeOptions as opt (opt)}
 					<option value={opt}>{opt || 'Any runtime'}</option>
 				{/each}
 			</select>
 		</label>
-		<label class="flex flex-col gap-1 text-xs text-[var(--color-text-muted)]">
+		<label class="flex flex-col gap-1 text-xs text-text-muted">
 			<span>Family</span>
 			<input
 				type="text"
 				bind:value={filterFamily}
 				placeholder="yolo, nanodet, …"
-				class="border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm text-[var(--color-text)]"
+				class="border border-border bg-bg px-2 py-1 text-sm text-text"
 			/>
 		</label>
 		<button
 			onclick={clearFilters}
-			class="border border-[var(--color-border)] px-3 py-1 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+			class="border border-border px-3 py-1 text-sm text-text-muted hover:text-text"
 			type="button"
 		>
 			Reset
@@ -129,7 +129,7 @@
 	{#if loading && !data}
 		<div class="flex justify-center py-12"><Spinner size={32} /></div>
 	{:else if data && data.items.length === 0}
-		<div class="border border-dashed border-[var(--color-border)] p-8 text-center text-sm text-[var(--color-text-muted)]">
+		<div class="border border-dashed border-border p-8 text-center text-sm text-text-muted">
 			No models match the current filters.
 		</div>
 	{:else if data}
@@ -144,18 +144,18 @@
 				<button
 					disabled={currentPage <= 1}
 					onclick={() => { currentPage = Math.max(1, currentPage - 1); }}
-					class="border border-[var(--color-border)] px-3 py-1 text-sm disabled:opacity-40"
+					class="border border-border px-3 py-1 text-sm disabled:opacity-40"
 					type="button"
 				>
 					Prev
 				</button>
-				<span class="text-sm text-[var(--color-text-muted)]">
+				<span class="text-sm text-text-muted">
 					Page {data.page} / {data.pages} · {data.total} total
 				</span>
 				<button
 					disabled={currentPage >= data.pages}
 					onclick={() => { const total = data?.pages ?? 1; currentPage = Math.min(total, currentPage + 1); }}
-					class="border border-[var(--color-border)] px-3 py-1 text-sm disabled:opacity-40"
+					class="border border-border px-3 py-1 text-sm disabled:opacity-40"
 					type="button"
 				>
 					Next

--- a/software/hive/frontend/src/routes/models/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/models/[id]/+page.svelte
@@ -151,7 +151,7 @@
 </script>
 
 <div class="space-y-4">
-	<a href="/models" class="inline-flex items-center gap-1 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)]">← Back to models</a>
+	<a href="/models" class="inline-flex items-center gap-1 text-sm text-text-muted hover:text-text">← Back to models</a>
 
 	{#if loading}
 		<div class="flex justify-center py-12"><Spinner size={32} /></div>
@@ -159,15 +159,15 @@
 		<div class="border border-primary bg-primary-light p-3 text-sm text-primary">{error}</div>
 	{:else if model}
 		<!-- Hero — same DNA as ModelCard but bigger -->
-		<div class="border border-[var(--color-border)] bg-[var(--color-surface)]">
+		<div class="border border-border bg-surface">
 			<!-- items-stretch + aspect-square on the swatch makes its height auto-match the
 				 text block's natural height (codename H1 + slug + name = ~3 lines) so the
 				 dot reads as a hero element proportional to its label. -->
-			<div class="flex flex-wrap items-stretch gap-4 border-b border-[var(--color-border)] px-4 py-4 sm:flex-nowrap sm:px-5">
+			<div class="flex flex-wrap items-stretch gap-4 border-b border-border px-4 py-4 sm:flex-nowrap sm:px-5">
 				{#if model.codename_color}
 					<div class="flex shrink-0 items-center">
 						<span
-							class="block aspect-square w-20 rounded-full border border-[var(--color-border)]"
+							class="block aspect-square w-20 rounded-full border border-border"
 							style="background-color: {model.codename_color}"
 							aria-hidden="true"
 						></span>
@@ -175,15 +175,15 @@
 				{/if}
 				<div class="min-w-0 flex-1 self-center">
 					{#if model.codename}
-						<h1 class="text-3xl font-bold leading-tight tracking-tight text-[var(--color-text)]">{model.codename}</h1>
+						<h1 class="text-3xl font-bold leading-tight tracking-tight text-text">{model.codename}</h1>
 					{:else}
-						<h1 class="text-2xl font-semibold tracking-tight text-[var(--color-text)]">{model.name}</h1>
+						<h1 class="text-2xl font-semibold tracking-tight text-text">{model.name}</h1>
 					{/if}
-					<p class="mt-1 font-mono text-xs text-[var(--color-text-muted)]">
+					<p class="mt-1 font-mono text-xs text-text-muted">
 						{model.slug} · v{model.version} · {relativeTime(model.published_at)}
 					</p>
 					{#if model.codename && model.name}
-						<p class="mt-0.5 text-sm text-[var(--color-text-muted)]">{model.name}</p>
+						<p class="mt-0.5 text-sm text-text-muted">{model.name}</p>
 					{/if}
 				</div>
 				<div class="flex shrink-0 flex-col items-end gap-1 self-start">
@@ -193,59 +193,59 @@
 						<Badge text="Stable" variant="success" />
 					{/if}
 					{#if !model.is_public}
-						<span class="border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-0.5 text-[11px] uppercase tracking-wider text-[var(--color-text-muted)]">Private</span>
+						<span class="border border-border bg-bg px-2 py-0.5 text-[11px] uppercase tracking-wider text-text-muted">Private</span>
 					{/if}
 				</div>
 			</div>
 
 			<!-- Metric pills — 4 columns including Precision, since the detail page has room -->
 			{#if map50 !== null || map50_95 !== null || precision !== null || recall !== null}
-				<div class="grid grid-cols-2 gap-px border-b border-[var(--color-border)] bg-[var(--color-border)] sm:grid-cols-4">
-					<div class="bg-[var(--color-surface)] px-4 py-3">
-						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">mAP50</div>
-						<div class="font-mono text-lg font-semibold text-[var(--color-text)]">{formatPct(map50)}</div>
+				<div class="grid grid-cols-2 gap-px border-b border-border bg-border sm:grid-cols-4">
+					<div class="bg-surface px-4 py-3">
+						<div class="text-[10px] uppercase tracking-wider text-text-muted">mAP50</div>
+						<div class="font-mono text-lg font-semibold text-text">{formatPct(map50)}</div>
 					</div>
-					<div class="bg-[var(--color-surface)] px-4 py-3">
-						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">mAP50_95</div>
-						<div class="font-mono text-lg font-semibold text-[var(--color-text)]">{formatPct(map50_95)}</div>
+					<div class="bg-surface px-4 py-3">
+						<div class="text-[10px] uppercase tracking-wider text-text-muted">mAP50_95</div>
+						<div class="font-mono text-lg font-semibold text-text">{formatPct(map50_95)}</div>
 					</div>
-					<div class="bg-[var(--color-surface)] px-4 py-3">
-						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Precision</div>
-						<div class="font-mono text-lg font-semibold text-[var(--color-text)]">{formatPct(precision)}</div>
+					<div class="bg-surface px-4 py-3">
+						<div class="text-[10px] uppercase tracking-wider text-text-muted">Precision</div>
+						<div class="font-mono text-lg font-semibold text-text">{formatPct(precision)}</div>
 					</div>
-					<div class="bg-[var(--color-surface)] px-4 py-3">
-						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Recall</div>
-						<div class="font-mono text-lg font-semibold text-[var(--color-text)]">{formatPct(recall)}</div>
+					<div class="bg-surface px-4 py-3">
+						<div class="text-[10px] uppercase tracking-wider text-text-muted">Recall</div>
+						<div class="font-mono text-lg font-semibold text-text">{formatPct(recall)}</div>
 					</div>
 				</div>
 			{/if}
 
 			<!-- Spec pills: Model / Samples / Diversity -->
 			{#if arch || imgsz || samples !== null || diversityScore !== null}
-				<div class="grid grid-cols-2 gap-px bg-[var(--color-border)] sm:grid-cols-3">
-					<div class="bg-[var(--color-surface)] px-4 py-3">
-						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Model</div>
-						<div class="font-mono text-base font-semibold text-[var(--color-text)]">
+				<div class="grid grid-cols-2 gap-px bg-border sm:grid-cols-3">
+					<div class="bg-surface px-4 py-3">
+						<div class="text-[10px] uppercase tracking-wider text-text-muted">Model</div>
+						<div class="font-mono text-base font-semibold text-text">
 							{#if arch && imgsz}{arch} @ {imgsz}
 							{:else if arch}{arch}
 							{:else if imgsz}{imgsz}×{imgsz}
 							{:else}—{/if}
 						</div>
 					</div>
-					<div class="bg-[var(--color-surface)] px-4 py-3">
-						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Samples</div>
-						<div class="font-mono text-base font-semibold text-[var(--color-text)]">
+					<div class="bg-surface px-4 py-3">
+						<div class="text-[10px] uppercase tracking-wider text-text-muted">Samples</div>
+						<div class="font-mono text-base font-semibold text-text">
 							{samples !== null ? samples.toLocaleString() : '—'}
 						</div>
 					</div>
 					<div
-						class="bg-[var(--color-surface)] px-4 py-3"
+						class="bg-surface px-4 py-3"
 						title={machineCount !== null
 							? `Normalized Shannon entropy of per-machine sample shares across ${machineCount} rigs. 0 = single rig, 1.0 = perfect even split.`
 							: 'Normalized Shannon entropy of per-machine sample shares. 0 = single rig, 1.0 = perfect even split.'}
 					>
-						<div class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Diversity</div>
-						<div class="font-mono text-base font-semibold text-[var(--color-text)]">
+						<div class="text-[10px] uppercase tracking-wider text-text-muted">Diversity</div>
+						<div class="font-mono text-base font-semibold text-text">
 							{diversityScore !== null ? diversityScore.toFixed(3) : '—'}
 						</div>
 					</div>
@@ -255,16 +255,16 @@
 
 		<!-- Downloads — one visible tile per variant. No dropdown -->
 		{#if model.variants.length > 0}
-			<section class="border border-[var(--color-border)] bg-[var(--color-surface)]">
-				<div class="flex items-baseline justify-between border-b border-[var(--color-border)] px-5 py-3">
-					<h2 class="text-sm font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">Downloads</h2>
-					<span class="text-xs text-[var(--color-text-muted)]">{model.variants.length} variant{model.variants.length === 1 ? '' : 's'}</span>
+			<section class="border border-border bg-surface">
+				<div class="flex items-baseline justify-between border-b border-border px-5 py-3">
+					<h2 class="text-sm font-semibold uppercase tracking-wider text-text-muted">Downloads</h2>
+					<span class="text-xs text-text-muted">{model.variants.length} variant{model.variants.length === 1 ? '' : 's'}</span>
 				</div>
-				<div class="grid grid-cols-1 gap-px bg-[var(--color-border)] sm:grid-cols-2 lg:grid-cols-4">
+				<div class="grid grid-cols-1 gap-px bg-border sm:grid-cols-2 lg:grid-cols-4">
 					{#each model.variants as variant (variant.id)}
 						<a
 							href={downloadUrl(variant.id)}
-							class="group relative block bg-[var(--color-surface)] p-4 transition-colors hover:bg-[var(--color-bg)]"
+							class="group relative block bg-surface p-4 transition-colors hover:bg-bg"
 							download={downloadFilename(variant)}
 						>
 							<span class="absolute inset-y-0 left-0 w-1" style="background-color: {variantAccent(variant)};"></span>
@@ -273,15 +273,15 @@
 									<span class="font-mono text-sm font-bold uppercase tracking-wider" style="color: {variantAccent(variant)};">
 										{variant.runtime}
 									</span>
-									<span class="text-xs tabular-nums text-[var(--color-text-muted)]">{formatSize(variant.file_size)}</span>
+									<span class="text-xs tabular-nums text-text-muted">{formatSize(variant.file_size)}</span>
 								</div>
 								{#if runtimeTarget[variant.runtime.toLowerCase()]}
-									<p class="mt-0.5 text-[11px] text-[var(--color-text-muted)]">{runtimeTarget[variant.runtime.toLowerCase()]}</p>
+									<p class="mt-0.5 text-[11px] text-text-muted">{runtimeTarget[variant.runtime.toLowerCase()]}</p>
 								{/if}
-								<div class="mt-2 truncate font-mono text-[10px] text-[var(--color-text)]" title={downloadFilename(variant)}>
+								<div class="mt-2 truncate font-mono text-[10px] text-text" title={downloadFilename(variant)}>
 									{downloadFilename(variant)}
 								</div>
-								<div class="mt-0.5 font-mono text-[9px] text-[var(--color-text-muted)]" title={variant.sha256}>
+								<div class="mt-0.5 font-mono text-[9px] text-text-muted" title={variant.sha256}>
 									sha256 {variant.sha256.slice(0, 12)}…
 								</div>
 							</div>
@@ -293,15 +293,15 @@
 
 		<!-- Description + scopes — secondary detail, collapse to single line -->
 		{#if model.description || (model.scopes && model.scopes.length > 0)}
-			<section class="border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+			<section class="border border-border bg-surface p-4">
 				{#if model.description}
-					<p class="text-sm text-[var(--color-text)]">{model.description}</p>
+					<p class="text-sm text-text">{model.description}</p>
 				{/if}
 				{#if model.scopes && model.scopes.length > 0}
 					<div class="mt-3 flex flex-wrap items-center gap-1">
-						<span class="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)]">Scopes:</span>
+						<span class="text-[10px] uppercase tracking-wider text-text-muted">Scopes:</span>
 						{#each model.scopes as scope (scope)}
-							<span class="border border-[var(--color-border)] bg-[var(--color-bg)] px-1.5 py-0.5 font-mono text-[11px] text-[var(--color-text)]">{scope}</span>
+							<span class="border border-border bg-bg px-1.5 py-0.5 font-mono text-[11px] text-text">{scope}</span>
 						{/each}
 					</div>
 				{/if}


### PR DESCRIPTION
Follow-up to #261, which fixed the real dark-mode bug and converted the three `var()` classes in `link-machine/+page.svelte` along the way. This is the remaining bulk: ~200 arbitrary-value classes across six files.

These were never rendering wrong — `var(--color-*)` re-points under `.dark` exactly like the token utilities do — but they violate the "tokens, not arbitrary values" rule in `software/hive/frontend/CLAUDE.md`, and they make the hardcoded-color greps noisy.

## What changed

Purely mechanical: `X-[var(--color-N)]` -> `X-N`.

- `src/lib/components/ModelTrainingReport.svelte` (74)
- `src/routes/models/[id]/+page.svelte` (46)
- `src/lib/components/ModelCard.svelte` (28)
- `src/routes/models/+page.svelte` (16)
- `src/routes/machine-ip-lookup/+page.svelte` (11)
- `src/lib/components/ThemeToggle.svelte` (2)

Two of them carried opacity suffixes and converted with them: `border-[var(--color-success)]/40` -> `border-success/40`, `bg-[var(--color-success)]/[0.06]` -> `bg-success/[0.06]`.

## Appearance is unchanged

Checked against the built stylesheet rather than by eye. The plain conversions emit the identical declaration — `.text-text-muted{color:var(--color-text-muted)}`, `.bg-surface{background-color:var(--color-surface)}` — so nothing can shift in either theme.

The two success utilities compile to a hex fallback plus a `color-mix(in oklab, var(--color-success) …)` override, which is how every other `-success/N` in the app already compiles (`Alert.svelte` ships the same `bg-success/[0.06]`). `--color-success` is theme-independent — defined once in `app.css`, never re-pointed under `.dark` — so the fallback matches the override anyway.

`var()` inside `style=` attributes and JS color strings (the chart colors in `ModelTrainingReport.svelte`) is untouched; the rewrite only matched the Tailwind class form.

## Validation

- `pnpm --dir software/hive/frontend check` — 0 errors, 18 warnings, all pre-existing and none in the touched files
- `pnpm --dir software/hive/frontend build` — clean
- `rg "\[var\(--color" src/` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)