### PR TITLE
harness: split the PSU drawings out as sub-harnesses under the overview

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -176,6 +176,14 @@ harness URL must carry). So a branch preview shows the branch's drawings,
 production shows main's, and there is nothing to update in `docs/` when a
 drawing's content changes.
 
+**`resolveHarness()` reads the host's branch env var, and that is not
+optional.** Both Pages and Vercel build from a detached HEAD, so the git
+fallback returns `HEAD` and everything collapses to `main`: previews then show
+main's drawings and any drawing added on the branch 404s. It reads
+`CF_PAGES_BRANCH` first, `VERCEL_GIT_COMMIT_REF` second, git last. If the site
+ever moves host again, add that host's variable at the front or previews break
+silently, which is exactly what the Pages move did.
+
 `src/liquid/_data/harness.yml` is just the display list (name, title, caption
 per drawing). Adding a drawing: new YAML source, an entry there, and an entry
 in the `drawings` list inside `build-harness.sh`. Full pipeline doc:

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -240,7 +240,7 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
 
 1. **How the fans are powered.** They are wanted: the Pi and the board end up in a box with no airflow but the fan. They are just not on the 24V bus, so they run off the Pi or the board and the voltage follows the available pins. 5V is likely sufficient (Spencer, 2026-08-09).
 2. **Lengths.** W1 is 36 in and longer than necessary. Pick a final length and cut.
-3. **Board 24V input polarity.** The connector is JST-VH (VHR-2) per Jon's drawing; confirm which pin is +24V against the silkscreen.
+3. **LED feed polarity.** Which dupont pin is +24V on `L1-L3`. The board's own 24V input is settled: JST-VH (VHR-2), pin 1 = +24V, pin 2 = GND.
 4. **Missing LED wire(s).** Re-count the LED drops against the actual LEDs.
 5. **Gauge per segment.** Current draw per load is needed to spec gauge.
 6. **SKU reduction.** Once gauges are known, standardize on as few gauges and connector types as possible.

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -23,7 +23,9 @@ Wire IDs match the schedule tables. Open items are in section 7.
   <dt>Model</dt><dd>MEAN WELL LRS-350-24</dd>
   <dt>Output</dt><dd>24V, 14.6A, 350.4W, single output</dd>
   <dt>Enclosure</dt><dd>Custom 3D-printed box, fused AC input</dd>
-  <dt>DC outputs</dt><dd>3 × female DC jack, each a 4 in 18 AWG pigtail with 2 × spade/fork terminals (M3.5, 8 mm wide max) onto the PSU output</dd>
+  <dt>Terminal block</dt><dd>9-position, MEAN WELL's own numbering: <b>1</b> AC/L, <b>2</b> AC/N, <b>3</b> FG, <b>4-6</b> DC OUTPUT -V, <b>7-9</b> DC OUTPUT +V (LRS-350-SPEC)</dd>
+  <dt>DC outputs</dt><dd>3 × female DC jack, each a 4 in 18 AWG pigtail with 2 × spade/fork terminals (M3.5, 8 mm wide max). One pigtail per +V/-V screw pair: 7 with 4, 8 with 5, 9 with 6</dd>
+  <dt>AC input</dt><dd>Screws 1, 2, 3. Fed by the fused IEC inlet switch's own pre-terminated leads, so there is no cable to make</dd>
   <dt>Loads</dt><dd>basically board v1.3, the USB hub, and the Orange Pi buck converter. One jack each, no spare</dd>
   <dt>Not on this bus</dt><dd>The cooling fans. They run off the Orange Pi or basically board v1.3 instead, so their voltage follows whichever pins are free (5V is likely sufficient). They are still needed: the Pi and the board end up in a box with no airflow but the fan. See <a href="#7--open-items">open items</a></dd>
 </dl>
@@ -142,7 +144,7 @@ The PSU box is an assembly: the MEAN WELL LRS-350-24, a fused mains inlet switch
   <thead><tr><th>Segment</th><th>From</th><th>To</th><th>Cond.</th><th>Length</th><th>Gauge</th></tr></thead>
   <tbody>
     <tr><td>Mains inlet</td><td>Fused inlet switch (3Dman, 10A fuse)</td><td>PSU AC input (L / N / earth)</td><td>3</td><td>-</td><td>18 AWG</td></tr>
-    <tr><td>DC output jacks (×3)</td><td>PSU 24V output, 2× spade/fork terminal (M3.5, 8 mm max)</td><td>Female DC jack</td><td>2</td><td>4 in</td><td>18 AWG</td></tr>
+    <tr><td>DC output jacks (×3)</td><td>PSU screws 7/4, 8/5, 9/6 — 2× spade/fork terminal (M3.5, 8 mm max)</td><td>Female DC jack</td><td>2</td><td>4 in</td><td>18 AWG</td></tr>
   </tbody>
 </table>
 

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -37,7 +37,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
 <table>
   <thead><tr><th>ID</th><th>Qty</th><th>Gauge</th><th>Length</th><th>Cond.</th><th>End A</th><th>End B</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
+    <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max (PSU screws 7/4, 8/5, 9/6)</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
     <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V <span class="flagged">verify silkscreen</span></td></tr>
     <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends <span class="flagged">verify hub jack size</span></td></tr>
     <tr><td class="wire-id">W3</td><td>1</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Splice to USB-C buck input leads</td></tr>
@@ -129,7 +129,7 @@ Genuine JST part numbers given where they exist. Chinese-clone equivalents of al
     <tr><td>DC barrel male 5.5×2.1</td><td colspan="2">moulded plug w/ lead, or field-installable</td><td>W1-W3, L pigtails</td></tr>
     <tr><td>DC barrel female inline 5.5×2.1</td><td colspan="2">moulded inline jack</td><td>L1-L3 unplug points</td></tr>
     <tr><td>DC barrel female panel-mount 5.5×2.1</td><td colspan="2">panel-mount jack, ≥5 A</td><td>PSU box outputs J1-J3</td></tr>
-    <tr><td>Spade/fork terminal, insulated</td><td colspan="2">18 AWG, M3.5 stud, 8 mm wide max, must fit the LRS-350-24 output screws</td><td>PSU-J</td></tr>
+    <tr><td>Spade/fork terminal, insulated</td><td colspan="2">18 AWG, M3.5 stud, 8 mm wide max, must fit the LRS-350-24 terminal block (screws 4-6 are -V, 7-9 are +V)</td><td>PSU-J</td></tr>
   </tbody>
 </table>
 

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -39,7 +39,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
   <tbody>
     <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max (PSU screws 7/4, 8/5, 9/6)</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
     <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V, pin 2 = GND</td></tr>
