### PR TITLE
harness: put the drawing URLs in git, content-addressed

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -72,12 +72,26 @@ jobs:
 
       - run: ./electronics/wire_harness/build-harness.sh
 
+      # Uploading on every run is safe in a way it was not before: names carry
+      # a hash of their own bytes, so this can only ever add objects, never
+      # replace one somebody is already serving. A re-render of an unchanged
+      # drawing uploads nothing at all.
+      #
+      # Same-repo refs only: fork PRs have no secrets, so they stop at the
+      # render (which is the actual correctness check anyway).
       - name: Publish to the assets bucket
-        # Same-repo refs only: fork PRs have no secrets, so they stop at the
-        # render (which is the actual correctness check anyway).
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           SPACES_KEY: ${{ secrets.SPACES_KEY }}
           SPACES_SECRET: ${{ secrets.SPACES_SECRET }}
-          REF: ${{ github.head_ref || github.ref_name }}
-        run: python3 electronics/wire_harness/upload-harness.py --ref "$REF"
+        run: python3 electronics/wire_harness/upload-harness.py
+
+      # The URLs the docs serve are literal strings in the data file, pasted by
+      # whoever changed the drawing, exactly like every other asset in this
+      # bucket. This is what keeps that honest: change a drawing without
+      # pasting its new URLs and the job fails with the block to paste. It also
+      # means the objects are in the bucket before any commit names them, which
+      # is the property the old overwrite-in-place scheme lacked.
+      - name: Check the docs point at this render
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: python3 electronics/wire_harness/upload-harness.py --check docs/src/liquid/_data/harness.yml

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -63,9 +63,15 @@ jobs:
       # mid-cycle), so the binary's own string can't tell pinned from drifted.
       # The assert makes a future package change a loud failure and a
       # deliberate one-line bump, never drift.
+      #
+      # faketime is not pinned because it contributes nothing to the rendered
+      # bytes; it only stops dot stamping wall-clock time into the PDFs, which
+      # otherwise gives an unchanged harness a new hash on every run. It is
+      # required, not optional: build-harness.sh warns and carries on without
+      # it, and the URLs that came out would be unpasteable.
       - run: |
           sudo apt-get update
-          sudo apt-get install -y graphviz=2.42.2-9ubuntu0.1
+          sudo apt-get install -y graphviz=2.42.2-9ubuntu0.1 faketime
           dot -V
           dpkg-query -W -f='${Version}\n' graphviz
           [ "$(dpkg-query -W -f='${Version}' graphviz)" = "2.42.2-9ubuntu0.1" ] || { echo '::error::graphviz package is not the pinned 2.42.2-9ubuntu0.1'; exit 1; }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -164,29 +164,32 @@ show (`step2-hole-red-square`), not by source filename. Group step images under
 
 ## The WireViz harness
 
-Same rule as photos, nothing rendered is in the repo, but unlike photos there
-is no upload step at all: CI owns the whole pipeline.
+**Exactly the same rule as photos**, including the part that matters: the URL
+is a literal string in the repo, and it changes when the image changes. The
+only difference is that CI runs the upload instead of a person, because a
+render is 23 files at once.
 
 Sources live in `electronics/wire_harness/`. On any PR or main push touching
-them, `.github/workflows/harness.yml` renders and publishes to the assets
-bucket under the branch name, and the site build derives the prefix for the
-ref being built (`resolveHarness()` in `src/lib/server/content.ts` →
-`site.harness_base`, plus `site.harness_v`, a per-deploy cache-buster every
-harness URL must carry). So a branch preview shows the branch's drawings,
-production shows main's, and there is nothing to update in `docs/` when a
-drawing's content changes.
+them, `.github/workflows/harness.yml` renders with a pinned toolchain, uploads
+each artifact under a name containing a hash of its bytes
+(`harness/power.2c0ebc6cd1.png`), and then **fails the build unless
+`src/liquid/_data/harness.yml` already names exactly those URLs**, printing the
+block to paste. So changing a drawing is: push, paste the URLs CI prints, push
+again.
 
-**`resolveHarness()` reads the host's branch env var, and that is not
-optional.** Both Pages and Vercel build from a detached HEAD, so the git
-fallback returns `HEAD` and everything collapses to `main`: previews then show
-main's drawings and any drawing added on the branch 404s. It reads
-`CF_PAGES_BRANCH` first, `VERCEL_GIT_COMMIT_REF` second, git last. If the site
-ever moves host again, add that host's variable at the front or previews break
-silently, which is exactly what the Pages move did.
+`src/liquid/_data/harness.yml` carries the display list (name, title, caption,
+`of:`) *and* the six URLs per drawing (`png`, `svg`, `pdf`, `html`, `bom_tsv`,
+`yml`) plus the top-level `zip:`. Nothing in `src/lib/server/content.ts`
+derives harness URLs any more — `resolveHarness()`, `site.harness_base` and
+`site.harness_v` are gone. Do not reintroduce a computed harness URL: the docs
+build and the harness render start on the same push, so anything the docs
+compute can name bytes that have not been uploaded yet, and the `immutable`
+header on the images turns that into a year-long wrong picture in the reader's
+cache. That is a real outage this site had on 2026-08-09, written up in
+`electronics/wire_harness/AGENTS.md`.
 
-`src/liquid/_data/harness.yml` is just the display list (name, title, caption
-per drawing). Adding a drawing: new YAML source, an entry there, and an entry
-in the `drawings` list inside `build-harness.sh`. Full pipeline doc:
+Adding a drawing: new YAML source, an entry in the data file, an entry in the
+`drawings` list inside `build-harness.sh`, then the paste. Full pipeline doc:
 `electronics/wire_harness/AGENTS.md`.
 
 ## Parts
@@ -231,12 +234,13 @@ project setting, not a file in this repo, so they are recorded here:
 
 A `*` matches across `/`, so `docs/*` covers `docs/src/content/x.md`. Pushes
 that touch only firmware, `software/`, or hive do not build the docs.
-`electronics/wire_harness/*` is in that list for a non-obvious reason and
-must stay: a harness change re-renders drawings into the SAME bucket path,
-so the only thing that makes a browser fetch the new bytes is the docs
-rebuilding with a new `?v=<sha>`. Drop that path and a changed drawing would
-sit behind a year-long immutable cache entry under the old sha, with nothing
-anywhere reporting an error. To change the filter, edit the project's source
+`electronics/wire_harness/*` is in that list for historical reasons and is now
+harmless either way: it was load-bearing when a harness change re-rendered into
+the same bucket path and only a docs rebuild issued the `?v=<sha>` that made
+browsers refetch. Harness URLs are literal strings in
+`src/liquid/_data/harness.yml` now, so a drawing change always touches
+`docs/*` too and would trigger a build on its own. Leaving the path in costs a
+no-op build on a YAML-only push. To change the filter, edit the project's source
 config (dashboard, or `PATCH /accounts/<id>/pages/projects/sorter-v2-docs`)
 and update this block.
 
@@ -251,10 +255,13 @@ itself out of deploying; and everything else the docs depend on
 (`img.basically.website`, the DNS, the cache purge) already lives in the same
 Cloudflare account. The site is `@sveltejs/adapter-static` with
 `trailingSlash: 'always'` set in SvelteKit rather than in host config, so
