### PR TITLE
docs: add cmd+k spotlight search

### DIFF
--- a/docs/src/lib/components/SearchModal.svelte
+++ b/docs/src/lib/components/SearchModal.svelte
@@ -29,13 +29,19 @@
 		return out;
 	}
 
-	const index: SearchEntry[] = $derived(
-		nav.flatMap((section) => [
+	const index: SearchEntry[] = $derived.by(() => {
+		const seen = new Set<string>();
+		const all = nav.flatMap((section) => [
 			{ title: section.title, url: section.url, section: section.title, crumb: [] },
 			...flattenItems(section.pages, [section.title]),
 			...(section.groups ?? []).flatMap((g) => flattenItems(g.pages, [section.title, g.title]))
-		])
-	);
+		]);
+		return all.filter((e) => {
+			if (seen.has(e.url)) return false;
+			seen.add(e.url);
+			return true;
+		});
+	});
 
 	const results: SearchEntry[] = $derived(
 		query.trim() === ''

--- a/docs/src/lib/components/SearchModal.svelte
+++ b/docs/src/lib/components/SearchModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 
-	type NavItem = { title: string; url: string; children?: NavItem[] };
+	type NavItem = { title: string; url: string; lede?: string; children?: NavItem[] };
 	type NavGroup = { title: string; pages: NavItem[] };
 	type NavSection = {
 		id: string;
@@ -11,7 +11,7 @@
 		pages: NavItem[];
 		groups?: NavGroup[];
 	};
-	type SearchEntry = { title: string; url: string; section: string; crumb: string[] };
+	type SearchEntry = { title: string; url: string; lede?: string; section: string; crumb: string[] };
 
 	let { nav, open = $bindable(false) }: { nav: NavSection[]; open: boolean } = $props();
 
@@ -23,7 +23,13 @@
 	function flattenItems(items: NavItem[], crumb: string[]): SearchEntry[] {
 		const out: SearchEntry[] = [];
 		for (const item of items) {
-			out.push({ title: item.title, url: item.url, section: crumb[0] ?? '', crumb: crumb.slice(1) });
+			out.push({
+				title: item.title,
+				url: item.url,
+				lede: item.lede,
+				section: crumb[0] ?? '',
+				crumb: crumb.slice(1)
+			});
 			if (item.children) out.push(...flattenItems(item.children, [...crumb, item.title]));
 		}
 		return out;
@@ -32,7 +38,7 @@
 	const index: SearchEntry[] = $derived.by(() => {
 		const seen = new Set<string>();
 		const all = nav.flatMap((section) => [
-			{ title: section.title, url: section.url, section: section.title, crumb: [] },
+			{ title: section.title, url: section.url, lede: section.description, section: section.title, crumb: [] },
 			...flattenItems(section.pages, [section.title]),
 			...(section.groups ?? []).flatMap((g) => flattenItems(g.pages, [section.title, g.title]))
 		]);
@@ -139,11 +145,16 @@
 							onclick={(e) => { e.preventDefault(); navigate(entry.url); }}
 							tabindex="-1"
 						>
-							<span class="search-result-title">{entry.title}</span>
-							{#if entry.crumb.length > 0 || entry.section}
-								<span class="search-result-crumb">
-									{[entry.section, ...entry.crumb].filter(Boolean).join(' › ')}
-								</span>
+							<span class="search-result-row">
+								<span class="search-result-title">{entry.title}</span>
+								{#if entry.crumb.length > 0 || entry.section}
+									<span class="search-result-crumb">
+										{[entry.section, ...entry.crumb].filter(Boolean).join(' › ')}
+									</span>
+								{/if}
+							</span>
+							{#if entry.lede}
+								<span class="search-result-lede">{entry.lede}</span>
 							{/if}
 						</a>
 					</li>

--- a/docs/src/lib/components/SearchModal.svelte
+++ b/docs/src/lib/components/SearchModal.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+
+	type NavItem = { title: string; url: string; children?: NavItem[] };
+	type NavGroup = { title: string; pages: NavItem[] };
+	type NavSection = {
+		id: string;
+		title: string;
+		url: string;
+		description?: string;
+		pages: NavItem[];
+		groups?: NavGroup[];
+	};
+	type SearchEntry = { title: string; url: string; section: string; crumb: string[] };
+
+	let { nav, open = $bindable(false) }: { nav: NavSection[]; open: boolean } = $props();
+
+	let dialog: HTMLDialogElement | undefined = $state();
+	let inputEl: HTMLInputElement | undefined = $state();
+	let query = $state('');
+	let selected = $state(0);
+
+	function flattenItems(items: NavItem[], crumb: string[]): SearchEntry[] {
+		const out: SearchEntry[] = [];
+		for (const item of items) {
+			out.push({ title: item.title, url: item.url, section: crumb[0] ?? '', crumb: crumb.slice(1) });
+			if (item.children) out.push(...flattenItems(item.children, [...crumb, item.title]));
+		}
+		return out;
+	}
+
+	const index: SearchEntry[] = $derived(
+		nav.flatMap((section) => [
+			{ title: section.title, url: section.url, section: section.title, crumb: [] },
+			...flattenItems(section.pages, [section.title]),
+			...(section.groups ?? []).flatMap((g) => flattenItems(g.pages, [section.title, g.title]))
+		])
+	);
+
+	const results: SearchEntry[] = $derived(
+		query.trim() === ''
+			? index.slice(0, 8)
+			: index
+					.filter(
+						(e) =>
+							e.title.toLowerCase().includes(query.toLowerCase()) ||
+							e.url.toLowerCase().includes(query.toLowerCase())
+					)
+					.slice(0, 12)
+	);
+
+	$effect(() => {
+		if (open) {
+			query = '';
+			selected = 0;
+			dialog?.showModal();
+			requestAnimationFrame(() => inputEl?.focus());
+		} else {
+			dialog?.close();
+		}
+	});
+
+	$effect(() => {
+		// Reset selection whenever query changes
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+		query;
+		selected = 0;
+	});
+
+	function close() {
+		open = false;
+	}
+
+	function navigate(url: string) {
+		close();
+		goto(url);
+	}
+
+	function onInputKeydown(e: KeyboardEvent) {
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			selected = Math.min(selected + 1, results.length - 1);
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			selected = Math.max(selected - 1, 0);
+		} else if (e.key === 'Enter') {
+			e.preventDefault();
+			if (results[selected]) navigate(results[selected].url);
+		}
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<dialog
+	class="search-dialog"
+	bind:this={dialog}
+	onclose={() => { open = false; }}
+	onclick={(e) => { if (e.target === dialog) close(); }}
+	onkeydown={(e) => { if (e.key === 'Escape') close(); }}
+>
+	<div class="search-panel" role="presentation">
+		<div class="search-input-row">
+			<svg class="search-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+				<circle cx="8.5" cy="8.5" r="5.5" stroke="currentColor" stroke-width="1.6"/>
+				<path d="M13 13l3.5 3.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+			</svg>
+			<input
+				bind:this={inputEl}
+				class="search-input"
+				type="search"
+				placeholder="Search docs..."
+				autocomplete="off"
+				spellcheck="false"
+				bind:value={query}
+				onkeydown={onInputKeydown}
+			/>
+			<button type="button" class="search-esc-hint" onclick={close}>esc</button>
+		</div>
+
+		{#if results.length > 0}
+			<ul class="search-results" role="listbox" aria-label="Search results">
+				{#each results as entry, i (entry.url)}
+					<li
+						class="search-result"
+						class:search-result--selected={i === selected}
+						role="option"
+						aria-selected={i === selected}
+						onmouseenter={() => { selected = i; }}
+					>
+						<a
+							class="search-result-link"
+							href={entry.url}
+							onclick={(e) => { e.preventDefault(); navigate(entry.url); }}
+							tabindex="-1"
+						>
+							<span class="search-result-title">{entry.title}</span>
+							{#if entry.crumb.length > 0 || entry.section}
+								<span class="search-result-crumb">
+									{[entry.section, ...entry.crumb].filter(Boolean).join(' › ')}
+								</span>
+							{/if}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p class="search-empty">No results for <strong>"{query}"</strong></p>
+		{/if}
+
+		<div class="search-footer">
+			<span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
+			<span><kbd>↵</kbd> open</span>
+			<span><kbd>esc</kbd> close</span>
+		</div>
+	</div>
+</dialog>

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -59,7 +59,7 @@ export const site = {
 
 // ── Nav (verbatim port of _data/nav.yml semantics) ───────────────────────────
 
-export type NavItem = { title: string; url: string; children?: NavItem[] };
+export type NavItem = { title: string; url: string; lede?: string; children?: NavItem[] };
 export type NavGroup = { title: string; pages: NavItem[] };
 export type NavSection = {
 	id: string;
@@ -70,7 +70,7 @@ export type NavSection = {
 	groups?: NavGroup[];
 };
 
-export const navSections: NavSection[] = data.nav?.sections ?? [];
+const rawNavSections: NavSection[] = data.nav?.sections ?? [];
 
 // ── Frontmatter ──────────────────────────────────────────────────────────────
 
@@ -280,6 +280,24 @@ for (const [path, raw] of Object.entries(contentFiles)) {
 	const { fm } = parseFrontmatter(raw);
 	sources.set(urlFor(relPath, fm), { relPath, raw, fm: applyDefaults(relPath, fm) });
 }
+
+// Nav items don't carry their own frontmatter (nav.yml is just title/url), so
+// stitch each item's `lede` on from the matching content source by URL. This
+// rides along with the nav data every page already loads, so search results
+// can show a subtitle with no extra fetch.
+function withLede(items: NavItem[]): NavItem[] {
+	return items.map((item) => ({
+		...item,
+		lede: sources.get(item.url)?.fm.lede,
+		children: item.children ? withLede(item.children) : undefined
+	}));
+}
+
+export const navSections: NavSection[] = rawNavSections.map((section) => ({
+	...section,
+	pages: withLede(section.pages),
+	groups: section.groups?.map((g) => ({ ...g, pages: withLede(g.pages) }))
+}));
 
 const rendered = new Map<string, Page>();
 

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -2,11 +2,13 @@
 	import './layout.css';
 	import { page } from '$app/state';
 	import NavTree from '$lib/components/NavTree.svelte';
+	import SearchModal from '$lib/components/SearchModal.svelte';
 
 	let { data, children } = $props();
 
 	let modal: HTMLDialogElement | undefined = $state();
 	let sidebarOpen = $state(false);
+	let searchOpen = $state(false);
 	// The header scrolls away above the sticky sidebar, so the sidebar's height
 	// cap has to subtract it. It wraps at narrow widths, so measure it rather
 	// than hard-coding a number; layout.css carries a fallback until this lands.
@@ -19,7 +21,16 @@
 		!!currentSection &&
 			(currentSection.pages.length > 1 || (currentSection.groups?.length ?? 0) > 0)
 	);
+
+	function onGlobalKeydown(e: KeyboardEvent) {
+		if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+			e.preventDefault();
+			searchOpen = true;
+		}
+	}
 </script>
+
+<svelte:window onkeydown={onGlobalKeydown} />
 
 <div class="shell" style={headerHeight ? `--header-height: ${headerHeight}px` : undefined}>
 	<header class="site-header" bind:clientHeight={headerHeight}>
@@ -45,6 +56,19 @@
 					{section.title}
 				</a>
 			{/each}
+			<button
+				type="button"
+				class="search-nav-btn"
+				aria-label="Search docs"
+				onclick={() => { searchOpen = true; }}
+			>
+				<svg viewBox="0 0 20 20" fill="none" aria-hidden="true" width="16" height="16">
+					<circle cx="8.5" cy="8.5" r="5.5" stroke="currentColor" stroke-width="1.6"/>
+					<path d="M13 13l3.5 3.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+				</svg>
+				<span class="search-nav-label">Search</span>
+				<kbd class="search-nav-hint">⌘K</kbd>
+			</button>
 		</nav>
 	</header>
 
@@ -68,6 +92,8 @@
 			</p>
 		</div>
 	</dialog>
+
+	<SearchModal nav={data.nav} bind:open={searchOpen} />
 
 	{#if sidebarHasContent && currentSection}
 		<div class="layout-with-sidebar">

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1483,8 +1483,8 @@ blockquote {
 
 .search-result-link {
 	display: flex;
-	align-items: baseline;
-	gap: 10px;
+	flex-direction: column;
+	gap: 2px;
 	padding: 8px 14px;
 	text-decoration: none;
 	color: inherit;
@@ -1497,6 +1497,12 @@ blockquote {
 
 .search-result--selected .search-result-link {
 	background: color-mix(in srgb, var(--primary) 8%, var(--surface));
+}
+
+.search-result-row {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
 }
 
 .search-result-title {
@@ -1519,6 +1525,14 @@ blockquote {
 	color: var(--muted);
 	margin-left: auto;
 	white-space: nowrap;
+}
+
+.search-result-lede {
+	font-size: 0.78rem;
+	color: var(--muted);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .search-empty {

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1397,10 +1397,17 @@ blockquote {
 	padding: 0;
 	background: transparent;
 	border: none;
-	display: flex;
 	align-items: flex-start;
 	justify-content: center;
 	padding-top: clamp(60px, 12vh, 140px);
+}
+
+.search-dialog:not([open]) {
+	display: none;
+}
+
+.search-dialog[open] {
+	display: flex;
 }
 
 .search-dialog::backdrop {

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1345,3 +1345,199 @@ blockquote {
 		margin-bottom: 10px;
 	}
 }
+
+/* ── Search nav button ─────────────────────────────────────────────────── */
+
+.search-nav-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	padding: 6px 10px 6px 10px;
+	font: inherit;
+	font-size: 0.88rem;
+	font-weight: 500;
+	color: var(--muted);
+	background: transparent;
+	border: 1px solid transparent;
+	cursor: pointer;
+	transition:
+		color 0.12s ease,
+		background 0.12s ease;
+}
+
+.search-nav-btn:hover {
+	color: var(--ink);
+	background: var(--surface);
+}
+
+.search-nav-label {
+	/* Hide label on very small screens if needed — icon is enough */
+}
+
+.search-nav-hint {
+	display: inline-block;
+	padding: 1px 5px;
+	font: 0.72rem/1.4 var(--font-mono);
+	color: var(--muted);
+	background: var(--bg);
+	border: 1px solid var(--line);
+	border-radius: 3px;
+	pointer-events: none;
+}
+
+/* ── Search dialog ─────────────────────────────────────────────────────── */
+
+.search-dialog {
+	position: fixed;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	max-width: 100%;
+	max-height: 100%;
+	padding: 0;
+	background: transparent;
+	border: none;
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	padding-top: clamp(60px, 12vh, 140px);
+}
+
+.search-dialog::backdrop {
+	background: rgba(0, 0, 0, 0.46);
+}
+
+.search-panel {
+	width: min(560px, calc(100vw - 32px));
+	background: var(--surface);
+	border: 1px solid var(--line);
+	box-shadow:
+		0 4px 6px -1px rgba(0, 0, 0, 0.1),
+		0 16px 48px -8px rgba(0, 0, 0, 0.18);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.search-input-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 12px 14px;
+	border-bottom: 1px solid var(--line);
+}
+
+.search-icon {
+	flex-shrink: 0;
+	width: 18px;
+	height: 18px;
+	color: var(--muted);
+}
+
+.search-input {
+	flex: 1;
+	font: 1rem var(--font-sans);
+	color: var(--ink);
+	background: transparent;
+	border: none;
+	outline: none;
+	min-width: 0;
+}
+
+.search-input::placeholder {
+	color: var(--muted);
+}
+
+/* Remove default browser search clear button */
+.search-input::-webkit-search-cancel-button { display: none; }
+
+.search-esc-hint {
+	font: 0.72rem/1.4 var(--font-mono);
+	color: var(--muted);
+	background: var(--bg);
+	border: 1px solid var(--line);
+	border-radius: 3px;
+	padding: 1px 5px;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+.search-results {
+	list-style: none;
+	margin: 0;
+	padding: 6px 0;
+	max-height: 360px;
+	overflow-y: auto;
+}
+
+.search-result {
+	margin: 0;
+}
+
+.search-result-link {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+	padding: 8px 14px;
+	text-decoration: none;
+	color: inherit;
+}
+
+.search-result--selected .search-result-link,
+.search-result-link:hover {
+	background: color-mix(in srgb, var(--primary) 6%, var(--surface));
+}
+
+.search-result--selected .search-result-link {
+	background: color-mix(in srgb, var(--primary) 8%, var(--surface));
+}
+
+.search-result-title {
+	font-size: 0.92rem;
+	font-weight: 500;
+	color: var(--ink);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+}
+
+.search-result--selected .search-result-title {
+	color: var(--primary);
+}
+
+.search-result-crumb {
+	flex-shrink: 0;
+	font-size: 0.78rem;
+	color: var(--muted);
+	margin-left: auto;
+	white-space: nowrap;
+}
+
+.search-empty {
+	margin: 0;
+	padding: 18px 14px;
+	font-size: 0.9rem;
+	color: var(--muted);
+	text-align: center;
+}
+
+.search-footer {
+	display: flex;
+	gap: 14px;
+	padding: 8px 14px;
+	border-top: 1px solid var(--line);
+	font-size: 0.74rem;
+	color: var(--muted);
+}
+
+.search-footer kbd {
+	display: inline-block;
+	padding: 0 4px;
+	font: 0.7rem/1.5 var(--font-mono);
+	color: var(--muted);
+	background: var(--bg);
+	border: 1px solid var(--line);
+	border-radius: 3px;
+	margin-right: 2px;
+}


### PR DESCRIPTION
Adds instant cmd+k search to the docs site.

**How it works:** the nav index is already loaded in the layout server data, so search filters client-side with zero extra network requests — results appear as you type, no debounce needed.

**What's in here:**
- `SearchModal.svelte` — spotlight-style dialog with arrow-key navigation, Enter to jump, Escape to close
- Cmd+K (or Ctrl+K) opens it from anywhere on the page
- Search icon button added to the top nav, with a ⌘K hint label
- Results show title + breadcrumb path (so "External bracket" under Hardware › Assembly is distinguishable from anything else named similarly)
- Caps at 12 results; empty query shows the first 8 nav pages as a quick-launch list

Build is clean, no type errors.