### PR TITLE
machine names: labelled Generate New Name button, shared across every naming field

### DIFF
--- a/software/hive/frontend/src/routes/link-machine/+page.svelte
+++ b/software/hive/frontend/src/routes/link-machine/+page.svelte
@@ -325,11 +325,10 @@
 								type="button"
 								onclick={() => { machineName = randomMachineName(); }}
 								disabled={submitting}
-								title="Suggest another name"
-								aria-label="Suggest another name"
-								class="flex shrink-0 items-center justify-center border border-border bg-surface px-3 text-text-muted transition-colors hover:bg-bg hover:text-text disabled:opacity-60 dark:bg-bg dark:hover:bg-surface"
+								class="flex shrink-0 items-center gap-2 border border-border bg-surface px-3 text-sm whitespace-nowrap text-text-muted transition-colors hover:bg-bg hover:text-text disabled:opacity-60 dark:bg-bg dark:hover:bg-surface"
 							>
 								<Shuffle class="h-4 w-4" />
+								Generate New Name
 							</button>
 						</div>
 					</div>

--- a/software/sorter/backend/server/routers/detection.py
+++ b/software/sorter/backend/server/routers/detection.py
@@ -888,7 +888,7 @@ def hive_link(payload: HiveLinkPayload) -> Dict[str, Any]:
 
 
 @router.get("/api/settings/hive/suggested-machine-name")
-def hive_suggested_machine_name() -> Dict[str, Any]:
+def hive_suggested_machine_name(roll: bool = False) -> Dict[str, Any]:
     """The name to hand Hive when the user has not typed one on the link page.
 
     A sorter usually already has an identity: the nickname from setup, or the
@@ -896,7 +896,14 @@ def hive_suggested_machine_name() -> Dict[str, Any]:
     same machine reads the same everywhere, and only roll a fresh name when
     there is nothing to reuse — anything is better than every machine in every
     fleet arriving as "Lego Sorter".
+
+    ``roll=1`` skips straight to a fresh name: that is someone pressing the
+    shuffle button because they want a different one, and handing back the name
+    they are trying to get away from would make the button look broken.
     """
+    if roll:
+        return {"ok": True, "name": random_display_name(), "source": "generated"}
+
     nickname = (getMachineNickname() or "").strip()
     if nickname:
         return {"ok": True, "name": nickname, "source": "nickname"}

--- a/software/sorter/frontend/src/lib/components/MachineNameField.svelte
+++ b/software/sorter/frontend/src/lib/components/MachineNameField.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	// Everywhere this Sorter asks for a machine name: the setup wizard's naming
+	// step, and both Hive forms in settings. Each one starts from the name the
+	// machine already has for itself and offers another roll, so the three stay
+	// one behaviour rather than three that drift.
+	import { onMount } from 'svelte';
+	import { Shuffle } from 'lucide-svelte';
+
+	let {
+		value = $bindable(),
+		backendBaseUrl,
+		id,
+		placeholder = '',
+		variant = 'settings'
+	}: {
+		value: string;
+		backendBaseUrl: string;
+		id?: string;
+		placeholder?: string;
+		variant?: 'setup' | 'settings';
+	} = $props();
+
+	const inputClass = $derived(
+		variant === 'setup'
+			? 'setup-control min-w-0 flex-1 px-3 py-2 text-sm text-text'
+			: 'min-w-0 flex-1 border border-border bg-bg px-2 py-1.5 text-sm text-text'
+	);
+	const buttonClass = $derived(
+		variant === 'setup'
+			? 'setup-control flex shrink-0 items-center gap-2 px-3 text-sm whitespace-nowrap text-text-muted transition-colors hover:text-text'
+			: 'flex shrink-0 items-center gap-2 border border-border bg-bg px-2 py-1.5 text-sm whitespace-nowrap text-text-muted transition-colors hover:bg-surface hover:text-text'
+	);
+
+	// `roll` is the button: it wants a name nobody has seen yet, so it
+	// overwrites the field rather than only filling an empty one.
+	async function fill(roll: boolean) {
+		if (!roll && value.trim()) return;
+		try {
+			const res = await fetch(
+				`${backendBaseUrl}/api/settings/hive/suggested-machine-name${roll ? '?roll=1' : ''}`
+			);
+			if (!res.ok) return;
+			const data = await res.json();
+			const suggestion = typeof data?.name === 'string' ? data.name.trim() : '';
+			if (suggestion && (roll || !value.trim())) value = suggestion;
+		} catch {
+			// Leave the field as it is; every form here still takes typing.
+		}
+	}
+
+	onMount(() => {
+		void fill(false);
+	});
+</script>
+
+<div class="flex items-stretch gap-2">
+	<input {id} type="text" bind:value {placeholder} class={inputClass} />
+	<button type="button" onclick={() => void fill(true)} class={buttonClass}>
+		<Shuffle class="h-4 w-4" />
+		Generate New Name
+	</button>
+</div>