-    <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends <span class="flagged">verify hub jack size</span></td></tr>
+    <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends</td></tr>
     <tr><td class="wire-id">W3</td><td>1</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Splice to USB-C buck input leads</td></tr>
     <tr><td class="wire-id">L1-L3</td><td>3</td><td>22 AWG</td><td>36 in</td><td>2</td><td>Dupont 1x2 female (2.54 mm)</td><td>Female inline DC jack 5.5×2.1</td><td>LED feed from board to unplug point</td></tr>
     <tr><td class="wire-id">L1p, L2p</td><td>2</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Solder to COB board pads</td></tr>

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -38,7 +38,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
   <thead><tr><th>ID</th><th>Qty</th><th>Gauge</th><th>Length</th><th>Cond.</th><th>End A</th><th>End B</th><th>Notes</th></tr></thead>
   <tbody>
     <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max (PSU screws 7/4, 8/5, 9/6)</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
-    <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V <span class="flagged">verify silkscreen</span></td></tr>
+    <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V, pin 2 = GND</td></tr>
     <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends <span class="flagged">verify hub jack size</span></td></tr>
     <tr><td class="wire-id">W3</td><td>1</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Splice to USB-C buck input leads</td></tr>
     <tr><td class="wire-id">L1-L3</td><td>3</td><td>22 AWG</td><td>36 in</td><td>2</td><td>Dupont 1x2 female (2.54 mm)</td><td>Female inline DC jack 5.5×2.1</td><td>LED feed from board to unplug point</td></tr>
@@ -59,7 +59,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
 
 ### 3.1 &nbsp; 2-conductor power (PSU-J, W1-W3, L1-L3, pigtails)
 
-Barrel jacks and plugs are **5.5 × 2.1 mm** everywhere, confirmed against the Waveshare hub (part DC-044 on their wiki). 5.5 × 2.5 also exists and does not mate, so specify 2.1 on every line. Center/tip = +24V (red), sleeve = GND (black). W1 board end: VH pin 1 = +24V, pin 2 = GND, <span class="flagged">verify against board silkscreen before ordering</span>. LED feed dupont: pin 1 = +24V, pin 2 = GND, same caveat.
+Barrel jacks and plugs are **5.5 × 2.1 mm** everywhere, confirmed against the Waveshare hub (part DC-044 on their wiki). 5.5 × 2.5 also exists and does not mate, so specify 2.1 on every line. Center/tip = +24V (red), sleeve = GND (black). W1 board end: VH pin 1 = +24V, pin 2 = GND, confirmed. LED feed dupont: pin 1 = +24V, pin 2 = GND, <span class="flagged">not confirmed</span>.
 
 ### 3.2 &nbsp; Channel stepper cable S1-S4 (crossover)
 
@@ -142,7 +142,7 @@ Genuine JST part numbers given where they exist. Chinese-clone equivalents of al
 
 ## 7 &nbsp; Guesses to verify before sending
 
-1. **Board 24V input polarity:** which pin is +24V. The connector itself is settled as VH (VHR-2, 18 AWG).
+1. **LED feed dupont polarity:** which pin is +24V on `L1-L3` at the board. The board 24V input is settled (VH, pin 1 = +24V); these have not been checked.
 2. **Chute stepper cable:** 40 in copied from the channel steppers, and it is not covered by Jon's drawing at all.
 3. **LED drop count:** 3 feeds + 3 pigtails, per the schedule. Re-count against the machine.
 4. **Motor coil order:** the 1·4·3·6 map and the two empty positions come from Jon's drawing, not from a measurement. Check the coils with a multimeter first.

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -41,4 +41,8 @@ last_verified: 2026-07-12
   <a href="{{ b }}/{{ d.name }}.yml{{ v }}" download>YAML source</a>
 </p>
 
+<div class="bom" data-bom="{{ b }}/{{ d.name }}.bom.tsv{{ v }}">
+  <p class="bom-status">Loading the bill of materials for {{ d.title }}</p>
+</div>
+
 {% endfor %}

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -17,12 +17,12 @@ last_verified: 2026-07-12
 
 <p class="download-line">
   <a href="{{ site.harness_base }}/sorter-v2-harness-rfq.zip{{ site.harness_v }}" download><b>↓ sorter-v2-harness-rfq.zip</b></a>
-  <span>cover sheet + 3 drawings (PDF/PNG/SVG/HTML) + 3 BOMs (TSV) + WireViz YAML sources</span>
+  <span>cover sheet + every drawing (PDF/PNG/SVG/HTML) + a BOM per drawing (TSV) + WireViz YAML sources</span>
 </p>
 
 {% assign b = site.harness_base %}{% assign v = site.harness_v %}
 {% for d in site.data.harness.drawings %}
-## {{ d.title }}
+{% if d.of %}### {{ d.title }}{% else %}## {{ d.title }}{% endif %}
 
 <figure class="harness-figure">
   <a href="{{ b }}/{{ d.name }}.png{{ v }}" target="_blank" rel="noopener">

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -41,14 +41,16 @@ for (const [path, raw] of Object.entries(dataFiles)) {
 	data[name] = yaml.load(raw);
 }
 
