### PR TITLE
harness: default PN for the PSU output pigtail spade terminals

### DIFF
--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -24,7 +24,7 @@ Wire IDs match the schedule tables. Open items are in section 7.
   <dt>Output</dt><dd>24V, 14.6A, 350.4W, single output</dd>
   <dt>Enclosure</dt><dd>Custom 3D-printed box, fused AC input</dd>
   <dt>Terminal block</dt><dd>9-position, MEAN WELL's own numbering: <b>1</b> AC/L, <b>2</b> AC/N, <b>3</b> FG, <b>4-6</b> DC OUTPUT -V, <b>7-9</b> DC OUTPUT +V (LRS-350-SPEC)</dd>
-  <dt>DC outputs</dt><dd>3 × female DC jack, each a 4 in 18 AWG pigtail with 2 × spade/fork terminals (M3.5, 8 mm wide max). One pigtail per +V/-V screw pair: 7 with 4, 8 with 5, 9 with 6</dd>
+  <dt>DC outputs</dt><dd>3 × female DC jack, each a 4 in 18 AWG pigtail with 2 × spade/fork terminals (M3.5, 8 mm wide max, Molex 0191310031 or equivalent). One pigtail per +V/-V screw pair: 7 with 4, 8 with 5, 9 with 6</dd>
   <dt>AC input</dt><dd>Screws 1, 2, 3. Fed by the fused IEC inlet switch's own pre-terminated leads, so there is no cable to make</dd>
   <dt>Loads</dt><dd>basically board v1.3, the USB hub, and the Orange Pi buck converter. One jack each, no spare</dd>
   <dt>Not on this bus</dt><dd>The cooling fans. They run off the Orange Pi or basically board v1.3 instead, so their voltage follows whichever pins are free (5V is likely sufficient). They are still needed: the Pi and the board end up in a box with no airflow but the fan. See <a href="#7--open-items">open items</a></dd>

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -37,7 +37,7 @@ One row = one buildable cable SKU. End A is the PSU/board side. "Bare" ends are 
 <table>
   <thead><tr><th>ID</th><th>Qty</th><th>Gauge</th><th>Length</th><th>Cond.</th><th>End A</th><th>End B</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max (PSU screws 7/4, 8/5, 9/6)</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
+    <tr><td class="wire-id">PSU-J</td><td>3</td><td>18 AWG</td><td>4 in</td><td>2</td><td>2× insulated spade/fork terminal, M3.5, 8 mm wide max (PSU screws 7/4, 8/5, 9/6) — Molex 0191310031 or equivalent</td><td>Panel-mount female DC jack 5.5×2.1</td><td>Lives inside the PSU box. Usually comes already attached to the jack, so buy the jacks with leads</td></tr>
     <tr><td class="wire-id">W1</td><td>1</td><td>18 AWG</td><td>36 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>JST VHR-2 + SVH-21T-P1.1 contacts</td><td>Board 24V in. Pin 1 = +24V, pin 2 = GND</td></tr>
     <tr><td class="wire-id">W2</td><td>1</td><td>22 AWG</td><td>12 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Male DC plug 5.5×2.1</td><td>USB hub. Double-male, center-positive both ends</td></tr>
     <tr><td class="wire-id">W3</td><td>1</td><td>22 AWG</td><td>6 in</td><td>2</td><td>Male DC plug 5.5×2.1</td><td>Bare, tinned</td><td>Splice to USB-C buck input leads</td></tr>
@@ -115,7 +115,7 @@ Some parts come with their own fixed leads or solder pads, so the harness can't 
 
 ## 5 &nbsp; Connector BOM
 
-Genuine JST part numbers given where they exist. Chinese-clone equivalents of all of these are fine for a vendor quote.
+Genuine JST and Molex part numbers given where they exist. Chinese-clone equivalents of all of these are fine for a vendor quote.
 
 <table>
   <thead><tr><th>Connector</th><th>Housing</th><th>Contacts</th><th>Used on</th></tr></thead>
