### PR TITLE
hive: per-machine last_hour_pieces

### DIFF
--- a/software/hive/backend/app/routers/public_stats.py
+++ b/software/hive/backend/app/routers/public_stats.py
@@ -149,11 +149,12 @@ def get_public_fleet(db: Session = Depends(get_db)):
     machine, and no other owner field is ever served here (no email, no user id,
     no display name), so an unlinked owner is not merely unnamed but absent.
 
-    The per-machine counters come from machine_stats_cache, which a worker
-    refreshes hourly; reading them costs one indexed table scan rather than a
-    recompute over machine_pieces. The trailing-24h count is computed live
-    because it is the one number a leaderboard wants fresh, and it is a single
-    grouped query over the (machine_id, seen_at) index.
+    The per-machine lifetime counters come from machine_stats_cache, which a
+    worker refreshes hourly; reading them costs one indexed table scan rather
+    than a recompute over machine_pieces. The trailing-hour and trailing-24h
+    counts are computed live off the (machine_id, seen_at) index, because they
+    are what a consumer uses to say whether a machine is working RIGHT NOW and
+    an hour-stale answer to that is a wrong one.
     """
     rows = (
         db.query(Machine, UserIdentity)
@@ -170,7 +171,8 @@ def get_public_fleet(db: Session = Depends(get_db)):
     )
     ids = [machine.id for machine, _ in rows]
     lifetime = machine_stats.get_fleet_stats(db)
-    recent = _pieces_by_machine_24h(db, ids)
+    recent = _pieces_by_machine_since(db, ids, hours=24)
+    this_hour = _pieces_by_machine_since(db, ids, hours=1)
     machines = [
         {
             "id": str(machine.id),
@@ -182,6 +184,7 @@ def get_public_fleet(db: Session = Depends(get_db)):
             "distributed": int(lifetime.get(str(machine.id), {}).get("distributed") or 0),
             "overall_ppm": float(lifetime.get(str(machine.id), {}).get("overall_ppm") or 0.0),
             "last_24h_pieces": recent.get(str(machine.id), 0),
+            "last_hour_pieces": this_hour.get(str(machine.id), 0),
             "owner_discord": None
             if identity is None
             else {
@@ -199,12 +202,16 @@ def get_public_fleet(db: Session = Depends(get_db)):
     }
 
 
-def _pieces_by_machine_24h(db: Session, ids: list) -> dict[str, int]:
-    """Trailing-24h piece count per machine. Same window as the fleet-wide
-    number in /stats, so a leaderboard and the headline agree."""
+def _pieces_by_machine_since(db: Session, ids: list, *, hours: int) -> dict[str, int]:
+    """Piece count per machine over a trailing window.
+
+    The 24h call uses the same window as the fleet-wide number in /stats, so a
+    leaderboard and the headline agree. The 1h call is what tells a consumer a
+    machine is actually sorting rather than merely powered on.
+    """
     if not ids:
         return {}
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
     rows = (
         db.query(MachinePiece.machine_id, func.count())
         .filter(MachinePiece.machine_id.in_(ids))

--- a/software/hive/backend/tests/test_public_stats.py
+++ b/software/hive/backend/tests/test_public_stats.py
@@ -213,8 +213,28 @@ class TestFleetRoster:
             for x in client.get("/api/public/fleet", headers=_bearer(token)).json()["machines"]
             if x["name"] == "Counting Sorter"
         )
-        for field in ("pieces_seen", "distributed", "overall_ppm", "last_24h_pieces"):
+        for field in ("pieces_seen", "distributed", "overall_ppm", "last_24h_pieces",
+                      "last_hour_pieces"):
             assert field in entry, f"{field} missing from the roster entry"
         # A machine that has never sorted reports zeros rather than nulls, so a
         # consumer can sort on these without special-casing a fresh machine.
         assert entry["pieces_seen"] == 0 and entry["last_24h_pieces"] == 0
+        assert entry["last_hour_pieces"] == 0
+
+    def test_the_hour_window_is_narrower_than_the_day(self, client, db, monkeypatch, machine_token):
+        """A machine that sorted this morning but not this hour is powered on,
+        not working — the two counters have to be able to disagree."""
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        headers = self._admin_headers(client, db)
+        token = self._mint(client, headers, ["fleet:read"])
+        now = time.time()
+        _sync(client, machine_token, [
+            {"piece_uuid": "h-now", "local_id": 1, "seen_at": now - 60,
+             "classification_status": "classified", "part_id": "3001", "color_id": "5"},
+            {"piece_uuid": "h-old", "local_id": 2, "seen_at": now - 5 * 3600,
+             "classification_status": "classified", "part_id": "3001", "color_id": "5"},
+        ])
+        body = client.get("/api/public/fleet", headers=_bearer(token)).json()
+        mine = max(body["machines"], key=lambda m: m["last_24h_pieces"])
+        assert mine["last_24h_pieces"] == 2
+        assert mine["last_hour_pieces"] == 1

--- a/software/hive/frontend/src/routes/settings/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/+page.svelte
@@ -578,7 +578,11 @@
 
 			<!-- Connected accounts (OAuth identities) -->
 			{#if identities.length > 0 || providerEnabled('github') || providerEnabled('discord')}
-			<div class="border border-border bg-surface p-6">
+			<!-- The id is a link target: balloon's fleet board in Discord points a
+			     "Claim your machine" button at /settings#connected-accounts, so the
+			     person arrives at this panel rather than at the top of a long page.
+			     Renaming it breaks that button silently. -->
+			<div id="connected-accounts" class="scroll-mt-6 border border-border bg-surface p-6">
 				<h2 class="mb-1 font-semibold text-text">Connected Accounts</h2>
 				<p class="mb-4 text-sm text-text-muted">
 					Link other sign-in methods to this account. A connected Discord account also verifies you on the community server.


### PR DESCRIPTION
The fleet board needs three machine states — sorting, idle, offline — and `last_24h_pieces` cannot tell the first two apart. Adds a trailing-hour count per machine off the same `(machine_id, seen_at)` index, with the window parameterised rather than a second copy of the query.

Also puts an `id="connected-accounts"` on the settings panel so balloon's button can link straight to it.

249 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)