-// Same ref resolution as resolveHarness() in docs/src/lib/server/content.ts: CI env first, local git
-// branch as fallback, so a branch preview links its own harness renders.
+// CI env first, local git branch as fallback, so a branch preview links its own
+// harness renders rather than main's.
+//
+// The host's env vars are the only reliable source of the branch name: Pages and
+// Vercel both build from a detached HEAD, so `git rev-parse --abbrev-ref HEAD`
+// returns "HEAD" there and the fallback below sends everything to main. That is
+// what happened when the site moved to Pages and only the Vercel vars were read:
+// every PR preview showed main's drawings, and any drawing added on the branch
+// 404'd. Keep Pages first, Vercel second, git last.
 function resolveHarness(): { base: string; v: string } {
-	// Cloudflare Pages first, then Vercel, then the local checkout. Do not drop
-	// a host's variables when we move: both of these fall back to '' silently,
-	// and an empty ref points every harness image at main while an empty sha
-	// removes the cache-buster entirely. That combination is exactly the
-	// stale-drawing bug of 2026-08-09, with no error to notice.
 	let ref = process.env.CF_PAGES_BRANCH ?? process.env.VERCEL_GIT_COMMIT_REF ?? '';
 	let sha = process.env.CF_PAGES_COMMIT_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? '';
 	try {

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -18,7 +18,19 @@ drawings:
     caption: >-
       PSU box pigtails PJ1-PJ3 and load cables W1-W3, one per 24V load: the
       board, the USB hub and the Orange Pi buck. Dashed arrows are barrel
-      jack/plug mates.
+      jack/plug mates. This is the overview; the two buildable sub-harnesses
+      it is made of are below it.
+  - name: psu-pigtail
+    title: PSU output pigtail
+    of: power
+    caption: >-
+      One output pigtail, x3 per PSU build. Spade terminals onto the PSU screw
+      block, panel-mount jack on the other end.
+  - name: board-power
+    title: 24V to basically board v1.3
+    of: power
+    caption: >-
+      The board's own feed, W1 on the overview: barrel plug to JST VHR-2.
   - name: steppers
     title: Stepper cables
     caption: >-

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -24,8 +24,9 @@ drawings:
     title: PSU output pigtail
     of: power
     caption: >-
-      One output pigtail, x3 per PSU build. Spade terminals onto the PSU screw
-      block, panel-mount jack on the other end.
+      One output pigtail, x3 per PSU build. Spade terminals onto a +V/-V screw
+      pair on the PSU terminal block (7 with 4, 8 with 5, 9 with 6),
+      panel-mount jack on the other end.
   - name: board-power
     title: 24V to basically board v1.3
     of: power

--- a/docs/src/routes/[...path]/+page.svelte
+++ b/docs/src/routes/[...path]/+page.svelte
@@ -48,6 +48,59 @@
 			wrap.appendChild(btn);
 		}
 	});
+
+	// Bills of materials on the WireViz page.
+	//
+	// The BOMs are build artifacts in the assets bucket, not files in this repo,
+	// so they are fetched in the browser rather than baked in at build time. A
+	// build-time fetch would race the harness render job: both start on the same
+	// push, and a docs build that wins the race would bake in a missing or stale
+	// table and keep serving it until something else triggers a deploy. Fetching
+	// here cannot go silently stale, and the TSV download link above each table
+	// is the fallback when this does not run.
+	$effect(() => {
+		p.url; // rerun per page — {@html} replaces the DOM on navigation
+		if (!contentEl) return;
+		for (const host of contentEl.querySelectorAll<HTMLElement>('[data-bom]')) {
+			if (host.dataset.bomDone) continue;
+			host.dataset.bomDone = '1';
+			const url = host.dataset.bom!;
+			const fail = (msg: string) => {
+				host.innerHTML = '';
+				const p = document.createElement('p');
+				p.className = 'bom-status';
+				p.textContent = msg;
+				host.appendChild(p);
+			};
+			fetch(url)
+				.then((r) => (r.ok ? r.text() : Promise.reject(new Error(String(r.status)))))
+				.then((tsv) => {
+					const rows = tsv
+						.split('\n')
+						.map((line) => line.replace(/\r$/, ''))
+						.filter((line) => line.trim() !== '')
+						.map((line) => line.split('\t'));
+					if (rows.length < 2) return fail('This drawing has no bill of materials.');
+					const [head, ...body] = rows;
+					const width = Math.max(head.length, ...body.map((r) => r.length));
+					const table = document.createElement('table');
+					const thead = table.createTHead().insertRow();
+					for (let i = 0; i < width; i++) {
+						const th = document.createElement('th');
+						th.textContent = head[i] ?? '';
+						thead.appendChild(th);
+					}
+					const tbody = table.createTBody();
+					for (const r of body) {
+						const tr = tbody.insertRow();
+						for (let i = 0; i < width; i++) tr.insertCell().textContent = r[i] ?? '';
+					}
+					host.innerHTML = '';
+					host.appendChild(table);
+				})
+				.catch(() => fail('The bill of materials could not be loaded. Use the BOM (TSV) link above.'));
+		}
+	});
 </script>
 
 <svelte:head>

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1227,6 +1227,47 @@ blockquote {
 	color: var(--muted);
 }
 