--- a/software/sorter/frontend/src/lib/components/settings/HiveSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/HiveSection.svelte
@@ -9,6 +9,7 @@
 		defaultHiveTargetName
 	} from '$lib/hive/link-flow';
 	import { Cloud, Link2, Pencil, Plus, RefreshCw, Shield, Star, Trash2, Upload } from 'lucide-svelte';
+	import MachineNameField from '$lib/components/MachineNameField.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 
 	const machine = getMachineContext();
@@ -337,29 +338,12 @@
 		pairMachineName = '';
 	}
 
-	// This Sorter's own name for itself — its nickname, or the words in its
-	// Tailscale device name. Hive falls back to rolling one of its own when we
-	// have nothing to offer, so a failed lookup is not worth surfacing.
-	async function loadSuggestedMachineName() {
-		try {
-			const res = await fetch(`${currentBackendBaseUrl()}/api/settings/hive/suggested-machine-name`);
-			if (!res.ok) return;
-			const data = await res.json();
-			if (typeof data?.name === 'string' && data.name.trim() && !pairMachineName.trim()) {
-				pairMachineName = data.name.trim();
-			}
-		} catch {
-			// Leave the field empty; Hive names the machine instead.
-		}
-	}
-
 	function openPairForm() {
 		clearMessages();
 		editingTargetId = null;
 		showRegisterForm = false;
 		showPairForm = true;
 		resetPairForm();
-		void loadSuggestedMachineName();
 	}
 
 	function closeForms() {
@@ -968,11 +952,10 @@
 				</label>
 				<label class="flex flex-col gap-1 text-sm text-text">
 					Suggested machine name (optional)
-					<input
+					<MachineNameField
 						bind:value={pairMachineName}
-						type="text"
+						backendBaseUrl={currentBackendBaseUrl()}
 						placeholder="Hive names this machine if you leave it blank"
-						class="border border-border bg-bg px-2 py-1.5 text-sm text-text"
 					/>
 				</label>
 				<div class="flex justify-end gap-2">
@@ -1022,11 +1005,10 @@
 					placeholder="Account password"
 					class="border border-border bg-bg px-2 py-1.5 text-sm text-text"
 				/>
-				<input
+				<MachineNameField
 					bind:value={regMachineName}
-					type="text"
+					backendBaseUrl={currentBackendBaseUrl()}
 					placeholder="Machine name"
-					class="border border-border bg-bg px-2 py-1.5 text-sm text-text"
 				/>
 				<input
 					bind:value={regMachineDescription}

--- a/software/sorter/frontend/src/lib/components/setup/steps/IdentityStep.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/steps/IdentityStep.svelte
@@ -38,11 +38,10 @@
 			<button
 				type="button"
 				onclick={onSuggestAnother}
-				title="Suggest another name"
-				aria-label="Suggest another name"
-				class="setup-control flex shrink-0 items-center justify-center px-3 text-text-muted transition-colors hover:text-text"
+				class="setup-control flex shrink-0 items-center gap-2 px-3 text-sm whitespace-nowrap text-text-muted transition-colors hover:text-text"
 			>
 				<Shuffle class="h-4 w-4" />
+				Generate New Name
 			</button>
 		</div>
 	</div>

--- a/software/sorter/frontend/src/lib/components/setup/steps/IdentityStep.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/steps/IdentityStep.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
+	import { Shuffle } from 'lucide-svelte';
+
 	let {
 		machineId,
 		nicknameDraft = $bindable(),
 		nameError,
-		nameStatus
+		nameStatus,
+		onSuggestAnother
 	}: {
 		machineId: string;
 		nicknameDraft: string;
 		nameError: string | null;
 		nameStatus: string;
+		onSuggestAnother: () => void;
 	} = $props();
 
 	const MACHINE_NAME_INPUT_ID = 'setup-machine-name';
@@ -23,13 +27,24 @@
 		<label for={MACHINE_NAME_INPUT_ID} class="mb-2 block text-sm font-medium text-text">
 			Machine name
 		</label>
-		<input
-			id={MACHINE_NAME_INPUT_ID}
-			type="text"
-			bind:value={nicknameDraft}
-			placeholder="e.g. Sorting Bench A"
-			class="setup-control w-full px-3 py-2 text-sm text-text"
-		/>
+		<div class="flex items-stretch gap-2">
+			<input
+				id={MACHINE_NAME_INPUT_ID}
+				type="text"
+				bind:value={nicknameDraft}
+				placeholder="e.g. Sorting Bench A"
+				class="setup-control min-w-0 flex-1 px-3 py-2 text-sm text-text"
+			/>
+			<button
+				type="button"
+				onclick={onSuggestAnother}
+				title="Suggest another name"
+				aria-label="Suggest another name"
+				class="setup-control flex shrink-0 items-center justify-center px-3 text-text-muted transition-colors hover:text-text"
+			>
+				<Shuffle class="h-4 w-4" />
+			</button>
+		</div>
 	</div>
 	{#if nameError}
 		<div class="text-sm text-danger">{nameError}</div>

--- a/software/sorter/frontend/src/lib/components/setup/steps/IdentityStep.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/steps/IdentityStep.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-	import { Shuffle } from 'lucide-svelte';
+	import MachineNameField from '$lib/components/MachineNameField.svelte';
 
 	let {
 		machineId,
 		nicknameDraft = $bindable(),
 		nameError,
 		nameStatus,
-		onSuggestAnother
+		backendBaseUrl
 	}: {
 		machineId: string;
 		nicknameDraft: string;
 		nameError: string | null;
 		nameStatus: string;
-		onSuggestAnother: () => void;
+		backendBaseUrl: string;
 	} = $props();
 
 	const MACHINE_NAME_INPUT_ID = 'setup-machine-name';
@@ -27,23 +27,13 @@
 		<label for={MACHINE_NAME_INPUT_ID} class="mb-2 block text-sm font-medium text-text">
 			Machine name
 		</label>
-		<div class="flex items-stretch gap-2">
-			<input
-				id={MACHINE_NAME_INPUT_ID}
-				type="text"
-				bind:value={nicknameDraft}
-				placeholder="e.g. Sorting Bench A"
-				class="setup-control min-w-0 flex-1 px-3 py-2 text-sm text-text"
-			/>
-			<button
-				type="button"
-				onclick={onSuggestAnother}
-				class="setup-control flex shrink-0 items-center gap-2 px-3 text-sm whitespace-nowrap text-text-muted transition-colors hover:text-text"
-			>
-				<Shuffle class="h-4 w-4" />
-				Generate New Name
-			</button>
-		</div>
+		<MachineNameField
+			bind:value={nicknameDraft}
+			{backendBaseUrl}
+			id={MACHINE_NAME_INPUT_ID}
+			placeholder="e.g. Sorting Bench A"
+			variant="setup"
+		/>
 	</div>
 	{#if nameError}
 		<div class="text-sm text-danger">{nameError}</div>

--- a/software/sorter/frontend/src/routes/setup/+page.svelte
+++ b/software/sorter/frontend/src/routes/setup/+page.svelte
@@ -609,14 +609,18 @@
 	// Azure Brick"), or a fresh roll on a machine that never got one. Anyone
 	// who clicks past this step still ends up with a name of their own, and it
 	// is the same name Hive gets later.
-	async function suggestNickname() {
+	// `roll` is the shuffle button: the caller wants a name they have not seen,
+	// so it overwrites the field instead of only filling an empty one.
+	async function suggestNickname(roll = false) {
 		try {
-			const res = await fetch(`${currentBackendBaseUrl()}/api/settings/hive/suggested-machine-name`);
+			const res = await fetch(
+				`${currentBackendBaseUrl()}/api/settings/hive/suggested-machine-name${roll ? '?roll=1' : ''}`
+			);
 			if (!res.ok) return;
 			const data = await res.json();
-			if (typeof data?.name === 'string' && data.name.trim() && !nicknameDraft.trim()) {
-				nicknameDraft = data.name.trim();
-			}
+			const suggestion = typeof data?.name === 'string' ? data.name.trim() : '';
+			if (!suggestion) return;
+			if (roll || !nicknameDraft.trim()) nicknameDraft = suggestion;
 		} catch {
 			// Leave it empty; the step still asks for a name.
 		}
@@ -1050,6 +1054,7 @@
 							bind:nicknameDraft
 							{nameError}
 							{nameStatus}
+							onSuggestAnother={() => void suggestNickname(true)}
 						/>
 					{:else if activeStepId === 'theme'}
 						<ThemeStep />

--- a/software/sorter/frontend/src/routes/setup/+page.svelte
+++ b/software/sorter/frontend/src/routes/setup/+page.svelte
@@ -604,28 +604,6 @@
 		goToNextStep();
 	}
 
-	// An unnamed machine starts the naming step from the name it already picked
-	// for itself at firstboot (sorter-dark-azure-brick-… reads back as "Dark
-	// Azure Brick"), or a fresh roll on a machine that never got one. Anyone
-	// who clicks past this step still ends up with a name of their own, and it
-	// is the same name Hive gets later.
-	// `roll` is the shuffle button: the caller wants a name they have not seen,
-	// so it overwrites the field instead of only filling an empty one.
-	async function suggestNickname(roll = false) {
-		try {
-			const res = await fetch(
-				`${currentBackendBaseUrl()}/api/settings/hive/suggested-machine-name${roll ? '?roll=1' : ''}`
-			);
-			if (!res.ok) return;
-			const data = await res.json();
-			const suggestion = typeof data?.name === 'string' ? data.name.trim() : '';
-			if (!suggestion) return;
-			if (roll || !nicknameDraft.trim()) nicknameDraft = suggestion;
-		} catch {
-			// Leave it empty; the step still asks for a name.
-		}
-	}
-
 	async function loadWizard() {
 		loadingWizard = true;
 		wizardError = null;
@@ -637,8 +615,9 @@
 			hardwareState = payload.hardware.state;
 			hardwareError = payload.hardware.error;
 			homingStep = payload.hardware.homing_step;
-			nicknameDraft = payload.machine.nickname ?? '';
-			if (!nicknameDraft.trim()) void suggestNickname();
+			// An unnamed machine keeps whatever the naming step suggested rather
+			// than being blanked back out by a reload of the wizard state.
+			nicknameDraft = payload.machine.nickname ?? nicknameDraft;
 			const configuredLayout = payload.config.camera_assignments.layout;
 			selectedLayout =
 				configuredLayout === 'split_feeder'
@@ -1054,7 +1033,7 @@
 							bind:nicknameDraft
 							{nameError}
 							{nameStatus}
-							onSuggestAnother={() => void suggestNickname(true)}
+							backendBaseUrl={currentBackendBaseUrl()}
 						/>
 					{:else if activeStepId === 'theme'}
 						<ThemeStep />

--- a/software/sorter/frontend/src/routes/setup/+page.svelte
+++ b/software/sorter/frontend/src/routes/setup/+page.svelte
@@ -181,6 +181,9 @@
 	let wizardError = $state<string | null>(null);
 
 	let nicknameDraft = $state('');
+	// The saved name as of the last wizard load, so an edited field is
+	// recognisable and left alone.
+	let loadedNickname = $state('');
 	let savingName = $state(false);
 	let nameError = $state<string | null>(null);
 	let nameStatus = $state('');
@@ -615,9 +618,13 @@
 			hardwareState = payload.hardware.state;
 			hardwareError = payload.hardware.error;
 			homingStep = payload.hardware.homing_step;
-			// An unnamed machine keeps whatever the naming step suggested rather
-			// than being blanked back out by a reload of the wizard state.
-			nicknameDraft = payload.machine.nickname ?? nicknameDraft;
+			// The wizard reloads on its own (hardware state changes, machine
+			// switches), and it used to overwrite the name field every time —
+			// so a name typed or rolled on this step could vanish mid-edit.
+			// Follow the saved name only while the field still matches it.
+			const savedNickname = payload.machine.nickname ?? '';
+			if (nicknameDraft === loadedNickname) nicknameDraft = savedNickname;
+			loadedNickname = savedNickname;
 			const configuredLayout = payload.config.camera_assignments.layout;
 			selectedLayout =
 				configuredLayout === 'split_feeder'


### PR DESCRIPTION
Follow-up to #269.

- **The button says what it does.** "Generate New Name" with the shuffle icon, on the setup wizard's naming step and Hive's link page.
- **Settings gets it too.** Connecting from settings rather than `/setup` was the one path with a prefilled name and no way to change it — both the pair form and the legacy register form now prefill and offer the button.
- **One component.** `MachineNameField.svelte` owns the behaviour (prefill from the machine's own name on mount, roll a fresh one on press) instead of three copies drifting apart. Hive's link page keeps its own — separate app, client-side generator.
- **`?roll=1`** on `GET /api/settings/hive/suggested-machine-name` skips the nickname/hostname reuse chain, so pressing the button never hands back the name you are trying to get away from.
- **Bug found while testing:** the setup wizard reloads itself on hardware state changes and machine switches, and each reload assigned the saved nickname over whatever was in the field — a name being typed, or one just rolled, could vanish under the user. It now follows the saved name only while the field still matches it.

## Verified

Driven against kitbash's real backend, all three fields: setup step kitbash → "Light Aqua Grille"; settings pair form prefills "kitbash" → "Dark Brown Beam"; Hive link page → "Dark Brown Cylinder". Repeat presses keep rolling. `svelte-check` clean on both frontends (pre-existing errors only, no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)