### PR TITLE
hive: /api/public/fleet roster endpoint behind stats:read

### DIFF
--- a/software/hive/backend/app/routers/public_stats.py
+++ b/software/hive/backend/app/routers/public_stats.py
@@ -18,7 +18,7 @@ import hmac
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException
-from sqlalchemy import func
+from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -26,6 +26,7 @@ from app.deps import API_KEY_PREFIX, API_KEY_SCOPE_STATS_READ, _resolve_api_key,
 from app.models.machine import Machine
 from app.models.machine_daily_stats import MachineDailyStats
 from app.models.machine_piece import MachinePiece
+from app.models.user_identity import UserIdentity
 from app.services import analytics
 
 router = APIRouter(prefix="/api/public", tags=["public-stats"])
@@ -87,6 +88,48 @@ def get_public_stats(db: Session = Depends(get_db)):
         "last_24h_pieces": _rolling_24h_pieces(db, ids),
         **_local_day_in_progress(db, ids),
         **data,
+    }
+
+
+@router.get("/fleet", dependencies=[Depends(require_stats_key)])
+def get_public_fleet(db: Session = Depends(get_db)):
+    """The fleet roster: every non-archived machine, with the owner's Discord
+    identity attached only when that owner has linked one. Linking Discord is
+    the opt-in — an unlinked owner appears as an anonymous machine."""
+    rows = (
+        db.query(Machine, UserIdentity)
+        .outerjoin(
+            UserIdentity,
+            and_(
+                UserIdentity.user_id == Machine.owner_id,
+                UserIdentity.provider == "discord",
+            ),
+        )
+        .filter(Machine.archived_at.is_(None))
+        .order_by(Machine.created_at)
+        .all()
+    )
+    machines = [
+        {
+            "id": str(machine.id),
+            "name": machine.name,
+            "is_active": machine.is_active,
+            "last_seen_at": machine.last_seen_at.isoformat() if machine.last_seen_at else None,
+            "created_at": machine.created_at.isoformat(),
+            "owner_discord": None
+            if identity is None
+            else {
+                "id": identity.provider_user_id,
+                "login": identity.provider_login,
+                "avatar_url": identity.avatar_url,
+            },
+        }
+        for machine, identity in rows
+    ]
+    return {
+        "machines": machines,
+        "machine_count": len(machines),
+        "discord_linked_count": sum(1 for m in machines if m["owner_discord"] is not None),
     }
 
 

--- a/software/hive/backend/tests/test_public_stats.py
+++ b/software/hive/backend/tests/test_public_stats.py
@@ -104,3 +104,70 @@ class TestStatsScopeKeys:
         monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", STATS_KEY)
         r = client.get("/api/public/stats", headers={"X-Stats-Key": STATS_KEY})
         assert r.status_code == 200
+
+
+class TestFleetRoster:
+    """/api/public/fleet — machines with owner Discord identity where linked."""
+
+    def _admin_headers(self, client, db):
+        return TestStatsScopeKeys._admin_headers(TestStatsScopeKeys(), client, db)
+
+    def _mint(self, client, headers, scopes, machine_ids=None):
+        return TestStatsScopeKeys._mint(TestStatsScopeKeys(), client, headers, scopes, machine_ids)
+
+    def test_requires_key(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        assert client.get("/api/public/fleet").status_code in (401, 503)
+
+    def test_roster_masks_unlinked_owners(self, client, db, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        m = client.post(
+            "/api/machines",
+            json={"name": "Roster Sorter", "description": "d"},
+            headers=headers,
+        )
+        assert m.status_code in (200, 201)
+        token = self._mint(client, headers, ["stats:read"])
+
+        r = client.get("/api/public/fleet", headers=_bearer(token))
+        assert r.status_code == 200, r.text
+        body = r.json()
+        mine = next(x for x in body["machines"] if x["name"] == "Roster Sorter")
+        assert mine["owner_discord"] is None
+        assert body["machine_count"] == len(body["machines"])
+
+        # Link a Discord identity to the owner; the roster now names them.
+        from app.models.user import User
+        from app.models.user_identity import UserIdentity
+
+        user = db.query(User).filter(User.email == "stats-admin@test.com").first()
+        db.add(
+            UserIdentity(
+                user_id=user.id,
+                provider="discord",
+                provider_user_id="123456789012345678",
+                provider_login="spencer",
+            )
+        )
+        db.commit()
+
+        r = client.get("/api/public/fleet", headers=_bearer(token))
+        mine = next(x for x in r.json()["machines"] if x["name"] == "Roster Sorter")
+        assert mine["owner_discord"] == {
+            "id": "123456789012345678",
+            "login": "spencer",
+            "avatar_url": None,
+        }
+        assert r.json()["discord_linked_count"] >= 1
+
+    def test_machine_scoped_key_rejected(self, client, db, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        m = client.post(
+            "/api/machines",
+            json={"name": "Scoped Sorter", "description": "d"},
+            headers=headers,
+        )
+        token = self._mint(client, headers, ["stats:read"], machine_ids=[m.json()["id"]])
+        assert client.get("/api/public/fleet", headers=_bearer(token)).status_code == 403


### PR DESCRIPTION
Adds `GET /api/public/fleet`: every non-archived machine with the owner's Discord identity attached only when that owner has linked one (the `user_identities` opt-in). Unlinked owners appear as anonymous machines — no emails, no user ids.

Gated by the exact same `require_stats_key` dependency as `/api/public/stats`: an admin-minted, unconstrained `hv_*` key carrying `stats:read`. Machine-scoped keys are rejected.

Consumer: the balloon bot's upcoming fleet-stats board.

Full backend suite: 238 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)