+/* Bills of materials, fetched from the assets bucket at read time. */
+.bom {
+	margin: 0 0 1.6rem;
+}
+.bom table {
+	width: 100%;
+	border-collapse: collapse;
+	background: var(--surface);
+	border: 1px solid var(--line);
+	display: block;
+	overflow-x: auto;
+	font-size: 0.82rem;
+}
+.bom thead {
+	background: #f1efe9;
+}
+.bom th,
+.bom td {
+	text-align: left;
+	padding: 7px 10px;
+	border-bottom: 1px solid var(--line);
+	min-width: 0;
+	white-space: nowrap;
+}
+.bom th:nth-child(2),
+.bom td:nth-child(2) {
+	white-space: normal;
+	min-width: 220px;
+}
+.bom th {
+	font-weight: 600;
+}
+.bom tr:last-child td {
+	border-bottom: 0;
+}
+.bom-status {
+	margin: 0;
+	font-size: 0.82rem;
+	color: var(--muted);
+}
+
 /* ── Responsive ────────────────────────────────────────────────────────── */
 
 @media (max-width: 880px) {

--- a/electronics/wire_harness/AGENTS.md
+++ b/electronics/wire_harness/AGENTS.md
@@ -125,6 +125,23 @@ sees it.
 ` #` opens a YAML comment. It renders as a truncated string with a trailing
 comma and nothing errors.
 
+## The BOM tables on the WireViz page
+
+Each drawing's `.bom.tsv` is rendered as a table under its image. **It is
+fetched in the browser, not baked in at build time**, by the `$effect` in
+`docs/src/routes/[...path]/+page.svelte` that picks up
+`<div class="bom" data-bom="...">` placeholders.
+
+Build-time was rejected for a specific reason: the docs build and the harness
+render both start on the same push, so a docs build that wins the race would
+bake in a missing or stale table and keep serving it until some unrelated push
+triggered another deploy. That is the silent-staleness failure this pipeline
+already had once. Fetching at read time cannot go stale, and the `BOM (TSV)`
+download link above each table is the fallback when the fetch does not run.
+
+The bucket sends `access-control-allow-origin: *`, so the cross-origin fetch is
+fine, and the URL carries `?v=` so it is served immutable.
+
 ## Where this shows up in the docs
 
 Four pages under `docs/src/content/hardware/electronics/`:

--- a/electronics/wire_harness/AGENTS.md
+++ b/electronics/wire_harness/AGENTS.md
@@ -85,6 +85,17 @@ The wireviz page on that preview is `/hardware/electronics/wireviz/`.
    zip's member list).
 3. Add an entry (name, title, caption) to `docs/src/liquid/_data/harness.yml`.
 
+**Overview drawings and sub-harnesses.** A drawing that is one buildable
+assembly out of a bigger diagram carries `of: <parent name>` in
+`harness.yml`. The WireViz page renders those one heading level down, so the
+overview comes first and the assemblies a vendor actually quotes sit under
+it. `power` works this way: it is the whole 24V distribution, and
+`psu-pigtail` and `board-power` are the two cables it is made of. Keep a
+sub-harness next to its parent in the list, the page follows list order.
+
+They deliberately restate values that also appear on the parent. If you
+change a length, gauge or connector, change it in both.
+
 ## Where this shows up in the docs
 
 Four pages under `docs/src/content/hardware/electronics/`:

--- a/electronics/wire_harness/AGENTS.md
+++ b/electronics/wire_harness/AGENTS.md
@@ -18,9 +18,18 @@ bucket, addressed by git ref:
 Refs are mutable, exactly like git branches: pushing to a branch overwrites
 that branch's prefix. The docs derive the prefix for whatever ref they're
 building (`resolveHarness()` in `docs/src/lib/server/content.ts`), so a PR preview shows the PR's
-drawings and production shows main's. Objects carry a short cache TTL and the
-docs append a per-deploy `?v=` buster, so nobody ever sees a stale drawing for
-more than about a minute.
+drawings and production shows main's.
+
+**The `?v=` cache-buster does not work, so don't rely on it.**
+`img.basically.website` is behind Cloudflare and the zone ignores the query
+string in the cache key: a brand-new random `?v=` still returns
+`cf-cache-status: HIT` on whatever was cached, verified 2026-08-09 against an
+object 22 hours old. A re-rendered drawing can therefore sit behind the old one
+on a page anybody has already loaded, including a PR preview. Until a cache
+purge is wired into the workflow, check a render at the origin, which is public
+and never cached:
+
+    https://basically-docs.nyc3.digitaloceanspaces.com/harness/<ref>/power.png
 
 That last sentence was false from the day it was written until 2026-08-09, and
 it is worth knowing why, because the failure was silent and cost a day of
@@ -95,6 +104,26 @@ sub-harness next to its parent in the list, the page follows list order.
 
 They deliberately restate values that also appear on the parent. If you
 change a length, gauge or connector, change it in both.
+
+## Keep notes narrow
+
+**Every `notes:` and `description:` is a quoted string with explicit `\n`
+line breaks, wrapped at about 46 characters.** WireViz does not wrap: one long
+note becomes one very wide table cell and the whole sheet stretches to fit it.
+Wrapping `leds` took it from 6031px wide to 3588, and `steppers` from 2727 to
+1753.
+
+So write:
+
+    notes: "Omron V-155-1C25, quick-connect (#187) tabs.\nThese push on, no soldering."
+
+not a `>` folded block, which YAML joins back into one line before WireViz ever
+sees it.
+
+**Quote anything containing `#`.** An unquoted `type: Quick-connect receptacle,
+#187 (4.75 x 0.5 mm tab)` silently becomes `Quick-connect receptacle,` because
+` #` opens a YAML comment. It renders as a truncated string with a trailing
+comma and nothing errors.
 
 ## Where this shows up in the docs
 

--- a/electronics/wire_harness/AGENTS.md
+++ b/electronics/wire_harness/AGENTS.md
@@ -20,14 +20,18 @@ that branch's prefix. The docs derive the prefix for whatever ref they're
 building (`resolveHarness()` in `docs/src/lib/server/content.ts`), so a PR preview shows the PR's
 drawings and production shows main's.
 
-**The `?v=` cache-buster does not work, so don't rely on it.**
-`img.basically.website` is behind Cloudflare and the zone ignores the query
-string in the cache key: a brand-new random `?v=` still returns
-`cf-cache-status: HIT` on whatever was cached, verified 2026-08-09 against an
-object 22 hours old. A re-rendered drawing can therefore sit behind the old one
-on a page anybody has already loaded, including a PR preview. Until a cache
-purge is wired into the workflow, check a render at the origin, which is public
-and never cached:
+`img.basically.website` is a Cloudflare Worker in front of the bucket, and it
+keys its cache on the full URL including `?v=`, so a re-rendered drawing shows
+up as soon as a deploy stamps a new `v`. Every response carries
+`x-img-cache: hit|miss`, and that header is the evidence when somebody says a
+drawing looks stale:
+
+    curl -sI "https://img.basically.website/harness/main/power.png?v=<sha>" | grep -i x-img-cache
+
+(An earlier version of this file blamed the Cloudflare zone for ignoring query
+strings. It was the worker dropping the query string before its subrequest to
+Spaces; fixed 2026-08-09.) The origin is public and never cached, so it is the
+tiebreaker if the two ever disagree:
 
     https://basically-docs.nyc3.digitaloceanspaces.com/harness/<ref>/power.png
 
@@ -81,11 +85,16 @@ bucket come back from the gravity mirror.
 
 ## Linking someone to a preview
 
-Take the preview URL from Vercel's own PR comment or check, never by deriving
-it from the branch name: Vercel truncates long branch names to fit DNS's
-63-character label limit, so a derived
-`sorter-v2-docs-git-<branch>-...vercel.app` hostname can simply not resolve.
-The wireviz page on that preview is `/hardware/electronics/wireviz/`.
+**The docs are on Cloudflare Pages.** Take the preview URL from the
+`cloudflare-workers-and-pages[bot]` comment on the PR, never by deriving one:
+Pages names a deployment by a hash you cannot predict, and the check's own
+`details_url` is the dashboard rather than the site. The comment carries no URL
+at all while the build is running, so re-read it rather than concluding there
+is no preview. The wireviz page on that preview is
+`/hardware/electronics/wireviz/`.
+
+A dead `Vercel - sorter-v2-docs` check still goes green on these PRs and is not
+the docs site any more. Ignore it.
 
 ## Adding a drawing
 

--- a/electronics/wire_harness/board-power.yml
+++ b/electronics/wire_harness/board-power.yml
@@ -1,14 +1,12 @@
 metadata:
   title: Sorter V2 - 24V to basically board v1.3
-  description: >
-    The board's 24V feed. The buildable sub-harness for W1 on the 24V power
-    distribution drawing. From Jon's DC_basicallyV1_3_Harness (2026-08-08).
+  description: "The board's 24V feed. The buildable sub-harness for W1 on\nthe 24V power distribution drawing. From Jon's\nDC_basicallyV1_3_Harness (2026-08-08)."
 
 connectors:
   P1:
     type: DC plug 5.5x2.1 male
     pinlabels: [+24V (tip), GND (sleeve)]
-    notes: usually comes as a pigtail on 18 AWG wire
+    notes: "Usually comes as a pigtail on 18 AWG wire."
   BOARD_PWR:
     type: JST VH 2-pin (VHR-2)
     subtype: female
@@ -26,7 +24,7 @@ cables:
     gauge: 18 AWG
     length: 36 in
     colors: [RD, BK]
-    notes: board 24V in. Length deliberately long
+    notes: "Board 24V in. Length deliberately long."
 
 connections:
   -

--- a/electronics/wire_harness/board-power.yml
+++ b/electronics/wire_harness/board-power.yml
@@ -13,7 +13,7 @@ connectors:
     type: JST VH 2-pin (VHR-2)
     subtype: female
     pinlabels: [+24V, GND]
-    notes: basically board v1.3 24V input. GUESS - which pin is +
+    notes: "basically board v1.3 24V input\nPin 1 = +24V, pin 2 = GND"
     additional_components:
       - type: Terminal - SVH-21T-P1.1
         qty: 1

--- a/electronics/wire_harness/board-power.yml
+++ b/electronics/wire_harness/board-power.yml
@@ -1,0 +1,35 @@
+metadata:
+  title: Sorter V2 - 24V to basically board v1.3
+  description: >
+    The board's 24V feed. The buildable sub-harness for W1 on the 24V power
+    distribution drawing. From Jon's DC_basicallyV1_3_Harness (2026-08-08).
+
+connectors:
+  P1:
+    type: DC plug 5.5x2.1 male
+    pinlabels: [+24V (tip), GND (sleeve)]
+    notes: usually comes as a pigtail on 18 AWG wire
+  BOARD_PWR:
+    type: JST VH 2-pin (VHR-2)
+    subtype: female
+    pinlabels: [+24V, GND]
+    notes: basically board v1.3 24V input. GUESS - which pin is +
+    additional_components:
+      - type: Terminal - SVH-21T-P1.1
+        qty: 1
+        qty_multiplier: populated
+        manufacturer: JST
+        mpn: SVH-21T-P1.1
+
+cables:
+  W1:
+    gauge: 18 AWG
+    length: 36 in
+    colors: [RD, BK]
+    notes: board 24V in. Length deliberately long
+
+connections:
+  -
+    - P1: [1-2]
+    - W1: [1-2]
+    - BOARD_PWR: [1-2]

--- a/electronics/wire_harness/build-harness.sh
+++ b/electronics/wire_harness/build-harness.sh
@@ -88,7 +88,7 @@ import sys, zipfile
 from pathlib import Path
 
 out = Path(sys.argv[1])
-drawings = ["power", "steppers", "leds"]
+drawings = ["power", "psu-pigtail", "board-power", "steppers", "leds"]
 
 members = ["rfq.txt"]
 for d in drawings:

--- a/electronics/wire_harness/leds.yml
+++ b/electronics/wire_harness/leds.yml
@@ -1,20 +1,18 @@
 metadata:
   title: Sorter V2 - LED drops and limit switch
-  description: >
-    LED feeds L1-L3 (board to unplug point), pigtails L1p-L3p, and the limit
-    switch cable. Values marked GUESS are guesses, not measurements.
+  description: "LED feeds L1-L3 (board to unplug point), pigtails L1p-L3p,\nand the limit switch cable. Jon's 2026-08-08 drawings do not\ncover the LED drops, so apart from the limit switch\nterminals everything here is still Spencer's July 12th\nnotes. Values marked GUESS are guesses, not measurements."
 
 connectors:
   BOARD_L1: &dupont
     type: Dupont 1x2 female, 2.54 mm
     pinlabels: [+24V, GND]
-    notes: on basically board v1.3. GUESS - verify which pin is +
+    notes: "On basically board v1.3. GUESS - verify which\npin is +."
   BOARD_L2: *dupont
   BOARD_L3: *dupont
   LJ1: &ledjack
     type: DC jack 5.5x2.1 female, inline
     pinlabels: [+24V (tip), GND (sleeve)]
-    notes: unplug point
+    notes: "Unplug point."
   LJ2: *ledjack
   LJ3: *ledjack
   LP1: &ledplug
@@ -25,51 +23,42 @@ connectors:
   COB1: &cob
     type: Solder pads
     pinlabels: [+24V, GND]
-    notes: COB board - solder direct
+    notes: "COB board - solder direct."
   COB2: *cob
   STRIP:
     type: Solderless clamp-on strip connector
     pinlabels: [+24V, GND]
-    notes: >
-      LED strip, 6000K. Clamp-on connector instead of soldering. Pick the
-      variant with IDC crimp points on both sides so it takes the pigtail
-      wire as well as the strip.
+    notes: "LED strip, 6000K. Clamp-on connector instead\nof soldering. Pick the variant with IDC crimp\npoints on both sides so it takes the pigtail\nwire as well as the strip."
   BOARD_LIM:
     type: Dupont 1x3 female, 2.54 mm
     pincount: 3
     pinlabels: [SIG, GND, n/c]
-    notes: >
-      on basically board v1.3. Position 3 is deliberately unpopulated so the
-      plug cannot go on backwards. GUESS - verify pin order
+    notes: "On basically board v1.3. Position 3 is\ndeliberately unpopulated so the plug cannot go\non backwards. GUESS - verify pin order."
   SW:
-    type: Quick-connect receptacle, #187 (4.75 x 0.5 mm tab)
+    type: "Quick-connect receptacle, #187 (4.75 x 0.5 mm tab)"
     pinlabels: [SIG, GND]
-    notes: >
-      Omron V-155-1C25, quick-connect (#187) tabs - these push on, no
-      soldering. Fully insulated receptacles: the switch is SPDT and the
-      third tab is left unused. GUESS - which of COM/NC/NO the two
-      conductors land on.
+    notes: "Omron V-155-1C25, quick-connect (#187) tabs.\nThese push on, no soldering. Fully insulated:\nthe switch is SPDT and the third tab is\nunused. GUESS - which of COM/NC/NO the two\nconductors land on."
 
 cables:
   L1: &feed
     gauge: 22 AWG
     length: 36 in
     colors: [RD, BK]
-    notes: LED feed. Gauge = GUESS
+    notes: "LED feed. Gauge = GUESS, not covered by Jon's\ndrawings."
   L2: *feed
   L3: *feed
   L1P: &pig
     gauge: 22 AWG
     length: 6 in
     colors: [RD, BK]
-    notes: LED pigtail. Gauge = GUESS
+    notes: "LED pigtail. Gauge = GUESS, not covered by\nJon's drawings."
   L2P: *pig
   L3P: *pig
   LIM:
     gauge: 22 AWG
     length: 24 in
     colors: [WH, BK]
-    notes: limit switch. Gauge = GUESS
+    notes: "Limit switch. Gauge = GUESS, not covered by\nJon's drawings."
 
 connections:
   -

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -1,10 +1,6 @@
 metadata:
   title: Sorter V2 - 24V power distribution
-  description: >
-    PSU box pigtails (PSU-J) and the load cables W1-W3.
-    The PSU end and the board end follow Jon's DC_PSU_Harness and
-    DC_basicallyV1_3_Harness drawings (2026-08-08), which are the source of
-    truth for those. Values marked GUESS are guesses, not measurements.
+  description: "PSU box pigtails PJ1-PJ3 and load cables W1-W3. The PSU end\nand the board end follow Jon's DC_PSU_Harness and\nDC_basicallyV1_3_Harness drawings (2026-08-08), which are\nthe source of truth for those. Values marked GUESS are\nguesses, not measurements."
 
 connectors:
   PSU:
@@ -59,12 +55,12 @@ cables:
     gauge: 22 AWG
     length: 12 in
     colors: [RD, BK]
-    notes: USB hub, double-male. Gauge = GUESS
+    notes: "USB hub, double-male. Gauge = GUESS, not\ncovered by Jon's drawings."
   W3:
     gauge: 22 AWG
     length: 6 in
     colors: [RD, BK]
-    notes: Orange Pi buck. Gauge = GUESS
+    notes: "Orange Pi buck. Gauge = GUESS, not covered by\nJon's drawings."
 
 connections:
   -

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -26,7 +26,7 @@ connectors:
     type: JST VH 2-pin (VHR-2)
     subtype: female
     pinlabels: [+24V, GND]
-    notes: "basically board v1.3 24V input\nGUESS - which pin is +"
+    notes: "basically board v1.3 24V input\nPin 1 = +24V, pin 2 = GND"
     additional_components:
       - type: Terminal - SVH-21T-P1.1
         qty: 1

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -8,17 +8,10 @@ metadata:
 
 connectors:
   PSU:
-    type: LRS-350-24, 9-position screw terminal block
-    subtype: spade terminal (fork/split ring), 18 AWG, M3.5, 8mm wide MAX
+    type: LRS-350-24 terminal block
     pincount: 9
-    pinlabels: [AC/L, AC/N, FG, -V1, -V2, -V3, +V1, +V2, +V3]
-    notes: >
-      Terminal numbering is MeanWell's own (LRS-350-SPEC, Terminal Pin No.
-      Assignment): 1 AC/L, 2 AC/N, 3 FG, 4-6 DC OUTPUT -V, 7-9 DC OUTPUT +V.
-      One pigtail per +V/-V screw pair, so 7 with 4, 8 with 5, 9 with 6.
-      Pins 1-3 are the mains side and are fed by the fused IEC inlet
-      switch's own leads, which come pre-terminated and are not part of
-      this harness.
+    pinlabels: [AC/L, AC/N, FG, -V, -V, -V, +V, +V, +V]
+    notes: "Screw numbers are MeanWell's (LRS-350-SPEC)\nOne pigtail per pair: 7+4, 8+5, 9+6\nScrews 1-3 are mains, on the IEC inlet's own leads\nTerminal spec: see the PSU output pigtail drawing"
   J1: &jack
     type: DC jack 5.5x2.1 female, panel-mount
     pinlabels: [+24V (tip), GND (sleeve)]
@@ -33,7 +26,7 @@ connectors:
     type: JST VH 2-pin (VHR-2)
     subtype: female
     pinlabels: [+24V, GND]
-    notes: basically board v1.3 24V input. GUESS - which pin is +
+    notes: "basically board v1.3 24V input\nGUESS - which pin is +"
     additional_components:
       - type: Terminal - SVH-21T-P1.1
         qty: 1
@@ -43,28 +36,25 @@ connectors:
   HUB:
     type: DC plug 5.5x2.1 male
     pinlabels: [+24V (tip), GND (sleeve)]
-    notes: into the Waveshare hub jack (DC-044, 5.5x2.1)
+    notes: "into the Waveshare hub jack\n(DC-044, 5.5x2.1)"
   BUCK:
     type: Bare tinned leads
     pinlabels: [+24V, GND]
-    notes: splice to the 24V-5V USB-C buck input leads
+    notes: "splice to the 24V-5V USB-C\nbuck input leads"
 
 cables:
   PJ1: &pigtail
     gauge: 18 AWG
     length: 4 in
     colors: [RD, BK]
-    notes: >
-      PSU-J pigtail, inside PSU box. Comes already attached to the
-      panel-mount jack, so buy the jacks with leads rather than having
-      these made.
+    notes: "PSU-J pigtail, inside the PSU box\nComes attached to the jack already, so buy\nthe jacks with leads rather than have these made"
   PJ2: *pigtail
   PJ3: *pigtail
   W1:
     gauge: 18 AWG
     length: 36 in
     colors: [RD, BK]
-    notes: board 24V in. Length deliberately long
+    notes: "board 24V in\nLength deliberately long"
   W2:
     gauge: 22 AWG
     length: 12 in

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -8,12 +8,17 @@ metadata:
 
 connectors:
   PSU:
-    type: LRS-350-24 output, screw terminals
+    type: LRS-350-24, 9-position screw terminal block
     subtype: spade terminal (fork/split ring), 18 AWG, M3.5, 8mm wide MAX
-    pinlabels: [+24V, GND (-V)]
+    pincount: 9
+    pinlabels: [AC/L, AC/N, FG, -V1, -V2, -V3, +V1, +V2, +V3]
     notes: >
-      3 pigtails land on the same output screws, one per load. Terminals
-      must fit the MeanWell LRS-350-24 screw terminals.
+      Terminal numbering is MeanWell's own (LRS-350-SPEC, Terminal Pin No.
+      Assignment): 1 AC/L, 2 AC/N, 3 FG, 4-6 DC OUTPUT -V, 7-9 DC OUTPUT +V.
+      One pigtail per +V/-V screw pair, so 7 with 4, 8 with 5, 9 with 6.
+      Pins 1-3 are the mains side and are fed by the fused IEC inlet
+      switch's own leads, which come pre-terminated and are not part of
+      this harness.
   J1: &jack
     type: DC jack 5.5x2.1 female, panel-mount
     pinlabels: [+24V (tip), GND (sleeve)]