@@ -129,7 +129,7 @@ Genuine JST part numbers given where they exist. Chinese-clone equivalents of al
     <tr><td>DC barrel male 5.5×2.1</td><td colspan="2">moulded plug w/ lead, or field-installable</td><td>W1-W3, L pigtails</td></tr>
     <tr><td>DC barrel female inline 5.5×2.1</td><td colspan="2">moulded inline jack</td><td>L1-L3 unplug points</td></tr>
     <tr><td>DC barrel female panel-mount 5.5×2.1</td><td colspan="2">panel-mount jack, ≥5 A</td><td>PSU box outputs J1-J3</td></tr>
-    <tr><td>Spade/fork terminal, insulated</td><td colspan="2">18 AWG, M3.5 stud, 8 mm wide max, must fit the LRS-350-24 terminal block (screws 4-6 are -V, 7-9 are +V)</td><td>PSU-J</td></tr>
+    <tr><td>Spade/fork terminal, insulated</td><td colspan="2">18 AWG, M3.5 stud, 8 mm wide max, must fit the LRS-350-24 terminal block (screws 4-6 are -V, 7-9 are +V). Molex 0191310031 or equivalent</td><td>PSU-J</td></tr>
   </tbody>
 </table>
 

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -15,7 +15,7 @@
 # an entry in the `drawings` list in electronics/wire_harness/build-harness.sh
 # (the supplier zip's member list), then the same paste.
 
-zip: https://img.basically.website/harness/sorter-v2-harness-rfq.35659b2040.zip
+zip: https://img.basically.website/harness/sorter-v2-harness-rfq.ba5527f6b3.zip
 
 drawings:
   - name: power
@@ -38,12 +38,12 @@ drawings:
       One output pigtail, x3 per PSU build. Spade terminals onto a +V/-V screw
       pair on the PSU terminal block (7 with 4, 8 with 5, 9 with 6),
       panel-mount jack on the other end.
-    png: https://img.basically.website/harness/psu-pigtail.8e374550d3.png
-    svg: https://img.basically.website/harness/psu-pigtail.cebba4bf5b.svg
-    pdf: https://img.basically.website/harness/psu-pigtail.3f38946911.pdf
-    html: https://img.basically.website/harness/psu-pigtail.f8230c60dd.html
-    bom_tsv: https://img.basically.website/harness/psu-pigtail.e459cff16c.bom.tsv
-    yml: https://img.basically.website/harness/psu-pigtail.ee27031e74.yml
+    png: https://img.basically.website/harness/psu-pigtail.56181e15b1.png
+    svg: https://img.basically.website/harness/psu-pigtail.62b5f66c79.svg
+    pdf: https://img.basically.website/harness/psu-pigtail.a39d79160e.pdf
+    html: https://img.basically.website/harness/psu-pigtail.d211ab2c42.html
+    bom_tsv: https://img.basically.website/harness/psu-pigtail.0cb9707956.bom.tsv
+    yml: https://img.basically.website/harness/psu-pigtail.ba99475ba7.yml
   - name: board-power
     title: 24V to basically board v1.3
     of: power

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -15,7 +15,7 @@
 # an entry in the `drawings` list in electronics/wire_harness/build-harness.sh
 # (the supplier zip's member list), then the same paste.
 
-zip: https://img.basically.website/harness/sorter-v2-harness-rfq.ba5527f6b3.zip
+zip: https://img.basically.website/harness/sorter-v2-harness-rfq.78a514ccbf.zip
 
 drawings:
   - name: power
@@ -38,12 +38,12 @@ drawings:
       One output pigtail, x3 per PSU build. Spade terminals onto a +V/-V screw
       pair on the PSU terminal block (7 with 4, 8 with 5, 9 with 6),
       panel-mount jack on the other end.
