### PR TITLE
machine names: carry the sorter's own name into Hive, roll one otherwise

### DIFF
--- a/software/hive/frontend/src/lib/machineName.ts
+++ b/software/hive/frontend/src/lib/machineName.ts
@@ -1,0 +1,115 @@
+// The link page prefills the machine name, so whatever sits in that field is
+// the name most people keep. It used to be the constant "Lego Sorter", which
+// made every fleet a wall of identical names; now a Sorter that already knows
+// what it is called sends that along, and this is the fallback when it does
+// not — an older Sorter, or someone who opened the link page directly.
+//
+// Same words the Sorter draws its Tailscale device name from
+// (software/sorter/backend/server/machine_naming.py), so a machine named here
+// and a machine named at firstboot read as the same family.
+
+const LEGO_COLORS = [
+	'Aqua',
+	'Azure',
+	'Black',
+	'Blue',
+	'Bright Green',
+	'Bright Pink',
+	'Brown',
+	'Coral',
+	'Dark Azure',
+	'Dark Blue',
+	'Dark Brown',
+	'Dark Gray',
+	'Dark Green',
+	'Dark Orange',
+	'Dark Pink',
+	'Dark Purple',
+	'Dark Red',
+	'Dark Tan',
+	'Dark Turquoise',
+	'Gray',
+	'Green',
+	'Lavender',
+	'Light Aqua',
+	'Light Blue',
+	'Light Gray',
+	'Light Pink',
+	'Light Purple',
+	'Light Yellow',
+	'Lime',
+	'Magenta',
+	'Medium Azure',
+	'Medium Blue',
+	'Medium Green',
+	'Medium Lavender',
+	'Medium Nougat',
+	'Nougat',
+	'Olive',
+	'Orange',
+	'Pink',
+	'Purple',
+	'Red',
+	'Reddish Brown',
+	'Sand Blue',
+	'Sand Green',
+	'Tan',
+	'Teal',
+	'Warm Gold',
+	'White',
+	'Yellow'
+];
+
+const LEGO_PIECES = [
+	'Antenna',
+	'Arch',
+	'Axle',
+	'Baseplate',
+	'Beam',
+	'Bracket',
+	'Brick',
+	'Bushing',
+	'Clip',
+	'Cone',
+	'Cylinder',
+	'Dish',
+	'Dome',
+	'Door',
+	'Fence',
+	'Flag',
+	'Gear',
+	'Grille',
+	'Hinge',
+	'Hose',
+	'Jumper',
+	'Ladder',
+	'Lever',
+	'Minifig',
+	'Panel',
+	'Pin',
+	'Plate',
+	'Propeller',
+	'Rail',
+	'Ramp',
+	'Rod',
+	'Roof',
+	'Slope',
+	'Sprocket',
+	'Stud',
+	'Technic',
+	'Tile',
+	'Tube',
+	'Turntable',
+	'Wedge',
+	'Wheel',
+	'Windscreen',
+	'Wing'
+];
+
+function pick(words: string[]): string {
+	return words[Math.floor(Math.random() * words.length)];
+}
+
+export function randomMachineName(): string {
+	return `${pick(LEGO_COLORS)} ${pick(LEGO_PIECES)}`;
+}

--- a/software/hive/frontend/src/routes/link-machine/+page.svelte
+++ b/software/hive/frontend/src/routes/link-machine/+page.svelte
@@ -11,10 +11,12 @@
 	} from '$lib/api';
 	import { auth } from '$lib/auth.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
+	import { randomMachineName } from '$lib/machineName';
+	import Shuffle from 'lucide-svelte/icons/shuffle';
 
 	type LinkMode = 'existing' | 'new';
 
-	let machineName = $state(page.url.searchParams.get('suggested_machine_name') || 'Lego Sorter');
+	let machineName = $state(page.url.searchParams.get('suggested_machine_name') || randomMachineName());
 	let description = $state('');
 	let error = $state<string | null>(null);
 	let submitting = $state(false);