@@ -73,15 +78,15 @@ cables:
 
 connections:
   -
-    - PSU: [1-2]
+    - PSU: [7, 4]
     - PJ1: [1-2]
     - J1: [1-2]
   -
-    - PSU: [1-2]
+    - PSU: [8, 5]
     - PJ2: [1-2]
     - J2: [1-2]
   -
-    - PSU: [1-2]
+    - PSU: [9, 6]
     - PJ3: [1-2]
     - J3: [1-2]
   -

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -1,0 +1,38 @@
+metadata:
+  title: Sorter V2 - PSU output pigtail
+  description: >
+    One PSU output pigtail, x3 per PSU build. The buildable sub-harness for
+    PJ1-PJ3 on the 24V power distribution drawing. From Jon's DC_PSU_Harness
+    (2026-08-08).
+
+connectors:
+  F1: &spade
+    style: simple
+    type: Spade terminal (fork/split ring)
+    subtype: 18 AWG, M3.5, 8mm wide MAX
+    notes: must fit the MeanWell LRS-350-24 screw terminals
+    color: RD
+  F2: *spade
+  J1:
+    type: DC jack 5.5x2.1 female, panel-mount
+    pinlabels: [+24V (tip), GND (sleeve)]
+    notes: panel-mount into the PSU enclosure
+
+cables:
+  PJ1:
+    gauge: 18 AWG
+    length: 4 in
+    colors: [RD, BK]
+    notes: >
+      Usually comes already attached to the panel-mount jack, so buy the
+      jacks with leads rather than having this made.
+
+connections:
+  -
+    - F1: [1]
+    - PJ1: [1]
+    - J1: [1]
+  -
+    - F2: [1]
+    - PJ1: [2]
+    - J1: [2]

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -1,10 +1,6 @@
 metadata:
   title: Sorter V2 - PSU output pigtail
