### PR TITLE
Show each harness BOM inline on the WireViz page

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -163,6 +163,17 @@ harness URL must carry). So a branch preview shows the branch's drawings,
 production shows main's, and there is nothing to update in `docs/` when a
 drawing's content changes.
 
+Each drawing's bill of materials is shown inline on the WireViz page, fetched
+**in the browser** from `<harness_base>/<name>.bom.tsv` and turned into a table
+by `src/lib/bom.ts` (driven by an effect in `src/routes/[...path]/+page.svelte`,
+markup is the `.bom` div in `wireviz.md`). It is not baked in at build time on
+purpose: the harness workflow only runs on harness path changes and finishes
+well after Vercel starts, so a prerendered BOM would be missing or stale on most
+previews and could never correct itself. `img.basically.website` sends
+`access-control-allow-origin: *` on everything (`scripts/img-worker/worker.js`),
+which is what makes the fetch legal. When there is no render for the ref, the
+page says so and links the TSV.
+
 `src/liquid/_data/harness.yml` is just the display list (name, title, caption
 per drawing). Adding a drawing: new YAML source, an entry there, and an entry
 in the `drawings` list inside `build-harness.sh`. Full pipeline doc:

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -240,7 +240,7 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
 
 1. **How the fans are powered.** They are wanted: the Pi and the board end up in a box with no airflow but the fan. They are just not on the 24V bus, so they run off the Pi or the board and the voltage follows the available pins. 5V is likely sufficient (Spencer, 2026-08-09).
 2. **Lengths.** W1 is 36 in and longer than necessary. Pick a final length and cut.
-3. **Board 24V input polarity.** The connector is JST-VH (VHR-2) per Jon's drawing; confirm which pin is +24V against the silkscreen.
+3. **LED feed polarity.** Which dupont pin is +24V on `L1-L3`. The board's own 24V input is settled: JST-VH (VHR-2), pin 1 = +24V, pin 2 = GND.
 4. **Missing LED wire(s).** Re-count the LED drops against the actual LEDs.
 5. **Gauge per segment.** Current draw per load is needed to spec gauge.
 6. **SKU reduction.** Once gauges are known, standardize on as few gauges and connector types as possible.

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -23,7 +23,9 @@ Wire IDs match the schedule tables. Open items are in section 7.
   <dt>Model</dt><dd>MEAN WELL LRS-350-24</dd>
   <dt>Output</dt><dd>24V, 14.6A, 350.4W, single output</dd>
   <dt>Enclosure</dt><dd>Custom 3D-printed box, fused AC input</dd>
-  <dt>DC outputs</dt><dd>3 × female DC jack, each a 4 in 18 AWG pigtail with 2 × spade/fork terminals (M3.5, 8 mm wide max) onto the PSU output</dd>
+  <dt>Terminal block</dt><dd>9-position, MEAN WELL's own numbering: <b>1</b> AC/L, <b>2</b> AC/N, <b>3</b> FG, <b>4-6</b> DC OUTPUT -V, <b>7-9</b> DC OUTPUT +V (LRS-350-SPEC)</dd>
+  <dt>DC outputs</dt><dd>3 × female DC jack, each a 4 in 18 AWG pigtail with 2 × spade/fork terminals (M3.5, 8 mm wide max). One pigtail per +V/-V screw pair: 7 with 4, 8 with 5, 9 with 6</dd>
+  <dt>AC input</dt><dd>Screws 1, 2, 3. Fed by the fused IEC inlet switch's own pre-terminated leads, so there is no cable to make</dd>
   <dt>Loads</dt><dd>basically board v1.3, the USB hub, and the Orange Pi buck converter. One jack each, no spare</dd>
   <dt>Not on this bus</dt><dd>The cooling fans. They run off the Orange Pi or basically board v1.3 instead, so their voltage follows whichever pins are free (5V is likely sufficient). They are still needed: the Pi and the board end up in a box with no airflow but the fan. See <a href="#7--open-items">open items</a></dd>
 </dl>
@@ -142,7 +144,7 @@ The PSU box is an assembly: the MEAN WELL LRS-350-24, a fused mains inlet switch
   <thead><tr><th>Segment</th><th>From</th><th>To</th><th>Cond.</th><th>Length</th><th>Gauge</th></tr></thead>
   <tbody>
     <tr><td>Mains inlet</td><td>Fused inlet switch (3Dman, 10A fuse)</td><td>PSU AC input (L / N / earth)</td><td>3</td><td>-</td><td>18 AWG</td></tr>
-    <tr><td>DC output jacks (×3)</td><td>PSU 24V output, 2× spade/fork terminal (M3.5, 8 mm max)</td><td>Female DC jack</td><td>2</td><td>4 in</td><td>18 AWG</td></tr>
+    <tr><td>DC output jacks (×3)</td><td>PSU screws 7/4, 8/5, 9/6 — 2× spade/fork terminal (M3.5, 8 mm max)</td><td>Female DC jack</td><td>2</td><td>4 in</td><td>18 AWG</td></tr>
   </tbody>
 </table>
 

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -37,7 +37,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
 <table>
   <thead><tr><th>ID</th><th>Qty</th><th>Gauge</th><th>Length</th><th>Cond.</th><th>End A</th><th>End B</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
+    <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max (PSU screws 7/4, 8/5, 9/6)</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
     <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V <span class="flagged">verify silkscreen</span></td></tr>
     <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends <span class="flagged">verify hub jack size</span></td></tr>
     <tr><td class="wire-id">W3</td><td>1</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Splice to USB-C buck input leads</td></tr>
@@ -129,7 +129,7 @@ Genuine JST part numbers given where they exist. Chinese-clone equivalents of al
     <tr><td>DC barrel male 5.5×2.1</td><td colspan="2">moulded plug w/ lead, or field-installable</td><td>W1-W3, L pigtails</td></tr>
     <tr><td>DC barrel female inline 5.5×2.1</td><td colspan="2">moulded inline jack</td><td>L1-L3 unplug points</td></tr>
     <tr><td>DC barrel female panel-mount 5.5×2.1</td><td colspan="2">panel-mount jack, ≥5 A</td><td>PSU box outputs J1-J3</td></tr>
