### PR TITLE
migrate docs images to content addresses

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -139,8 +139,8 @@ yourself:
    `img-placeholder` divs (above) instead of guessing or embedding the image
    data directly in the page.
 3. **Reference the printed web URL** in the page:
-   `https://img.basically.website/web/<path>.<jpg|png>`. Plain URL, no Liquid.
-4. Nothing image-related gets committed. The URL works identically on PR
+   `https://img.basically.website/web/<path>.<hash>.<jpg|png>`. Plain URL, no Liquid.
+4. Commit the URL, never the image bytes. The URL works identically on PR
    previews and production, since the bucket is branch-independent.
 
 **A contributor's file sometimes carries images embedded as base64 data URIs**
@@ -161,6 +161,12 @@ bytes to each object name, so a changed image always prints a new URL that can
 be cached forever. Name the input path by what it shows (`step2-hole-red-square`),
 not by source filename. Group step images under `assembly/<page>/`, part renders
 under `parts/…`, tools under `tools/`.
+
+**This is the invariant.** Every `img.basically.website/web/` URL in docs source
+must contain the hash of its actual bytes. Never overwrite an object, use a
+descriptive stable URL, add a query-string cache buster, or add browser retry
+code. `npm run build` runs `scripts/validate_images.py`, which rejects a missing
+image, a non-content-addressed URL, or bytes that do not match the URL hash.
 
 ## The WireViz harness
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
+		"prebuild": "python3 scripts/validate_images.py",
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",

--- a/docs/scripts/validate_images.py
+++ b/docs/scripts/validate_images.py
@@ -1,5 +1,6 @@
 """Reject docs image URLs that are not immutable objects or cannot be fetched."""
 
+import hashlib
 import re
 import sys
 import urllib.request
@@ -7,7 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1] / "src"
 URL = re.compile(r"https://img\.basically\.website/web/[^\s\"<>)]+")