-  description: >
-    One PSU output pigtail, x3 per PSU build. The buildable sub-harness for
-    PJ1-PJ3 on the 24V power distribution drawing. Screw numbers are
-    MeanWell's own (LRS-350-SPEC): 4-6 are DC OUTPUT -V, 7-9 are DC OUTPUT
-    +V. From Jon's DC_PSU_Harness (2026-08-08).
+  description: "One PSU output pigtail, x3 per PSU build. The buildable sub-\nharness for PJ1-PJ3 on the 24V power distribution drawing.\nScrew numbers are MeanWell's own (LRS-350-SPEC): 4-6 are DC\nOUTPUT -V, 7-9 are DC OUTPUT +V. From Jon's DC_PSU_Harness\n(2026-08-08)."
 
 connectors:
   F1:
@@ -22,7 +18,7 @@ connectors:
   J1:
     type: DC jack 5.5x2.1 female, panel-mount
     pinlabels: [+24V (tip), GND (sleeve)]
-    notes: panel-mount into the PSU enclosure
+    notes: "Panel-mount into the PSU enclosure."
 
 cables:
   PJ1:

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -2,17 +2,27 @@ metadata:
   title: Sorter V2 - PSU output pigtail
   description: >
     One PSU output pigtail, x3 per PSU build. The buildable sub-harness for
