### PR TITLE
public fleet: separate active machines from registrations

### DIFF
--- a/software/hive/backend/app/routers/public_stats.py
+++ b/software/hive/backend/app/routers/public_stats.py
@@ -63,6 +63,21 @@ router = APIRouter(prefix="/api/public", tags=["public-stats"])
 # sync with the widget's `SorterStats.sorterTimeZone`.
 PUBLIC_STATS_LOCAL_TZ = "America/Los_Angeles"
 
+# Lifetime pieces above which a machine is a REAL machine rather than a row in
+# the machines table.
+#
+# Registering is free and a registration proves nothing: a bench that was
+# powered on once, a duplicate somebody made while setting up, a unit that
+# never got past its first bag. Counting those in "the fleet" inflates the
+# denominator with machines that have never sorted anything, which makes every
+# ratio built on it — how many are live, how many owners have claimed theirs —
+# read worse than the truth and mean less than it should.
+#
+# 250 pieces is roughly one real run. It is deliberately low: the bar is "this
+# thing has actually sorted", not "this thing is impressive". Consumers get
+# BOTH counts and choose which to say — see the two counters on /fleet.
+ACTIVE_MACHINE_MIN_PIECES = 250
+
 
 def _presented_key(authorization: str | None, x_stats_key: str | None) -> str:
     presented = x_stats_key
@@ -179,6 +194,12 @@ def get_public_fleet(db: Session = Depends(get_db)):
     an hour-stale answer to that is a wrong one. The 30-day count is the one a
     leaderboard should rank on: a day is too short to mean much and a lifetime
     total is the same order forever.
