### PR TITLE
return 404 for missing docs assets

### DIFF
--- a/docs/static/404.html
+++ b/docs/static/404.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page not found | Sorter V2 Documentation</title>
+  </head>
+  <body>
+    <main>
+      <h1>Page not found</h1>
+      <p><a href="/">Return to Sorter V2 Documentation</a></p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Add a static 404 page so Cloudflare Pages does not return the cacheable docs HTML shell for a missing Svelte module. This prevents a transient missing /_app asset from being cached as text/html and retried as JavaScript.