### PR TITLE
hive: fleet:read scope splits the identified tier from the aggregates

### DIFF
--- a/software/hive/backend/app/deps.py
+++ b/software/hive/backend/app/deps.py
@@ -19,7 +19,17 @@ API_KEY_SCOPE_MODELS_WRITE = "models:write"
 API_KEY_SCOPE_SAMPLES_READ = "samples:read"
 API_KEY_SCOPE_SAMPLES_WRITE = "samples:write"
 API_KEY_SCOPE_KEYS_MANAGE = "keys:manage"
+# The two tiers of fleet reporting, and the reason they are two scopes rather
+# than one. `stats:read` is the ANONYMOUS tier: fleet-wide aggregates with no
+# machine and no person in them, safe for a consumer that is itself public —
+# the website widget, anything cached at an edge. `fleet:read` is the
+# IDENTIFIED tier: which machines exist, how each is doing, and the owner's
+# Discord where that owner linked one. The consumers differ in how well the
+# credential is kept (a private box and Spencer's phone, versus a website), so
+# the credential has to be able to differ too. One scope for both would mean
+# every key that can draw a public counter can also enumerate owners.
 API_KEY_SCOPE_STATS_READ = "stats:read"
+API_KEY_SCOPE_FLEET_READ = "fleet:read"
 VALID_API_KEY_SCOPES = frozenset(
     {
         API_KEY_SCOPE_MODELS_READ,
@@ -28,6 +38,7 @@ VALID_API_KEY_SCOPES = frozenset(
         API_KEY_SCOPE_SAMPLES_WRITE,
         API_KEY_SCOPE_KEYS_MANAGE,
         API_KEY_SCOPE_STATS_READ,
+        API_KEY_SCOPE_FLEET_READ,
     }
 )
 

--- a/software/hive/backend/app/routers/public_stats.py
+++ b/software/hive/backend/app/routers/public_stats.py
@@ -1,17 +1,28 @@
-"""Service-to-service aggregate stats.
+"""Service-to-service fleet reporting, in two tiers.
 
-Exposes the same aggregate analytics an admin sees on the all-machines page
-(totals + daily time-series + distributions across every non-archived machine).
-Meant for other basically services (e.g. the public website) to pull headline
-numbers without a user session — regular Hive users cannot reach these
-aggregate stats through the normal analytics API.
+**`GET /stats` is the anonymous tier** (scope `stats:read`): fleet-wide
+aggregates — totals, a daily time-series, distributions — with no machine and
+no person in the payload. This is what a consumer that is itself public may
+hold: the website's headline numbers, a widget, anything cached at an edge.
 
-Auth, preferred: an `hv_*` API key carrying the `stats:read` scope, owned by an
-admin and not machine-constrained (a machine-limited key must not read
-fleet-wide aggregates). Legacy: the `settings.PUBLIC_STATS_API_KEY` shared
-secret, presented as `Authorization: Bearer <key>` or `X-Stats-Key: <key>` —
-kept only until every consumer holds a scoped key; delete the env var (and the
-legacy branch below) after cutover.
+**`GET /fleet` is the identified tier** (scope `fleet:read`): the roster. Which
+machines exist, how much each has sorted, and the owner's Discord where that
+owner linked one. Only for consumers whose credential is kept as well as the
+data is — the balloon box, Spencer's phone — never a public website.
+
+The split is enforced by SCOPE and not by convention, which is the whole point:
+a key minted for the website carries `stats:read` alone and is refused the
+roster, so leaking it costs aggregates rather than a list of owners. Both tiers
+additionally require the key's owner to be an admin and the key to be
+unconstrained; a machine-scoped key is strictly less powerful than its owner
+and must not read fleet-wide anything.
+
+Legacy: the `settings.PUBLIC_STATS_API_KEY` shared secret, presented as
+`Authorization: Bearer <key>` or `X-Stats-Key: <key>`. It opens the ANONYMOUS
+tier only — it predates the split, it is shared rather than per-consumer, and
+it must never be a way around the scope that protects the roster. Kept until
+every consumer holds a scoped key; delete the env var and the legacy branch
+below after cutover.
 """
 
 import hmac
@@ -22,12 +33,18 @@ from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 
 from app.config import settings
-from app.deps import API_KEY_PREFIX, API_KEY_SCOPE_STATS_READ, _resolve_api_key, get_db
+from app.deps import (
+    API_KEY_PREFIX,
+    API_KEY_SCOPE_FLEET_READ,
+    API_KEY_SCOPE_STATS_READ,
+    _resolve_api_key,
+    get_db,
+)
 from app.models.machine import Machine
 from app.models.machine_daily_stats import MachineDailyStats
 from app.models.machine_piece import MachinePiece
 from app.models.user_identity import UserIdentity
-from app.services import analytics
+from app.services import analytics, machine_stats
 
 router = APIRouter(prefix="/api/public", tags=["public-stats"])
 
@@ -39,21 +56,27 @@ router = APIRouter(prefix="/api/public", tags=["public-stats"])
 PUBLIC_STATS_LOCAL_TZ = "America/Los_Angeles"
 
 
-def require_stats_key(
-    db: Session = Depends(get_db),
-    authorization: str | None = Header(default=None),
-    x_stats_key: str | None = Header(default=None),
-) -> None:
+def _presented_key(authorization: str | None, x_stats_key: str | None) -> str:
     presented = x_stats_key
     if not presented and authorization and authorization.startswith("Bearer "):
         presented = authorization[7:]
-    presented = (presented or "").strip()
+    return (presented or "").strip()
 
-    # Preferred: a user API key with the stats:read scope.
+
+def _require_scope(db: Session, presented: str, scope: str, *, allow_legacy: bool) -> None:
+    """Admit an admin-owned, unconstrained `hv_*` key carrying `scope`.
+
+    `allow_legacy` says whether the shared secret is also accepted, and it is
+    false for every tier above the aggregates. A shared secret cannot be
+    revoked for one consumer or scoped to one tier, so letting it stand in for
+    a scope would undo the split it predates.
+    """
     if presented.startswith(API_KEY_PREFIX):
         user, scopes, machine_ids = _resolve_api_key(db, presented)
-        if API_KEY_SCOPE_STATS_READ not in scopes:
-            raise HTTPException(status_code=403, detail="API key is missing required scopes: stats:read")
+        if scope not in scopes:
+            raise HTTPException(
+                status_code=403, detail=f"API key is missing required scopes: {scope}"
+            )
         if user.role != "admin":
             raise HTTPException(status_code=403, detail="Insufficient permissions")
         if machine_ids is not None:
@@ -62,12 +85,38 @@ def require_stats_key(
             )
         return
 
+    if not allow_legacy:
+        raise HTTPException(
+            status_code=401, detail=f"This endpoint requires an API key with the {scope} scope"
+        )
     # Legacy shared secret — delete once every consumer holds a scoped key.
     configured = (settings.PUBLIC_STATS_API_KEY or "").strip()
     if not configured:
         raise HTTPException(status_code=503, detail="Public stats API is not configured")
     if not presented or not hmac.compare_digest(presented, configured):
         raise HTTPException(status_code=401, detail="Invalid stats API key")
+
+
+def require_stats_key(
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(default=None),
+    x_stats_key: str | None = Header(default=None),
+) -> None:
+    """The anonymous tier: aggregates only, so the legacy secret still opens it."""
+    _require_scope(
+        db, _presented_key(authorization, x_stats_key), API_KEY_SCOPE_STATS_READ, allow_legacy=True
+    )
+
+
+def require_fleet_key(
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(default=None),
+    x_stats_key: str | None = Header(default=None),
+) -> None:
+    """The identified tier: machines and owners, so a scoped key or nothing."""
+    _require_scope(
+        db, _presented_key(authorization, x_stats_key), API_KEY_SCOPE_FLEET_READ, allow_legacy=False
+    )
 
 
 @router.get("/stats", dependencies=[Depends(require_stats_key)])
@@ -91,11 +140,21 @@ def get_public_stats(db: Session = Depends(get_db)):
     }
 
 
-@router.get("/fleet", dependencies=[Depends(require_stats_key)])
+@router.get("/fleet", dependencies=[Depends(require_fleet_key)])
 def get_public_fleet(db: Session = Depends(get_db)):
-    """The fleet roster: every non-archived machine, with the owner's Discord
-    identity attached only when that owner has linked one. Linking Discord is
-    the opt-in — an unlinked owner appears as an anonymous machine."""
+    """The fleet roster: every non-archived machine, what it has sorted, and the
+    owner's Discord identity attached only when that owner has linked one.
+
+    Linking Discord is the opt-in — an unlinked owner appears as an anonymous
+    machine, and no other owner field is ever served here (no email, no user id,
+    no display name), so an unlinked owner is not merely unnamed but absent.
+
+    The per-machine counters come from machine_stats_cache, which a worker
+    refreshes hourly; reading them costs one indexed table scan rather than a
+    recompute over machine_pieces. The trailing-24h count is computed live
+    because it is the one number a leaderboard wants fresh, and it is a single
+    grouped query over the (machine_id, seen_at) index.
+    """
     rows = (
         db.query(Machine, UserIdentity)
         .outerjoin(
@@ -109,6 +168,9 @@ def get_public_fleet(db: Session = Depends(get_db)):
         .order_by(Machine.created_at)
         .all()
     )
+    ids = [machine.id for machine, _ in rows]
+    lifetime = machine_stats.get_fleet_stats(db)
+    recent = _pieces_by_machine_24h(db, ids)
     machines = [
         {
             "id": str(machine.id),
@@ -116,6 +178,10 @@ def get_public_fleet(db: Session = Depends(get_db)):
             "is_active": machine.is_active,
             "last_seen_at": machine.last_seen_at.isoformat() if machine.last_seen_at else None,
             "created_at": machine.created_at.isoformat(),
+            "pieces_seen": int(lifetime.get(str(machine.id), {}).get("pieces_seen") or 0),
+            "distributed": int(lifetime.get(str(machine.id), {}).get("distributed") or 0),
+            "overall_ppm": float(lifetime.get(str(machine.id), {}).get("overall_ppm") or 0.0),
+            "last_24h_pieces": recent.get(str(machine.id), 0),
             "owner_discord": None
             if identity is None
             else {
@@ -131,6 +197,22 @@ def get_public_fleet(db: Session = Depends(get_db)):
         "machine_count": len(machines),
         "discord_linked_count": sum(1 for m in machines if m["owner_discord"] is not None),
     }
+
+
+def _pieces_by_machine_24h(db: Session, ids: list) -> dict[str, int]:
+    """Trailing-24h piece count per machine. Same window as the fleet-wide
+    number in /stats, so a leaderboard and the headline agree."""
+    if not ids:
+        return {}
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    rows = (
+        db.query(MachinePiece.machine_id, func.count())
+        .filter(MachinePiece.machine_id.in_(ids))
+        .filter(MachinePiece.seen_at >= cutoff)
+        .group_by(MachinePiece.machine_id)
+        .all()
+    )
+    return {str(mid): int(n) for mid, n in rows}
 
 
 def _rolling_24h_pieces(db: Session, ids: list) -> int:

--- a/software/hive/backend/tests/test_public_stats.py
+++ b/software/hive/backend/tests/test_public_stats.py
@@ -119,6 +119,34 @@ class TestFleetRoster:
         monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
         assert client.get("/api/public/fleet").status_code in (401, 503)
 
+    def test_a_stats_only_key_cannot_read_the_roster(self, client, db, monkeypatch):
+        """The whole point of the two scopes: a key minted for a public consumer
+        draws the aggregates and is refused the list of machines and owners."""
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        token = self._mint(client, headers, ["stats:read"])
+        assert client.get("/api/public/stats", headers=_bearer(token)).status_code == 200
+        r = client.get("/api/public/fleet", headers=_bearer(token))
+        assert r.status_code == 403
+        assert "fleet:read" in r.json()["error"]
+
+    def test_a_fleet_only_key_cannot_read_the_aggregates(self, client, db, monkeypatch):
+        """And the reverse, so neither scope is quietly a superset of the other."""
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        token = self._mint(client, headers, ["fleet:read"])
+        assert client.get("/api/public/fleet", headers=_bearer(token)).status_code == 200
+        r = client.get("/api/public/stats", headers=_bearer(token))
+        assert r.status_code == 403
+        assert "stats:read" in r.json()["error"]
+
+    def test_the_legacy_shared_secret_does_not_open_the_roster(self, client, monkeypatch):
+        """It opens the anonymous tier and only that. A shared secret cannot be
+        revoked per consumer, so it must never stand in for fleet:read."""
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", STATS_KEY)
+        assert client.get("/api/public/stats", headers={"X-Stats-Key": STATS_KEY}).status_code == 200
+        assert client.get("/api/public/fleet", headers={"X-Stats-Key": STATS_KEY}).status_code == 401
+
     def test_roster_masks_unlinked_owners(self, client, db, monkeypatch):
         monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
         headers = self._admin_headers(client, db)
@@ -128,7 +156,7 @@ class TestFleetRoster:
             headers=headers,
         )
         assert m.status_code in (200, 201)
-        token = self._mint(client, headers, ["stats:read"])
+        token = self._mint(client, headers, ["fleet:read"])
 
         r = client.get("/api/public/fleet", headers=_bearer(token))
         assert r.status_code == 200, r.text
@@ -169,5 +197,24 @@ class TestFleetRoster:
             json={"name": "Scoped Sorter", "description": "d"},
             headers=headers,
         )
-        token = self._mint(client, headers, ["stats:read"], machine_ids=[m.json()["id"]])
+        token = self._mint(client, headers, ["fleet:read"], machine_ids=[m.json()["id"]])
         assert client.get("/api/public/fleet", headers=_bearer(token)).status_code == 403
+
+    def test_roster_carries_the_numbers_a_leaderboard_needs(self, client, db, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        m = client.post(
+            "/api/machines", json={"name": "Counting Sorter", "description": "d"}, headers=headers
+        )
+        assert m.status_code in (200, 201)
+        token = self._mint(client, headers, ["fleet:read"])
+        entry = next(
+            x
+            for x in client.get("/api/public/fleet", headers=_bearer(token)).json()["machines"]
+            if x["name"] == "Counting Sorter"
+        )
+        for field in ("pieces_seen", "distributed", "overall_ppm", "last_24h_pieces"):
+            assert field in entry, f"{field} missing from the roster entry"
+        # A machine that has never sorted reports zeros rather than nulls, so a
+        # consumer can sort on these without special-casing a fresh machine.
+        assert entry["pieces_seen"] == 0 and entry["last_24h_pieces"] == 0

--- a/software/hive/frontend/src/routes/settings/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/+page.svelte
@@ -99,7 +99,8 @@
 		{ scope: 'samples:read', label: 'Read samples' },
 		{ scope: 'samples:write', label: 'Write samples' },
 		{ scope: 'keys:manage', label: 'Manage API keys' },
-		{ scope: 'stats:read', label: 'Read aggregate stats' }
+		{ scope: 'stats:read', label: 'Read aggregate stats' },
+		{ scope: 'fleet:read', label: 'Read the fleet roster (machines + linked owners)' }
 	];
 	let apiKeySelectedScopes = $state<string[]>([]);
 	let apiKeyExpiresInDays = $state('');


### PR DESCRIPTION
Follow-up to #265. The two fleet-reporting tiers were routes but not credentials — both accepted `stats:read`, so any key you would hand a public website could also enumerate machines and linked owners.

- New `fleet:read` scope. `/api/public/stats` keeps `stats:read`; `/api/public/fleet` requires `fleet:read`. Neither is a superset of the other (tested both directions).
- The legacy `PUBLIC_STATS_API_KEY` shared secret opens the anonymous tier **only** — a shared secret cannot be revoked per consumer, so it must not stand in for the scope protecting the roster.
- Roster gains `pieces_seen`, `distributed`, `overall_ppm` (from the hourly `machine_stats_cache`, one indexed read) and a live `last_24h_pieces` per machine, using the same 24h window as the fleet-wide number so a leaderboard and the headline agree.
- Settings UI offers the new scope.

248 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)