-there was nothing host-specific to port. `vercel.json` is gone. If you are
-about to move it again, the thing that breaks silently is `resolveHarness()`
-in `src/lib/server/content.ts`: it reads the branch and sha from host env
-vars, and on a host that sets neither it falls back to a detached HEAD and
-quietly points every harness image at `main` with no cache-buster.
+there was nothing host-specific to port. `vercel.json` is gone.
+
+The Pages move did break one thing silently and it is worth knowing about even
+though the code is gone: `resolveHarness()` read the branch from
+`VERCEL_GIT_COMMIT_REF` only, so on Pages every preview fell back to a detached
+HEAD and pointed at `main`'s drawings. That whole class of bug is why harness
+URLs are literal strings now and nothing about them is derived from host env
+vars. If you move hosts again, no harness code needs touching.
 
 Commit only when verified; push only when asked.

--- a/docs/scripts/img-worker/worker.js
+++ b/docs/scripts/img-worker/worker.js
@@ -1,10 +1,32 @@
 const ORIGIN = "https://basically-docs.nyc3.digitaloceanspaces.com";
 
-// The docs append `?v=<sha>` to every asset URL, so a URL carrying one names an
-// immutable snapshot and can be cached hard. A bare URL is a mutable ref and
-// gets the bucket's own short TTL.
 const IMMUTABLE = "public, max-age=31536000, immutable";
 const MUTABLE = "public, max-age=60";