-CONTENT_ADDRESSED = re.compile(r"\.[0-9a-f]{10,}\.")
+CONTENT_ADDRESSED = re.compile(r"\.([0-9a-f]{10,})\.")
 
 urls = {
     url
@@ -17,14 +18,17 @@ urls = {
 }
 errors = []
 for url in sorted(urls):
-    if not CONTENT_ADDRESSED.search(url):
+    match = CONTENT_ADDRESSED.search(url)
+    if not match:
         errors.append(f"not content-addressed: {url}")
         continue
     try:
-        request = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0", "Range": "bytes=0-0"})
+        request = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
         with urllib.request.urlopen(request, timeout=15) as response:
             if response.status != 200:
                 errors.append(f"HTTP {response.status}: {url}")
+            elif not hashlib.sha256(response.read()).hexdigest().startswith(match.group(1)):
+                errors.append(f"hash mismatch: {url}")
     except OSError as error:
         errors.append(f"unavailable ({error}): {url}")
 

--- a/docs/scripts/validate_images.py
+++ b/docs/scripts/validate_images.py
@@ -1,0 +1,35 @@
+"""Reject docs image URLs that are not immutable objects or cannot be fetched."""
+
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "src"
+URL = re.compile(r"https://img\.basically\.website/web/[^\s\"<>)]+")
+CONTENT_ADDRESSED = re.compile(r"\.[0-9a-f]{10,}\.")
+
+urls = {
+    url
+    for path in ROOT.rglob("*")
+    if path.suffix in {".md", ".yml"}
+    for url in URL.findall(path.read_text())
+}
+errors = []
+for url in sorted(urls):
+    if not CONTENT_ADDRESSED.search(url):
+        errors.append(f"not content-addressed: {url}")
+        continue
+    try:
+        request = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0", "Range": "bytes=0-0"})
+        with urllib.request.urlopen(request, timeout=15) as response:
+            if response.status != 200:
+                errors.append(f"HTTP {response.status}: {url}")
+    except OSError as error:
+        errors.append(f"unavailable ({error}): {url}")
+
+if errors:
+    print("\n".join(errors), file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"validated {len(urls)} immutable docs assets")

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -30,10 +30,10 @@ The bottom interface stacks the chute mount, a spacer ring, the Lazy Susan beari
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/exploded-view.png" alt="Exploded view of the bottom interface: chute mount on top, spacer ring, Lazy Susan bearing, and the corner mounting brackets below">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/exploded-view.5b2e19be78b674c4.png" alt="Exploded view of the bottom interface: chute mount on top, spacer ring, Lazy Susan bearing, and the corner mounting brackets below">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/exploded-view-detail.png" alt="Close-up exploded view of the bottom interface parts separating from the mounting brackets">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/exploded-view-detail.43115f353ffc8e8a.png" alt="Close-up exploded view of the bottom interface parts separating from the mounting brackets">
   </figure>
 </div>
 
@@ -41,7 +41,7 @@ Once assembled, it mounts into the machine frame:
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/mounted-in-frame.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/mounted-in-frame.476d171d148ec300.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
     <figcaption>Diagram pictures courtesy of Adrianbaker in the basically Discord.</figcaption>
   </figure>
 </div>
@@ -52,10 +52,10 @@ Set the spacer on the chute mount and the [Lazy Susan]({{ '/hardware/parts/lazy-
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step1-line-up-hole.jpg" alt="Lining up the first screw hole with the chute mount's heat insert">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/step1-line-up-hole.68efcd2365b95c9f.jpg" alt="Lining up the first screw hole with the chute mount's heat insert">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step1-drive-screw.jpg" alt="Driving the screw into the chute mount">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/step1-drive-screw.622f05a7a4fe703e.jpg" alt="Driving the screw into the chute mount">
   </figure>
 </div>
 
@@ -66,7 +66,7 @@ The Lazy Susan is two discs, inner and outer, that spin independently. One disc'
   <p>The M4 × 12 mm countersunk screws must be very tight. Most electric screwdrivers won't tighten them enough. They're a hassle to reach if they come loose, and machine vibration can work them loose.</p>
 </div>
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/lazy-susan-on-chute-mount.jpg" alt="Lazy Susan bearing mounted on the chute mount with the spacer between them">
+<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/lazy-susan-on-chute-mount.d478621b1f81e5ae.jpg" alt="Lazy Susan bearing mounted on the chute mount with the spacer between them">
 
 {% include step.html n="2" title="Mount the Lazy Susan to the bottom static part" %}
 
@@ -74,11 +74,11 @@ The Lazy Susan's other disc screws down into the bottom static part. You reach t
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-holes-aligned.jpg" alt="Lazy Susan hole aligned with the pass-through hole, seen from the top">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-holes-aligned.ebf0c303cdb41f27.jpg" alt="Lazy Susan hole aligned with the pass-through hole, seen from the top">
     <figcaption>Holes lined up. You can see through to the chute mount.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-pass-through.jpg" alt="Pass-through hole in the chute mount with the screw reachable underneath">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-pass-through.0522b2c6e67778df.jpg" alt="Pass-through hole in the chute mount with the screw reachable underneath">
     <figcaption>The pass-through hole lets a screwdriver reach the screw.</figcaption>
   </figure>
 </div>
@@ -87,30 +87,30 @@ Set the chute mount + Lazy Susan assembly onto the bottom static part and line u
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-place-chute-adapter.jpg" alt="Placing the chute mount and Lazy Susan assembly onto the bottom static part">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-place-chute-adapter.5d3dfd2a5794d4ef.jpg" alt="Placing the chute mount and Lazy Susan assembly onto the bottom static part">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-hole-red-square.jpg" alt="Pass-through hole lined up over the heat insert, marked with a red square">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-hole-red-square.fd314fd2c0a2a527.jpg" alt="Pass-through hole lined up over the heat insert, marked with a red square">
     <figcaption>Line up over the marked hole (red square).</figcaption>
   </figure>
 </div>
 
 Drive the first screw through the pass-through hole.
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/step2-screwed-in.jpg" alt="First screw driven through the pass-through hole">
+<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/step2-screwed-in.92f81fc1417a1a21.jpg" alt="First screw driven through the pass-through hole">
 
 Then rotate the chute with the Lazy Susan, turning it the way it turns in normal operation, not by forcing the whole assembly, to bring the pass-through hole to the next insert. Repeat for all four screws.
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-rotate-90.jpg" alt="Rotating the chute with the Lazy Susan to the next screw position">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-rotate-90.7139a08a65e920ad.jpg" alt="Rotating the chute with the Lazy Susan to the next screw position">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-after-rotate.jpg" alt="Pass-through hole lined up over the next heat insert after rotating">
+    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-after-rotate.cdec5eba44af1747.jpg" alt="Pass-through hole lined up over the next heat insert after rotating">
     <figcaption>Pass-through hole now over the next insert.</figcaption>
   </figure>
 </div>
 
 The finished bottom interface:
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/complete.jpg" alt="The completed bottom interface with chute mount, Lazy Susan bearing, and bottom static part assembled">
+<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/complete.8aa4adc4ac4c5ad9.jpg" alt="The completed bottom interface with chute mount, Lazy Susan bearing, and bottom static part assembled">

--- a/docs/src/content/hardware/assembly/distribution/external-bracket.md
+++ b/docs/src/content/hardware/assembly/distribution/external-bracket.md
@@ -37,17 +37,17 @@ Three printed parts that bolt together into one external bracket. **6 per distri
 - Matching parts from the same print run are embossed with a shared set code (e.g. **"b2"**) on both the side bracket and the bottom-vertical part, keep marked pairs together so brackets don't get mixed across sets.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/parts-laid-out.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/parts-laid-out.0a59300a73b4f6c2.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
   <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four M5 × 16 mm screws. The cover is fitted last, in Step 4.</figcaption>
 </figure>
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/side-bracket.jpg" alt="Close-up of the side bracket alone, showing the U-shaped extrusion clamp and the two mounting-hole wings">
+    <img src="https://img.basically.website/web/assembly/external-bracket/side-bracket.6649e3954a498346.jpg" alt="Close-up of the side bracket alone, showing the U-shaped extrusion clamp and the two mounting-hole wings">
     <figcaption>The side bracket on its own: the U-shaped opening clamps around the extrusion, and each of the two wings carries a pair of mounting holes.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/bottom-vertical-flange.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
+    <img src="https://img.basically.website/web/assembly/external-bracket/bottom-vertical-flange.4b9a511aea49346c.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
     <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two M5 × 16 mm screws in Step 1 go into.</figcaption>
   </figure>
 </div>
@@ -57,7 +57,7 @@ Three printed parts that bolt together into one external bracket. **6 per distri
 Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two M5 × 16 mm socket head screws down through the flange into the side bracket.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step1-screwed-underside.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step1-screwed-underside.d3637471f50acb1b.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
   <figcaption>Two M5 × 16 mm screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.</figcaption>
 </figure>
 
@@ -71,7 +71,7 @@ Set the bottom-vertical leg's flanged top into the U-shaped opening of the side 
 Slide the C-Layer vertical support (the vertical aluminum extrusion) down through the side bracket's U-shaped clamp and into the square socket in the bottom-vertical leg below. The socket is sized to the extrusion's profile, so it can only seat in the correct orientation.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step2-extrusion-inserted.jpg" alt="C-Layer vertical support extrusion inserted down through the side bracket and into the square socket of the bottom-vertical leg">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step2-extrusion-inserted.c56df607b17c4a6c.jpg" alt="C-Layer vertical support extrusion inserted down through the side bracket and into the square socket of the bottom-vertical leg">
   <figcaption>C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3.</figcaption>
 </figure>
 
@@ -81,11 +81,11 @@ Two more M5 × 16 mm screws clamp the side bracket against the C-Layer vertical 
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-hole-empty.jpg" alt="Retention screw hole empty, before the screw is driven in">
+    <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-hole-empty.1086433be655ac1f.jpg" alt="Retention screw hole empty, before the screw is driven in">
     <figcaption>Before: retention-screw hole empty.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-driven-in.jpg" alt="Retention screw driven in, seated flush in the hex socket">
+    <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-driven-in.259bbc4b6fdbb5b2.jpg" alt="Retention screw driven in, seated flush in the hex socket">
     <figcaption>After: M5 × 16 mm screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
   </figure>
 </div>
@@ -96,11 +96,11 @@ Clip the cover onto the side bracket to close it off. The cover takes no screws,
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/step4-cover-unattached.jpg" alt="The unattached cover sitting next to the assembled bracket, at the face where it clips on">
+    <img src="https://img.basically.website/web/assembly/external-bracket/step4-cover-unattached.9b93d76f94596b23.jpg" alt="The unattached cover sitting next to the assembled bracket, at the face where it clips on">
     <figcaption>The cover (left), not yet attached, next to the face of the assembly it clips onto.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/step4-cover-clipped-on.jpg" alt="Finished bracket with the cover clipped into place">
+    <img src="https://img.basically.website/web/assembly/external-bracket/step4-cover-clipped-on.1fea5b9a357cc5df.jpg" alt="Finished bracket with the cover clipped into place">
     <figcaption>Cover clipped into place. It sits flush against the side bracket, which is why the seam is subtle in photos.</figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -33,7 +33,7 @@ Wire IDs match the schedule tables. Open items are in section 7.
 ## 2 &nbsp; Component layout
 
 <figure class="harness-figure">
-  <img src="https://img.basically.website/web/electronics/component-layout-topdown.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
+  <img src="https://img.basically.website/web/electronics/component-layout-topdown.2d38b86c4b2e4d05.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
   <figcaption>Physical placement on the machine (top-down): PSU, Orange Pi, basically board v1.3, USB hub, Pico, the chute stepper and its limit switch, and the ribbon run.</figcaption>
 </figure>
 
@@ -209,7 +209,7 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
   </tbody>
 </table>
 
-<img class="doc-figure" src="https://img.basically.website/web/electronics/idc-ribbon-16pin.jpg" alt="uxcell 16-pin IDC flat ribbon cable, gray, with FC connectors at both ends">
+<img class="doc-figure" src="https://img.basically.website/web/electronics/idc-ribbon-16pin.21fee4f419fb723d.jpg" alt="uxcell 16-pin IDC flat ribbon cable, gray, with FC connectors at both ends">
 
 ## 5 &nbsp; Parts
 

--- a/docs/src/content/hardware/helpers/heat-inserts.md
+++ b/docs/src/content/hardware/helpers/heat-inserts.md
@@ -9,7 +9,7 @@ lede: Pressing brass heat-set inserts into printed parts.
 permalink: /hardware/helpers/heat-inserts/
 ---
 
-<img class="doc-figure" src="https://img.basically.website/web/tools/heat-insert-press.jpg" alt="Benchtop heat-set insert press with a set of tips">
+<img class="doc-figure" src="https://img.basically.website/web/tools/heat-insert-press.3890a976bbb772d5.jpg" alt="Benchtop heat-set insert press with a set of tips">
 
 Easiest with a {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-Heat-Insertion-Threaded-Components/dp/B0FRXF1ZH6" text="heat-set insert press" %}. You can also use a regular soldering iron.
 

--- a/docs/src/content/hardware/helpers/lazy-susan.md
+++ b/docs/src/content/hardware/helpers/lazy-susan.md
@@ -10,7 +10,7 @@ permalink: /hardware/helpers/lazy-susan/
 author: spencer
 ---
 
-<img class="doc-figure" src="https://img.basically.website/web/helpers/lazy-susan.jpg" alt="8-inch lazy Susan bearing; the rubber foot to remove is boxed in red">
+<img class="doc-figure" src="https://img.basically.website/web/helpers/lazy-susan.624357a2efa7d60e.jpg" alt="8-inch lazy Susan bearing; the rubber foot to remove is boxed in red">
 
 Background on the part — sourcing, load rating, the 8" variant — is on the [Lazy Susan part page]({{ '/hardware/parts/lazy-susan/' | relative_url }}).
 

--- a/docs/src/content/hardware/parts/lazy-susan.md
+++ b/docs/src/content/hardware/parts/lazy-susan.md
@@ -10,7 +10,7 @@ permalink: /hardware/parts/lazy-susan/
 author: spencer
 ---
 
-<img class="doc-figure" src="https://img.basically.website/web/lazy-susan-top.jpg" alt="8-inch lazy Susan bearing, top view">
+<img class="doc-figure" src="https://img.basically.website/web/lazy-susan-top.f7085d147da1318c.jpg" alt="8-inch lazy Susan bearing, top view">
 
 Repurposed from a dinner-table lazy Susan. It's rated for heavy loads — at least 50 lb, likely more — and holds up well over long run times, with no manufacturing issues seen across Amazon and AliExpress sources. Use the **8" variant**; see the [BOM](https://docs.google.com/spreadsheets/d/1aoxcyK0xa0i3iWYlO4u3-vsruOGU8V_U9XT65YhMZmY/edit?gid=0#gid=0) for sources.
 

--- a/docs/src/content/sorter/safe-shutdown.md
+++ b/docs/src/content/sorter/safe-shutdown.md
@@ -15,13 +15,13 @@ The machine's computer writes files continuously while it runs. Cutting power mi
 
 Click the dropdown at the top right of the UI and select **Full Machine Power Down**.
 
-<img class="doc-figure" src="https://img.basically.website/web/sorter/safe-shutdown/full-machine-power-down-menu.jpg" alt="The top-right UI dropdown open, showing the Full Machine Power Down action">
+<img class="doc-figure" src="https://img.basically.website/web/sorter/safe-shutdown/full-machine-power-down-menu.fb7d3867ed810a3c.jpg" alt="The top-right UI dropdown open, showing the Full Machine Power Down action">
 
 ## Option 2: the button on the Orange Pi
 
 Press the small black button on the side of the Orange Pi once (circled below). That begins the shutdown procedure.
 
-<img class="doc-figure" src="https://img.basically.website/web/sorter/safe-shutdown/orange-pi-power-button.jpg" alt="Orange Pi 5 board with the side power button circled in red">
+<img class="doc-figure" src="https://img.basically.website/web/sorter/safe-shutdown/orange-pi-power-button.a39aa5a490fc08a0.jpg" alt="Orange Pi 5 board with the side power button circled in red">
 
 You'll know it's shut down when the red and green light on the board have stopped blinking.
 

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -11,7 +11,6 @@ import remarkRehype from 'remark-rehype';
 import rehypeRaw from 'rehype-raw';
 import rehypeSlug from 'rehype-slug';
 import rehypeStringify from 'rehype-stringify';
-import { env } from '$env/dynamic/private';
 
 // ── Raw sources ──────────────────────────────────────────────────────────────
 
@@ -39,20 +38,6 @@ const data: Record<string, any> = {};
 for (const [path, raw] of Object.entries(dataFiles)) {
 	const name = path.split('/').pop()!.replace(/\.yml$/, '');
 	data[name] = yaml.load(raw);
-}
-
-// Legacy photo keys were descriptive and some browsers still hold stale
-// immutable responses for them. Each Pages build gives only those keys a fresh
-// URL; new uploads have content-addressed filenames and remain cacheable.
-const IMAGE_VERSION = env.CF_PAGES_COMMIT_SHA ?? '20260810';
-const CONTENT_ADDRESSED = /\.[0-9a-f]{10,}\.[^.]+$/;
-
-function versionImageURL(value: string): string {
-	if (!value.startsWith('https://img.basically.website/')) return value;
-	const url = new URL(value);
-	if (url.searchParams.has('v') || CONTENT_ADDRESSED.test(url.pathname)) return value;
-	url.searchParams.set('v', IMAGE_VERSION);
-	return url.toString();
 }
 
 // Harness drawing URLs are literal strings in _data/harness.yml, pasted from
@@ -253,7 +238,7 @@ function resolveParts(partsNeeded: any[]): { groups: PartsGroup[]; notes: Resolv
 		return {
 			id,
 			name: part.name,
-			image: part.image ? versionImageURL(part.image) : undefined,
+			image: part.image,
 			page: part.page,
 			notes: part.notes,
 			qty,
@@ -333,10 +318,7 @@ export async function getPage(pathParam: string): Promise<Page | null> {
 	body = expandAffiliateLinks(body);
 	body = expandHeadingIds(body);
 	body = await liquid.parseAndRender(body, { site, page: { ...fm, url } });
-	const html = String(await markdown.process(body)).replace(
-		/(<img\b[^>]*\bsrc=")([^"]+)(")/gi,
-		(_match, before: string, src: string, after: string) => before + versionImageURL(src) + after
-	);
+	const html = String(await markdown.process(body));
 
 	const page: Page = { url, fm, html };
 

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -11,13 +11,13 @@
 lazy-susan:
   name: Lazy Susan
   category: Bearings
-  image: https://img.basically.website/web/lazy-susan-top.jpg
+  image: https://img.basically.website/web/lazy-susan-top.f7085d147da1318c.jpg
   page: /hardware/parts/lazy-susan/
 
 ls-mount-to-chute:
   name: Lazy Susan chute mount
   category: Printed parts
-  image: https://img.basically.website/web/parts/ls-mount-to-chute.png
+  image: https://img.basically.website/web/parts/ls-mount-to-chute.6e5e37d01abc3ae2.png
   notes: Prepared with 4× M4 Ruthex long heat inserts.
   heat_inserts:
     - insert: m4-ruthex-long
@@ -26,7 +26,7 @@ ls-mount-to-chute:
 ls-bottom-static:
   name: Lazy Susan bottom static
   category: Printed parts
-  image: https://img.basically.website/web/parts/ls-bottom-static.png
+  image: https://img.basically.website/web/parts/ls-bottom-static.4776c7617442386d.png
   notes: Prepared with 4× M4 Ruthex long heat inserts.
   heat_inserts:
     - insert: m4-ruthex-long
@@ -35,34 +35,34 @@ ls-bottom-static:
 ls-washer:
   name: Lazy Susan washer
   category: Printed parts
-  image: https://img.basically.website/web/parts/ls-washer.png
+  image: https://img.basically.website/web/parts/ls-washer.0d2cfa373c54ad53.png
 
 m4-ruthex-long:
   name: M4 Ruthex heat insert (long)
   category: Heat inserts
-  image: https://img.basically.website/web/parts/hardware/heat-inserts/m4-ruthex-long/insert.jpg
+  image: https://img.basically.website/web/parts/hardware/heat-inserts/m4-ruthex-long/insert.aabba833ab98e7db.jpg
 
 m4-12mm-countersunk:
   name: M4 × 12 mm countersunk screw
   category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/m4-12mm-countersunk.jpg
+  image: https://img.basically.website/web/parts/hardware/screws/m4-12mm-countersunk.eb3c4468cf87495d.jpg
 
 ext-bracket-left:
   name: External bracket — side
   category: Printed parts
-  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-left.png
+  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-left.20d9d8ffb7d799a2.png
   page: /hardware/assembly/distribution/external-bracket/
 
 ext-bracket-bottom-vertical:
   name: External bracket — bottom vertical
   category: Printed parts
-  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-bottom-vertical.png
+  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-bottom-vertical.b4f4642d21d46378.png
   page: /hardware/assembly/distribution/external-bracket/
 
 ext-bracket-cover:
   name: External bracket — cover
   category: Printed parts
-  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-cover.png
+  image: https://img.basically.website/web/parts/external-bracket/ext-bracket-cover.d9260aef7e3d6197.png
   page: /hardware/assembly/distribution/external-bracket/
 
 scr-m5-16-shcs:

--- a/docs/src/routes/[...path]/+page.svelte
+++ b/docs/src/routes/[...path]/+page.svelte
@@ -28,18 +28,6 @@
 	$effect(() => {
 		p.url; // rerun per page — {@html} replaces the DOM on navigation
 		if (!contentEl) return;
-		for (const image of contentEl.querySelectorAll<HTMLImageElement>('img')) {
-			if (!image.src.startsWith('https://img.basically.website/')) continue;
-			const retry = () => {
-				if (image.dataset.cacheRetry) return;
-				image.dataset.cacheRetry = '1';
-				const url = new URL(image.src);
-				url.searchParams.set('retry', crypto.randomUUID());
-				image.src = url.toString();
-			};
-			if (image.complete && image.naturalWidth === 0) retry();
-			else image.addEventListener('error', retry, { once: true });
-		}
 		for (const pre of contentEl.querySelectorAll('pre')) {
 			if (pre.parentElement?.classList.contains('code-block')) continue;
 			const wrap = document.createElement('div');


### PR DESCRIPTION
Migrates every legacy docs photo URL to a SHA-256-named object in Spaces and removes the cache-busting and browser-retry workarounds. The docs build now validates every referenced page image is content-addressed and reachable.