### PR TITLE
hive: fix the piece_has_candidates predicate so its index is usable

### DIFF
--- a/software/hive/backend/alembic/versions/d4f6a8b0c2e1_fix_piece_has_candidates_predicate.py
+++ b/software/hive/backend/alembic/versions/d4f6a8b0c2e1_fix_piece_has_candidates_predicate.py
@@ -1,0 +1,96 @@
+"""fix piece_has_candidates: isolate c.ts so the index is usable
+
+Revision ID: d4f6a8b0c2e1
+Revises: c9e1f3a5b7d9
+Create Date: 2026-08-12 17:10:00.000000
+
+The a8c1d2e3f4a5 matview was created to kill a correlated EXISTS that Postgres
+planned as a machine_id-only semi join, scanning each machine's entire crop set
+per piece. The matview's own defining query then reproduced that exact plan,
+because the crop-side condition was written with `c.ts` buried under interval
+arithmetic:
+
+    coalesce(p.seen_at, p.recorded_at) >= c.ts - interval '1.5 seconds'
+    coalesce(p.seen_at, p.recorded_at) <= c.ts + interval '60 seconds'
+
+An index on machine_channel_crops(machine_id, ts) cannot serve that. `c.ts` is
+not a bare column on one side of the operator, so the planner can only use the
+`machine_id` equality as an index condition and applies the time window as a
+Filter — scanning ~24,800 crop rows per piece and discarding almost all of them.
+
+Measured on prod 2026-08-12: REFRESH MATERIALIZED VIEW CONCURRENTLY had been
+running for 6h20m and had never completed. CandidateMatviewWorker reloops it
+every 300s, so postgres ground this one query continuously; it was the whole of
+the box's ~180% CPU and its sustained load average of 3.1 on 2 cores.
+
+The fix moves the interval arithmetic to the piece side, which is algebraically
+identical and isolates `c.ts`:
+
+    c.ts <= coalesce(p.seen_at, p.recorded_at) + interval '1.5 seconds'
+    c.ts >= coalesce(p.seen_at, p.recorded_at) - interval '60 seconds'
+
+Now ix_machine_channel_crops_machine_ts serves the whole predicate as an Index
+Cond and the probe is an Index Only Scan returning ~23 rows in 0.06ms. Measured
+end to end with EXPLAIN (ANALYZE) on prod: 6h20m+ -> 17.0s, and the per-probe
+inner cost drops 6,142 -> 621.
+
+The view's semantics are unchanged, so this is a pure drop-and-recreate. It runs
+in the migration's transaction, so readers keep seeing the old view until commit
+rather than observing a missing relation; the tradeoff is that CREATE populates
+the view before committing, so the deploy holds the lock for that ~17s.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "d4f6a8b0c2e1"
+down_revision: Union[str, None] = "c9e1f3a5b7d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# The window constants still mirror channel_crop_lookup_params.DEFAULT_PARAMS
+# (lookback_window_s = 60, fwd_slop_s = 1.5). Crop-side form, for reference:
+#   c.ts BETWEEN arrival - 60s AND arrival + 1.5s
+_FIXED = """
+    CREATE MATERIALIZED VIEW piece_has_candidates AS
+    SELECT DISTINCT p.machine_id, p.piece_uuid
+    FROM machine_channel_crops c
+    JOIN machine_pieces p
+      ON p.machine_id = c.machine_id
+     AND c.ts <= coalesce(p.seen_at, p.recorded_at) + interval '1.5 seconds'
+     AND c.ts >= coalesce(p.seen_at, p.recorded_at) - interval '60 seconds'
+    WHERE c.ts IS NOT NULL
+"""
+
+_ORIGINAL = """
+    CREATE MATERIALIZED VIEW piece_has_candidates AS
+    SELECT DISTINCT p.machine_id, p.piece_uuid
+    FROM machine_channel_crops c
+    JOIN machine_pieces p
+      ON p.machine_id = c.machine_id
+     AND coalesce(p.seen_at, p.recorded_at) >= c.ts - interval '1.5 seconds'
+     AND coalesce(p.seen_at, p.recorded_at) <= c.ts + interval '60 seconds'
+    WHERE c.ts IS NOT NULL
+"""
+
+# REFRESH ... CONCURRENTLY requires a unique index, so it is recreated with the
+# view rather than left behind by the DROP.
+_UNIQUE_INDEX = (
+    "CREATE UNIQUE INDEX uq_piece_has_candidates_machine_piece "
+    "ON piece_has_candidates (machine_id, piece_uuid)"
+)
+
+
+def upgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS piece_has_candidates")
+    op.execute(_FIXED)
+    op.execute(_UNIQUE_INDEX)
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS piece_has_candidates")
+    op.execute(_ORIGINAL)
+    op.execute(_UNIQUE_INDEX)

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -384,11 +384,19 @@ def color_coverage(
 
 
 # "Has same-piece candidates" — a channel crop exists within the piece's
-# arrival window (DEFAULT_PARAMS lookback/slop). Computed live this was a
-# correlated EXISTS that Postgres planned as a machine_id-only hash semi join
-# (scanning each machine's whole crop set per piece, >100s); it's precomputed
-# into the piece_has_candidates materialized view instead (a8c1d2e3f4a5
-# migration, refreshed by CandidateMatviewWorker) and hash-joined here.
+# arrival window (DEFAULT_PARAMS lookback/slop). Precomputed into the
+# piece_has_candidates materialized view (a8c1d2e3f4a5, refreshed by
+# CandidateMatviewWorker) and hash-joined here; both the with_candidates filter
+# and the priority sort key read it, so it is needed for every row of the grid
+# before pagination, not just for a piece someone opens.
+#
+# The live correlated EXISTS this replaced was slow (>100s) for one specific
+# reason: `c.ts` sat under interval arithmetic, so no index could serve the time
+# window and each piece scanned its machine's whole crop set. d4f6a8b0c2e1 fixes
+# that by isolating `c.ts`. With that predicate the live EXISTS measures ~2.3s
+# for the worst case (unfiltered, priority sort, every piece), so dropping the
+# matview and computing this inline is a real option if the refresh ever becomes
+# a nuisance again — it was never the concept that was expensive.
 _piece_has_candidates = sa_table(
     "piece_has_candidates",
     sa_column("machine_id", PGUUID(as_uuid=True)),


### PR DESCRIPTION
## What

`REFRESH MATERIALIZED VIEW CONCURRENTLY piece_has_candidates` had been running for **6 h 20 m** on prod and had never completed. `CandidateMatviewWorker` reloops it every 300 s, so Postgres was grinding this one query **continuously** — it accounted for the entirety of the box's ~180% CPU and its sustained load average of 3.1 on 2 cores. It logs at INFO and the app runs above that, so it was silent.

## Cause

The crop-side condition buried `c.ts` under interval arithmetic:

```sql
coalesce(p.seen_at, p.recorded_at) >= c.ts - interval '1.5 seconds'
coalesce(p.seen_at, p.recorded_at) <= c.ts + interval '60 seconds'
```

`c.ts` is not isolated, so `ix_machine_channel_crops_machine_ts` cannot serve it. The planner got only the `machine_id` equality as an Index Cond and applied the time window as a **Filter**, scanning ~24,800 crop rows per piece to keep ~23.

This is exactly the pathology the `a8c1d2e3f4a5` migration docstring says the matview was created to fix. The matview reproduced it.

## Fix

Move the arithmetic to the piece side. Algebraically identical, and it isolates `c.ts`:

```sql
c.ts <= coalesce(p.seen_at, p.recorded_at) + interval '1.5 seconds'
c.ts >= coalesce(p.seen_at, p.recorded_at) - interval '60 seconds'
```

## Measured on prod, with `EXPLAIN (ANALYZE)`

| | before | after |
|---|---|---|
| refresh | 6 h 20 m+, never finished | **17.0 s** |
| inner probe cost | 6,142 | **621** |
| per probe | 24,819 rows scanned | **23 rows, 0.061 ms** |

Plan changes from `Index Scan using ix_machine_channel_crops_machine_local_id` (window as a Filter) to `Index Only Scan using ix_machine_channel_crops_machine_ts` with the full window as an Index Cond.

## Correctness

Verified, not assumed. On overlapping sampled prod rows both forms return **1,091 identical keys**, with an empty `EXCEPT` in both directions.

## Notes

- Pure drop-and-recreate; view semantics unchanged. It runs inside the migration transaction, so readers keep seeing the old view until commit — the tradeoff is the deploy holds the lock for the ~17 s the `CREATE` takes to populate.
- Also corrects the comment in `piece_color_labels.py` that blamed the live `EXISTS` for being inherently slow. It was slow for this same reason; with the predicate fixed the live `EXISTS` measures ~2.3 s worst case, so dropping the matview entirely is a real future option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)