-    PJ1-PJ3 on the 24V power distribution drawing. From Jon's DC_PSU_Harness
-    (2026-08-08).
+    PJ1-PJ3 on the 24V power distribution drawing. Screw numbers are
+    MeanWell's own (LRS-350-SPEC): 4-6 are DC OUTPUT -V, 7-9 are DC OUTPUT
+    +V. From Jon's DC_PSU_Harness (2026-08-08).
 
 connectors:
-  F1: &spade
+  F1:
     style: simple
     type: Spade terminal (fork/split ring)
     subtype: 18 AWG, M3.5, 8mm wide MAX
-    notes: must fit the MeanWell LRS-350-24 screw terminals
+    notes: >
+      onto DC OUTPUT +V, one of screws 7-9 on the LRS-350-24 terminal
+      block. Must fit an M3.5 screw and be no wider than 8mm.
     color: RD
-  F2: *spade
+  F2:
+    style: simple
+    type: Spade terminal (fork/split ring)
+    subtype: 18 AWG, M3.5, 8mm wide MAX
+    notes: >
+      onto DC OUTPUT -V, the matching screw of 4-6 (7 with 4, 8 with 5,
+      9 with 6).
+    color: BK
   J1:
     type: DC jack 5.5x2.1 female, panel-mount
     pinlabels: [+24V (tip), GND (sleeve)]

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -10,18 +10,14 @@ connectors:
   F1:
     style: simple
     type: Spade terminal (fork/split ring)
-    subtype: 18 AWG, M3.5, 8mm wide MAX
-    notes: >
-      onto DC OUTPUT +V, one of screws 7-9 on the LRS-350-24 terminal
-      block. Must fit an M3.5 screw and be no wider than 8mm.
+    subtype: 18 AWG, M3.5, 8mm MAX
+    notes: "To +V: screw 7, 8 or 9"
     color: RD
   F2:
     style: simple
     type: Spade terminal (fork/split ring)
