### PR TITLE
harness: say which guesses Jon's drawings did not cover

### DIFF
--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -39,7 +39,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
   <tbody>
     <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
     <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V <span class="flagged">verify silkscreen</span></td></tr>
-    <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends <span class="flagged">verify hub jack size</span></td></tr>
+    <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends</td></tr>
     <tr><td class="wire-id">W3</td><td>1</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Splice to USB-C buck input leads</td></tr>
     <tr><td class="wire-id">L1-L3</td><td>3</td><td>22 AWG</td><td>36 in</td><td>2</td><td>Dupont 1x2 female (2.54 mm)</td><td>Female inline DC jack 5.5×2.1</td><td>LED feed from board to unplug point</td></tr>
     <tr><td class="wire-id">L1p, L2p</td><td>2</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Solder to COB board pads</td></tr>

--- a/electronics/wire_harness/leds.yml
+++ b/electronics/wire_harness/leds.yml
@@ -2,7 +2,9 @@ metadata:
   title: Sorter V2 - LED drops and limit switch
   description: >
     LED feeds L1-L3 (board to unplug point), pigtails L1p-L3p, and the limit
-    switch cable. Values marked GUESS are guesses, not measurements.
+    switch cable. Jon's 2026-08-08 drawings do not cover the LED drops, so
+    apart from the limit switch terminals everything here is still Spencer's
+    July 12th notes. Values marked GUESS are guesses, not measurements.
 
 connectors:
   BOARD_L1: &dupont

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -64,12 +64,15 @@ cables:
     gauge: 22 AWG
     length: 12 in
     colors: [RD, BK]
-    notes: USB hub, double-male. Gauge = GUESS
+    notes: >
+      USB hub, double-male. Gauge = GUESS, not covered by Jon's drawings
+      (they cover the pigtail and the board feed only).
   W3:
     gauge: 22 AWG
     length: 6 in
     colors: [RD, BK]
-    notes: Orange Pi buck. Gauge = GUESS
+    notes: >
+      Orange Pi buck. Gauge = GUESS, not covered by Jon's drawings.
 
 connections:
   -

--- a/electronics/wire_harness/steppers.yml
+++ b/electronics/wire_harness/steppers.yml
@@ -59,8 +59,8 @@ cables:
     length: 40 in
     colors: [BK, GN, RD, BU]
     notes: >
-      qty 1. Gauge = GUESS. Length = GUESS. Straight-through.
-      Not covered by Jon's drawing.
+      qty 1. Straight-through. Not covered by Jon's drawing, so unlike S
+      above both Gauge and Length here are still GUESS.
 
 connections:
   -


### PR DESCRIPTION
Spencer asked why values still say `GUESS` when they came from Jon's drawings.

**Audit result: nothing Jon specified is still marked `GUESS`.** The instances visible on the live WireViz page are a stale CDN object, the 8 Aug render, which is a separate problem (the `?v=` cache-buster is inert because the zone ignores query strings in the cache key).

What is still marked `GUESS`, and why each one is legitimately still a guess:

```
value                     covered by Jon?
LED feed gauge L1-L3      no  - he sent nothing for LEDs
LED pigtail gauge L1P-L3P no  - same
LIM gauge                 no  - same
CH gauge and length       no  - his sheet is the channel cable only
W2 hub gauge              no  - his DC files are the pigtail and board feed
W3 buck gauge             no  - same
LED / limit dupont pin order   no
which of COM/NC/NO on the switch   no
```

So rather than change any value, each of those now says on the drawing that Jon's drawings do not cover it. Otherwise a reader sees `S` with a hard 24 AWG and `CH` right above it marked `GUESS` on the same sheet and has no way to know why.

One thing did become stale and is removed: the `verify hub jack size` flag on `W2`. That was settled in the call off the Waveshare wiki (`DC-044` is 5.5 × 2.1), and the pin-map section two lines below already says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)