@@ -308,16 +310,29 @@
 				</div>
 
 				{#if linkMode === 'new'}
-					<label class="grid gap-1">
-						<span class="text-sm font-medium text-text">Machine name in Hive</span>
-						<input
-							bind:value={machineName}
-							type="text"
-							required
-							disabled={submitting}
-							class="border border-border bg-surface px-3 py-2 text-sm text-text focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none disabled:opacity-60 dark:bg-bg"
-						/>
-					</label>
+					<div class="grid gap-1">
+						<label for="machine-name" class="text-sm font-medium text-text">Machine name in Hive</label>
+						<div class="flex items-stretch gap-2">
+							<input
+								id="machine-name"
+								bind:value={machineName}
+								type="text"
+								required
+								disabled={submitting}
+								class="min-w-0 flex-1 border border-border bg-surface px-3 py-2 text-sm text-text focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none disabled:opacity-60 dark:bg-bg"
+							/>
+							<button
+								type="button"
+								onclick={() => { machineName = randomMachineName(); }}
+								disabled={submitting}
+								title="Suggest another name"
+								aria-label="Suggest another name"
+								class="flex shrink-0 items-center justify-center border border-border bg-surface px-3 text-text-muted transition-colors hover:bg-bg hover:text-text disabled:opacity-60 dark:bg-bg dark:hover:bg-surface"
+							>
+								<Shuffle class="h-4 w-4" />
+							</button>
+						</div>
+					</div>
 
 					<label class="grid gap-1">
 						<span class="text-sm font-medium text-text">Description <span class="text-text-muted">(optional)</span></span>

--- a/software/sorter/backend/server/machine_naming.py
+++ b/software/sorter/backend/server/machine_naming.py
@@ -1,0 +1,99 @@
+"""Machine naming vocabulary shared by the Tailscale hostname and the Hive link.
+
+One scheme, two renderings: `sorter-dark-azure-brick-0ffbef` as a hostname,
+"Dark Azure Brick" as the name a person reads in Hive. A machine that already
+carries a generated hostname reuses those words for Hive, so the same sorter
+looks like itself everywhere.
+
+Keep the word lists in sync with sorteros-firstboot.py's copy so machines named
+at firstboot and machines named from the UI draw from the same vocabulary.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from pathlib import Path
+
+# SystemRandom so the picks stay OS-seeded no matter what else in the process
+# has touched the shared random module.
+_rng = random.SystemRandom()
+
+LEGO_COLORS = [
+    "aqua", "azure", "black", "blue", "bright-green", "bright-pink",
+    "brown", "coral", "dark-azure", "dark-blue", "dark-brown", "dark-gray",
+    "dark-green", "dark-orange", "dark-pink", "dark-purple", "dark-red",
+    "dark-tan", "dark-turquoise", "gray", "green", "lavender", "light-aqua",
+    "light-blue", "light-gray", "light-pink", "light-purple", "light-yellow",
+    "lime", "magenta", "medium-azure", "medium-blue", "medium-green",
+    "medium-lavender", "medium-nougat", "nougat", "olive", "orange", "pink",
+    "purple", "red", "reddish-brown", "sand-blue", "sand-green", "tan",
+    "teal", "warm-gold", "white", "yellow",
+]
+
+LEGO_PIECES = [
+    "antenna", "arch", "axle", "baseplate", "beam", "bracket", "brick",
+    "bushing", "clip", "cone", "cylinder", "dish", "dome", "door", "fence",
+    "flag", "gear", "grille", "hinge", "hose", "jumper", "ladder", "lever",
+    "minifig", "panel", "pin", "plate", "propeller", "rail", "ramp", "rod",
+    "roof", "slope", "sprocket", "stud", "technic", "tile", "tube",
+    "turntable", "wedge", "wheel", "windscreen", "wing",
+]
+
+_HOSTNAME_PREFIX = "sorter-"
+_MAC_SUFFIX_RE = re.compile(r"^[0-9a-f]{6}$")
+
+
+def mac_suffix() -> str:
+    """Last six hex digits of the first real NIC — stable across regenerations."""
+    net = Path("/sys/class/net")
+    if net.exists():
+        for iface in sorted(net.iterdir()):
+            if iface.name == "lo":
+                continue
+            addr_file = iface / "address"
+            if addr_file.exists():
+                mac = addr_file.read_text().strip().replace(":", "")
+                if mac and mac != "000000000000":
+                    return mac[-6:].lower()
+    return format(_rng.randint(0, 0xFFFFFF), "06x")
+
+
+def generate_hostname() -> str:
+    """A fresh Tailscale device name, e.g. `sorter-dark-azure-brick-0ffbef`."""
+    return f"{_HOSTNAME_PREFIX}{_rng.choice(LEGO_COLORS)}-{_rng.choice(LEGO_PIECES)}-{mac_suffix()}"
+
+
+def random_display_name() -> str:
+    """A fresh human-facing name, e.g. "Dark Azure Brick"."""
+    return _titleize(f"{_rng.choice(LEGO_COLORS)}-{_rng.choice(LEGO_PIECES)}")
+
+
+def display_name_from_hostname(hostname: str | None) -> str | None:
+    """Read a generated hostname back as a display name, or None if it is not one.
+
+    Only a hostname this scheme actually produced counts: the words have to be a
+    real colour followed by a real piece. A machine that never ran firstboot,
+    or whose device name is whatever the OS image shipped with ("orangepi",
+    "ubuntu", a hand-typed "sorter-01"), has nothing worth reusing, and a
+    freshly rolled name beats a scrap of someone's infrastructure.
+
+    The MAC suffix is dropped: it disambiguates devices on a tailnet, but it
+    only makes noise in a machine list someone actually reads.
+    """
+    raw = (hostname or "").strip().lower()
+    if not raw.startswith(_HOSTNAME_PREFIX):
+        return None
+
+    words = [word for word in raw[len(_HOSTNAME_PREFIX):].split("-") if word]
+    if len(words) > 1 and _MAC_SUFFIX_RE.match(words[-1]):
+        words = words[:-1]
+    if len(words) < 2 or words[-1] not in LEGO_PIECES:
+        return None
+    if "-".join(words[:-1]) not in LEGO_COLORS:
+        return None
+    return _titleize("-".join(words))
+
+
+def _titleize(slug: str) -> str:
+    return " ".join(word.capitalize() for word in slug.split("-") if word)

--- a/software/sorter/backend/server/routers/detection.py
+++ b/software/sorter/backend/server/routers/detection.py
@@ -23,6 +23,7 @@ from blob_manager import (
     getClassificationDetectionConfig,
     getFeederDetectionConfig,
     getHiveConfig,
+    getMachineNickname,
     setApiKeys,
     setCarouselDetectionConfig,
     setClassificationDetectionConfig,
@@ -38,6 +39,8 @@ from hive_telemetry import (
 from perception.overlay import drawChannelZones
 from server import shared_state
 from server.classification_training import getClassificationTrainingManager
+from server.machine_naming import display_name_from_hostname, random_display_name
+from server.routers.tailscale import current_hostname
 from vision.detection_registry import (
     detection_algorithm_definition,
     detection_algorithm_options,
@@ -882,6 +885,27 @@ def hive_link(payload: HiveLinkPayload) -> Dict[str, Any]:
         "machine_name": payload.machine_name,
         "token_prefix": payload.token_prefix or api_token[:8],
     }
+
+
+@router.get("/api/settings/hive/suggested-machine-name")
+def hive_suggested_machine_name() -> Dict[str, Any]:
+    """The name to hand Hive when the user has not typed one on the link page.
+
+    A sorter usually already has an identity: the nickname from setup, or the
+    words in the Tailscale device name it picked at firstboot. Reuse that so the
+    same machine reads the same everywhere, and only roll a fresh name when
+    there is nothing to reuse — anything is better than every machine in every
+    fleet arriving as "Lego Sorter".
+    """
+    nickname = (getMachineNickname() or "").strip()
+    if nickname:
+        return {"ok": True, "name": nickname, "source": "nickname"}
+
+    from_hostname = display_name_from_hostname(current_hostname())
+    if from_hostname:
+        return {"ok": True, "name": from_hostname, "source": "tailscale"}
+
+    return {"ok": True, "name": random_display_name(), "source": "generated"}
 
 
 @router.post("/api/settings/hive/backfill")

--- a/software/sorter/backend/server/routers/tailscale.py
+++ b/software/sorter/backend/server/routers/tailscale.py
@@ -3,40 +3,19 @@ from __future__ import annotations
 
 import json
 import os
-import random
 import shutil
 import subprocess
-from pathlib import Path
 from typing import Any, Dict
 
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from server.machine_naming import generate_hostname
 from server.security import refresh_device_identity
 
 router = APIRouter()
 
 _TAILSCALE_SOCKET = os.getenv("TAILSCALE_SOCKET_PATH", "").strip()
-
-# Keep this naming scheme in sync with sorteros-firstboot.py's
-# _generate_machine_name() so UI-joined and firstboot-joined machines look alike.
-LEGO_COLORS = [
-    "aqua", "azure", "black", "blue", "bright-green", "bright-pink",
-    "brown", "coral", "dark-azure", "dark-blue", "dark-brown", "dark-gray",
-    "dark-green", "dark-orange", "dark-pink", "dark-purple", "dark-red",
-    "dark-tan", "dark-turquoise", "gray", "green", "lavender", "light-aqua",
-    "light-blue", "light-gray", "light-pink", "light-purple", "light-yellow",
-    "lime", "magenta", "medium-azure", "medium-blue", "medium-green",
-    "medium-lavender", "medium-nougat", "nougat", "olive", "orange", "pink",
-    "purple", "red", "reddish-brown", "sand-blue", "sand-green", "tan",
-    "teal", "warm-gold", "white", "yellow",
-]
-
-LEGO_PIECES = [
-    "arch", "axle", "beam", "bracket", "brick", "clip", "cone", "cylinder",
-    "dome", "gear", "hinge", "panel", "pin", "plate", "rail", "slope",
-    "stud", "technic", "tile", "turntable", "wedge",
-]
 
 
 def _cli(*args: str) -> list[str]:
@@ -44,26 +23,6 @@ def _cli(*args: str) -> list[str]:
     if _TAILSCALE_SOCKET:
         base += [f"--socket={_TAILSCALE_SOCKET}"]
     return base + list(args)
-
-
-def _mac_suffix() -> str:
-    net = Path("/sys/class/net")
-    if net.exists():
-        for iface in sorted(net.iterdir()):
-            if iface.name == "lo":
-                continue
-            addr_file = iface / "address"
-            if addr_file.exists():
-                mac = addr_file.read_text().strip().replace(":", "")
-                if mac and mac != "000000000000":
-                    return mac[-6:].lower()
-    return format(random.randint(0, 0xFFFFFF), "06x")
-
-
-def _generate_machine_name() -> str:
-    color = random.choice(LEGO_COLORS)
-    piece = random.choice(LEGO_PIECES)
-    return f"sorter-{color}-{piece}-{_mac_suffix()}"
 
 
 def _get_status() -> Dict[str, Any]:
@@ -119,6 +78,13 @@ def get_tailscale_status() -> Dict[str, Any]:
     return _get_status()
 
 
+def current_hostname() -> str | None:
+    """This machine's Tailscale device name, or None when it has not joined."""
+    status = _get_status()
+    hostname = status.get("hostname")
+    return hostname.strip() if isinstance(hostname, str) and hostname.strip() else None
+
+
 class TailscaleUpPayload(BaseModel):
     auth_key: str
 
@@ -136,7 +102,7 @@ def tailscale_up(payload: TailscaleUpPayload) -> Dict[str, Any]:
     # machine; replace a generic name (e.g. "orangepi") or generate one on first
     # join, so every UI-joined machine lands as sorter-color-piece-mac.
     existing = (_get_status().get("hostname") or "").strip()
-    hostname = existing if existing.startswith("sorter-") else _generate_machine_name()
+    hostname = existing if existing.startswith("sorter-") else generate_hostname()
 
     try:
         result = subprocess.run(

--- a/software/sorter/frontend/src/lib/components/settings/HiveSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/HiveSection.svelte
@@ -337,12 +337,29 @@
 		pairMachineName = '';
 	}
 
+	// This Sorter's own name for itself — its nickname, or the words in its
+	// Tailscale device name. Hive falls back to rolling one of its own when we
+	// have nothing to offer, so a failed lookup is not worth surfacing.
+	async function loadSuggestedMachineName() {
+		try {
+			const res = await fetch(`${currentBackendBaseUrl()}/api/settings/hive/suggested-machine-name`);
+			if (!res.ok) return;
+			const data = await res.json();
+			if (typeof data?.name === 'string' && data.name.trim() && !pairMachineName.trim()) {
+				pairMachineName = data.name.trim();
+			}
+		} catch {
+			// Leave the field empty; Hive names the machine instead.
+		}
+	}
+
 	function openPairForm() {
 		clearMessages();
 		editingTargetId = null;
 		showRegisterForm = false;
 		showPairForm = true;
 		resetPairForm();
+		void loadSuggestedMachineName();
 	}
 
 	function closeForms() {
@@ -954,7 +971,7 @@
 					<input
 						bind:value={pairMachineName}
 						type="text"
-						placeholder="Lego Sorter"
+						placeholder="Hive names this machine if you leave it blank"
 						class="border border-border bg-bg px-2 py-1.5 text-sm text-text"
 					/>
 				</label>

--- a/software/sorter/frontend/src/routes/setup/+page.svelte
+++ b/software/sorter/frontend/src/routes/setup/+page.svelte
@@ -604,6 +604,24 @@
 		goToNextStep();
 	}
 
+	// An unnamed machine starts the naming step from the name it already picked
+	// for itself at firstboot (sorter-dark-azure-brick-… reads back as "Dark
+	// Azure Brick"), or a fresh roll on a machine that never got one. Anyone
+	// who clicks past this step still ends up with a name of their own, and it
+	// is the same name Hive gets later.
+	async function suggestNickname() {
+		try {
+			const res = await fetch(`${currentBackendBaseUrl()}/api/settings/hive/suggested-machine-name`);
+			if (!res.ok) return;
+			const data = await res.json();
+			if (typeof data?.name === 'string' && data.name.trim() && !nicknameDraft.trim()) {
+				nicknameDraft = data.name.trim();
+			}
+		} catch {
+			// Leave it empty; the step still asks for a name.
+		}
+	}
+
 	async function loadWizard() {
 		loadingWizard = true;
 		wizardError = null;
@@ -616,6 +634,7 @@
 			hardwareError = payload.hardware.error;
 			homingStep = payload.hardware.homing_step;
 			nicknameDraft = payload.machine.nickname ?? '';
+			if (!nicknameDraft.trim()) void suggestNickname();
 			const configuredLayout = payload.config.camera_assignments.layout;
 			selectedLayout =
 				configuredLayout === 'split_feeder'
@@ -670,10 +689,9 @@
 		hiveConnecting = true;
 		hiveError = null;
 		hiveStatus = null;
-		const machineName =
-			(wizard?.machine.nickname ?? '').trim() ||
-			nicknameDraft.trim() ||
-			(wizard?.machine.machine_id ?? '');
+		// No name yet means no suggestion: Hive rolls one rather than showing
+		// the machine id, which reads as a serial number in a machine list.
+		const machineName = (wizard?.machine.nickname ?? '').trim() || nicknameDraft.trim();
 		try {
 			beginHiveLink({
 				hiveUrl: url,

--- a/software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py
+++ b/software/sorteros/build/overlay/usr/local/sbin/sorteros-firstboot.py
@@ -30,6 +30,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Callable
 
+# Keep these lists in sync with the Sorter backend's server/machine_naming.py,
+# which draws Hive machine names from the same vocabulary.
 LEGO_COLORS = [
     "aqua", "azure", "black", "blue", "bright-green", "bright-pink",
     "brown", "coral", "dark-azure", "dark-blue", "dark-brown", "dark-gray",
@@ -43,9 +45,12 @@ LEGO_COLORS = [
 ]
 
 LEGO_PIECES = [
-    "arch", "axle", "beam", "bracket", "brick", "clip", "cone", "cylinder",
-    "dome", "gear", "hinge", "panel", "pin", "plate", "rail", "slope",
-    "stud", "technic", "tile", "turntable", "wedge",
+    "antenna", "arch", "axle", "baseplate", "beam", "bracket", "brick",
+    "bushing", "clip", "cone", "cylinder", "dish", "dome", "door", "fence",
+    "flag", "gear", "grille", "hinge", "hose", "jumper", "ladder", "lever",
+    "minifig", "panel", "pin", "plate", "propeller", "rail", "ramp", "rod",
+    "roof", "slope", "sprocket", "stud", "technic", "tile", "tube",
+    "turntable", "wedge", "wheel", "windscreen", "wing",
 ]
 
 # tomllib is stdlib on Python 3.11+; Ubuntu Jammy ships 3.10 so we fall


### PR DESCRIPTION
Hive's link page prefilled the constant **"Lego Sorter"**, so anyone who did not retype it landed a machine named the same as everyone else's.

A sorter already knows what it is called by the time it reaches that page: sorteros picks `sorter-<color>-<piece>-<mac>` at firstboot for the Tailscale device name, and setup asks for a nickname.

## What changes

- **Sorter backend** — `GET /api/settings/hive/suggested-machine-name` answers with the machine's own identity: nickname first, else the words from a device name this scheme actually generated (`sorter-dark-brown-turntable-bffe6b` → "Dark Brown Turntable"), else a fresh roll. A stock `orangepi`/`ubuntu` device name, or a hand-typed `sorter-01`, is not a name worth reusing and falls through to the roll.
- **Sorter frontend** — the settings pair form and the setup wizard's naming step both prefill that suggestion, so clicking straight past the naming step still leaves a machine named something of its own.
- **Hive frontend** — rolls a name from the same vocabulary when the Sorter suggests nothing (older Sorter, or the page opened directly), with a shuffle button beside the field.
- Word lists move to `server/machine_naming.py`; sorteros-firstboot keeps its own copy since it runs standalone on the image. Pieces widen 21 → 43 (2107 combinations) so two rolls stop looking alike, and picks use `SystemRandom`.

## Verified

- On kitbash, against the real backend and the real `tailscale` CLI: endpoint returns `{"name":"kitbash","source":"nickname"}`, and its device name reads back as "Dark Brown Turntable". Backend healthy in standby after the reload.
- Hive link page in the browser: prefilled name, shuffle rolls a new one, `suggested_machine_name` still wins when supplied. Light and dark both fine.
- `svelte-check` clean on both frontends (pre-existing errors only, none in touched files); generated hostnames round-trip through the parser 500/500, and generic hostnames all reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)