-    png: https://img.basically.website/harness/psu-pigtail.56181e15b1.png
-    svg: https://img.basically.website/harness/psu-pigtail.62b5f66c79.svg
-    pdf: https://img.basically.website/harness/psu-pigtail.a39d79160e.pdf
-    html: https://img.basically.website/harness/psu-pigtail.d211ab2c42.html
-    bom_tsv: https://img.basically.website/harness/psu-pigtail.0cb9707956.bom.tsv
-    yml: https://img.basically.website/harness/psu-pigtail.ba99475ba7.yml
+    png: https://img.basically.website/harness/psu-pigtail.e7a2cf6fc8.png
+    svg: https://img.basically.website/harness/psu-pigtail.7cdf562b21.svg
+    pdf: https://img.basically.website/harness/psu-pigtail.791cdb0604.pdf
+    html: https://img.basically.website/harness/psu-pigtail.6919ff5b2f.html
+    bom_tsv: https://img.basically.website/harness/psu-pigtail.dc2ee3359b.bom.tsv
+    yml: https://img.basically.website/harness/psu-pigtail.d51830f22e.yml
   - name: board-power
     title: 24V to basically board v1.3
     of: power

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -8,16 +8,16 @@ connectors:
     type: Spade terminal (fork/split ring)
     subtype: 18 AWG, M3.5, 8mm MAX
     manufacturer: Molex
-    mpn: 0191310031
-    notes: "To +V: screw 7, 8 or 9\nOr Equivalent"
+    mpn: "0191310031\nOr Equivalent"
+    notes: "To +V: screw 7, 8 or 9"
     color: RD
   F2:
     style: simple
     type: Spade terminal (fork/split ring)
     subtype: 18 AWG, M3.5, 8mm MAX
     manufacturer: Molex
-    mpn: 0191310031
-    notes: "To -V: the matching screw\n7+4, 8+5, 9+6\nOr Equivalent"
+    mpn: "0191310031\nOr Equivalent"
+    notes: "To -V: screw 4, 5, 6"
     color: BK
   J1:
     type: DC jack 5.5x2.1 female, panel-mount

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -7,13 +7,17 @@ connectors:
     style: simple
     type: Spade terminal (fork/split ring)
     subtype: 18 AWG, M3.5, 8mm MAX
-    notes: "To +V: screw 7, 8 or 9"
+    manufacturer: Molex
+    mpn: 0191310031
+    notes: "To +V: screw 7, 8 or 9\nOr Equivalent"
     color: RD
   F2:
     style: simple
     type: Spade terminal (fork/split ring)
     subtype: 18 AWG, M3.5, 8mm MAX
-    notes: "To -V: the matching screw\n7+4, 8+5, 9+6"
+    manufacturer: Molex
+    mpn: 0191310031
+    notes: "To -V: the matching screw\n7+4, 8+5, 9+6\nOr Equivalent"
     color: BK
   J1:
     type: DC jack 5.5x2.1 female, panel-mount


### PR DESCRIPTION
Jon reported the PSU output pigtail's spade terminals had no manufacturer or PN attached ("The PSU output pigtail section wireviz has no manufacturer or PN associated with the spade terminals.") [here](https://discord.com/channels/1430279849171222682/1536088194557419660/1536400391300718592).

Adds Molex `0191310031` to `F1`/`F2` in `psu-pigtail.yml` as the default, marked "Or Equivalent" per his instruction, since it's a default to source against rather than the only part that fits. Carried through to the rendered BOM and the two docs pages that restate the spec (`index.md`, `order.md`).

Molex 0191310031: insulated fork/spade, #6 stud (~M3.5), 18-22 AWG, 6.2 mm wide, well under the 8 mm max the LRS-350-24 screw terminals need.

## Test plan
- [x] Sanity-checked the YAML locally with `wireviz==0.4.1` (`wireviz psu-pigtail.yml -f gt`) — BOM now carries `Molex 0191310031` on both terminal rows
- [ ] CI render/upload + paste the drawing URLs into `harness.yml`