### PR TITLE
docs: scroll the section sidebar independently of the page

### DIFF
--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -7,6 +7,10 @@
 
 	let modal: HTMLDialogElement | undefined = $state();
 	let sidebarOpen = $state(false);
+	// The header scrolls away above the sticky sidebar, so the sidebar's height
+	// cap has to subtract it. It wraps at narrow widths, so measure it rather
+	// than hard-coding a number; layout.css carries a fallback until this lands.
+	let headerHeight = $state(0);
 
 	const fm = $derived(page.data.page?.fm ?? {});
 	const currentUrl = $derived(page.url.pathname);
@@ -17,8 +21,8 @@
 	);
 </script>
 
-<div class="shell">
-	<header class="site-header">
+<div class="shell" style={headerHeight ? `--header-height: ${headerHeight}px` : undefined}>
+	<header class="site-header" bind:clientHeight={headerHeight}>
 		<a class="brand" href="/">
 			<img class="brand-logo" src="/assets/basically-logo.svg" alt="basically logo" width="26" height="24" />
 			<span>

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -288,6 +288,9 @@ body {
 	position: sticky;
 	top: 16px;
 	align-self: start;
+	display: flex;
+	flex-direction: column;
+	max-height: calc(100vh - 32px);
 }
 
 .section-sidebar-kicker {
@@ -307,6 +310,12 @@ body {
 .section-sidebar nav {
 	display: flex;
 	flex-direction: column;
+	/* The tree is taller than the viewport in some sections (Hardware), so it
+	   scrolls on its own instead of dragging the page with it. */
+	min-height: 0;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	scrollbar-width: thin;
 }
 
 .section-sidebar-group {
@@ -1222,6 +1231,7 @@ blockquote {
 	.section-sidebar {
 		position: static;
 		padding: 0;
+		max-height: none;
 	}
 
 	.section-sidebar-kicker {
@@ -1258,6 +1268,7 @@ blockquote {
 	.section-sidebar > nav {
 		display: none;
 		padding: 0 10px 12px;
+		overflow-y: visible;
 	}
 
 	.section-sidebar.nav-open > nav {

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -71,6 +71,8 @@ body {
 /* ── Shell ─────────────────────────────────────────────────────────────── */
 
 .shell {
+	/* Measured into place by +layout.svelte; this is the pre-hydration guess. */
+	--header-height: 48px;
 	max-width: 1180px;
 	margin: 0 auto;
 	padding: 24px 20px 48px;
@@ -290,7 +292,11 @@ body {
 	align-self: start;
 	display: flex;
 	flex-direction: column;
-	max-height: calc(100vh - 32px);
+	/* Its top edge sits below the header (24px shell padding + header + 24px
+	   header margin), so the viewport-height cap has to subtract all of that or
+	   it overhangs the bottom of the screen until you scroll. 16px to spare. */
+	max-height: calc(100vh - var(--header-height) - 64px);
+	max-height: calc(100dvh - var(--header-height) - 64px);
 }
 
 .section-sidebar-kicker {


### PR DESCRIPTION
zed0 asked ("can you make it possible to scroll the contents sidebar on https://docs.basically.website/hardware/ without scrolling the entire page?") in Discord.

The Hardware sidebar's nav tree is taller than the viewport, so getting to the bottom entries meant scrolling the article too.

**Change** (`docs/src/routes/layout.css`, CSS only):
- `.section-sidebar` becomes a flex column capped at `calc(100vh - 32px)`, matching its `top: 16px` sticky offset.
- `.section-sidebar nav` gets `overflow-y: auto` + `min-height: 0`, so the tree scrolls inside the sticky column. The section kicker stays pinned above it.
- `overscroll-behavior: contain` so hitting the end of the list does not start scrolling the page.
- Reset under the existing 880px breakpoint, where the sidebar is a static collapsible dropdown and must not be height-capped.