+
+// What may be cached for a year. Two things qualify, and the difference
+// matters:
+//
+//   1. A content-addressed name -- `harness/power.2021d6c5f7.png`, where the
+//      hex is a hash of the bytes. Nothing can ever be served under that name
+//      but those bytes, so `immutable` is a fact about the object.
+//   2. A URL carrying `?v=<sha>`, which is a promise by the caller that the
+//      path is a snapshot. Photos work this way (upload_image.py + a name
+//      nobody reuses) and it is only as good as that discipline.
+//
+// The harness used to rely on (2) over a path that was overwritten on every
+// render, which made the header a lie and pinned a stale drawing in readers'
+// caches for a year. It relies on (1) now. Do not "simplify" this back to the
+// query check alone: a content-addressed URL has no reason to carry a buster,
+// and without the name rule it would be served with the short TTL.
+// Matches the hash segment anywhere in the filename, not just before the last
+// dot: `power.514757618c.bom.tsv` keeps its whole `.bom.tsv` suffix chain, so
+// anchoring to a single trailing extension would miss every BOM.
+const CONTENT_ADDRESSED = /\.[0-9a-f]{10,}\./;
+
+function cacheControlFor(url) {
+  if (CONTENT_ADDRESSED.test(url.pathname)) return IMMUTABLE;
+  return url.searchParams.has("v") ? IMMUTABLE : MUTABLE;
+}
 
 export default {
   async fetch(request, env, ctx) {
@@ -52,7 +74,7 @@ export default {
       headers.delete("age");
       headers.delete("cf-cache-status");
       headers.set("access-control-allow-origin", "*");
-      headers.set("cache-control", url.searchParams.has("v") ? IMMUTABLE : MUTABLE);
+      headers.set("cache-control", cacheControlFor(url));
       response = new Response(upstream.body, { status: upstream.status, headers });
       ctx.waitUntil(cache.put(key, response.clone()));
     }

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -16,32 +16,31 @@ last_verified: 2026-07-12
 </div>
 
 <p class="download-line">
-  <a href="{{ site.harness_base }}/sorter-v2-harness-rfq.zip{{ site.harness_v }}" download><b>↓ sorter-v2-harness-rfq.zip</b></a>
+  <a href="{{ site.data.harness.zip }}" download><b>↓ sorter-v2-harness-rfq.zip</b></a>
   <span>cover sheet + every drawing (PDF/PNG/SVG/HTML) + a BOM per drawing (TSV) + WireViz YAML sources</span>
 </p>
 
-{% assign b = site.harness_base %}{% assign v = site.harness_v %}
 {% for d in site.data.harness.drawings %}
 {% if d.of %}### {{ d.title }}{% else %}## {{ d.title }}{% endif %}
 
 <figure class="harness-figure">
-  <a href="{{ b }}/{{ d.name }}.png{{ v }}" target="_blank" rel="noopener">
-    <img src="{{ b }}/{{ d.name }}.png{{ v }}" alt="WireViz drawing: {{ d.title }}">
+  <a href="{{ d.png }}" target="_blank" rel="noopener">
+    <img src="{{ d.png }}" alt="WireViz drawing: {{ d.title }}">
   </a>
   <figcaption>{{ d.caption }} Click for full size.</figcaption>
 </figure>
 
 <p class="download-line">
   <span>Download:</span>
-  <a href="{{ b }}/{{ d.name }}.pdf{{ v }}">PDF</a> ·
-  <a href="{{ b }}/{{ d.name }}.png{{ v }}" download>PNG</a> ·
-  <a href="{{ b }}/{{ d.name }}.svg{{ v }}" download>SVG</a> ·
-  <a href="{{ b }}/{{ d.name }}.html{{ v }}">HTML (drawing + BOM)</a> ·
-  <a href="{{ b }}/{{ d.name }}.bom.tsv{{ v }}" download>BOM (TSV)</a> ·
-  <a href="{{ b }}/{{ d.name }}.yml{{ v }}" download>YAML source</a>
+  <a href="{{ d.pdf }}">PDF</a> ·
+  <a href="{{ d.png }}" download>PNG</a> ·
+  <a href="{{ d.svg }}" download>SVG</a> ·
+  <a href="{{ d.html }}">HTML (drawing + BOM)</a> ·
+  <a href="{{ d.bom_tsv }}" download>BOM (TSV)</a> ·
+  <a href="{{ d.yml }}" download>YAML source</a>
 </p>
 
-<div class="bom" data-bom="{{ b }}/{{ d.name }}.bom.tsv{{ v }}">
+<div class="bom" data-bom="{{ d.bom_tsv }}">
   <p class="bom-status">Loading the bill of materials for {{ d.title }}</p>
 </div>
 

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -2,7 +2,6 @@
 // files carry the same frontmatter and Liquid includes as before, but here
 // they are rendered once at build time (liquidjs → unified) and the output is
 // prerendered static HTML. Nothing in this module runs in the browser.
-import { execSync } from 'node:child_process';
 import yaml from 'js-yaml';
 import { Liquid } from 'liquidjs';
 import { unified } from 'unified';
@@ -41,39 +40,20 @@ for (const [path, raw] of Object.entries(dataFiles)) {
 	data[name] = yaml.load(raw);
 }
 
-// CI env first, local git branch as fallback, so a branch preview links its own
-// harness renders rather than main's.
-//
-// The host's env vars are the only reliable source of the branch name: Pages and
-// Vercel both build from a detached HEAD, so `git rev-parse --abbrev-ref HEAD`
-// returns "HEAD" there and the fallback below sends everything to main. That is
-// what happened when the site moved to Pages and only the Vercel vars were read:
-// every PR preview showed main's drawings, and any drawing added on the branch
-// 404'd. Keep Pages first, Vercel second, git last.
-function resolveHarness(): { base: string; v: string } {
-	let ref = process.env.CF_PAGES_BRANCH ?? process.env.VERCEL_GIT_COMMIT_REF ?? '';
-	let sha = process.env.CF_PAGES_COMMIT_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? '';
-	try {
-		if (!ref) ref = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-		if (!sha) sha = execSync('git rev-parse HEAD').toString().trim();
-	} catch {
-		// not a git checkout — fall through to main
-	}
-	if (!ref || ref === 'HEAD') ref = 'main';
-	return {
-		base: `https://img.basically.website/harness/${ref}`,
-		v: sha ? `?v=${sha.slice(0, 12)}` : ''
-	};
-}
-const harness = resolveHarness();
+// Harness drawing URLs are literal strings in _data/harness.yml, pasted from
+// the render that produced them, exactly like every other asset in the images
+// bucket. Nothing about them is derived here on purpose. The scheme this
+// replaced built them from the branch name plus a ?v=<this build's sha>, which
+// meant the docs could emit a URL for bytes that had not been uploaded yet —
+// the harness render and the docs build start on the same push — and the
+// reader who lost that race cached a stale or truncated drawing under a
+// year-long immutable header. See electronics/wire_harness/AGENTS.md.
 
 export const site = {
 	title: 'Sorter V2 Documentation',
 	description:
 		'Documentation for Sorter, the LEGO sorting machine. Assembly, operation, and software.',
 	url: 'https://docs.basically.website',
-	harness_base: harness.base,
-	harness_v: harness.v,
 	data
 };
 

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -15,7 +15,7 @@
 # an entry in the `drawings` list in electronics/wire_harness/build-harness.sh
 # (the supplier zip's member list), then the same paste.
 
-zip: https://img.basically.website/harness/sorter-v2-harness-rfq.5ce0afd6b7.zip
+zip: https://img.basically.website/harness/sorter-v2-harness-rfq.35659b2040.zip
 
 drawings:
   - name: power
@@ -51,7 +51,7 @@ drawings:
       The board's own feed, W1 on the overview: barrel plug to JST VHR-2.
     png: https://img.basically.website/harness/board-power.cbda5409b6.png
     svg: https://img.basically.website/harness/board-power.d7b15ac11d.svg
-    pdf: https://img.basically.website/harness/board-power.85b5802911.pdf
+    pdf: https://img.basically.website/harness/board-power.056646935e.pdf
     html: https://img.basically.website/harness/board-power.e8a77bfb82.html
     bom_tsv: https://img.basically.website/harness/board-power.8a0dcbe9b9.bom.tsv
     yml: https://img.basically.website/harness/board-power.a25e847465.yml

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -1,16 +1,21 @@
 # The drawings on the WireViz page, in display order.
 #
-# `name` is the basename of every artifact for a drawing:
-# electronics/wire_harness/<name>.yml is the source, and the published outputs
-# live in the assets bucket at <harness_base>/<name>.{png,svg,pdf,html,bom.tsv,yml},
-# where harness_base is derived per-build from the git ref by
-# resolveHarness() in docs/src/lib/server/content.ts. CI renders and publishes on any harness change;
-# nothing rendered lives in this repo and nothing here needs updating when a
-# drawing's content changes.
+# The URLs below are literal on purpose. Every harness artifact is published
+# under a name containing a hash of its own bytes, nothing in the bucket is
+# ever overwritten, and nothing here is derived at build time -- so a drawing's
+# URL changes in the same commit that changes the drawing, and the docs can
+# never name bytes that have not been uploaded yet. Do not replace these with
+# anything computed; see electronics/wire_harness/AGENTS.md for the outage that
+# rule comes from.
 #
-# Adding a drawing: a new YAML source, an entry here, and an entry in the
-# `drawings` list in electronics/wire_harness/build-harness.sh (the supplier
-# zip's member list).
+# `name` is the basename of the drawing's source, electronics/wire_harness/<name>.yml.
+#
+# Changing a drawing: edit the source, push, and CI fails with the exact block
+# of URLs to paste back in here. Adding one: a new YAML source, an entry here,
+# an entry in the `drawings` list in electronics/wire_harness/build-harness.sh
+# (the supplier zip's member list), then the same paste.
+
+zip: https://img.basically.website/harness/sorter-v2-harness-rfq.ef5fdb8d0d.zip
 
 drawings:
   - name: power
@@ -20,6 +25,12 @@ drawings:
       board, the USB hub and the Orange Pi buck. Dashed arrows are barrel
       jack/plug mates. This is the overview; the two buildable sub-harnesses
       it is made of are below it.
+    png: https://img.basically.website/harness/power.2021d6c5f7.png
+    svg: https://img.basically.website/harness/power.c07b691d4e.svg
+    pdf: https://img.basically.website/harness/power.01b58fd835.pdf
+    html: https://img.basically.website/harness/power.e1f5a23a92.html
+    bom_tsv: https://img.basically.website/harness/power.514757618c.bom.tsv
+    yml: https://img.basically.website/harness/power.b9dc96651e.yml
   - name: psu-pigtail
     title: PSU output pigtail
     of: power
@@ -27,19 +38,43 @@ drawings:
       One output pigtail, x3 per PSU build. Spade terminals onto a +V/-V screw
       pair on the PSU terminal block (7 with 4, 8 with 5, 9 with 6),
       panel-mount jack on the other end.
+    png: https://img.basically.website/harness/psu-pigtail.8e374550d3.png
+    svg: https://img.basically.website/harness/psu-pigtail.cebba4bf5b.svg
+    pdf: https://img.basically.website/harness/psu-pigtail.81398920b0.pdf
+    html: https://img.basically.website/harness/psu-pigtail.f8230c60dd.html
+    bom_tsv: https://img.basically.website/harness/psu-pigtail.e459cff16c.bom.tsv
+    yml: https://img.basically.website/harness/psu-pigtail.ee27031e74.yml
   - name: board-power
     title: 24V to basically board v1.3
     of: power
     caption: >-
       The board's own feed, W1 on the overview: barrel plug to JST VHR-2.
+    png: https://img.basically.website/harness/board-power.cbda5409b6.png
+    svg: https://img.basically.website/harness/board-power.d7b15ac11d.svg
+    pdf: https://img.basically.website/harness/board-power.209539281a.pdf
+    html: https://img.basically.website/harness/board-power.e8a77bfb82.html
+    bom_tsv: https://img.basically.website/harness/board-power.8a0dcbe9b9.bom.tsv
+    yml: https://img.basically.website/harness/board-power.a25e847465.yml
   - name: steppers
     title: Stepper cables
     caption: >-
       The S1-S4 cable, board PHR-4 to the motor's own PHR-6 with positions 2
       and 5 empty, and the straight-through chute cable to bare labeled leads.
+    png: https://img.basically.website/harness/steppers.550d7af474.png
+    svg: https://img.basically.website/harness/steppers.9b7334282c.svg
+    pdf: https://img.basically.website/harness/steppers.a879c517ac.pdf
+    html: https://img.basically.website/harness/steppers.08158bdd59.html
+    bom_tsv: https://img.basically.website/harness/steppers.3ac179ba97.bom.tsv
+    yml: https://img.basically.website/harness/steppers.8820bec2e6.yml
   - name: leds
     title: LED drops and limit switch
     caption: >-
       LED feeds L1-L3 to their unplug-point jacks, pigtails L1p-L3p to the COB
       boards and strip, and the limit switch cable (keyed 1x3 dupont at the
       board, push-on blade terminals at the switch).
+    png: https://img.basically.website/harness/leds.3a9294c2ee.png
+    svg: https://img.basically.website/harness/leds.3916b8ade2.svg
+    pdf: https://img.basically.website/harness/leds.d6183b68e7.pdf
+    html: https://img.basically.website/harness/leds.2c728ca11f.html
+    bom_tsv: https://img.basically.website/harness/leds.8e56b3c7a6.bom.tsv
+    yml: https://img.basically.website/harness/leds.e93d31515a.yml

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -15,7 +15,7 @@
 # an entry in the `drawings` list in electronics/wire_harness/build-harness.sh
 # (the supplier zip's member list), then the same paste.
 
-zip: https://img.basically.website/harness/sorter-v2-harness-rfq.ef5fdb8d0d.zip
+zip: https://img.basically.website/harness/sorter-v2-harness-rfq.5ce0afd6b7.zip
 
 drawings:
   - name: power
@@ -27,7 +27,7 @@ drawings:
       it is made of are below it.
     png: https://img.basically.website/harness/power.2021d6c5f7.png
     svg: https://img.basically.website/harness/power.c07b691d4e.svg
-    pdf: https://img.basically.website/harness/power.01b58fd835.pdf
+    pdf: https://img.basically.website/harness/power.cb10337110.pdf
     html: https://img.basically.website/harness/power.e1f5a23a92.html
     bom_tsv: https://img.basically.website/harness/power.514757618c.bom.tsv
     yml: https://img.basically.website/harness/power.b9dc96651e.yml
@@ -40,7 +40,7 @@ drawings:
       panel-mount jack on the other end.
     png: https://img.basically.website/harness/psu-pigtail.8e374550d3.png
     svg: https://img.basically.website/harness/psu-pigtail.cebba4bf5b.svg
-    pdf: https://img.basically.website/harness/psu-pigtail.81398920b0.pdf
+    pdf: https://img.basically.website/harness/psu-pigtail.3f38946911.pdf
     html: https://img.basically.website/harness/psu-pigtail.f8230c60dd.html
     bom_tsv: https://img.basically.website/harness/psu-pigtail.e459cff16c.bom.tsv
     yml: https://img.basically.website/harness/psu-pigtail.ee27031e74.yml
@@ -51,7 +51,7 @@ drawings:
       The board's own feed, W1 on the overview: barrel plug to JST VHR-2.
     png: https://img.basically.website/harness/board-power.cbda5409b6.png
     svg: https://img.basically.website/harness/board-power.d7b15ac11d.svg
-    pdf: https://img.basically.website/harness/board-power.209539281a.pdf
+    pdf: https://img.basically.website/harness/board-power.85b5802911.pdf
     html: https://img.basically.website/harness/board-power.e8a77bfb82.html
     bom_tsv: https://img.basically.website/harness/board-power.8a0dcbe9b9.bom.tsv
     yml: https://img.basically.website/harness/board-power.a25e847465.yml
@@ -62,7 +62,7 @@ drawings:
       and 5 empty, and the straight-through chute cable to bare labeled leads.
     png: https://img.basically.website/harness/steppers.550d7af474.png
     svg: https://img.basically.website/harness/steppers.9b7334282c.svg
-    pdf: https://img.basically.website/harness/steppers.a879c517ac.pdf
+    pdf: https://img.basically.website/harness/steppers.17631ea5d7.pdf
     html: https://img.basically.website/harness/steppers.08158bdd59.html
     bom_tsv: https://img.basically.website/harness/steppers.3ac179ba97.bom.tsv
     yml: https://img.basically.website/harness/steppers.8820bec2e6.yml
@@ -74,7 +74,7 @@ drawings:
       board, push-on blade terminals at the switch).
     png: https://img.basically.website/harness/leds.3a9294c2ee.png
     svg: https://img.basically.website/harness/leds.3916b8ade2.svg
-    pdf: https://img.basically.website/harness/leds.d6183b68e7.pdf
+    pdf: https://img.basically.website/harness/leds.3791720032.pdf
     html: https://img.basically.website/harness/leds.2c728ca11f.html
     bom_tsv: https://img.basically.website/harness/leds.8e56b3c7a6.bom.tsv
     yml: https://img.basically.website/harness/leds.e93d31515a.yml

--- a/electronics/wire_harness/AGENTS.md
+++ b/electronics/wire_harness/AGENTS.md
@@ -5,49 +5,80 @@ into everything the docs and a cable vendor need.
 
 ## The one idea
 
-**Sources are in git. Renders never are.**
+**Sources are in git. Renders never are. URLs are.**
 
 `power.yml`, `steppers.yml`, `leds.yml` and `rfq.txt` are the source of truth:
 small, diffable text. Reviewing a harness change means reviewing them.
 Everything derived (PNG, SVG, PDF, HTML, per-cable BOM, the supplier RFQ zip)
 is a build artifact, and build artifacts live in the `basically-docs` assets
-bucket, addressed by git ref:
+bucket under a name carrying a hash of their own bytes:
 
-    https://img.basically.website/harness/<branch>/power.png
+    https://img.basically.website/harness/power.2c0ebc6cd1.png
 
-Refs are mutable, exactly like git branches: pushing to a branch overwrites
-that branch's prefix. The docs derive the prefix for whatever ref they're
-building (`resolveHarness()` in `docs/src/lib/server/content.ts`), so a PR preview shows the PR's
-drawings and production shows main's.
+**Nothing in the bucket is ever overwritten**, and nothing about these URLs is
+derived at docs-build time. They are literal strings in
+`docs/src/liquid/_data/harness.yml`, pasted from the render that produced them
+— the same contract `docs/scripts/upload_image.py` has always had for photos,
+where the tool prints a URL and you paste it into the page. Change a drawing
+and its URL changes in the same commit, right next to the change, visible in
+the diff. A PR preview shows the PR's drawings because the PR's data file names
+them, not because anything resolved a branch.
 
-`img.basically.website` is a Cloudflare Worker in front of the bucket, and it
-keys its cache on the full URL including `?v=`, so a re-rendered drawing shows
-up as soon as a deploy stamps a new `v`. Every response carries
-`x-img-cache: hit|miss`, and that header is the evidence when somebody says a
-drawing looks stale:
+### Why, at length, because this cost a day
 
-    curl -sI "https://img.basically.website/harness/main/power.png?v=<sha>" | grep -i x-img-cache
+The scheme this replaced wrote every render to `harness/<branch>/power.png`,
+overwriting in place, and had the docs build the URL from the branch name plus
+`?v=<the docs build's commit sha>`. Three things were wrong with it, and they
+compounded:
 
-(An earlier version of this file blamed the Cloudflare zone for ignoring query
-strings. It was the worker dropping the query string before its subrequest to
-Spaces; fixed 2026-08-09.) The origin is public and never cached, so it is the
-tiebreaker if the two ever disagree:
+1. The sha in the URL was the *docs build's*, not the drawing's. So a
+   docs-only push reissued all five drawings' URLs (2.3 MB refetched for
+   nothing), and a changed drawing got a new URL for an unrelated reason.
+2. The object behind a URL was mutable, but the worker served it
+   `cache-control: public, max-age=31536000, immutable`. That header was a
+   lie.
+3. The harness render and the docs build start on the *same push*. The docs
+   build can win. In that window the page names `power.png?v=<newsha>` while
+   the bucket still holds the previous render at that path — or a
+   half-uploaded one. Whoever loads the page then pins wrong bytes for a year,
+   in their own browser and in the edge cache, with no recovery but a hard
+   reload they have no reason to attempt.
 