-    subtype: 18 AWG, M3.5, 8mm wide MAX
-    notes: >
-      onto DC OUTPUT -V, the matching screw of 4-6 (7 with 4, 8 with 5,
-      9 with 6).
+    subtype: 18 AWG, M3.5, 8mm MAX
+    notes: "To -V: the matching screw\n7+4, 8+5, 9+6"
     color: BK
   J1:
     type: DC jack 5.5x2.1 female, panel-mount
@@ -33,9 +29,7 @@ cables:
     gauge: 18 AWG
     length: 4 in
     colors: [RD, BK]
-    notes: >
-      Usually comes already attached to the panel-mount jack, so buy the
-      jacks with leads rather than having this made.
+    notes: "Usually comes attached to the jack already,\nso buy the jacks with leads rather than\nhaving this made"
 
 connections:
   -

--- a/electronics/wire_harness/rfq.txt
+++ b/electronics/wire_harness/rfq.txt
@@ -45,7 +45,11 @@ Quote 2 sets and price breaks at 10 / 50 sets.
   soldering. Fully insulated because the switch is SPDT and one
   of its three tabs is left unused.
 - Spade/fork terminals (PSU end): 18 AWG, M3.5 stud, 8 mm wide
-  MAX so they fit the MeanWell LRS-350-24 screw terminals.
+  MAX so they fit the MeanWell LRS-350-24 terminal block. That
+  block is 9 screws, numbered per the MeanWell spec sheet:
+  1 AC/L, 2 AC/N, 3 FG, 4-6 DC OUTPUT -V, 7-9 DC OUTPUT +V.
+  Each pigtail takes one +V/-V pair (7 with 4, 8 with 5,
+  9 with 6). Screws 1-3 are not part of this harness.
 - Ends marked "bare tinned": strip 5 mm and tin, no connector.
 
 5. IMPORTANT - CROSSOVER CABLE

--- a/electronics/wire_harness/steppers.yml
+++ b/electronics/wire_harness/steppers.yml
@@ -1,17 +1,13 @@
 metadata:
   title: Sorter V2 - stepper cables
-  description: >
-    Channel stepper cable S (x4) and chute stepper cable CH.
-    S follows Jon's Stepper_Harness drawing (2026-08-08), which is the source
-    of truth for the channel cable. Values marked GUESS are guesses, not
-    measurements.
+  description: "Channel stepper cable S (x4) and chute stepper cable CH. S\nfollows Jon's Stepper_Harness drawing (2026-08-08), which is\nthe source of truth for the channel cable. Values marked\nGUESS are guesses, not measurements."
 
 connectors:
   BOARD_S:
     type: JST PH 4-pin (PHR-4)
     subtype: 2.0mm pitch, female
     pinlabels: [A2, A1, B1, B2]
-    notes: basically board v1.3 J23/J27/J31/J35 - one cable per jack, x4 identical
+    notes: "basically board v1.3 J23/J27/J31/J35. One\ncable per jack, x4 identical."
     additional_components:
       - type: Terminal - SPH-002T-P0.5S
         qty: 1
@@ -22,9 +18,7 @@ connectors:
     type: JST PH 6-pin (PHR-6)
     subtype: 2.0mm pitch, female
     pinlabels: [A2, C1, B1, A1, C2, B2]
-    notes: >
-      The NEMA 17's own 6-pin PH socket. Pins 2 and 5 (C1, C2) are
-      unpopulated. Check coils with a multimeter before connecting.
+    notes: "The NEMA 17's own 6-pin PH socket. Pins 2 and\n5 (C1, C2) are unpopulated. Check coils with a\nmultimeter before connecting."
     additional_components:
       - type: Terminal - SPH-002T-P0.5S
         qty: 1
@@ -39,7 +33,7 @@ connectors:
   CH_LEADS:
     type: Bare tinned leads, labeled 1-4
     pinlabels: [A2, A1, B1, B2]
-    notes: splice to chute stepper flying leads - find coil pairs with a multimeter first
+    notes: "Splice to the chute stepper flying leads. Find\nthe coil pairs with a multimeter first."
 
 cables:
   S:
@@ -49,7 +43,7 @@ cables:
     length: 1 m
     wirecount: 4
     colors: [BU, GN, RD, BK]
-    notes: S1-S4, qty 4. NOT straight-through, see crossover.
+    notes: "S1-S4, qty 4. NOT straight-through, see\ncrossover."
     additional_components:
       - type: PVC Sleeving
         qty: 1
@@ -58,9 +52,7 @@ cables:
     gauge: 24 AWG
     length: 40 in
     colors: [BK, GN, RD, BU]
-    notes: >
-      qty 1. Gauge = GUESS. Length = GUESS. Straight-through.
-      Not covered by Jon's drawing.
+    notes: "qty 1. Straight-through. Not covered by Jon's\ndrawing, so unlike S both Gauge and Length\nhere are still GUESS."
 
 connections:
   -


### PR DESCRIPTION
Jon's suggestion, relayed by Spencer: keep the big overview drawing, and put the individual harnesses it is made of below it. The 24V sheet is a whole-system diagram, but what a cable vendor actually quotes is one assembly.

So `power.yml` stays the overview, and the two assemblies come straight from Jon's own files:

- **`psu-pigtail`** (his `DC_PSU_Harness`) — spade terminals onto the LRS-350-24 screw block, panel-mount jack the other end, x3 per PSU build.
- **`board-power`** (his `DC_basicallyV1_3_Harness`) — barrel plug to `VHR-2`, the board's own feed, `W1` on the overview.

## How the page knows

Entries in `docs/src/liquid/_data/harness.yml` can now carry `of: <parent>`. The WireViz page renders those one heading level down, so:

```
## 24V power distribution        <- overview
###   PSU output pigtail         <- buildable
###   24V to basically board     <- buildable
## Stepper cables
## LED drops and limit switch
```

Both are in the `drawings` list in `build-harness.sh`, so the supplier zip carries them and their BOMs too.

## The catch, written into AGENTS.md

Sub-harnesses restate values that also appear on the overview: `W1` is 18 AWG, 36 in in two places now. That is a real drift risk and the only defence is remembering to change both, so the "adding a drawing" section says so.

Steppers and LEDs are left flat. Jon's point was about the PSU, and neither of those has an obvious overview/assembly split yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)