### PR TITLE
models: sorter shows Hive's codename + color; Hive UI stops speaking German

### DIFF
--- a/software/hive/frontend/src/lib/components/ModelCard.svelte
+++ b/software/hive/frontend/src/lib/components/ModelCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { DetectionModelSummary } from '$lib/api';
+	import { relativeTime } from '$lib/time';
 	import Badge from './Badge.svelte';
 
 	interface Props {
@@ -56,23 +57,6 @@
 
 	const arch = $derived(typeof modelMeta?.architecture === 'string' ? (modelMeta.architecture as string) : null);
 	const imgsz = $derived(asInt(modelMeta?.imgsz));
-
-	function relativeTime(iso: string): string {
-		const then = new Date(iso).getTime();
-		if (!Number.isFinite(then)) return '';
-		const diffMs = Date.now() - then;
-		const sec = Math.round(diffMs / 1000);
-		if (sec < 60) return 'gerade eben';
-		const min = Math.round(sec / 60);
-		if (min < 60) return `vor ${min} min`;
-		const hr = Math.round(min / 60);
-		if (hr < 24) return `vor ${hr} Std`;
-		const days = Math.round(hr / 24);
-		if (days < 7) return `vor ${days} Tag${days === 1 ? '' : 'en'}`;
-		const weeks = Math.round(days / 7);
-		if (weeks < 5) return `vor ${weeks} Woche${weeks === 1 ? '' : 'n'}`;
-		return new Date(iso).toLocaleDateString('de-DE', { year: 'numeric', month: 'short', day: 'numeric' });
-	}
 
 	function formatPct(v: number | null): string {
 		return v === null ? '—' : v.toFixed(3);

--- a/software/hive/frontend/src/lib/time.ts
+++ b/software/hive/frontend/src/lib/time.ts
@@ -1,0 +1,33 @@
+/** Shared time formatting. Hive's UI copy is English — keep it that way.
+ *
+ * Locale-sensitive calls pass an explicit `en-US` rather than `undefined`, so
+ * the output does not change with whatever locale the viewer's browser reports.
+ * The wording matches the Sorter's own relative-age formatter
+ * (`HiveModelsSection.svelte`) so the same model reads identically on both.
+ */
+
+/** "just now" / "3 hours ago" / "2 weeks ago", falling back to a date past ~5 weeks. */
+export function relativeTime(iso: string): string {
+	const then = new Date(iso).getTime();
+	if (!Number.isFinite(then)) return '';
+	const sec = Math.max(0, Math.round((Date.now() - then) / 1000));
+	if (sec < 60) return 'just now';
+	const min = Math.round(sec / 60);
+	if (min < 60) return `${min} min ago`;
+	const hr = Math.round(min / 60);
+	if (hr < 24) return `${hr} hour${hr === 1 ? '' : 's'} ago`;
+	const days = Math.round(hr / 24);
+	if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+	const weeks = Math.round(days / 7);
+	if (weeks < 5) return `${weeks} week${weeks === 1 ? '' : 's'} ago`;
+	return formatDate(iso);
+}
+
+/** "Aug 9, 2026". */
+export function formatDate(iso: string): string {
+	return new Date(iso).toLocaleDateString('en-US', {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric'
+	});
+}

--- a/software/hive/frontend/src/routes/admin/teacher-jobs/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/teacher-jobs/+page.svelte
@@ -76,7 +76,7 @@
 
 	function formatDate(iso: string | null): string {
 		if (!iso) return '—';
-		return new Date(iso).toLocaleString('de-DE', {
+		return new Date(iso).toLocaleString('en-US', {
 			day: '2-digit',
 			month: '2-digit',
 			year: 'numeric',

--- a/software/hive/frontend/src/routes/admin/teacher-jobs/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/admin/teacher-jobs/[id]/+page.svelte
@@ -111,7 +111,7 @@
 
 	function formatDate(iso: string | null): string {
 		if (!iso) return '—';
-		return new Date(iso).toLocaleString('de-DE', {
+		return new Date(iso).toLocaleString('en-US', {
 			day: '2-digit',
 			month: '2-digit',
 			year: 'numeric',

--- a/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
+++ b/software/hive/frontend/src/routes/machines/[machine_id]/+page.svelte
@@ -41,7 +41,7 @@
 
 	function formatDate(iso: string | null): string {
 		if (!iso) return '—';
-		return new Date(iso).toLocaleString('de-DE', {
+		return new Date(iso).toLocaleString('en-US', {
 			year: 'numeric',
 			month: 'short',
 			day: 'numeric',

--- a/software/hive/frontend/src/routes/models/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/models/[id]/+page.svelte
@@ -6,6 +6,7 @@
 		type DetectionModelVariant,
 		type ModelDatasetMachine
 	} from '$lib/api';
+	import { relativeTime } from '$lib/time';
 	import ModelTrainingReport from '$lib/components/ModelTrainingReport.svelte';
 	import Badge from '$lib/components/Badge.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
@@ -129,23 +130,6 @@
 		const maxEntropy = Math.log(counts.length);
 		return maxEntropy > 0 ? entropy / maxEntropy : 0;
 	});
-
-	function relativeTime(iso: string): string {
-		const then = new Date(iso).getTime();
-		if (!Number.isFinite(then)) return '';
-		const diffMs = Date.now() - then;
-		const sec = Math.round(diffMs / 1000);
-		if (sec < 60) return 'gerade eben';
-		const min = Math.round(sec / 60);
-		if (min < 60) return `vor ${min} min`;
-		const hr = Math.round(min / 60);
-		if (hr < 24) return `vor ${hr} Std`;
-		const days = Math.round(hr / 24);
-		if (days < 7) return `vor ${days} Tag${days === 1 ? '' : 'en'}`;
-		const weeks = Math.round(days / 7);
-		if (weeks < 5) return `vor ${weeks} Woche${weeks === 1 ? '' : 'n'}`;
-		return new Date(iso).toLocaleDateString('de-DE', { year: 'numeric', month: 'short', day: 'numeric' });
-	}
 
 	function formatPct(v: number | null): string {
 		return v === null ? '—' : v.toFixed(3);

--- a/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
@@ -961,8 +961,8 @@
 
 	function formatDate(iso: string): string {
 		const d = new Date(iso);
-		return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: '2-digit' })
-			+ ' ' + d.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+		return d.toLocaleDateString('en-US', { day: '2-digit', month: '2-digit', year: '2-digit' })
+			+ ' ' + d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
 	}
 
 	// --- AI ---

--- a/software/hive/frontend/src/routes/review/+page.svelte
+++ b/software/hive/frontend/src/routes/review/+page.svelte
@@ -460,7 +460,7 @@
 
 	function formatDate(value: string | null | undefined) {
 		if (!value) return '—';
-		return new Date(value).toLocaleString('de-DE', {
+		return new Date(value).toLocaleString('en-US', {
 			day: '2-digit',
 			month: '2-digit',
 			year: 'numeric',

--- a/software/hive/frontend/src/routes/samples/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/+page.svelte
@@ -619,7 +619,7 @@
 		return {
 			remainingLabel: formatRemaining(remaining),
 			rate,
-			startedAtLabel: new Date(job.started_at).toLocaleTimeString('de-DE', {
+			startedAtLabel: new Date(job.started_at).toLocaleTimeString('en-US', {
 				hour: '2-digit', minute: '2-digit'
 			})
 		};

--- a/software/hive/frontend/src/routes/samples/[id]/+page.svelte
+++ b/software/hive/frontend/src/routes/samples/[id]/+page.svelte
@@ -466,7 +466,7 @@
 	}
 
 	function formatDate(d: string): string {
-		return new Date(d).toLocaleString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+		return new Date(d).toLocaleString('en-US', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
 	}
 
 	function shortId(id: string): string {

--- a/software/sorter/backend/server/hive_models.py
+++ b/software/sorter/backend/server/hive_models.py
@@ -301,6 +301,13 @@ def _scan_models_dir(root: Path, *, bundled: bool) -> list[dict]:
                 "local_id": child.name,
                 "target_id": hive_meta.get("target_id"),
                 "model_id": hive_meta.get("model_id"),
+                # Hive's human-friendly handle ("Ember") and its swatch color,
+                # captured at download time so the installed list can identify a
+                # model the same way Hive does without going back to the network.
+                # Absent for repo-bundled models and for installs that predate
+                # this field — see ``_backfill_codenames``.
+                "codename": hive_meta.get("codename"),
+                "codename_color": hive_meta.get("codename_color"),
                 "variant_runtime": variant_runtime,
                 "purpose": purpose,
                 "inert": purpose in INERT_PURPOSES,
@@ -340,25 +347,76 @@ def _installed_index() -> set[tuple[str, str]]:
     return index
 
 
+def _backfill_codenames(target_id: str, items: list[dict], entries: list[dict]) -> None:
+    """Write codenames into run.json for installs that predate the field.
+
+    Downloads have carried ``codename`` / ``codename_color`` in their run.json
+    since those became part of the Hive payload, but anything installed before
+    then knows only its model id. Rather than spend a network call on the
+    Installed tab — which otherwise works with no Hive reachable — we top those
+    entries up opportunistically while browsing the catalog, where the answer is
+    already in hand. Best-effort: a run.json we cannot rewrite is left alone and
+    retried on the next browse.
+    """
+    stale = [
+        entry
+        for entry in entries
+        if not entry.get("codename")
+        and not entry.get("bundled")
+        and entry.get("target_id") == target_id
+    ]
+    if not stale:
+        return
+
+    by_model_id = {
+        item["id"]: item
+        for item in items
+        if isinstance(item.get("id"), str) and isinstance(item.get("codename"), str)
+    }
+    for entry in stale:
+        remote = by_model_id.get(entry.get("model_id"))
+        if remote is None:
+            continue
+        run_path = Path(entry["path"]) / "run.json"
+        payload = _read_run_json(run_path)
+        if payload is None or not isinstance(payload.get(HIVE_SENTINEL_KEY), dict):
+            continue
+        payload[HIVE_SENTINEL_KEY]["codename"] = remote.get("codename")
+        payload[HIVE_SENTINEL_KEY]["codename_color"] = remote.get("codename_color")
+        try:
+            tmp_path = run_path.with_suffix(".json.tmp")
+            tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+            os.replace(tmp_path, run_path)
+        except OSError:
+            log.debug("codename backfill failed for %s", run_path, exc_info=True)
+
+
 def list_remote_models(target_id: str, **filters: Any) -> dict:
     """Fetch the remote model catalog for ``target_id`` and tag installs."""
     client, target = _get_client_for_target(target_id)
     page = client.list_models(**filters)
 
-    installed = _installed_index()
+    # One scan feeds both the installed tagging and the codename backfill —
+    # walking the model dirs means stat'ing every weight file, so don't do it
+    # twice per browse.
+    entries = list_installed_models()
+    installed = {
+        (entry["target_id"], entry["model_id"])
+        for entry in entries
+        if isinstance(entry.get("target_id"), str) and isinstance(entry.get("model_id"), str)
+    }
     items = page.get("items") if isinstance(page, dict) else None
     if isinstance(items, list):
-        for item in items:
-            if not isinstance(item, dict):
-                continue
+        dicts = [item for item in items if isinstance(item, dict)]
+        for item in dicts:
             model_id = item.get("id")
-            if isinstance(model_id, str):
-                item["installed"] = (target_id, model_id) in installed
-            else:
-                item["installed"] = False
+            item["installed"] = (
+                isinstance(model_id, str) and (target_id, model_id) in installed
+            )
             item["target_id"] = target_id
             item["target_url"] = target.get("url")
             item["target_name"] = target.get("name")
+        _backfill_codenames(target_id, dicts, entries)
     return page
 
 
@@ -847,6 +905,9 @@ class DownloadJobManager:
         if variant_runtime and "runtime" not in base:
             base["runtime"] = variant_runtime
 
+        codename = detail.get("codename") if isinstance(detail, dict) else None
+        codename_color = detail.get("codename_color") if isinstance(detail, dict) else None
+
         base[HIVE_SENTINEL_KEY] = {
             "target_id": target_id,
             "model_id": model_id,
@@ -854,6 +915,12 @@ class DownloadJobManager:
             "purpose": purpose or DEFAULT_PURPOSE,
             "sha256": sha256,
             "downloaded_at": _now_iso(),
+            # Carried over so the installed list can show the same identity Hive
+            # does (codename + color swatch) with no network round-trip.
+            "codename": codename if isinstance(codename, str) and codename else None,
+            "codename_color": (
+                codename_color if isinstance(codename_color, str) and codename_color else None
+            ),
         }
 
         dest_dir.mkdir(parents=True, exist_ok=True)

--- a/software/sorter/backend/tests/test_hive_models.py
+++ b/software/sorter/backend/tests/test_hive_models.py
@@ -504,3 +504,109 @@ class TestRemoveInstalledModel:
         (target / "run.json").write_text("{}")
         hive_models.remove_installed_model("hive-abc")
         assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# Codenames — Hive's human-readable identity carried onto the machine
+# ---------------------------------------------------------------------------
+
+
+class TestCodenames:
+    def test_download_records_codename_and_color(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(hive_models, "LOCAL_MODELS_DIR", tmp_path)
+        _configure_target(monkeypatch)
+
+        detail = {**_make_detail(), "codename": "Ember", "codename_color": "#E25822"}
+
+        def _downloader(
+            model_id: str,
+            variant_id: str,
+            dest_path: Path,
+            on_progress: Callable[[int, int], None] | None,
+            expected_sha256: str | None,
+        ) -> str:
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+            dest_path.write_bytes(b"bytes")
+            return "expected-sha"
+
+        _install_stub_client(monkeypatch, _StubClient(detail=detail, downloader=_downloader))
+
+        manager = hive_models.DownloadJobManager()
+        job_id = manager.enqueue("hive-a", "model-1")
+        assert manager.wait_for_terminal(job_id, timeout=5.0).get("status") == "done"
+
+        sentinel = json.loads((tmp_path / "hive-model-1-onnx" / "run.json").read_text())[
+            hive_models.HIVE_SENTINEL_KEY
+        ]
+        assert sentinel["codename"] == "Ember"
+        assert sentinel["codename_color"] == "#E25822"
+
+        installed = hive_models.list_installed_models()
+        assert installed[0]["codename"] == "Ember"
+        assert installed[0]["codename_color"] == "#E25822"
+
+    def test_installs_predating_the_field_report_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(hive_models, "LOCAL_MODELS_DIR", tmp_path)
+        _write_legacy_install(tmp_path)
+
+        installed = hive_models.list_installed_models()
+        assert installed[0]["codename"] is None
+        assert installed[0]["codename_color"] is None
+
+    def test_browsing_backfills_a_legacy_install(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(hive_models, "LOCAL_MODELS_DIR", tmp_path)
+        _configure_target(monkeypatch)
+        run_path = _write_legacy_install(tmp_path)
+
+        stub = _StubClient(detail=_make_detail())
+        stub.list_models = lambda **_: {  # type: ignore[method-assign]
+            "items": [
+                {
+                    "id": "model-1",
+                    "name": "Test Detector",
+                    "codename": "Ember",
+                    "codename_color": "#E25822",
+                }
+            ],
+            "total": 1,
+            "page": 1,
+            "page_size": 30,
+            "pages": 1,
+        }
+        _install_stub_client(monkeypatch, stub)
+
+        page = hive_models.list_remote_models("hive-a")
+        assert page["items"][0]["installed"] is True
+
+        sentinel = json.loads(run_path.read_text())[hive_models.HIVE_SENTINEL_KEY]
+        assert sentinel["codename"] == "Ember"
+        assert sentinel["codename_color"] == "#E25822"
+        assert hive_models.list_installed_models()[0]["codename"] == "Ember"
+
+
+def _write_legacy_install(root: Path) -> Path:
+    """An installed model whose run.json predates the codename fields."""
+    dest = root / "hive-model-1-onnx"
+    (dest / "exports").mkdir(parents=True)
+    run_path = dest / "run.json"
+    run_path.write_text(
+        json.dumps(
+            {
+                "name": "Test Detector",
+                "model_family": "yolo",
+                hive_models.HIVE_SENTINEL_KEY: {
+                    "target_id": "hive-a",
+                    "model_id": "model-1",
+                    "variant_runtime": "onnx",
+                    "sha256": "abc",
+                },
+            }
+        )
+    )
+    return run_path

--- a/software/sorter/frontend/src/lib/components/settings/HiveModelsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/HiveModelsSection.svelte
@@ -17,6 +17,10 @@
 		id: string;
 		slug: string;
 		version: number;
+		// Hive's human-friendly handle ("Ember") plus the swatch color it renders
+		// alongside it. Null for models published before codenames existed.
+		codename?: string | null;
+		codename_color?: string | null;
 		name: string;
 		description: string | null;
 		purpose?: string;
@@ -50,6 +54,10 @@
 		local_id: string;
 		target_id: string | null;
 		model_id: string;
+		// Recorded in run.json at download time; absent for bundled models and
+		// for installs that predate the field.
+		codename?: string | null;
+		codename_color?: string | null;
 		variant_runtime: string;
 		purpose?: string;
 		// Installed correctly, but nothing on this machine consumes it yet.
@@ -111,6 +119,18 @@
 
 	function isInert(item: { purpose?: string; inert?: boolean }): boolean {
 		return item.inert === true || INERT_PURPOSES.has(purposeOf(item));
+	}
+
+	// Hive identifies a model by its codename ("Ember") and a color swatch, with
+	// the long descriptive name as the subtitle. Mirror that here so a model
+	// reads the same on both sites. Anything without a codename — bundled
+	// models, pre-codename publishes — keeps the descriptive name as its title.
+	function titleOf(item: { codename?: string | null; name: string }): string {
+		return item.codename || item.name;
+	}
+
+	function subtitleOf(item: { codename?: string | null; name: string }): string | null {
+		return item.codename ? item.name : null;
 	}
 
 	let targets = $state<HiveTarget[]>([]);
@@ -839,6 +859,13 @@
 							>
 								<div class="min-w-0 flex-1">
 									<div class="flex flex-wrap items-center gap-2">
+										{#if model.codename_color}
+											<span
+												class="h-3 w-3 shrink-0 border border-border"
+												style={`background-color: ${model.codename_color}`}
+												aria-hidden="true"
+											></span>
+										{/if}
 										{#if browseHref}
 											<a
 												href={browseHref}
@@ -847,10 +874,10 @@
 												class="font-mono text-sm font-medium text-text hover:text-primary hover:underline"
 												title={`Open in source Hive: ${browseHref}`}
 											>
-												{model.name}
+												{titleOf(model)}
 											</a>
 										{:else}
-											<span class="font-mono text-sm font-medium text-text">{model.name}</span>
+											<span class="font-mono text-sm font-medium text-text">{titleOf(model)}</span>
 										{/if}
 										{#if model.installed}
 											<span class="inline-flex items-center gap-1 bg-text-muted/20 px-2 py-0.5 text-xs font-semibold uppercase tracking-wider text-text">
@@ -875,6 +902,10 @@
 										</p>
 									{/if}
 									<div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-muted">
+										{#if subtitleOf(model)}
+											<span class="font-mono text-text">{subtitleOf(model)}</span>
+											<span aria-hidden="true">·</span>
+										{/if}
 										<span>{model.model_family}</span>
 										<span aria-hidden="true">·</span>
 										<span>v{model.version}</span>
@@ -1003,6 +1034,13 @@
 								<div class="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
 									<div class="min-w-0 flex-1">
 										<div class="flex flex-wrap items-center gap-2">
+											{#if entry.codename_color}
+												<span
+													class="h-3 w-3 shrink-0 border border-border"
+													style={`background-color: ${entry.codename_color}`}
+													aria-hidden="true"
+												></span>
+											{/if}
 											{#if detailHref}
 												<a
 													href={detailHref}
@@ -1011,11 +1049,11 @@
 													class="font-mono text-sm font-medium text-text hover:text-primary hover:underline"
 													title={`Open in source Hive: ${detailHref}`}
 												>
-													{entry.name}
+													{titleOf(entry)}
 												</a>
 											{:else}
 												<span class="font-mono text-sm font-medium text-text">
-													{entry.name}
+													{titleOf(entry)}
 												</span>
 											{/if}
 											{#if entry.bundled}
@@ -1041,6 +1079,10 @@
 											</p>
 										{/if}
 										<div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-text-muted">
+											{#if subtitleOf(entry)}
+												<span class="font-mono text-text">{subtitleOf(entry)}</span>
+												<span aria-hidden="true">·</span>
+											{/if}
 											<span>{entry.model_family}</span>
 											<span aria-hidden="true">·</span>
 											<span>{entry.variant_runtime}</span>


### PR DESCRIPTION
## Sorter: inherit the codename and color from Hive

A model on Hive is identified by its codename and a color swatch — **Ember**, orange — with the long descriptive name as the subtitle. The sorter's Models settings ignored both and led with the descriptive name, so the same model read as two different things depending on which site you were looking at.

Both tabs now lead with the codename and its swatch and demote the descriptive name to the meta line:

```
■ Ember  [INSTALLED]
  r5 C-Channel Full YOLO11s 320 · yolo · v1 · 2 formats (onnx, pytorch) · published 3 hours ago · hive.basically.website
```

The swatch is a **square**, not Hive's circle — the sorter UI forbids `rounded-*`. Anything without a codename (repo-bundled models, pre-codename publishes) keeps the descriptive name as its title, so nothing loses its label.

**Browse** already had the data. The catalog proxy passes Hive's payload through untouched, so `codename` / `codename_color` were arriving and simply going unread — this is a frontend-only change on that tab.

**Installed** had nothing to read, so downloads now record both in the `run.json` hive block alongside `sha256` / `purpose`.

Models installed *before* this predate the field. Rather than put a network call behind the Installed tab — which otherwise renders with no Hive reachable at all — browsing the catalog backfills their `run.json` from the listing it already fetched. So an existing install picks up its codename the first time you open **Browse Hive**, and re-downloading isn't required. The scan feeding both the installed-tagging and the backfill is now done once per browse instead of twice; walking the model dirs means stat'ing every weight file.

## Hive: remove the German

The model card and model detail page rendered their timestamps in German — `vor 3 Std`, `gerade eben`, `vor 2 Wochen` — from two copies of the same formatter. Both now use a shared `$lib/time`, in English, worded the same as the sorter's own relative-age formatter so one model reads identically on both sites.

The other seven `toLocale*('de-DE')` literals across the site are flipped to `en-US` in the same pass. Most only produced `dd.mm.yyyy`, but `machines/[machine_id]` used `month: 'short'` and was emitting German month names. Dates on those pages now read `mm/dd/yyyy` and 12-hour times.

## Verification

- Hive models list + detail checked in the real dev Hive against seeded rows (removed afterward): cards render the codename and swatch, and read `3 hours ago` / `Jun 30, 2026` instead of `vor 3 Std`.
- `pnpm --dir software/hive/frontend check` — 0 errors.
- `pnpm --dir software/sorter/frontend check` — no new errors (5 pre-existing, all in `settings/jitter-test`).
- `pytest tests/test_hive_models.py tests/test_detection_registry_hive.py` — 33 passed, including three new cases: a download records the codename, a legacy install reports `None`, and browsing backfills it.

The sorter UI itself is unverified locally — the only reachable sorter backend is a tunnel to a machine running older code, and its CORS allowlist is pinned to port 5173. Worth a look on kitbash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)