### PR TITLE
hive: per-sample dataset provenance for published models

### DIFF
--- a/software/hive/backend/alembic/versions/c9e1f3a5b7d9_add_model_dataset_samples.py
+++ b/software/hive/backend/alembic/versions/c9e1f3a5b7d9_add_model_dataset_samples.py
@@ -1,0 +1,39 @@
+"""add model_dataset_samples
+
+Revision ID: c9e1f3a5b7d9
+Revises: b8d0f2a4c6e8
+Create Date: 2026-08-09 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c9e1f3a5b7d9"
+down_revision: Union[str, None] = "b8d0f2a4c6e8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "model_dataset_samples",
+        sa.Column("model_id", sa.UUID(), nullable=False),
+        sa.Column("sample_id", sa.UUID(), nullable=False),
+        sa.Column("split", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(["model_id"], ["detection_models.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["sample_id"], ["samples.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("model_id", "sample_id"),
+        sa.CheckConstraint("split IN ('train', 'val')", name="ck_model_dataset_samples_split"),
+    )
+    op.create_index(
+        "ix_model_dataset_samples_sample_id", "model_dataset_samples", ["sample_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_model_dataset_samples_sample_id", table_name="model_dataset_samples")
+    op.drop_table("model_dataset_samples")

--- a/software/hive/backend/app/models/__init__.py
+++ b/software/hive/backend/app/models/__init__.py
@@ -30,6 +30,7 @@ from app.models.machine_set_progress import MachineSetProgress  # noqa: E402, F4
 from app.models.machine_config_backup import MachineConfigBackup  # noqa: E402, F401
 from app.models.machine_hardware_report import MachineHardwareReport  # noqa: E402, F401
 from app.models.detection_model import DetectionModel, DetectionModelVariant  # noqa: E402, F401
+from app.models.model_dataset_sample import ModelDatasetSample  # noqa: E402, F401
 from app.models.user_api_key import UserApiKey  # noqa: E402, F401
 from app.models.user_identity import UserIdentity  # noqa: E402, F401
 from app.models.teacher_job import TeacherJob, TeacherJobItem  # noqa: E402, F401

--- a/software/hive/backend/app/models/model_dataset_sample.py
+++ b/software/hive/backend/app/models/model_dataset_sample.py
@@ -1,0 +1,39 @@
+from sqlalchemy import CheckConstraint, Column, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.models import Base
+
+SPLIT_TRAIN = "train"
+SPLIT_VAL = "val"
+DATASET_SPLITS = (SPLIT_TRAIN, SPLIT_VAL)
+
+
+class ModelDatasetSample(Base):
+    """One row per Hive sample that went into a published model's dataset.
+
+    The structured counterpart to the free-form ``training_metadata`` blob: it
+    records exactly which samples a model trained on, so machine composition,
+    diversity, and sample-level provenance are queryable joins instead of
+    prose. Rows cascade away with either side — a deleted sample shrinks the
+    recorded dataset rather than leaving a dangling reference, which is why
+    aggregate counts in ``training_metadata`` remain the historical record.
+    """
+
+    __tablename__ = "model_dataset_samples"
+
+    model_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("detection_models.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    sample_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("samples.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    split = Column(String, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint("split IN ('train', 'val')", name="ck_model_dataset_samples_split"),
+        Index("ix_model_dataset_samples_sample_id", "sample_id"),
+    )

--- a/software/hive/backend/app/routers/models.py
+++ b/software/hive/backend/app/routers/models.py
@@ -17,6 +17,9 @@ from app.deps import (
 )
 from app.errors import APIError
 from app.models.detection_model import MODEL_PURPOSES, DetectionModel, DetectionModelVariant
+from app.models.machine import Machine
+from app.models.model_dataset_sample import ModelDatasetSample
+from app.models.sample import Sample
 from app.models.user import User
 from app.schemas.model import (
     DetectionModelCreateRequest,
@@ -27,6 +30,10 @@ from app.schemas.model import (
     DetectionModelSummary,
     DetectionModelVariantDetail,
     DetectionModelVariantUploadResponse,
+    ModelDatasetMachine,
+    ModelDatasetMachinesResponse,
+    ModelDatasetSamplesAttachRequest,
+    ModelDatasetSamplesAttachResponse,
 )
 from app.services.storage import (
     build_download_filename,
@@ -217,6 +224,117 @@ def create_model(
     db.commit()
     db.refresh(model)
     return DetectionModelCreateResponse(id=model.id, slug=model.slug, version=model.version, codename=model.codename)
+
+
+@router.post("/{model_id}/dataset-samples", response_model=ModelDatasetSamplesAttachResponse)
+def attach_dataset_samples(
+    model_id: UUID,
+    payload: ModelDatasetSamplesAttachRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_role_flex("admin")),
+    _scope_guard: User = Depends(require_api_key_scopes(API_KEY_SCOPE_MODELS_WRITE)),
+    _csrf: None = Depends(verify_csrf),
+):
+    """Record which Hive samples a model's dataset was built from.
+
+    Called by the training-side publisher (repeatedly, in chunks) after the
+    variants are uploaded. Idempotent: already-recorded (model, sample) pairs
+    are left in place, so a retried chunk can't duplicate. Sample IDs that
+    don't exist on this Hive are skipped and counted rather than failing the
+    whole batch — a dataset built weeks ago may reference since-deleted
+    samples.
+    """
+    model = db.query(DetectionModel).filter(DetectionModel.id == model_id).first()
+    if model is None:
+        raise APIError(404, "Model not found", "MODEL_NOT_FOUND")
+
+    if payload.replace:
+        db.query(ModelDatasetSample).filter(ModelDatasetSample.model_id == model_id).delete()
+
+    requested = {ref.sample_id: ref.split for ref in payload.samples}
+    known_ids = {
+        row[0]
+        for row in db.query(Sample.id).filter(Sample.id.in_(requested.keys())).all()
+    }
+    existing_ids = {
+        row[0]
+        for row in db.query(ModelDatasetSample.sample_id)
+        .filter(
+            ModelDatasetSample.model_id == model_id,
+            ModelDatasetSample.sample_id.in_(known_ids),
+        )
+        .all()
+    }
+    to_insert = known_ids - existing_ids
+    db.bulk_save_objects(
+        [
+            ModelDatasetSample(model_id=model_id, sample_id=sid, split=requested[sid])
+            for sid in to_insert
+        ]
+    )
+    db.commit()
+
+    total = (
+        db.query(func.count(ModelDatasetSample.sample_id))
+        .filter(ModelDatasetSample.model_id == model_id)
+        .scalar()
+    )
+    return ModelDatasetSamplesAttachResponse(
+        attached=len(to_insert),
+        skipped_unknown=len(requested) - len(known_ids),
+        total_recorded=total or 0,
+    )
+
+
+@router.get("/{model_id}/dataset-machines", response_model=ModelDatasetMachinesResponse)
+def get_dataset_machines(
+    model_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_api_key_scopes(API_KEY_SCOPE_MODELS_READ)),
+):
+    """Per-machine composition of a model's recorded dataset.
+
+    Aggregated live from the model_dataset_samples join, so it reflects the
+    machines as they are named now. Empty when the model predates sample
+    recording — the UI falls back to the training_metadata blob then.
+    """
+    model = (
+        _apply_visibility(db.query(DetectionModel), current_user)
+        .filter(DetectionModel.id == model_id)
+        .first()
+    )
+    if model is None:
+        raise APIError(404, "Model not found", "MODEL_NOT_FOUND")
+
+    rows = (
+        db.query(
+            Machine.id,
+            Machine.name,
+            func.count(ModelDatasetSample.sample_id).filter(ModelDatasetSample.split == "train"),
+            func.count(ModelDatasetSample.sample_id).filter(ModelDatasetSample.split == "val"),
+            func.count(ModelDatasetSample.sample_id),
+        )
+        .select_from(ModelDatasetSample)
+        .join(Sample, Sample.id == ModelDatasetSample.sample_id)
+        .join(Machine, Machine.id == Sample.machine_id)
+        .filter(ModelDatasetSample.model_id == model_id)
+        .group_by(Machine.id, Machine.name)
+        .order_by(func.count(ModelDatasetSample.sample_id).desc())
+        .all()
+    )
+    total = sum(r[4] for r in rows)
+    machines = [
+        ModelDatasetMachine(
+            machine_id=r[0],
+            machine_name=r[1],
+            train_samples=r[2],
+            val_samples=r[3],
+            total=r[4],
+            share=(r[4] / total) if total else 0.0,
+        )
+        for r in rows
+    ]
+    return ModelDatasetMachinesResponse(machines=machines, total_recorded=total)
 
 
 @router.post("/{model_id}/variants", response_model=DetectionModelVariantUploadResponse)

--- a/software/hive/backend/app/schemas/model.py
+++ b/software/hive/backend/app/schemas/model.py
@@ -104,3 +104,37 @@ class DetectionModelVariantUploadResponse(BaseModel):
     file_name: str
     file_size: int
     sha256: str
+
+
+class DatasetSampleRef(BaseModel):
+    sample_id: UUID
+    split: str = Field(..., pattern="^(train|val)$")
+
+
+class ModelDatasetSamplesAttachRequest(BaseModel):
+    """Bulk-record which Hive samples a model's dataset was built from."""
+    samples: list[DatasetSampleRef] = Field(..., min_length=1, max_length=20000)
+    replace: bool = Field(
+        default=False,
+        description="Drop any previously recorded samples for this model first.",
+    )
+
+
+class ModelDatasetSamplesAttachResponse(BaseModel):
+    attached: int
+    skipped_unknown: int  # sample IDs not present in this Hive (e.g. deleted since training)
+    total_recorded: int
+
+
+class ModelDatasetMachine(BaseModel):
+    machine_id: UUID
+    machine_name: str
+    train_samples: int
+    val_samples: int
+    total: int
+    share: float  # fraction of the model's recorded samples
+
+
+class ModelDatasetMachinesResponse(BaseModel):
+    machines: list[ModelDatasetMachine]
+    total_recorded: int