-    <tr><td>Spade/fork terminal, insulated</td><td colspan="2">18 AWG, M3.5 stud, 8 mm wide max, must fit the LRS-350-24 output screws</td><td>PSU-J</td></tr>
+    <tr><td>Spade/fork terminal, insulated</td><td colspan="2">18 AWG, M3.5 stud, 8 mm wide max, must fit the LRS-350-24 terminal block (screws 4-6 are -V, 7-9 are +V)</td><td>PSU-J</td></tr>
   </tbody>
 </table>
 

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -39,7 +39,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
   <tbody>
     <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max (PSU screws 7/4, 8/5, 9/6)</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
     <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V, pin 2 = GND</td></tr>
-    <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends <span class="flagged">verify hub jack size</span></td></tr>
+    <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends</td></tr>
     <tr><td class="wire-id">W3</td><td>1</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Splice to USB-C buck input leads</td></tr>
     <tr><td class="wire-id">L1-L3</td><td>3</td><td>22 AWG</td><td>36 in</td><td>2</td><td>Dupont 1x2 female (2.54 mm)</td><td>Female inline DC jack 5.5×2.1</td><td>LED feed from board to unplug point</td></tr>
     <tr><td class="wire-id">L1p, L2p</td><td>2</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Solder to COB board pads</td></tr>

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -38,7 +38,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
   <thead><tr><th>ID</th><th>Qty</th><th>Gauge</th><th>Length</th><th>Cond.</th><th>End A</th><th>End B</th><th>Notes</th></tr></thead>
   <tbody>
     <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max (PSU screws 7/4, 8/5, 9/6)</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
-    <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V <span class="flagged">verify silkscreen</span></td></tr>
+    <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V, pin 2 = GND</td></tr>
     <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends <span class="flagged">verify hub jack size</span></td></tr>
     <tr><td class="wire-id">W3</td><td>1</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Splice to USB-C buck input leads</td></tr>
     <tr><td class="wire-id">L1-L3</td><td>3</td><td>22 AWG</td><td>36 in</td><td>2</td><td>Dupont 1x2 female (2.54 mm)</td><td>Female inline DC jack 5.5×2.1</td><td>LED feed from board to unplug point</td></tr>
@@ -59,7 +59,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
 
 ### 3.1 &nbsp; 2-conductor power (PSU-J, W1-W3, L1-L3, pigtails)
 
-Barrel jacks and plugs are **5.5 × 2.1 mm** everywhere, confirmed against the Waveshare hub (part DC-044 on their wiki). 5.5 × 2.5 also exists and does not mate, so specify 2.1 on every line. Center/tip = +24V (red), sleeve = GND (black). W1 board end: VH pin 1 = +24V, pin 2 = GND, <span class="flagged">verify against board silkscreen before ordering</span>. LED feed dupont: pin 1 = +24V, pin 2 = GND, same caveat.
+Barrel jacks and plugs are **5.5 × 2.1 mm** everywhere, confirmed against the Waveshare hub (part DC-044 on their wiki). 5.5 × 2.5 also exists and does not mate, so specify 2.1 on every line. Center/tip = +24V (red), sleeve = GND (black). W1 board end: VH pin 1 = +24V, pin 2 = GND, confirmed. LED feed dupont: pin 1 = +24V, pin 2 = GND, <span class="flagged">not confirmed</span>.
 
 ### 3.2 &nbsp; Channel stepper cable S1-S4 (crossover)
 
@@ -142,7 +142,7 @@ Genuine JST part numbers given where they exist. Chinese-clone equivalents of al
 
 ## 7 &nbsp; Guesses to verify before sending
 
-1. **Board 24V input polarity:** which pin is +24V. The connector itself is settled as VH (VHR-2, 18 AWG).
+1. **LED feed dupont polarity:** which pin is +24V on `L1-L3` at the board. The board 24V input is settled (VH, pin 1 = +24V); these have not been checked.
 2. **Chute stepper cable:** 40 in copied from the channel steppers, and it is not covered by Jon's drawing at all.
 3. **LED drop count:** 3 feeds + 3 pigtails, per the schedule. Re-count against the machine.
 4. **Motor coil order:** the 1·4·3·6 map and the two empty positions come from Jon's drawing, not from a measurement. Check the coils with a multimeter first.

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -41,4 +41,9 @@ last_verified: 2026-07-12
   <a href="{{ b }}/{{ d.name }}.yml{{ v }}" download>YAML source</a>
 </p>
 
+<div class="bom" data-bom-src="{{ b }}/{{ d.name }}.bom.tsv{{ v }}" data-bom-label="{{ d.title }} bill of materials">
+  <p class="bom-title">Bill of materials</p>
+  <p class="bom-status">Loading the bill of materials.</p>
+</div>
+
 {% endfor %}

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -17,12 +17,12 @@ last_verified: 2026-07-12
 
 <p class="download-line">
   <a href="{{ site.harness_base }}/sorter-v2-harness-rfq.zip{{ site.harness_v }}" download><b>↓ sorter-v2-harness-rfq.zip</b></a>
-  <span>cover sheet + 3 drawings (PDF/PNG/SVG/HTML) + 3 BOMs (TSV) + WireViz YAML sources</span>
+  <span>cover sheet + every drawing (PDF/PNG/SVG/HTML) + a BOM per drawing (TSV) + WireViz YAML sources</span>
 </p>
 
 {% assign b = site.harness_base %}{% assign v = site.harness_v %}
 {% for d in site.data.harness.drawings %}
-## {{ d.title }}
+{% if d.of %}### {{ d.title }}{% else %}## {{ d.title }}{% endif %}
 
 <figure class="harness-figure">
   <a href="{{ b }}/{{ d.name }}.png{{ v }}" target="_blank" rel="noopener">