-    https://basically-docs.nyc3.digitaloceanspaces.com/harness/<ref>/power.png
+That is not hypothetical: it is what put a broken drawing on the live WireViz
+page on 2026-08-09, visible in Spencer's browser and fine in incognito. A
+content-addressed name fixes all three at once, because the object now exists
+before any commit can name it.
 
-That last sentence was false from the day it was written until 2026-08-09, and
-it is worth knowing why, because the failure was silent and cost a day of
-looking at the wrong drawing. `img.basically.website` is a Cloudflare Worker
-(`docs/scripts/img-worker/`), and it used to fetch `ORIGIN + url.pathname`,
-dropping the query string before the subrequest. So the cache key never
-contained the buster and every `?v=` we appended hit the same cached object,
-which a 24h `cacheTtlByStatus` then pinned in place — a fresh render in the
-bucket, a day-old render on the page, and the YAML link on the same page
-disagreeing with the picture above it. Zone purge could not clear it either:
-the key was a `digitaloceanspaces.com` URL, not one in the `basically.website`
-zone, so `purge_cache` returned success and did nothing. The worker now caches
-under its own hostname with the query in the key. If you change that file,
-keep both properties.
+`img.basically.website` is a Cloudflare Worker (`docs/scripts/img-worker/`) in
+front of the bucket. Every response carries `x-img-cache: hit|miss`, which is
+the evidence when somebody says a drawing looks wrong:
+
+    curl -sI "https://img.basically.website/harness/power.<hash>.png" | grep -i x-img-cache
+
+The origin is public and never cached, so it is the tiebreaker if the two ever
+disagree:
+
+    https://basically-docs.nyc3.digitaloceanspaces.com/harness/power.<hash>.png
+
+Caching is no longer load-bearing for correctness here, and that is the point
+of content-addressed names: a URL's bytes cannot change, so a stale cache
+entry and a fresh one are the same bytes. Two caching bugs got fixed on the way
+to that and are worth not reintroducing. The worker used to fetch
+`ORIGIN + url.pathname`, dropping the query string before its subrequest, so
+every `?v=` we appended hit one cached object which a 24h `cacheTtlByStatus`
+pinned in place — a fresh render in the bucket, a day-old render on the page,
+and the YAML link disagreeing with the picture above it. Zone purge could not
+clear it either: the key was a `digitaloceanspaces.com` URL, not one in the
+`basically.website` zone, so `purge_cache` returned success and did nothing.
+The worker now caches under its own hostname with the full URL in the key
+(#284, 2026-08-09). Keep both properties if you touch that file.
+
+**If a drawing ever looks wrong again, the first question is which URL the page
+is serving**, and the answer is in the page source and in
+`docs/src/liquid/_data/harness.yml` — no derivation, no build sha, no branch
+resolution. If the URL is the one you expect and the bytes are wrong, that is a
+real cache bug worth chasing. If the URL is not the one you expect, somebody
+skipped the paste.
 
 Permanent, content-addressed copies are a release-time concern (the lockfile
 mechanism in the unified parts plan), not a live-docs one. The bucket is
@@ -56,22 +87,31 @@ pinned toolchain.
 
 ## Changing a harness
 
-Edit the YAML. Push. That's all.
+Edit the YAML. Push. CI renders and uploads, then fails the
+**Check the docs point at this render** step with the exact block of URLs to
+paste into `docs/src/liquid/_data/harness.yml`. Paste it, commit, push again.
+Two rounds, and the second one is copy-paste out of the job log.
 
-`.github/workflows/harness.yml` renders on any PR or main push touching this
-directory and publishes to the branch's prefix, typically within ~90 seconds.
-You do not need WireViz, graphviz, or any credentials to contribute, and there
-is no step to remember: the preview self-corrects when the render lands. Fork
-PRs render without publishing (GitHub withholds secrets from forks), which
-still proves the YAML builds.
+That failing step is the point, not an annoyance: it is what makes it
+impossible to change a drawing and leave the page serving the old one. The
+upload is safe to run on every push precisely because names are content
+addressed — it can only ever add objects, never replace one somebody is
+already serving, and a re-render of an unchanged drawing uploads nothing.
+
+You do not need WireViz, graphviz, or any credentials to contribute. Fork PRs
+render without publishing (GitHub withholds secrets from forks), which still
+proves the YAML builds; a maintainer's push publishes and produces the URLs.
 
 To render locally (optional, for a fast inner loop):
 
     ./electronics/wire_harness/build-harness.sh      # renders into out/ (gitignored)
+    ./electronics/wire_harness/upload-harness.py --dry-run   # names + paste block, uploads nothing
 
-and to publish by hand (rarely needed; CI does this):
-
-    ./electronics/wire_harness/upload-harness.py --ref <branch>
+**Do not paste URLs from a local render.** graphviz's version is part of the
+rendered pixels, so a local render on a different graphviz hashes differently
+than CI's pinned 2.42.2 and the URLs will be for bytes CI would never produce.
+Local renders are for looking at a change. CI is the only renderer whose
+output gets pasted.
 
 Local creds come from `~/.config/basically/do-spaces.env`; CI uses repo
 secrets holding a key scoped to this one bucket. Note CI is the canonical
@@ -102,6 +142,10 @@ the docs site any more. Ignore it.
 2. Add `<name>` to the `drawings` list in `build-harness.sh` (the supplier
    zip's member list).
 3. Add an entry (name, title, caption) to `docs/src/liquid/_data/harness.yml`.
+4. Push; paste the URL block CI prints into that same entry. The check fails
+   until every drawing listed there carries the six URLs
+   (`png`, `svg`, `pdf`, `html`, `bom_tsv`, `yml`) from the current render,
+   and fails too if you rendered a drawing you never listed.
 
 **Overview drawings and sub-harnesses.** A drawing that is one buildable
 assembly out of a bigger diagram carries `of: <parent name>` in
@@ -141,15 +185,16 @@ fetched in the browser, not baked in at build time**, by the `$effect` in
 `docs/src/routes/[...path]/+page.svelte` that picks up
 `<div class="bom" data-bom="...">` placeholders.
 
-Build-time was rejected for a specific reason: the docs build and the harness
-render both start on the same push, so a docs build that wins the race would
-bake in a missing or stale table and keep serving it until some unrelated push
-triggered another deploy. That is the silent-staleness failure this pipeline
-already had once. Fetching at read time cannot go stale, and the `BOM (TSV)`
-download link above each table is the fallback when the fetch does not run.
+Build-time was rejected because the docs build and the harness render used to
+start on the same push, so a docs build that won the race would bake in a
+missing or stale table and keep serving it. Content-addressed URLs removed that
+race — the TSV is uploaded before any commit names it — so baking in at build
+time would now be safe. It is still fetched at read time because there is no
+reason to change it and the `BOM (TSV)` download link above each table is the
+fallback when the fetch does not run.
 
 The bucket sends `access-control-allow-origin: *`, so the cross-origin fetch is
-fine, and the URL carries `?v=` so it is served immutable.
+fine, and the name contains the hash, so it is served immutable and honestly.
 
 ## Where this shows up in the docs
 

--- a/electronics/wire_harness/build-harness.sh
+++ b/electronics/wire_harness/build-harness.sh
@@ -47,8 +47,11 @@ cd "$(dirname "$0")/../.."
 SRC=electronics/wire_harness
 OUT=electronics/wire_harness/out
 
-# Arbitrary fixed instant (2023-11-14T22:13:20Z). Only its constancy matters.
+# Arbitrary fixed instant. Only its constancy matters. The two spellings are
+# the same moment (2023-11-14T22:13:20Z) for two different consumers: tools
+# that honour SOURCE_DATE_EPOCH, and faketime, which wants a date string.
 export SOURCE_DATE_EPOCH=1700000000
+SOURCE_DATE_STRING='2023-11-14 22:13:20'
 
 command -v wireviz >/dev/null || { echo "build-harness: wireviz not on PATH" >&2; exit 1; }
 command -v dot     >/dev/null || { echo "build-harness: graphviz 'dot' not on PATH" >&2; exit 1; }
@@ -90,8 +93,14 @@ cp "$SRC"/*.yml "$SRC"/rfq.txt "$OUT"/
 # Without faketime (a local Mac, usually) the PDFs still move every run. That
 # is fine for looking at a change and is one more reason CI is the only
 # renderer whose URLs get pasted -- see AGENTS.md next to this script.
+#
+# The instant is spelled out rather than derived from SOURCE_DATE_EPOCH:
+# libfaketime's -f takes a date string and cannot parse "@<epoch>" (it fails
+# with "failed to parse FAKETIME timestamp" and takes the build down with it),
+# and converting one to the other needs `date -d`, which is GNU-only and this
+# script runs on Spencer's Mac. Keep the two in sync if you ever change either.
 if command -v faketime >/dev/null; then
-  pin_clock() { faketime -f "@$SOURCE_DATE_EPOCH" "$@"; }
+  pin_clock() { faketime -f "@$SOURCE_DATE_STRING" "$@"; }
 else
   echo "build-harness: faketime not on PATH, PDF timestamps will not be reproducible" >&2
   pin_clock() { "$@"; }

--- a/electronics/wire_harness/build-harness.sh
+++ b/electronics/wire_harness/build-harness.sh
@@ -15,20 +15,22 @@
 # Needs `wireviz` and graphviz's `dot` on PATH. CI installs both; locally,
 # `pip install wireviz==0.4.1` and `brew install graphviz`.
 #
-# Output is byte-for-byte reproducible, which is what lets CI commit only
-# when a drawing actually changed rather than on every run:
+# Output is byte-for-byte reproducible, and that is now load-bearing rather
+# than merely tidy: every artifact is published under a name containing a hash
+# of its bytes, so anything that moves between runs mints a new URL for an
+# unchanged drawing and demands a re-paste into the docs. Two sources of drift,
+# both handled:
 #
-#   - dot's PDF writer stamps a creation time into a compressed object, so
-#     a PDF is only rebuilt when the .gv it comes from actually changed.
-#     SOURCE_DATE_EPOCH below pins the stamp on a graphviz new enough to
-#     honour it and is not sufficient on its own: graphviz 2.43, which is
-#     what Ubuntu 24.04 and therefore CI has, ignores it, and the resulting
-#     PDFs differed by one byte per run and committed on every run. The .gv
-#     is WireViz's own output and carries no timestamp, so it is the honest
-#     thing to key on.
+#   - dot's PDF writer stamps wall-clock time into a compressed object as
+#     /CreationDate. SOURCE_DATE_EPOCH only pins it on a graphviz new enough to
+#     honour it: 2.42.2, which is what Ubuntu 24.04 and therefore CI has,
+#     ignores it, and two runs of identical sources produced PDFs differing in
+#     exactly those 262 bytes. faketime below pins the clock dot sees, which
+#     fixes it at the source rather than by patching the PDF afterwards.
 #   - zip stores mtimes, so the archive is built by Python with a fixed
-#     timestamp and a fixed member order instead of the zip(1) binary. Its
-#     members are stable by the rule above, so it needs no guard of its own.
+#     timestamp and a fixed member order instead of the zip(1) binary. It
+#     contains the PDFs, so it was drifting for their reason too, and is stable
+#     once they are.
 #
 # The version of graphviz IS part of the output: it shifts glyph positions,
 # so a different one rewrites every PNG, SVG and HTML at once. CI pins it
@@ -73,14 +75,38 @@ wireviz "$SRC"/*.yml -f ghpst -o "$OUT"
 # and because the WireViz docs page links it directly.
 cp "$SRC"/*.yml "$SRC"/rfq.txt "$OUT"/
 
+# dot stamps wall-clock time into the PDF as /CreationDate, inside a compressed
+# object stream, and Ubuntu's graphviz ignores SOURCE_DATE_EPOCH. Two runs of
+# identical sources therefore produced PDFs differing in exactly those 262
+# bytes -- and, because the supplier zip contains them, a different zip too.
+#
+# That was survivable when renders overwrote a fixed bucket path. It is not now
+# that a published name is a hash of the bytes: every CI run would mint five
+# new PDF URLs and a new zip URL for an unchanged harness, and demand they be
+# pasted back into the docs. So pin the clock dot sees. faketime is the whole
+# fix; the PDFs come out byte-identical run to run, which makes the zip
+# byte-identical too.
+#
+# Without faketime (a local Mac, usually) the PDFs still move every run. That
+# is fine for looking at a change and is one more reason CI is the only
+# renderer whose URLs get pasted -- see AGENTS.md next to this script.
+if command -v faketime >/dev/null; then
+  pin_clock() { faketime -f "@$SOURCE_DATE_EPOCH" "$@"; }
+else
+  echo "build-harness: faketime not on PATH, PDF timestamps will not be reproducible" >&2
+  pin_clock() { "$@"; }
+fi
+
 for gv in "$OUT"/*.gv; do
   pdf="${gv%.gv}.pdf"
-  # Same drawing and a PDF already on disk: re-rendering would only move the
-  # embedded date, so leave it alone.
+  # Same drawing and a PDF already on disk: re-rendering is a no-op with the
+  # clock pinned, and without it would only move the embedded date. Either way
+  # there is nothing to gain. CI always starts from an empty out/, so this only
+  # ever fires on a local re-run.
   if [ -f "$pdf" ] && cmp -s "$gv" "$PREV/$(basename "$gv")"; then
     continue
   fi
-  dot -Tpdf "$gv" -o "$pdf"
+  pin_clock dot -Tpdf "$gv" -o "$pdf"
 done
 
 python3 - "$OUT" <<'PY'

--- a/electronics/wire_harness/build-harness.sh
+++ b/electronics/wire_harness/build-harness.sh
@@ -99,8 +99,15 @@ cp "$SRC"/*.yml "$SRC"/rfq.txt "$OUT"/
 # with "failed to parse FAKETIME timestamp" and takes the build down with it),
 # and converting one to the other needs `date -d`, which is GNU-only and this
 # script runs on Spencer's Mac. Keep the two in sync if you ever change either.
+# `x0.0` freezes the clock instead of merely starting it at a fixed instant.
+# Starting it was not enough: faketime lets time tick from there, so a dot run
+# that happened to cross a second boundary stamped 22:13:21 while the others
+# stamped 22:13:20. That reproduced four of five PDFs and left board-power
+# drifting run to run, which is worse than an obvious failure -- it looks fixed
+# until one drawing quietly demands a repaste. Frozen, every dot invocation
+# sees the same instant no matter how long it takes.
 if command -v faketime >/dev/null; then
-  pin_clock() { faketime -f "@$SOURCE_DATE_STRING" "$@"; }
+  pin_clock() { faketime -f "@$SOURCE_DATE_STRING x0.0" "$@"; }
 else
   echo "build-harness: faketime not on PATH, PDF timestamps will not be reproducible" >&2
   pin_clock() { "$@"; }

--- a/electronics/wire_harness/upload-harness.py
+++ b/electronics/wire_harness/upload-harness.py
@@ -1,41 +1,61 @@
-"""Publish the rendered harness to the assets bucket under a git ref.
+"""Publish the rendered harness to the assets bucket and print the URLs to paste.
 
     ./electronics/wire_harness/build-harness.sh
-    ./electronics/wire_harness/upload-harness.py --ref my-branch
+    ./electronics/wire_harness/upload-harness.py
 
-Uploads everything in out/ to harness/<ref>/ in the basically-docs Space,
-overwriting whatever that ref held before. The docs build derives the same
-prefix from the ref it is building (resolveHarness() in docs/src/lib/server/content.ts), so a branch's
-Vercel preview shows that branch's drawings and production (main) shows main's.
-Nothing rendered is ever committed to git.
+Same contract as docs/scripts/upload_image.py, which is the convention every
+other asset in this bucket already follows: the tool puts bytes in the bucket
+and hands back URLs, and those URLs are pasted into the content as literal
+strings. A drawing's URL changes in the commit that changes the drawing, right
+next to it, and reviewing a harness change shows the new URLs in the diff.
 
-Refs are mutable, like git branches, so objects are served with a short cache
-TTL plus a per-deploy ?v= cache-buster on the docs side. Permanent
-content-addressed copies are a release-time concern (the lockfile mechanism in
-the unified parts plan), not a live-docs one.
+Nothing is ever overwritten. Every object's name carries a hash of its own
+bytes:
 
-CI runs this on every PR touching the harness sources, with SPACES_KEY /
-SPACES_SECRET from repo secrets (a key scoped to the basically-docs bucket
-only). Locally it reads ~/.config/basically/do-spaces.env like
-docs/scripts/upload_image.py. Requires boto3.
+    harness/power.a1b2c3d4e5.png
+
+so a re-render of an unchanged drawing lands on the name it already has (and
+uploads nothing), and a changed drawing gets a name nothing has ever served.
+That is what makes the year-long `immutable` cache header on these objects
+true, and it is what the previous scheme got wrong: it wrote every render to
+harness/<ref>/power.png, overwriting in place, and left the docs to invent a
+?v=<docs build sha> query that named bytes which might not exist yet. A reader
+who loaded a page inside that window pinned a stale or half-uploaded drawing
+in their browser cache for a year.
+
+Renders are not reproducible across graphviz versions -- the version shifts
+glyph positions, so it is part of the output -- which makes CI the canonical
+renderer (it pins graphviz 2.42.2 and WireViz 0.4.1). Publishing from a local
+render on a different graphviz produces correct but non-canonical bytes, and
+the hash will disagree with what CI would have produced. Use
+`gh workflow run harness.yml` and paste from the job log unless you know why
+you want otherwise.
+
+Credentials come from ~/.config/basically/do-spaces.env (SPACES_KEY /
+SPACES_SECRET) or the environment. Requires boto3.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import mimetypes
 import os
 import sys
 from pathlib import Path
 
 import boto3
+from botocore.exceptions import ClientError
 
 BUCKET = "basically-docs"
 ENDPOINT = "https://nyc3.digitaloceanspaces.com"
 PUBLIC_BASE = "https://img.basically.website"
 PREFIX = "harness"
-# Refs are mutable, so short TTL. The docs also append ?v=<commit> per deploy.
-CACHE_CONTROL = "public, max-age=60"
+# Honest now: the name contains a hash of the bytes, so the bytes behind a URL
+# can never change. Nothing else in this pipeline may reintroduce a mutable
+# name under this cache header.
+CACHE_CONTROL = "public, max-age=31536000, immutable"
+HASH_CHARS = 10
 CREDS_FILE = Path.home() / ".config" / "basically" / "do-spaces.env"
 OUT = Path(__file__).resolve().parent / "out"
 
@@ -44,6 +64,9 @@ OUT = Path(__file__).resolve().parent / "out"
 # legitimate render actually grows past them.
 MAX_TOTAL_BYTES = 25 * 1024 * 1024
 MAX_FILES = 60
+
+# The zip is the only artifact not named after a drawing.
+ZIP_NAME = "sorter-v2-harness-rfq.zip"
 
 
 def load_creds() -> tuple[str, str]:
@@ -85,29 +108,128 @@ def content_type(p: Path) -> str:
     return guessed or "application/octet-stream"
 
 
+def hashed_key(name: str, body: bytes) -> str:
+    """harness/power.bom.tsv + bytes -> harness/power.<hash>.bom.tsv
+
+    The hash goes after the first dot rather than before the last one so that
+    the whole suffix chain stays intact: `.bom.tsv` is how the docs page finds
+    a BOM and how a vendor knows what they were sent.
+    """
+    stem, _, rest = name.partition(".")
+    digest = hashlib.sha256(body).hexdigest()[:HASH_CHARS]
+    return f"{PREFIX}/{stem}.{digest}.{rest}" if rest else f"{PREFIX}/{stem}.{digest}"
+
+
+# What the docs page links per drawing. `.gv` is uploaded too (it is what the
+# PDF is rendered from and it is occasionally worth diffing) but nothing links
+# it, and rfq.txt is a hand-written source that ships inside the zip rather
+# than a drawing of its own. Neither belongs in the data file.
+LINKED = ("png", "svg", "pdf", "html", "bom.tsv", "yml")
+
+
+def by_drawing(urls: dict[str, str]) -> dict[str, dict[str, str]]:
+    """Group the rendered URLs by drawing, keeping only what the docs link.
+
+    A stem counts as a drawing only if it produced a PNG, which is what makes
+    rfq.txt fall out: WireViz renders a drawing to the whole set at once, so
+    anything without one is not a drawing.
+    """
+    grouped: dict[str, dict[str, str]] = {}
+    for name, url in urls.items():
+        if name == ZIP_NAME:
+            continue
+        stem, _, rest = name.partition(".")
+        if rest in LINKED:
+            grouped.setdefault(stem, {})[rest] = url
+    return {stem: exts for stem, exts in grouped.items() if "png" in exts}
+
+
+def paste_block(urls: dict[str, str]) -> str:
+    """The YAML to paste into docs/src/liquid/_data/harness.yml.
+
+    Printed rather than written: the data file also carries titles, captions
+    and `of:` relationships that only a person edits, and a script that
+    rewrote it in place would be one more derived-file-in-git to keep honest.
+    """
+    drawings = by_drawing(urls)
+    lines = [f"zip: {urls[ZIP_NAME]}", "", "# Paste each drawing's block under its entry in `drawings:`."]
+    for stem in sorted(drawings):
+        lines.append(f"  - name: {stem}")
+        for ext in LINKED:
+            url = drawings[stem].get(ext)
+            if url:
+                lines.append(f"    {ext.replace('.', '_')}: {url}")
+    return "\n".join(lines)
+
+
+def check(data_file: Path, urls: dict[str, str]) -> int:
+    """Fail unless the data file's literal URLs are the ones this render produced.
+
+    Without this the paste is optional, and a drawing change that forgot it
+    would publish new objects while the page kept serving the old ones -- the
+    same silent staleness the overwrite scheme had, just with a different
+    shape. CI runs it on every harness change.
+    """
+    import yaml  # a wireviz dependency; CI has it wherever this runs
+
+    doc = yaml.safe_load(data_file.read_text()) or {}
+    drawings = by_drawing(urls)
+    want = {ZIP_NAME: urls[ZIP_NAME]}
+    have = {ZIP_NAME: doc.get("zip")}
+    listed: set[str] = set()
+    for entry in doc.get("drawings") or []:
+        stem = entry.get("name")
+        listed.add(stem)
+        for ext, url in drawings.get(stem, {}).items():
+            want[f"{stem}.{ext}"] = url
+            have[f"{stem}.{ext}"] = entry.get(ext.replace(".", "_"))
+
+    wrong = sorted(n for n in want if have.get(n) != want[n])
+    missing = sorted(set(drawings) - listed)
+    if not wrong and not missing:
+        print(f"{data_file} matches this render ({len(want)} URLs)")
+        return 0
+
+    if wrong:
+        print(f"::error::{data_file} does not point at this render", file=sys.stderr)
+        for n in wrong:
+            print(f"  {n}\n    in the data file: {have.get(n)}\n    this render:      {want[n]}", file=sys.stderr)
+    if missing:
+        print(f"::error::rendered but not listed in {data_file}: {', '.join(missing)}", file=sys.stderr)
+    print("\nPaste this into docs/src/liquid/_data/harness.yml:\n", file=sys.stderr)
+    print(paste_block(urls), file=sys.stderr)
+    return 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--ref",
-        required=True,
-        help="git ref to publish under (branch name; CI passes github.head_ref or github.ref_name)",
+        "--dry-run", action="store_true", help="report what would upload, touch nothing"
     )
     parser.add_argument(
-        "--dry-run", action="store_true", help="report what would upload, touch nothing"
+        "--check",
+        type=Path,
+        metavar="HARNESS_YML",
+        help="upload nothing; fail unless this data file's URLs match the render in out/",
     )
     args = parser.parse_args()
 
-    ref = args.ref.strip().strip("/")
-    if not ref or ref == "HEAD":
-        sys.exit(f"--ref {args.ref!r} is not a usable ref")
-
     files = rendered_files()
-    base = f"{PUBLIC_BASE}/{PREFIX}/{ref}"
+    bodies = {p.name: p.read_bytes() for p in files}
+    keys = {name: hashed_key(name, body) for name, body in bodies.items()}
+    urls = {name: f"{PUBLIC_BASE}/{key}" for name, key in keys.items()}
+
+    if ZIP_NAME not in bodies:
+        sys.exit(f"refusing: {ZIP_NAME} missing from {OUT}; run build-harness.sh first")
+
+    if args.check:
+        return check(args.check, urls)
 
     if args.dry_run:
-        for p in files:
-            print(f"  would upload {PREFIX}/{ref}/{p.name}")
-        print(f"\nbase: {base}")
+        for name in sorted(keys):
+            print(f"  would upload {keys[name]}")
+        print()
+        print(paste_block(urls))
         return 0
 
     key_id, secret = load_creds()
@@ -118,18 +240,30 @@ def main() -> int:
         aws_secret_access_key=secret,
     )
 
-    for p in files:
+    uploaded = 0
+    for name in sorted(bodies):
+        key = keys[name]
+        # A name already in the bucket holds these exact bytes -- the name is a
+        # hash of them. Skipping keeps a re-render of an unchanged drawing free
+        # and makes it structurally impossible for this script to overwrite.
+        try:
+            s3.head_object(Bucket=BUCKET, Key=key)
+            continue
+        except ClientError as e:
+            if e.response["Error"]["Code"] not in ("404", "NoSuchKey", "NotFound"):
+                raise
         s3.put_object(
             Bucket=BUCKET,
-            Key=f"{PREFIX}/{ref}/{p.name}",
-            Body=p.read_bytes(),
+            Key=key,
+            Body=bodies[name],
             ACL="public-read",
-            ContentType=content_type(p),
+            ContentType=content_type(Path(name)),
             CacheControl=CACHE_CONTROL,
         )
+        uploaded += 1
 
-    print(f"uploaded {len(files)} files to {PREFIX}/{ref}/")
-    print(f"base: {base}")
+    print(f"uploaded {uploaded} new object(s); {len(bodies) - uploaded} already present\n")
+    print(paste_block(urls))
     return 0
 
 


### PR DESCRIPTION
## What broke

The WireViz page served a broken drawing on 2026-08-09. Harness drawing URLs were the only assets in the images bucket that were **computed at build time** instead of written down: the docs built them from the branch name plus `?v=<the docs build's commit sha>`, and every render overwrote `harness/<branch>/power.png` in place.

The harness render and the docs build start on the same push, so the docs can go live naming `power.png?v=<newsha>` while the bucket still holds the *previous* render at that path — or a half-uploaded one. The worker serves it `cache-control: immutable, max-age=31536000`, a header that was never true of a mutable path. Whoever loads the page in that window pins wrong bytes for a year, in their own browser and in the edge cache, with no recovery but a hard reload they have no reason to attempt.

Two smaller consequences of the same design: a docs-only push reissued all five drawings' URLs and refetched 2.3 MB for nothing, and the Pages move silently pointed every PR preview at `main`'s drawings because `resolveHarness()` only read Vercel's branch env var.

## What this does

Photos never had this problem — `upload_image.py` prints a URL, you paste it into the page, a changed image gets a new name. Harness artifacts now work the same way:

- Every object's name carries a hash of its own bytes: `harness/power.2c0ebc6cd1.png`. **Nothing is ever overwritten.**
- The URLs are literal strings in `docs/src/liquid/_data/harness.yml`. A drawing's URL changes in the commit that changes the drawing, in the diff, next to the change.
- `resolveHarness()`, `site.harness_base` and `site.harness_v` are deleted. The docs derive nothing.
- CI uploads on every run, which is safe now that names are content addressed: it can only add objects, never replace one somebody is serving, and an unchanged drawing uploads nothing. It then **fails unless the data file names exactly the render it just produced**, printing the block to paste.

That last check is what keeps the paste from being optional. Forgetting it would publish new drawings while the page served the old ones — the same silent staleness in a different shape.

## Reviewing

The first commit is the mechanism. The URLs land in a follow-up commit on this branch, pasted from this PR's own workflow output: graphviz's version is part of the rendered pixels, so only CI's pinned 2.42.2 produces hashes worth committing. **The check step is expected to fail on the first run** — that failure is the feature, and its log carries the block to paste.

Verified locally: a render + `--dry-run` produces six URLs per drawing plus the zip (`rfq.txt` and the `.gv` files correctly excluded), `--check` against an un-pasted data file exits 1 with the paste block, and the docs build passes and emits `<img src="">`, the correct waiting-on-paste state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)