### PR TITLE
hive: per-machine last_30d_pieces

### DIFF
--- a/software/hive/backend/app/routers/public_stats.py
+++ b/software/hive/backend/app/routers/public_stats.py
@@ -154,7 +154,9 @@ def get_public_fleet(db: Session = Depends(get_db)):
     than a recompute over machine_pieces. The trailing-hour and trailing-24h
     counts are computed live off the (machine_id, seen_at) index, because they
     are what a consumer uses to say whether a machine is working RIGHT NOW and
-    an hour-stale answer to that is a wrong one.
+    an hour-stale answer to that is a wrong one. The 30-day count is the one a
+    leaderboard should rank on: a day is too short to mean much and a lifetime
+    total is the same order forever.
     """
     rows = (
         db.query(Machine, UserIdentity)
@@ -173,6 +175,7 @@ def get_public_fleet(db: Session = Depends(get_db)):
     lifetime = machine_stats.get_fleet_stats(db)
     recent = _pieces_by_machine_since(db, ids, hours=24)
     this_hour = _pieces_by_machine_since(db, ids, hours=1)
+    this_month = _pieces_by_machine_since(db, ids, hours=24 * 30)
     machines = [
         {
             "id": str(machine.id),
@@ -185,6 +188,7 @@ def get_public_fleet(db: Session = Depends(get_db)):
             "overall_ppm": float(lifetime.get(str(machine.id), {}).get("overall_ppm") or 0.0),
             "last_24h_pieces": recent.get(str(machine.id), 0),
             "last_hour_pieces": this_hour.get(str(machine.id), 0),
+            "last_30d_pieces": this_month.get(str(machine.id), 0),
             "owner_discord": None
             if identity is None
             else {

--- a/software/hive/backend/tests/test_public_stats.py
+++ b/software/hive/backend/tests/test_public_stats.py
@@ -214,7 +214,7 @@ class TestFleetRoster:
             if x["name"] == "Counting Sorter"
         )
         for field in ("pieces_seen", "distributed", "overall_ppm", "last_24h_pieces",
-                      "last_hour_pieces"):
+                      "last_hour_pieces", "last_30d_pieces"):
             assert field in entry, f"{field} missing from the roster entry"
         # A machine that has never sorted reports zeros rather than nulls, so a
         # consumer can sort on these without special-casing a fresh machine.
@@ -238,3 +238,5 @@ class TestFleetRoster:
         mine = max(body["machines"], key=lambda m: m["last_24h_pieces"])
         assert mine["last_24h_pieces"] == 2
         assert mine["last_hour_pieces"] == 1
+        # The month contains both, so the windows nest rather than overlap.
+        assert mine["last_30d_pieces"] == 2


### PR DESCRIPTION
Adds a 30-day trailing count per machine to `/api/public/fleet`, using the window-parameterised query already there. It is the span a leaderboard should rank on — a day is noisy and a lifetime total never reorders.

Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)