--- a/docs/src/lib/bom.ts
+++ b/docs/src/lib/bom.ts
@@ -1,0 +1,56 @@
+// Turns a WireViz `<name>.bom.tsv` into a table element.
+//
+// The TSVs are build artifacts in the assets bucket, never in git, so this
+// runs in the browser rather than at build time. See the effect in
+// routes/[...path]/+page.svelte for why.
+
+// WireViz emits `Id, Description, Qty, Unit, Designators` and, when a part
+// carries them, `Manufacturer, MPN`.
+const CELL_CLASS: Record<string, string> = {
+	id: 'bom-num',
+	qty: 'bom-num',
+	unit: 'bom-unit'
+};
+
+export function parseBomTsv(text: string): string[][] {
+	return text
+		.split(/\r?\n/)
+		.filter((line) => line.trim() !== '')
+		.map((line) => line.split('\t'));
+}
+
+// Cells are frequently empty and a row can be short a trailing column, so the
+// width is the widest row and every cell is padded out to it.
+export function buildBomTable(rows: string[][], label: string): HTMLTableElement {
+	const cols = Math.max(...rows.map((r) => r.length));
+	const head = Array.from({ length: cols }, (_, i) => (rows[0][i] ?? '').trim());
+
+	const table = document.createElement('table');
+	table.className = 'bom-table';
+	table.setAttribute('aria-label', label);
+
+	const thead = document.createElement('thead');
+	const headRow = document.createElement('tr');
+	for (const name of head) {
+		const th = document.createElement('th');
+		th.textContent = name;
+		th.className = CELL_CLASS[name.toLowerCase()] ?? '';
+		headRow.appendChild(th);
+	}
+	thead.appendChild(headRow);
+	table.appendChild(thead);
+
+	const tbody = document.createElement('tbody');
+	for (const row of rows.slice(1)) {
+		const tr = document.createElement('tr');
+		for (let i = 0; i < cols; i++) {
+			const td = document.createElement('td');
+			td.textContent = (row[i] ?? '').trim();
+			td.className = CELL_CLASS[head[i].toLowerCase()] ?? '';
+			tr.appendChild(td);
+		}
+		tbody.appendChild(tr);
+	}
+	table.appendChild(tbody);
+	return table;
+}

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -18,7 +18,19 @@ drawings:
     caption: >-
       PSU box pigtails PJ1-PJ3 and load cables W1-W3, one per 24V load: the
       board, the USB hub and the Orange Pi buck. Dashed arrows are barrel
-      jack/plug mates.
+      jack/plug mates. This is the overview; the two buildable sub-harnesses
+      it is made of are below it.
+  - name: psu-pigtail
+    title: PSU output pigtail
+    of: power
+    caption: >-
+      One output pigtail, x3 per PSU build. Spade terminals onto the PSU screw
+      block, panel-mount jack on the other end.
+  - name: board-power
+    title: 24V to basically board v1.3
+    of: power
+    caption: >-
+      The board's own feed, W1 on the overview: barrel plug to JST VHR-2.
   - name: steppers
     title: Stepper cables
     caption: >-

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -24,8 +24,9 @@ drawings:
     title: PSU output pigtail
     of: power
     caption: >-
-      One output pigtail, x3 per PSU build. Spade terminals onto the PSU screw
-      block, panel-mount jack on the other end.
+      One output pigtail, x3 per PSU build. Spade terminals onto a +V/-V screw
+      pair on the PSU terminal block (7 with 4, 8 with 5, 9 with 6),
+      panel-mount jack on the other end.
   - name: board-power
     title: 24V to basically board v1.3
     of: power

--- a/docs/src/routes/[...path]/+page.svelte
+++ b/docs/src/routes/[...path]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import PageMeta from '$lib/components/PageMeta.svelte';
 	import Requirements from '$lib/components/Requirements.svelte';
+	import { parseBomTsv, buildBomTable } from '$lib/bom';
 
 	let { data } = $props();
 
@@ -48,6 +49,52 @@
 			wrap.appendChild(btn);
 		}
 	});
+
+	// Harness bills of materials, fetched in the browser.
+	//
+	// Each `<name>.bom.tsv` is a build artifact in the assets bucket, never in
+	// git, and CI renders it on a schedule the docs build cannot wait for: the
+	// harness workflow only fires on harness path changes, so a docs-only
+	// branch has no `harness/<ref>/` prefix at all, and on a harness branch the
+	// Vercel build starts on push while the render lands ~90s later. Baking the
+	// table in at build time would therefore be missing or stale on most
+	// previews and could never correct itself. Fetching client side makes the
+	// BOM behave exactly like the drawing images above it: whatever is in the
+	// bucket when you load the page. img.basically.website sends
+	// `access-control-allow-origin: *` on every response (scripts/img-worker).
+	$effect(() => {
+		p.url; // rerun per page: {@html} replaces the DOM on navigation
+		if (!contentEl) return;
+		let live = true;
+		for (const box of contentEl.querySelectorAll<HTMLElement>('.bom[data-bom-src]')) {
+			if (box.dataset.bomDone) continue;
+			box.dataset.bomDone = '1';
+			void fillBom(box, () => live);
+		}
+		return () => {
+			live = false;
+		};
+	});
+
+	async function fillBom(box: HTMLElement, live: () => boolean) {
+		const src = box.dataset.bomSrc!;
+		const status = box.querySelector('.bom-status');
+		try {
+			const res = await fetch(src);
+			if (!res.ok) throw new Error(String(res.status));
+			const rows = parseBomTsv(await res.text());
+			if (!live()) return;
+			if (rows.length < 2) throw new Error('empty');
+			status?.replaceWith(buildBomTable(rows, box.dataset.bomLabel ?? 'Bill of materials'));
+		} catch {
+			if (!live() || !status) return;
+			status.textContent = 'Not published for this build yet. ';
+			const link = document.createElement('a');
+			link.href = src;
+			link.textContent = 'Open the TSV';
+			status.appendChild(link);
+		}
+	}
 </script>
 
 <svelte:head>

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1212,6 +1212,52 @@ blockquote {
 	color: var(--muted);
 }
 