--- a/software/hive/backend/tests/test_model_dataset_samples.py
+++ b/software/hive/backend/tests/test_model_dataset_samples.py
@@ -1,0 +1,175 @@
+"""Tests for per-sample dataset provenance on detection models."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.machine import Machine
+from app.models.sample import Sample
+from app.models.upload_session import UploadSession
+from app.models.user import User
+from tests.conftest import _auth_headers, _login_user, _register_user
+
+
+def _promote(db: Session, email: str, role: str) -> None:
+    user = db.query(User).filter(User.email == email).first()
+    assert user is not None
+    user.role = role
+    db.commit()
+
+
+@pytest.fixture()
+def admin_headers(client: TestClient, db: Session) -> dict[str, str]:
+    _register_user(client, "admin@test.com", "Password123!", "Admin")
+    _login_user(client, "admin@test.com", "Password123!")
+    _promote(db, "admin@test.com", "admin")
+    return _auth_headers(client)
+
+
+def _make_machine_with_samples(db: Session, name: str, count: int) -> list[str]:
+    owner = db.query(User).first()
+    assert owner is not None
+    token = uuid.uuid4().hex
+    machine = Machine(
+        owner_id=owner.id,
+        token_hash=token,
+        token_prefix=token[:8],
+        name=name,
+    )
+    db.add(machine)
+    db.flush()
+    session = UploadSession(
+        machine_id=machine.id,
+        source_session_id=f"session-{machine.token_prefix}",
+        name=f"Session {name}",
+    )
+    db.add(session)
+    db.flush()
+    ids = []
+    for i in range(count):
+        sample = Sample(
+            machine_id=machine.id,
+            upload_session_id=session.id,
+            local_sample_id=f"{machine.token_prefix}-{i}",
+            image_path=f"samples/{machine.token_prefix}-{i}.jpg",
+        )
+        db.add(sample)
+        db.flush()
+        ids.append(str(sample.id))
+    db.commit()
+    return ids
+
+
+def _create_model(client: TestClient, headers: dict[str, str]) -> str:
+    resp = client.post(
+        "/api/models",
+        json={"slug": "prov-test", "name": "Prov Test", "model_family": "yolo"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+class TestAttachDatasetSamples:
+    def test_requires_admin(
+        self, client: TestClient, db: Session, admin_headers: dict[str, str]
+    ) -> None:
+        model_id = _create_model(client, admin_headers)
+        ids = _make_machine_with_samples(db, "Rig A", 1)
+        # Sessions are cookie-based on the shared client — switch to a member.
+        _register_user(client, "member@test.com", "Password123!", "Member")
+        _login_user(client, "member@test.com", "Password123!")
+        resp = client.post(
+            f"/api/models/{model_id}/dataset-samples",
+            json={"samples": [{"sample_id": ids[0], "split": "train"}]},
+            headers=_auth_headers(client),
+        )
+        assert resp.status_code == 403
+
+    def test_attach_idempotent_and_skips_unknown(
+        self, client: TestClient, db: Session, admin_headers: dict[str, str]
+    ) -> None:
+        model_id = _create_model(client, admin_headers)
+        ids = _make_machine_with_samples(db, "Rig A", 3)
+        body = {
+            "samples": [{"sample_id": sid, "split": "train"} for sid in ids]
+            + [{"sample_id": str(uuid.uuid4()), "split": "val"}]
+        }
+        r1 = client.post(f"/api/models/{model_id}/dataset-samples", json=body, headers=admin_headers)
+        assert r1.status_code == 200, r1.text
+        assert r1.json() == {"attached": 3, "skipped_unknown": 1, "total_recorded": 3}
+
+        # Retrying the same chunk must not duplicate.
+        r2 = client.post(f"/api/models/{model_id}/dataset-samples", json=body, headers=admin_headers)
+        assert r2.status_code == 200
+        assert r2.json() == {"attached": 0, "skipped_unknown": 1, "total_recorded": 3}
+
+    def test_replace_drops_previous(
+        self, client: TestClient, db: Session, admin_headers: dict[str, str]
+    ) -> None:
+        model_id = _create_model(client, admin_headers)
+        old = _make_machine_with_samples(db, "Rig A", 2)
+        new = _make_machine_with_samples(db, "Rig B", 1)
+        client.post(
+            f"/api/models/{model_id}/dataset-samples",
+            json={"samples": [{"sample_id": sid, "split": "train"} for sid in old]},
+            headers=admin_headers,
+        )
+        resp = client.post(
+            f"/api/models/{model_id}/dataset-samples",
+            json={"samples": [{"sample_id": new[0], "split": "val"}], "replace": True},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total_recorded"] == 1
+
+    def test_rejects_bad_split(
+        self, client: TestClient, db: Session, admin_headers: dict[str, str]
+    ) -> None:
+        model_id = _create_model(client, admin_headers)
+        ids = _make_machine_with_samples(db, "Rig A", 1)
+        resp = client.post(
+            f"/api/models/{model_id}/dataset-samples",
+            json={"samples": [{"sample_id": ids[0], "split": "test"}]},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 422
+
+
+class TestDatasetMachines:
+    def test_aggregates_by_machine(
+        self, client: TestClient, db: Session, admin_headers: dict[str, str]
+    ) -> None:
+        model_id = _create_model(client, admin_headers)
+        rig_a = _make_machine_with_samples(db, "Rig A", 3)
+        rig_b = _make_machine_with_samples(db, "Rig B", 1)
+        samples = [{"sample_id": sid, "split": "train"} for sid in rig_a[:2]]
+        samples += [{"sample_id": rig_a[2], "split": "val"}]
+        samples += [{"sample_id": rig_b[0], "split": "train"}]
+        client.post(
+            f"/api/models/{model_id}/dataset-samples",
+            json={"samples": samples},
+            headers=admin_headers,
+        )
+
+        resp = client.get(f"/api/models/{model_id}/dataset-machines", headers=admin_headers)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["total_recorded"] == 4
+        assert [m["machine_name"] for m in data["machines"]] == ["Rig A", "Rig B"]
+        a, b = data["machines"]
+        assert (a["train_samples"], a["val_samples"], a["total"]) == (2, 1, 3)
+        assert (b["train_samples"], b["val_samples"], b["total"]) == (1, 0, 1)
+        assert a["share"] == pytest.approx(0.75)
+
+    def test_empty_for_unrecorded_model(
+        self, client: TestClient, admin_headers: dict[str, str]
+    ) -> None:
+        model_id = _create_model(client, admin_headers)
+        resp = client.get(f"/api/models/{model_id}/dataset-machines", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.json() == {"machines": [], "total_recorded": 0}

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -2308,6 +2308,9 @@ export const api = {
 	getModel(id: string) {
 		return request<DetectionModelDetail>('GET', `/api/models/${id}`);
 	},
+	getModelDatasetMachines(id: string) {
+		return request<ModelDatasetMachinesResponse>('GET', `/api/models/${id}/dataset-machines`);
+	},
 	modelVariantDownloadUrl(modelId: string, variantId: string) {
 		return resolveApiPath(`/api/models/${modelId}/variants/${variantId}/download`);
 	},
@@ -2456,6 +2459,20 @@ export interface DetectionModelSummary {
 export interface DetectionModelDetail extends DetectionModelSummary {
 	training_metadata: Record<string, unknown> | null;
 	variants: DetectionModelVariant[];
+}
+
+export interface ModelDatasetMachine {
+	machine_id: string;
+	machine_name: string;
+	train_samples: number;
+	val_samples: number;
+	total: number;
+	share: number;
+}
+
+export interface ModelDatasetMachinesResponse {
+	machines: ModelDatasetMachine[];
+	total_recorded: number;
 }
 
 export interface ApiKeySummary {

--- a/software/hive/frontend/src/routes/models/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/models/[id]/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { api, type DetectionModelDetail, type DetectionModelVariant } from '$lib/api';
+	import {
+		api,
+		type DetectionModelDetail,
+		type DetectionModelVariant,
+		type ModelDatasetMachine
+	} from '$lib/api';
 	import ModelTrainingReport from '$lib/components/ModelTrainingReport.svelte';
 	import Badge from '$lib/components/Badge.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
@@ -8,6 +13,10 @@
 	let model = $state<DetectionModelDetail | null>(null);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
+	// Structured per-machine dataset composition (models published with sample
+	// recording). Empty for older models — the metadata blob covers those.
+	let datasetMachines = $state<ModelDatasetMachine[]>([]);
+	let datasetRecorded = $state(0);
 
 	$effect(() => {
 		const id = page.params.id;
@@ -25,6 +34,15 @@
 			error = apiErr?.error || 'Failed to load model';
 		} finally {
 			loading = false;
+		}
+		try {
+			const ds = await api.getModelDatasetMachines(id);
+			datasetMachines = ds.machines;
+			datasetRecorded = ds.total_recorded;
+		} catch {
+			// Non-fatal: page renders from training_metadata alone.
+			datasetMachines = [];
+			datasetRecorded = 0;
 		}
 	}
 
@@ -51,21 +69,58 @@
 	const precision = $derived(asNumber(best?.precision));
 
 	const samples = $derived(asInt(datasetMeta?.total) ?? asInt(datasetMeta?.train_samples));
-	const machineCount = $derived(asInt(asRecord(datasetMeta?.machines)?.count));
+
+	// Rows for the Dataset Machines section: the structured per-sample recording
+	// when the model has one, else parsed out of the metadata blob so older
+	// models still show their composition.
+	type MachineRow = {
+		name: string;
+		train: number | null;
+		val: number | null;
+		total: number;
+		share: number;
+	};
+	const machineRows = $derived.by<MachineRow[]>(() => {
+		if (datasetMachines.length > 0) {
+			return datasetMachines.map((m) => ({
+				name: m.machine_name,
+				train: m.train_samples,
+				val: m.val_samples,
+				total: m.total,
+				share: m.share
+			}));
+		}
+		const dist = asRecord(asRecord(datasetMeta?.machines)?.distribution_after_balance);
+		if (!dist) return [];
+		const rows: MachineRow[] = [];
+		for (const [name, value] of Object.entries(dist)) {
+			const txt = typeof value === 'string' ? value : String(value);
+			const match = txt.match(/(\d[\d.,]*)/);
+			if (match)
+				rows.push({
+					name,
+					train: null,
+					val: null,
+					total: parseInt(match[1].replace(/[.,]/g, ''), 10),
+					share: 0
+				});
+		}
+		const total = rows.reduce((acc, r) => acc + r.total, 0);
+		for (const r of rows) r.share = total ? r.total / total : 0;
+		return rows.sort((a, b) => b.total - a.total);
+	});
+
+	const machineCount = $derived(
+		machineRows.length > 0 ? machineRows.length : asInt(asRecord(datasetMeta?.machines)?.count)
+	);
 
 	const arch = $derived(typeof modelMeta?.architecture === 'string' ? (modelMeta.architecture as string) : null);
 	const imgsz = $derived(asInt(modelMeta?.imgsz));
 
-	// Same diversity-score formula as the card — Shannon entropy of per-machine shares.
+	// Same diversity-score formula as the card — Shannon entropy of per-machine
+	// shares — but fed from machineRows so it works for both sources.
 	const diversityScore = $derived.by<number | null>(() => {
-		const dist = asRecord(asRecord(datasetMeta?.machines)?.distribution_after_balance);
-		if (!dist) return null;
-		const counts: number[] = [];
-		for (const value of Object.values(dist)) {
-			const txt = typeof value === 'string' ? value : String(value);
-			const match = txt.match(/(\d[\d.,]*)/);
-			if (match) counts.push(parseInt(match[1].replace(/[.,]/g, ''), 10));
-		}
+		const counts = machineRows.map((r) => r.total);
 		if (counts.length < 2) return counts.length === 1 ? 0 : null;
 		const total = counts.reduce((a, b) => a + b, 0);
 		if (total === 0) return null;
@@ -304,6 +359,63 @@
 							<span class="border border-border bg-bg px-1.5 py-0.5 font-mono text-[11px] text-text">{scope}</span>
 						{/each}
 					</div>
+				{/if}
+			</section>
+		{/if}
+
+		<!-- Machines in the dataset — structured per-sample recording when present,
+			 else derived from the training_metadata blob -->
+		{#if machineRows.length > 0}
+			<section class="border border-border bg-surface">
+				<div class="flex items-baseline justify-between border-b border-border px-5 py-3">
+					<h2 class="text-sm font-semibold uppercase tracking-wider text-text-muted">Dataset machines</h2>
+					<span class="text-xs text-text-muted">
+						{machineRows.length} machine{machineRows.length === 1 ? '' : 's'}{#if datasetRecorded > 0}&nbsp;· {datasetRecorded.toLocaleString()} samples recorded{/if}
+					</span>
+				</div>
+				<div class="overflow-x-auto">
+					<table class="w-full text-sm">
+						<thead>
+							<tr class="border-b border-border text-left text-[10px] uppercase tracking-wider text-text-muted">
+								<th class="px-5 py-2 font-medium">Machine</th>
+								<th class="px-3 py-2 text-right font-medium">Train</th>
+								<th class="px-3 py-2 text-right font-medium">Val</th>
+								<th class="px-3 py-2 text-right font-medium">Total</th>
+								<th class="w-1/3 px-5 py-2 font-medium">Share</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each machineRows as row (row.name)}
+								<tr class="border-b border-border last:border-b-0">
+									<td class="px-5 py-2 text-text">{row.name}</td>
+									<td class="px-3 py-2 text-right font-mono tabular-nums text-text-muted">
+										{row.train !== null ? row.train.toLocaleString() : '—'}
+									</td>
+									<td class="px-3 py-2 text-right font-mono tabular-nums text-text-muted">
+										{row.val !== null ? row.val.toLocaleString() : '—'}
+									</td>
+									<td class="px-3 py-2 text-right font-mono font-semibold tabular-nums text-text">
+										{row.total.toLocaleString()}
+									</td>
+									<td class="px-5 py-2">
+										<div class="flex items-center gap-2">
+											<div class="h-1.5 flex-1 bg-bg">
+												<div class="h-full bg-primary" style="width: {(row.share * 100).toFixed(1)}%"></div>
+											</div>
+											<span class="w-12 text-right font-mono text-[11px] tabular-nums text-text-muted">
+												{(row.share * 100).toFixed(1)}%
+											</span>
+										</div>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+				{#if datasetRecorded === 0}
+					<p class="border-t border-border px-5 py-2 text-[11px] text-text-muted">
+						From training metadata — this model predates per-sample dataset recording.
+					</p>
 				{/if}
 			</section>
 		{/if}

--- a/software/hive/sorter-client/hive_client.py
+++ b/software/hive/sorter-client/hive_client.py
@@ -286,6 +286,21 @@ class HiveAdminClient:
         """POST /api/models."""
         return self._request("POST", "/api/models", json=payload)
 
+    def attach_dataset_samples(
+        self, model_id: str, samples: list[dict], replace: bool = False
+    ) -> dict:
+        """POST /api/models/{id}/dataset-samples.
+
+        ``samples`` is ``[{"sample_id": <uuid>, "split": "train"|"val"}, ...]``.
+        Idempotent server-side; ``replace=True`` drops previously recorded rows
+        first (use on the first chunk of a re-publish).
+        """
+        return self._request(
+            "POST",
+            f"/api/models/{model_id}/dataset-samples",
+            json={"samples": samples, "replace": replace},
+        )
+
     def upload_variant(
         self,
         model_id: str,

--- a/software/training/RUNBOOK.md
+++ b/software/training/RUNBOOK.md
@@ -219,6 +219,14 @@ Key flags:
   `training_metadata` (model + dataset + selection + benchmarks) from
   `build.json` + `track_*_results.json`. **Always pass it.** Without it
   the Hive UI's hero cards stay blank.
+- `--dataset-dir` also records **per-sample dataset provenance**: the sample
+  UUIDs under `labels/{train,val}/` get written to Hive's
+  `model_dataset_samples` table, which powers the "Dataset machines" section
+  on the model page (queryable joins, not metadata prose). For a model that
+  was published without it, backfill later with
+  `uv run train attach-samples --model-id <id> --dataset-dir <dir> --hive-url <url>`
+  — the dataset dir on the Lambda NFS (`/lambda/nfs/one/sorter-npu/...`)
+  survives instance termination, so this works whenever a box is next up.
 - `--benchmark-json` adds the CPU/CoreML latency block.
 - `--model-key A7` picks the right entry when the track ran several
   models — match the `A1/A3/A5/A7/A8` label from `track_a_results.json`.

--- a/software/training/src/training/cli.py
+++ b/software/training/src/training/cli.py
@@ -530,10 +530,59 @@ def publish(**kwargs) -> None:
             benchmark_json=Path(benchmark_json) if benchmark_json else None,
             model_key=model_key,
         )
+        # Publish also records per-sample dataset provenance from this dir.
+        kwargs["dataset_dir"] = dataset_dir
 
     from training.hive import publish as publish_mod
 
     sys.exit(publish_mod.cli(kwargs))
+
+
+@main.command("attach-samples")
+@click.option("--model-id", required=True, help="Hive model UUID to record the dataset against.")
+@click.option("--dataset-dir", required=True, type=click.Path(exists=True, file_okay=False))
+@click.option("--hive-url", required=True)
+@click.option("--token", default=None, help="Hive API key; falls back to stored token for this URL.")
+@click.option(
+    "--replace/--append",
+    default=True,
+    help="Replace any previously recorded samples for this model (default) or append.",
+)
+def attach_samples(model_id: str, dataset_dir: str, hive_url: str, token: str | None, replace: bool) -> None:
+    """Backfill per-sample dataset provenance for an already-published model.
+
+    Reads the sample UUIDs from <dataset-dir>/labels/{train,val}/*.txt stems —
+    the same source `train publish --dataset-dir` uses at publish time.
+    """
+    from pathlib import Path
+
+    from training import auth
+    from training.hive.publish import _ATTACH_CHUNK, collect_dataset_sample_refs
+
+    api_key = token or auth.get_token(hive_url)
+    if not api_key:
+        click.echo(f"No stored API key for {hive_url}; run `train auth login` or pass --token.", err=True)
+        sys.exit(1)
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "hive" / "sorter-client"))
+    from hive_client import HiveAdminClient
+
+    client = HiveAdminClient(hive_url, api_key=api_key)
+    refs = collect_dataset_sample_refs(Path(dataset_dir))
+    if not refs:
+        click.echo("No sample-UUID label stems found under the dataset dir.", err=True)
+        sys.exit(1)
+    attached = unknown = 0
+    for i in range(0, len(refs), _ATTACH_CHUNK):
+        result = client.attach_dataset_samples(
+            model_id, refs[i : i + _ATTACH_CHUNK], replace=(replace and i == 0)
+        )
+        attached += result.get("attached", 0)
+        unknown = result.get("skipped_unknown", 0) + unknown
+    click.echo(
+        f"Recorded {attached}/{len(refs)} samples on model {model_id}"
+        + (f" ({unknown} unknown to this Hive)" if unknown else "")
+    )
 
 
 @main.command("benchmark")

--- a/software/training/src/training/hive/publish.py
+++ b/software/training/src/training/hive/publish.py
@@ -64,6 +64,53 @@ def _tar_directory(src_dir: Path) -> Path:
     return Path(tmp.name)
 
 
+_ATTACH_CHUNK = 5000
+
+
+def collect_dataset_sample_refs(dataset_dir: Path) -> list[dict]:
+    """Sample refs [{sample_id, split}] from a built dataset's label stems.
+
+    Label files are named by Hive sample UUID (that's how `train build` writes
+    them); anything that doesn't parse as a UUID (stray files, non-Hive
+    sources) is skipped with a note rather than failing the publish.
+    """
+    import uuid as uuid_mod
+
+    refs: list[dict] = []
+    skipped = 0
+    for split in ("train", "val"):
+        for label in sorted((dataset_dir / "labels" / split).glob("*.txt")):
+            try:
+                sid = str(uuid_mod.UUID(label.stem))
+            except ValueError:
+                skipped += 1
+                continue
+            refs.append({"sample_id": sid, "split": split})
+    if skipped:
+        print(f"  dataset-samples: skipped {skipped} non-UUID label stems", file=sys.stderr)
+    return refs
+
+
+def attach_dataset_samples(client, model_id: str, dataset_dir: Path) -> None:
+    """Record the dataset's per-sample provenance on the published model."""
+    refs = collect_dataset_sample_refs(dataset_dir)
+    if not refs:
+        print("  dataset-samples: none found — skipping", file=sys.stderr)
+        return
+    total_attached = 0
+    skipped_unknown = 0
+    for i in range(0, len(refs), _ATTACH_CHUNK):
+        chunk = refs[i : i + _ATTACH_CHUNK]
+        result = client.attach_dataset_samples(model_id, chunk, replace=(i == 0))
+        total_attached += result.get("attached", 0)
+        skipped_unknown += result.get("skipped_unknown", 0)
+    print(
+        f"  dataset-samples: recorded {total_attached}/{len(refs)}"
+        + (f" ({skipped_unknown} unknown to this Hive)" if skipped_unknown else ""),
+        file=sys.stderr,
+    )
+
+
 def _load_run_metadata(run_dir: Path) -> dict:
     run_json = run_dir / "run.json"
     if not run_json.exists():
@@ -137,6 +184,7 @@ def _run_publish(
     password: str | None = None,
     api_key: str | None = None,
     is_public: bool,
+    dataset_dir: Path | None = None,
 ) -> int:
     run_dir = run_dir.resolve()
     meta = _load_run_metadata(run_dir)
@@ -192,6 +240,14 @@ def _run_publish(
                 except OSError:
                     pass
 
+    if dataset_dir is not None:
+        print("Recording dataset sample provenance", file=sys.stderr)
+        try:
+            attach_dataset_samples(client, model_id, dataset_dir)
+        except HiveError as exc:
+            # Older Hives don't have the endpoint yet — the publish itself is done.
+            print(f"  dataset-samples: not recorded ({exc})", file=sys.stderr)
+
     print(f"Published {slug} v{created['version']} ({len(variants)} variants)", file=sys.stderr)
     return 0
 
@@ -235,6 +291,7 @@ def cli(kwargs: dict) -> int:
         password=password,
         api_key=api_key,
         is_public=kwargs.get("public", True),
+        dataset_dir=Path(kwargs["dataset_dir"]) if kwargs.get("dataset_dir") else None,
     )
 
 


### PR DESCRIPTION
Structured, queryable record of which Hive samples each published model trained on — Spencer's ask: dataset composition in the DB proper, not giant JSON blobs.

## What
- **`model_dataset_samples`** join table: `(model_id, sample_id, split)`, FK cascade on both sides, alembic migration `c9e1f3a5b7d9`.
- **`POST /api/models/{id}/dataset-samples`** — chunked, idempotent bulk attach (admin + `models:write`). Unknown sample IDs are counted and skipped, retries can't duplicate, `replace` resets a re-publish.
- **`GET /api/models/{id}/dataset-machines`** — live per-machine aggregation (train/val/total/share) via joins to `samples`/`machines`.
- **Model detail page**: new *Dataset machines* section — per-rig table with share bars; falls back to parsing `training_metadata.dataset.machines` for models that predate recording. Machine count + diversity score now prefer the structured rows.
- **`train publish --dataset-dir`** additionally records provenance from the dataset's label stems; new **`train attach-samples`** command backfills already-published models (r5 backfill can run whenever a Lambda box next mounts the NFS).

## Tests
- `tests/test_model_dataset_samples.py`: attach idempotency, unknown-ID skip, replace semantics, split validation, per-machine aggregation, role gate. Full backend suite passes; `svelte-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)