+
+    Every non-archived machine is listed, each flagged `is_active` against
+    ACTIVE_MACHINE_MIN_PIECES, and both counts are returned. Filtering here
+    would be the wrong call — a consumer that wants to know how many
+    registrations exist can still ask — but `active_machine_count` is the
+    number meant for people, and the balloon board says only that one.
     """
     rows = (
         db.query(Machine, UserIdentity)
@@ -198,33 +219,53 @@ def get_public_fleet(db: Session = Depends(get_db)):
     recent = _pieces_by_machine_since(db, ids, hours=24)
     this_hour = _pieces_by_machine_since(db, ids, hours=1)
     this_month = _pieces_by_machine_since(db, ids, hours=24 * 30)
-    machines = [
-        {
-            "id": str(machine.id),
-            "name": machine.name,
-            "is_active": machine.is_active,
-            "last_seen_at": machine.last_seen_at.isoformat() if machine.last_seen_at else None,
-            "created_at": machine.created_at.isoformat(),
-            "pieces_seen": int(lifetime.get(str(machine.id), {}).get("pieces_seen") or 0),
-            "distributed": int(lifetime.get(str(machine.id), {}).get("distributed") or 0),
-            "overall_ppm": float(lifetime.get(str(machine.id), {}).get("overall_ppm") or 0.0),
-            "last_24h_pieces": recent.get(str(machine.id), 0),
-            "last_hour_pieces": this_hour.get(str(machine.id), 0),
-            "last_30d_pieces": this_month.get(str(machine.id), 0),
-            "owner_discord": None
-            if identity is None
-            else {
-                "id": identity.provider_user_id,
-                "login": identity.provider_login,
-                "avatar_url": identity.avatar_url,
-            },
-        }
-        for machine, identity in rows
-    ]
+    machines = []
+    for machine, identity in rows:
+        mid = str(machine.id)
+        stats_row = lifetime.get(mid, {})
+        pieces_seen = int(stats_row.get("pieces_seen") or 0)
+        machines.append(
+            {
+                "id": mid,
+                "name": machine.name,
+                # NOTE: this is the FLEET-ACTIVE predicate — has this machine
+                # sorted enough to be a real one (see ACTIVE_MACHINE_MIN_PIECES)
+                # — and NOT the machines table's enabled flag, which used to be
+                # served under this name and which no consumer of this endpoint
+                # ever read. One endpoint, one meaning of "active".
+                "is_active": pieces_seen > ACTIVE_MACHINE_MIN_PIECES,
+                "last_seen_at": machine.last_seen_at.isoformat() if machine.last_seen_at else None,
+                "created_at": machine.created_at.isoformat(),
+                "pieces_seen": pieces_seen,
+                "distributed": int(stats_row.get("distributed") or 0),
+                "overall_ppm": float(stats_row.get("overall_ppm") or 0.0),
+                "last_24h_pieces": recent.get(mid, 0),
+                "last_hour_pieces": this_hour.get(mid, 0),
+                "last_30d_pieces": this_month.get(mid, 0),
+                "owner_discord": None
+                if identity is None
+                else {
+                    "id": identity.provider_user_id,
+                    "login": identity.provider_login,
+                    "avatar_url": identity.avatar_url,
+                },
+            }
+        )
+    active = [m for m in machines if m["is_active"]]
+    # Two counts, and a consumer says whichever it means. REGISTERED is the row
+    # count and is the wrong number to put in front of people — it counts
+    # benches that have never sorted a piece. ACTIVE is the fleet as anybody
+    # would describe it out loud. The linked counts are given per population so
+    # a ratio is never built out of two different denominators.
     return {
         "machines": machines,
-        "machine_count": len(machines),
-        "discord_linked_count": sum(1 for m in machines if m["owner_discord"] is not None),
+        "active_threshold_pieces": ACTIVE_MACHINE_MIN_PIECES,
+        "registered_machine_count": len(machines),
+        "active_machine_count": len(active),
+        "registered_discord_linked_count": sum(
+            1 for m in machines if m["owner_discord"] is not None
+        ),
+        "active_discord_linked_count": sum(1 for m in active if m["owner_discord"] is not None),
     }
 
 

--- a/software/hive/backend/tests/test_public_stats.py
+++ b/software/hive/backend/tests/test_public_stats.py
@@ -163,7 +163,7 @@ class TestFleetRoster:
         body = r.json()
         mine = next(x for x in body["machines"] if x["name"] == "Roster Sorter")
         assert mine["owner_discord"] is None
-        assert body["machine_count"] == len(body["machines"])
+        assert body["registered_machine_count"] == len(body["machines"])
 
         # Link a Discord identity to the owner; the roster now names them.
         from app.models.user import User
@@ -187,7 +187,7 @@ class TestFleetRoster:
             "login": "spencer",
             "avatar_url": None,
         }
-        assert r.json()["discord_linked_count"] >= 1
+        assert r.json()["registered_discord_linked_count"] >= 1
 
     def test_machine_scoped_key_rejected(self, client, db, monkeypatch):
         monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
@@ -220,6 +220,51 @@ class TestFleetRoster:
         # consumer can sort on these without special-casing a fresh machine.
         assert entry["pieces_seen"] == 0 and entry["last_24h_pieces"] == 0
         assert entry["last_hour_pieces"] == 0
+
+    def test_a_machine_is_active_only_once_it_has_really_sorted(
+        self, client, db, monkeypatch, machine_token
+    ):
+        """Registering is free, so the roster separates rows from real machines.
+
+        Both counts are served: the registered one for anybody who genuinely
+        wants it, the active one for anybody about to say a number out loud.
+        """
+        from app.routers import public_stats
+        from app.services import machine_stats
+
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "")
+        # Three pieces stands in for the real 250 — the point under test is the
+        # comparison, not the constant, and 251 inserts would only be slower.
+        monkeypatch.setattr(public_stats, "ACTIVE_MACHINE_MIN_PIECES", 2)
+        headers = self._admin_headers(client, db)
+        # A registration that never sorts anything — the exact thing the
+        # threshold exists to keep out of the number people are shown.
+        client.post(
+            "/api/machines", json={"name": "Bench Sorter", "description": "d"}, headers=headers
+        )
+        token = self._mint(client, headers, ["fleet:read"])
+
+        body = client.get("/api/public/fleet", headers=_bearer(token)).json()
+        assert body["active_threshold_pieces"] == 2
+        assert body["active_machine_count"] == 0
+        assert body["registered_machine_count"] == len(body["machines"])
+        assert all(not m["is_active"] for m in body["machines"])
+
+        now = time.time()
+        _sync(client, machine_token, [
+            {"piece_uuid": f"real-{i}", "local_id": i, "seen_at": now - 60 * i,
+             "classification_status": "classified", "part_id": "3001", "color_id": "5"}
+            for i in range(1, 4)
+        ])
+        # The roster reads the hourly cache rather than recomputing, so the
+        # worker's pass has to happen before the machine can look real.
+        machine_stats.refresh_cache(db)
+
+        body = client.get("/api/public/fleet", headers=_bearer(token)).json()
+        sorted_one = max(body["machines"], key=lambda m: m["pieces_seen"])
+        assert sorted_one["pieces_seen"] == 3 and sorted_one["is_active"]
+        assert body["active_machine_count"] == 1
+        assert body["registered_machine_count"] > body["active_machine_count"]
 
     def test_the_hour_window_is_narrower_than_the_day(self, client, db, monkeypatch, machine_token):
         """A machine that sorted this morning but not this hour is powered on,


### PR DESCRIPTION
The fleet roster counted every non-archived machine, so "20 machines" included a dozen registrations that have never sorted a piece. Every ratio built on that denominator — how many are live, how many owners have claimed theirs — read worse than the truth.

Each roster entry now carries `is_active` (lifetime pieces > `ACTIVE_MACHINE_MIN_PIECES`, 250) and the payload returns both populations: `registered_machine_count` / `active_machine_count`, each with its own linked-Discord count so a ratio is never built from two denominators. Prod today: 20 registered, 8 active.

Nothing is filtered server-side — a consumer that wants the registration count can still have it. The balloon fleet board reads only the active pair.

`is_active` on a roster entry used to be the machines table's enabled flag, which no consumer of this endpoint ever read; reusing the name would have left two meanings of "active" in one payload.