+/* Harness bill of materials, filled in by the browser from the bucket's TSV
+   (see routes/[...path]/+page.svelte). Cells are narrower than the site's
+   default table so a 7-column BOM fits a phone; the table still scrolls
+   inside itself rather than dragging the page sideways. */
+.bom {
+	margin: 0 0 2rem;
+}
+.bom-title {
+	margin: 0;
+	font-size: 0.76rem;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--muted);
+}
+.bom-status {
+	margin: 0.5rem 0 0;
+	font-size: 0.875rem;
+	color: var(--muted);
+}
+.md-content .bom-table {
+	margin: 0.6rem 0 0;
+	table-layout: auto;
+}
+.md-content .bom-table th,
+.md-content .bom-table td {
+	min-width: 0;
+	padding: 7px 10px;
+	font-size: 0.82rem;
+	line-height: 1.4;
+	vertical-align: top;
+}
+.md-content .bom-table th {
+	font-size: 0.7rem;
+	white-space: nowrap;
+}
+.md-content .bom-table .bom-num,
+.md-content .bom-table .bom-unit {
+	white-space: nowrap;
+	width: 1%;
+}
+.md-content .bom-table .bom-num {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
 /* ── Responsive ────────────────────────────────────────────────────────── */
 
 @media (max-width: 880px) {

--- a/electronics/wire_harness/AGENTS.md
+++ b/electronics/wire_harness/AGENTS.md
@@ -18,9 +18,18 @@ bucket, addressed by git ref:
 Refs are mutable, exactly like git branches: pushing to a branch overwrites
 that branch's prefix. The docs derive the prefix for whatever ref they're
 building (`resolveHarness()` in `docs/src/lib/server/content.ts`), so a PR preview shows the PR's
-drawings and production shows main's. Objects carry a short cache TTL and the
-docs append a per-deploy `?v=` buster, so nobody ever sees a stale drawing for
-more than about a minute.
+drawings and production shows main's.
+
+**The `?v=` cache-buster does not work, so don't rely on it.**
+`img.basically.website` is behind Cloudflare and the zone ignores the query
+string in the cache key: a brand-new random `?v=` still returns
+`cf-cache-status: HIT` on whatever was cached, verified 2026-08-09 against an
+object 22 hours old. A re-rendered drawing can therefore sit behind the old one
+on a page anybody has already loaded, including a PR preview. Until a cache
+purge is wired into the workflow, check a render at the origin, which is public
+and never cached:
+
+    https://basically-docs.nyc3.digitaloceanspaces.com/harness/<ref>/power.png
 
 Permanent, content-addressed copies are a release-time concern (the lockfile
 mechanism in the unified parts plan), not a live-docs one. The bucket is
@@ -81,6 +90,26 @@ sub-harness next to its parent in the list, the page follows list order.
 
 They deliberately restate values that also appear on the parent. If you
 change a length, gauge or connector, change it in both.
+
+## Keep notes narrow
+
+**Every `notes:` and `description:` is a quoted string with explicit `\n`
+line breaks, wrapped at about 46 characters.** WireViz does not wrap: one long
+note becomes one very wide table cell and the whole sheet stretches to fit it.
+Wrapping `leds` took it from 6031px wide to 3588, and `steppers` from 2727 to
+1753.
+
+So write:
+
+    notes: "Omron V-155-1C25, quick-connect (#187) tabs.\nThese push on, no soldering."
+
+not a `>` folded block, which YAML joins back into one line before WireViz ever
+sees it.
+
+**Quote anything containing `#`.** An unquoted `type: Quick-connect receptacle,
+#187 (4.75 x 0.5 mm tab)` silently becomes `Quick-connect receptacle,` because
+` #` opens a YAML comment. It renders as a truncated string with a trailing
+comma and nothing errors.
 
 ## Where this shows up in the docs
 

--- a/electronics/wire_harness/AGENTS.md
+++ b/electronics/wire_harness/AGENTS.md
@@ -71,6 +71,17 @@ The wireviz page on that preview is `/hardware/electronics/wireviz/`.
    zip's member list).
 3. Add an entry (name, title, caption) to `docs/src/liquid/_data/harness.yml`.
 
+**Overview drawings and sub-harnesses.** A drawing that is one buildable
+assembly out of a bigger diagram carries `of: <parent name>` in
+`harness.yml`. The WireViz page renders those one heading level down, so the
+overview comes first and the assemblies a vendor actually quotes sit under
+it. `power` works this way: it is the whole 24V distribution, and
+`psu-pigtail` and `board-power` are the two cables it is made of. Keep a
+sub-harness next to its parent in the list, the page follows list order.
+
+They deliberately restate values that also appear on the parent. If you
+change a length, gauge or connector, change it in both.
+
 ## Where this shows up in the docs
 
 Four pages under `docs/src/content/hardware/electronics/`:

--- a/electronics/wire_harness/board-power.yml
+++ b/electronics/wire_harness/board-power.yml
@@ -1,14 +1,12 @@
 metadata:
   title: Sorter V2 - 24V to basically board v1.3
-  description: >
-    The board's 24V feed. The buildable sub-harness for W1 on the 24V power
-    distribution drawing. From Jon's DC_basicallyV1_3_Harness (2026-08-08).
+  description: "The board's 24V feed. The buildable sub-harness for W1 on\nthe 24V power distribution drawing. From Jon's\nDC_basicallyV1_3_Harness (2026-08-08)."
 
 connectors:
   P1:
     type: DC plug 5.5x2.1 male
     pinlabels: [+24V (tip), GND (sleeve)]
-    notes: usually comes as a pigtail on 18 AWG wire
+    notes: "Usually comes as a pigtail on 18 AWG wire."
   BOARD_PWR:
     type: JST VH 2-pin (VHR-2)
     subtype: female
@@ -26,7 +24,7 @@ cables:
     gauge: 18 AWG
     length: 36 in
     colors: [RD, BK]
-    notes: board 24V in. Length deliberately long
+    notes: "Board 24V in. Length deliberately long."
 
 connections:
   -

--- a/electronics/wire_harness/board-power.yml
+++ b/electronics/wire_harness/board-power.yml
@@ -13,7 +13,7 @@ connectors:
     type: JST VH 2-pin (VHR-2)
     subtype: female
     pinlabels: [+24V, GND]
-    notes: basically board v1.3 24V input. GUESS - which pin is +
+    notes: "basically board v1.3 24V input\nPin 1 = +24V, pin 2 = GND"
     additional_components:
       - type: Terminal - SVH-21T-P1.1
         qty: 1

--- a/electronics/wire_harness/board-power.yml
+++ b/electronics/wire_harness/board-power.yml
@@ -1,0 +1,35 @@
+metadata:
+  title: Sorter V2 - 24V to basically board v1.3
+  description: >
+    The board's 24V feed. The buildable sub-harness for W1 on the 24V power
+    distribution drawing. From Jon's DC_basicallyV1_3_Harness (2026-08-08).
+
+connectors:
+  P1:
+    type: DC plug 5.5x2.1 male
+    pinlabels: [+24V (tip), GND (sleeve)]
+    notes: usually comes as a pigtail on 18 AWG wire
+  BOARD_PWR:
+    type: JST VH 2-pin (VHR-2)
+    subtype: female
+    pinlabels: [+24V, GND]
+    notes: basically board v1.3 24V input. GUESS - which pin is +
+    additional_components:
+      - type: Terminal - SVH-21T-P1.1
+        qty: 1
+        qty_multiplier: populated
+        manufacturer: JST
+        mpn: SVH-21T-P1.1
+
+cables:
+  W1:
+    gauge: 18 AWG
+    length: 36 in
+    colors: [RD, BK]
+    notes: board 24V in. Length deliberately long
+
+connections:
+  -
+    - P1: [1-2]
+    - W1: [1-2]
+    - BOARD_PWR: [1-2]

--- a/electronics/wire_harness/build-harness.sh
+++ b/electronics/wire_harness/build-harness.sh
@@ -88,7 +88,7 @@ import sys, zipfile
 from pathlib import Path
 
 out = Path(sys.argv[1])
-drawings = ["power", "steppers", "leds"]
+drawings = ["power", "psu-pigtail", "board-power", "steppers", "leds"]
 
 members = ["rfq.txt"]
 for d in drawings:

--- a/electronics/wire_harness/leds.yml
+++ b/electronics/wire_harness/leds.yml
@@ -1,20 +1,18 @@
 metadata:
   title: Sorter V2 - LED drops and limit switch
-  description: >
-    LED feeds L1-L3 (board to unplug point), pigtails L1p-L3p, and the limit
-    switch cable. Values marked GUESS are guesses, not measurements.
+  description: "LED feeds L1-L3 (board to unplug point), pigtails L1p-L3p,\nand the limit switch cable. Jon's 2026-08-08 drawings do not\ncover the LED drops, so apart from the limit switch\nterminals everything here is still Spencer's July 12th\nnotes. Values marked GUESS are guesses, not measurements."
 
 connectors:
   BOARD_L1: &dupont
     type: Dupont 1x2 female, 2.54 mm
     pinlabels: [+24V, GND]
-    notes: on basically board v1.3. GUESS - verify which pin is +
+    notes: "On basically board v1.3. GUESS - verify which\npin is +."
   BOARD_L2: *dupont
   BOARD_L3: *dupont
   LJ1: &ledjack
     type: DC jack 5.5x2.1 female, inline
     pinlabels: [+24V (tip), GND (sleeve)]
-    notes: unplug point
+    notes: "Unplug point."
   LJ2: *ledjack
   LJ3: *ledjack
   LP1: &ledplug
@@ -25,51 +23,42 @@ connectors:
   COB1: &cob
     type: Solder pads
     pinlabels: [+24V, GND]
-    notes: COB board - solder direct
+    notes: "COB board - solder direct."
   COB2: *cob
   STRIP:
     type: Solderless clamp-on strip connector
     pinlabels: [+24V, GND]
-    notes: >
-      LED strip, 6000K. Clamp-on connector instead of soldering. Pick the
-      variant with IDC crimp points on both sides so it takes the pigtail
-      wire as well as the strip.
+    notes: "LED strip, 6000K. Clamp-on connector instead\nof soldering. Pick the variant with IDC crimp\npoints on both sides so it takes the pigtail\nwire as well as the strip."
   BOARD_LIM:
     type: Dupont 1x3 female, 2.54 mm
     pincount: 3
     pinlabels: [SIG, GND, n/c]
-    notes: >
-      on basically board v1.3. Position 3 is deliberately unpopulated so the
-      plug cannot go on backwards. GUESS - verify pin order
+    notes: "On basically board v1.3. Position 3 is\ndeliberately unpopulated so the plug cannot go\non backwards. GUESS - verify pin order."
   SW:
-    type: Quick-connect receptacle, #187 (4.75 x 0.5 mm tab)
+    type: "Quick-connect receptacle, #187 (4.75 x 0.5 mm tab)"
     pinlabels: [SIG, GND]
-    notes: >
-      Omron V-155-1C25, quick-connect (#187) tabs - these push on, no
-      soldering. Fully insulated receptacles: the switch is SPDT and the
-      third tab is left unused. GUESS - which of COM/NC/NO the two
-      conductors land on.
+    notes: "Omron V-155-1C25, quick-connect (#187) tabs.\nThese push on, no soldering. Fully insulated:\nthe switch is SPDT and the third tab is\nunused. GUESS - which of COM/NC/NO the two\nconductors land on."
 
 cables:
   L1: &feed
     gauge: 22 AWG
     length: 36 in
     colors: [RD, BK]
-    notes: LED feed. Gauge = GUESS
+    notes: "LED feed. Gauge = GUESS, not covered by Jon's\ndrawings."
   L2: *feed
   L3: *feed
   L1P: &pig
     gauge: 22 AWG
     length: 6 in
     colors: [RD, BK]
-    notes: LED pigtail. Gauge = GUESS
+    notes: "LED pigtail. Gauge = GUESS, not covered by\nJon's drawings."
   L2P: *pig
   L3P: *pig
   LIM:
     gauge: 22 AWG
     length: 24 in
     colors: [WH, BK]
-    notes: limit switch. Gauge = GUESS
+    notes: "Limit switch. Gauge = GUESS, not covered by\nJon's drawings."
 
 connections:
   -

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -1,10 +1,6 @@
 metadata:
   title: Sorter V2 - 24V power distribution
-  description: >
-    PSU box pigtails (PSU-J) and the load cables W1-W3.
-    The PSU end and the board end follow Jon's DC_PSU_Harness and
-    DC_basicallyV1_3_Harness drawings (2026-08-08), which are the source of
-    truth for those. Values marked GUESS are guesses, not measurements.
+  description: "PSU box pigtails PJ1-PJ3 and load cables W1-W3. The PSU end\nand the board end follow Jon's DC_PSU_Harness and\nDC_basicallyV1_3_Harness drawings (2026-08-08), which are\nthe source of truth for those. Values marked GUESS are\nguesses, not measurements."
 
 connectors:
   PSU:
@@ -59,12 +55,12 @@ cables:
     gauge: 22 AWG
     length: 12 in
     colors: [RD, BK]
-    notes: USB hub, double-male. Gauge = GUESS
+    notes: "USB hub, double-male. Gauge = GUESS, not\ncovered by Jon's drawings."
   W3:
     gauge: 22 AWG
     length: 6 in
     colors: [RD, BK]
-    notes: Orange Pi buck. Gauge = GUESS
+    notes: "Orange Pi buck. Gauge = GUESS, not covered by\nJon's drawings."
 
 connections:
   -

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -26,7 +26,7 @@ connectors:
     type: JST VH 2-pin (VHR-2)
     subtype: female
     pinlabels: [+24V, GND]
-    notes: "basically board v1.3 24V input\nGUESS - which pin is +"
+    notes: "basically board v1.3 24V input\nPin 1 = +24V, pin 2 = GND"
     additional_components:
       - type: Terminal - SVH-21T-P1.1
         qty: 1

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -8,17 +8,10 @@ metadata:
 
 connectors:
   PSU:
-    type: LRS-350-24, 9-position screw terminal block
-    subtype: spade terminal (fork/split ring), 18 AWG, M3.5, 8mm wide MAX
+    type: LRS-350-24 terminal block
     pincount: 9
-    pinlabels: [AC/L, AC/N, FG, -V1, -V2, -V3, +V1, +V2, +V3]
-    notes: >
-      Terminal numbering is MeanWell's own (LRS-350-SPEC, Terminal Pin No.
-      Assignment): 1 AC/L, 2 AC/N, 3 FG, 4-6 DC OUTPUT -V, 7-9 DC OUTPUT +V.
-      One pigtail per +V/-V screw pair, so 7 with 4, 8 with 5, 9 with 6.
-      Pins 1-3 are the mains side and are fed by the fused IEC inlet
-      switch's own leads, which come pre-terminated and are not part of
-      this harness.
+    pinlabels: [AC/L, AC/N, FG, -V, -V, -V, +V, +V, +V]
+    notes: "Screw numbers are MeanWell's (LRS-350-SPEC)\nOne pigtail per pair: 7+4, 8+5, 9+6\nScrews 1-3 are mains, on the IEC inlet's own leads\nTerminal spec: see the PSU output pigtail drawing"
   J1: &jack
     type: DC jack 5.5x2.1 female, panel-mount
     pinlabels: [+24V (tip), GND (sleeve)]
@@ -33,7 +26,7 @@ connectors:
     type: JST VH 2-pin (VHR-2)
     subtype: female
     pinlabels: [+24V, GND]
-    notes: basically board v1.3 24V input. GUESS - which pin is +
+    notes: "basically board v1.3 24V input\nGUESS - which pin is +"
     additional_components:
       - type: Terminal - SVH-21T-P1.1
         qty: 1
@@ -43,28 +36,25 @@ connectors:
   HUB:
     type: DC plug 5.5x2.1 male
     pinlabels: [+24V (tip), GND (sleeve)]
-    notes: into the Waveshare hub jack (DC-044, 5.5x2.1)
+    notes: "into the Waveshare hub jack\n(DC-044, 5.5x2.1)"
   BUCK:
     type: Bare tinned leads
     pinlabels: [+24V, GND]
-    notes: splice to the 24V-5V USB-C buck input leads
+    notes: "splice to the 24V-5V USB-C\nbuck input leads"
 
 cables:
   PJ1: &pigtail
     gauge: 18 AWG
     length: 4 in
     colors: [RD, BK]
-    notes: >
-      PSU-J pigtail, inside PSU box. Comes already attached to the
-      panel-mount jack, so buy the jacks with leads rather than having
-      these made.
+    notes: "PSU-J pigtail, inside the PSU box\nComes attached to the jack already, so buy\nthe jacks with leads rather than have these made"
   PJ2: *pigtail
   PJ3: *pigtail
   W1:
     gauge: 18 AWG
     length: 36 in
     colors: [RD, BK]
-    notes: board 24V in. Length deliberately long
+    notes: "board 24V in\nLength deliberately long"
   W2:
     gauge: 22 AWG
     length: 12 in

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -8,12 +8,17 @@ metadata:
 
 connectors:
   PSU:
-    type: LRS-350-24 output, screw terminals
+    type: LRS-350-24, 9-position screw terminal block
     subtype: spade terminal (fork/split ring), 18 AWG, M3.5, 8mm wide MAX
-    pinlabels: [+24V, GND (-V)]
+    pincount: 9
+    pinlabels: [AC/L, AC/N, FG, -V1, -V2, -V3, +V1, +V2, +V3]
     notes: >
-      3 pigtails land on the same output screws, one per load. Terminals
-      must fit the MeanWell LRS-350-24 screw terminals.
+      Terminal numbering is MeanWell's own (LRS-350-SPEC, Terminal Pin No.
+      Assignment): 1 AC/L, 2 AC/N, 3 FG, 4-6 DC OUTPUT -V, 7-9 DC OUTPUT +V.
+      One pigtail per +V/-V screw pair, so 7 with 4, 8 with 5, 9 with 6.
+      Pins 1-3 are the mains side and are fed by the fused IEC inlet
+      switch's own leads, which come pre-terminated and are not part of
+      this harness.
   J1: &jack
     type: DC jack 5.5x2.1 female, panel-mount
     pinlabels: [+24V (tip), GND (sleeve)]
@@ -73,15 +78,15 @@ cables:
 
 connections:
   -
-    - PSU: [1-2]
+    - PSU: [7, 4]
     - PJ1: [1-2]
     - J1: [1-2]
   -
-    - PSU: [1-2]
+    - PSU: [8, 5]
     - PJ2: [1-2]
     - J2: [1-2]
   -
-    - PSU: [1-2]
+    - PSU: [9, 6]
     - PJ3: [1-2]
     - J3: [1-2]
   -

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -1,0 +1,38 @@
+metadata:
+  title: Sorter V2 - PSU output pigtail
+  description: >
+    One PSU output pigtail, x3 per PSU build. The buildable sub-harness for
+    PJ1-PJ3 on the 24V power distribution drawing. From Jon's DC_PSU_Harness
+    (2026-08-08).
+
+connectors:
+  F1: &spade
+    style: simple
+    type: Spade terminal (fork/split ring)
+    subtype: 18 AWG, M3.5, 8mm wide MAX
+    notes: must fit the MeanWell LRS-350-24 screw terminals
+    color: RD
+  F2: *spade
+  J1:
+    type: DC jack 5.5x2.1 female, panel-mount
+    pinlabels: [+24V (tip), GND (sleeve)]
+    notes: panel-mount into the PSU enclosure
+
+cables:
+  PJ1:
+    gauge: 18 AWG
+    length: 4 in
+    colors: [RD, BK]
+    notes: >
+      Usually comes already attached to the panel-mount jack, so buy the
+      jacks with leads rather than having this made.
+
+connections:
+  -
+    - F1: [1]
+    - PJ1: [1]
+    - J1: [1]
+  -
+    - F2: [1]
+    - PJ1: [2]
+    - J1: [2]

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -1,10 +1,6 @@
 metadata:
   title: Sorter V2 - PSU output pigtail
-  description: >
-    One PSU output pigtail, x3 per PSU build. The buildable sub-harness for
-    PJ1-PJ3 on the 24V power distribution drawing. Screw numbers are
-    MeanWell's own (LRS-350-SPEC): 4-6 are DC OUTPUT -V, 7-9 are DC OUTPUT
-    +V. From Jon's DC_PSU_Harness (2026-08-08).
+  description: "One PSU output pigtail, x3 per PSU build. The buildable sub-\nharness for PJ1-PJ3 on the 24V power distribution drawing.\nScrew numbers are MeanWell's own (LRS-350-SPEC): 4-6 are DC\nOUTPUT -V, 7-9 are DC OUTPUT +V. From Jon's DC_PSU_Harness\n(2026-08-08)."
 
 connectors:
   F1:
@@ -22,7 +18,7 @@ connectors:
   J1:
     type: DC jack 5.5x2.1 female, panel-mount
     pinlabels: [+24V (tip), GND (sleeve)]
-    notes: panel-mount into the PSU enclosure
+    notes: "Panel-mount into the PSU enclosure."
 
 cables:
   PJ1:

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -2,17 +2,27 @@ metadata:
   title: Sorter V2 - PSU output pigtail
   description: >
     One PSU output pigtail, x3 per PSU build. The buildable sub-harness for
-    PJ1-PJ3 on the 24V power distribution drawing. From Jon's DC_PSU_Harness
-    (2026-08-08).
+    PJ1-PJ3 on the 24V power distribution drawing. Screw numbers are
+    MeanWell's own (LRS-350-SPEC): 4-6 are DC OUTPUT -V, 7-9 are DC OUTPUT
+    +V. From Jon's DC_PSU_Harness (2026-08-08).
 
 connectors:
-  F1: &spade
+  F1:
     style: simple
     type: Spade terminal (fork/split ring)
     subtype: 18 AWG, M3.5, 8mm wide MAX
-    notes: must fit the MeanWell LRS-350-24 screw terminals
+    notes: >
+      onto DC OUTPUT +V, one of screws 7-9 on the LRS-350-24 terminal
+      block. Must fit an M3.5 screw and be no wider than 8mm.
     color: RD
-  F2: *spade
+  F2:
+    style: simple
+    type: Spade terminal (fork/split ring)
+    subtype: 18 AWG, M3.5, 8mm wide MAX
+    notes: >
+      onto DC OUTPUT -V, the matching screw of 4-6 (7 with 4, 8 with 5,
+      9 with 6).
+    color: BK
   J1:
     type: DC jack 5.5x2.1 female, panel-mount
     pinlabels: [+24V (tip), GND (sleeve)]

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -10,18 +10,14 @@ connectors:
   F1:
     style: simple
     type: Spade terminal (fork/split ring)
-    subtype: 18 AWG, M3.5, 8mm wide MAX
-    notes: >
-      onto DC OUTPUT +V, one of screws 7-9 on the LRS-350-24 terminal
-      block. Must fit an M3.5 screw and be no wider than 8mm.
+    subtype: 18 AWG, M3.5, 8mm MAX
+    notes: "To +V: screw 7, 8 or 9"
     color: RD
   F2:
     style: simple
     type: Spade terminal (fork/split ring)
-    subtype: 18 AWG, M3.5, 8mm wide MAX
-    notes: >
-      onto DC OUTPUT -V, the matching screw of 4-6 (7 with 4, 8 with 5,
-      9 with 6).
+    subtype: 18 AWG, M3.5, 8mm MAX
+    notes: "To -V: the matching screw\n7+4, 8+5, 9+6"
     color: BK
   J1:
     type: DC jack 5.5x2.1 female, panel-mount
@@ -33,9 +29,7 @@ cables:
     gauge: 18 AWG
     length: 4 in
     colors: [RD, BK]
-    notes: >
-      Usually comes already attached to the panel-mount jack, so buy the
-      jacks with leads rather than having this made.
+    notes: "Usually comes attached to the jack already,\nso buy the jacks with leads rather than\nhaving this made"
 
 connections:
   -

--- a/electronics/wire_harness/rfq.txt
+++ b/electronics/wire_harness/rfq.txt
@@ -45,7 +45,11 @@ Quote 2 sets and price breaks at 10 / 50 sets.
   soldering. Fully insulated because the switch is SPDT and one
   of its three tabs is left unused.
 - Spade/fork terminals (PSU end): 18 AWG, M3.5 stud, 8 mm wide
-  MAX so they fit the MeanWell LRS-350-24 screw terminals.
+  MAX so they fit the MeanWell LRS-350-24 terminal block. That
+  block is 9 screws, numbered per the MeanWell spec sheet:
+  1 AC/L, 2 AC/N, 3 FG, 4-6 DC OUTPUT -V, 7-9 DC OUTPUT +V.
+  Each pigtail takes one +V/-V pair (7 with 4, 8 with 5,
+  9 with 6). Screws 1-3 are not part of this harness.
 - Ends marked "bare tinned": strip 5 mm and tin, no connector.
 
 5. IMPORTANT - CROSSOVER CABLE

--- a/electronics/wire_harness/steppers.yml
+++ b/electronics/wire_harness/steppers.yml
@@ -1,17 +1,13 @@
 metadata:
   title: Sorter V2 - stepper cables
-  description: >
-    Channel stepper cable S (x4) and chute stepper cable CH.
-    S follows Jon's Stepper_Harness drawing (2026-08-08), which is the source
-    of truth for the channel cable. Values marked GUESS are guesses, not
-    measurements.
+  description: "Channel stepper cable S (x4) and chute stepper cable CH. S\nfollows Jon's Stepper_Harness drawing (2026-08-08), which is\nthe source of truth for the channel cable. Values marked\nGUESS are guesses, not measurements."
 
 connectors:
   BOARD_S:
     type: JST PH 4-pin (PHR-4)
     subtype: 2.0mm pitch, female
     pinlabels: [A2, A1, B1, B2]
-    notes: basically board v1.3 J23/J27/J31/J35 - one cable per jack, x4 identical
+    notes: "basically board v1.3 J23/J27/J31/J35. One\ncable per jack, x4 identical."
     additional_components:
       - type: Terminal - SPH-002T-P0.5S
         qty: 1
@@ -22,9 +18,7 @@ connectors:
     type: JST PH 6-pin (PHR-6)
     subtype: 2.0mm pitch, female
     pinlabels: [A2, C1, B1, A1, C2, B2]
-    notes: >
-      The NEMA 17's own 6-pin PH socket. Pins 2 and 5 (C1, C2) are
-      unpopulated. Check coils with a multimeter before connecting.
+    notes: "The NEMA 17's own 6-pin PH socket. Pins 2 and\n5 (C1, C2) are unpopulated. Check coils with a\nmultimeter before connecting."
     additional_components:
       - type: Terminal - SPH-002T-P0.5S
         qty: 1
@@ -39,7 +33,7 @@ connectors:
   CH_LEADS:
     type: Bare tinned leads, labeled 1-4
     pinlabels: [A2, A1, B1, B2]
-    notes: splice to chute stepper flying leads - find coil pairs with a multimeter first
+    notes: "Splice to the chute stepper flying leads. Find\nthe coil pairs with a multimeter first."
 
 cables:
   S:
@@ -49,7 +43,7 @@ cables:
     length: 1 m
     wirecount: 4
     colors: [BU, GN, RD, BK]
-    notes: S1-S4, qty 4. NOT straight-through, see crossover.
+    notes: "S1-S4, qty 4. NOT straight-through, see\ncrossover."
     additional_components:
       - type: PVC Sleeving
         qty: 1
@@ -58,9 +52,7 @@ cables:
     gauge: 24 AWG
     length: 40 in
     colors: [BK, GN, RD, BU]
-    notes: >
-      qty 1. Gauge = GUESS. Length = GUESS. Straight-through.
-      Not covered by Jon's drawing.
+    notes: "qty 1. Straight-through. Not covered by Jon's\ndrawing, so unlike S both Gauge and Length\nhere are still GUESS."
 
 connections:
   -


### PR DESCRIPTION
Every drawing on `/hardware/electronics/wireviz/` now shows its bill of materials as a table, directly under the image and the download line. Same content the generated `.html` carries, without leaving the page.

### The choice: fetched in the browser, not baked in at build time

The `.bom.tsv` files are build artifacts in the assets bucket, never in git, so the page has to fetch them from somewhere. I looked at both options and picked client side:

- **The harness workflow only fires on changes under `electronics/wire_harness/`.** A docs-only branch (like this one) never renders, so there is no `harness/<ref>/` prefix in the bucket for it at all. A build-time fetch would 404 on all five drawings for most previews, not occasionally.
- **On a harness branch it does run, but on `pull_request`, while Vercel builds on push.** The render lands ~90 seconds later. The docs build reliably wins that race, so a prerendered table would bake in whatever was in the bucket beforehand and then sit there stale. That breaks the property the whole pipeline is designed around: push the YAML, the preview self-corrects. The drawings above it already work that way because the browser fetches them.
- It also keeps the docs build from depending on the bucket being reachable.

**Verified CORS before committing to this**, since it is the thing that could have killed the approach: `scripts/img-worker/worker.js` sets `access-control-allow-origin: *` on every response unconditionally, and it is present on a cache MISS, on a HIT, and with a query string.

### Caveats

- **The BOM needs JavaScript.** That is the same deal the drawings take (they are remote images), and the `BOM (TSV)` download link stays in the download line as the fallback.
- **If the render has not published for the ref yet**, the page says `Not published for this build yet.` with a link to the TSV, rather than an empty table or a broken layout. Reload once the render lands and the table fills in.
- The `?v=` cache-buster is carried for consistency with every other harness URL, but it does nothing (Cloudflare ignores the query string, and the worker strips it going upstream). A re-rendered BOM can sit behind the CDN cache exactly like a re-rendered PNG can.

### Parsing

Designed against the five real TSVs on `harness-sub-drawings`, not guessed. Handles the optional `Manufacturer`/`MPN` columns (`power`, `board-power` and `steppers` have them, `psu-pigtail` and `leds` do not), empty cells, CRLF, and rows short a trailing column (the width is the widest row, every cell padded out to it). Cells are set with `textContent`, so nothing coming out of the bucket can inject markup.

Mobile: the site's tables already scroll inside themselves rather than dragging the page sideways, and `.bom-table` drops the default 140px minimum cell width so a 7-column BOM compresses instead of forcing a scroll at all.

### Checks

- `npm run build` passes, all five `.bom` containers are in the prerendered HTML.
- `validate_frontmatter.py` reports the same 5 pre-existing errors as the base branch, none new.
- Table construction exercised against all five published TSVs plus ragged/CRLF/injection cases.

**Files:** `docs/src/lib/bom.ts` (new, the parse and table build), the effect in `docs/src/routes/[...path]/+page.svelte`, the `.bom` markup in `wireviz.md`, styles in `layout.css`, and a note in `docs/AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)