### PR TITLE
sorteros-setup: skip Vercel builds when the app didn't change

### DIFF
--- a/software/sorteros/sorteros-setup/README.md
+++ b/software/sorteros/sorteros-setup/README.md
@@ -82,6 +82,23 @@ vercel --prod             # ship to setup.basically.website
 Spencer has the Vercel project and domain set up. CI hookup is TBD; for
 now, deploy by hand.
 
+The Vercel project's Root Directory is `software/sorteros/sorteros-setup`,
+but its Git integration fires on *every* push to the monorepo. So
+`vercel.json` carries an `ignoreCommand` that exits 0 (= skip the build)
+when the pushed commit touched nothing under this directory. The pathspec
+is anchored with `:/` so it resolves from the repo root no matter which
+directory the ignore step runs in.
+
+Two things the ignore step does *not* fix:
+
+- Vercel still creates a deployment record per push and marks it
+  `Canceled`; only the build is skipped. Those records count against the
+  Hobby plan's 100-deployments-per-day limit.
+- On a branch that predates this directory, Vercel fails on `The
+  specified Root Directory ... does not exist` before it ever runs the
+  ignore step, and posts a red **Error** into the PR. Rebasing the branch
+  onto `main` is the only cure.
+
 ## Files in this scaffold
 
 - `README.md` — this file.

--- a/software/sorteros/sorteros-setup/vercel.json
+++ b/software/sorteros/sorteros-setup/vercel.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/software/sorteros/sorteros-setup'"
+}


### PR DESCRIPTION
The `sorteros-setup` Vercel project has Root Directory `software/sorteros/sorteros-setup`, but its Git integration fires on **every** push to the monorepo.

Today it's governed by a dashboard-level Ignored Build Step — `if [ "$VERCEL_ENV" != "production" ]; then exit 0; else exit 1; fi` — which means: never build a preview, *always* rebuild production, even for a commit that only touched `docs/` or `electronics/`.

This replaces that with a path-aware rule in `vercel.json` (a `vercel.json` `ignoreCommand` overrides the dashboard setting):

```
git diff --quiet HEAD^ HEAD -- ':/software/sorteros/sorteros-setup'
```

`git diff --quiet` exits 0 when the commit touched nothing under that path, and Vercel treats exit 0 as "skip this build". The `:/` prefix anchors the pathspec to the repo root so it resolves regardless of the ignore step's cwd. Net effect: production stops rebuilding for unrelated commits, and PRs that *do* touch the setup site get a real preview instead of a permanent skip.

Two limits, documented in the README alongside the change:

- Vercel still **creates** a deployment record per push (marked `Canceled`) — the ignore step only skips the build. Those records count against the Hobby plan's 100/day deployment limit, which is what the account is currently sitting on.
- On a branch that predates the directory, Vercel errors on `The specified Root Directory ... does not exist` *before* the ignore step runs — that's the red Error currently showing up on `board-v1.3-fixes`. Only a rebase onto `main` fixes that one.

CI note: this PR's own Vercel checks report `Deployment rate limited — retry in 24 hours`, so the config can't be exercised until the daily limit resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)