### PR TITLE
docs(top-interface): framing step + parts-needed section

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -202,7 +202,8 @@ Adding a drawing: new YAML source, an entry in the data file, an entry in the
 
 `src/liquid/_data/parts.yml` is the catalog, keyed by id. Fields: `name`,
 `image`, `page` (detail page, optional), `category` (groups the "Parts
-needed" block), `notes` (short, shown under the block),
+needed" block), `notes` (short, collected into a list under the whole block),
+`caption` (small text under a single card, e.g. a cut length),
 `heat_inserts: [{insert, qty}]`. ids and render filenames mirror the
 `sorter-v2-filament-calculator` repo so the two merge cleanly later.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -215,6 +215,10 @@ needed" block), `notes` (short, collected into a list under the whole block),
   with no page.
 - The **Preparation** page (`hardware/preparation/`) auto-lists every part with
   `heat_inserts` — add that field and the part appears in the checklist.
+- Name the specific fastener inline in a step where it is used. When a step
+  uses a screw whose size/type is not known yet, mark it with
+  `<span class="fastener-todo">fastener not recorded</span>` so contributors
+  can find and fill the gaps (styled in `layout.css`).
 - Keep procedural warnings (torque, ordering) in a **callout on the assembly
   page**, not in a part's `notes`.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -43,6 +43,8 @@ parts_needed:
     qty: 5
   - part: interface-cage-bracket-cable
     qty: 1
+  - part: top-plate
+    qty: 1
   - part: cable-cage-top
     qty: 1
   - part: cable-cage-bottom
@@ -93,6 +95,13 @@ parts_needed:
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p>The screws, T-nuts, and nuts in the parts list above, and all of the quantities, are a best guess and need checking before this page is published. The printed parts, extrusion, bearing, motor, and cabling are drawn from the assembly itself.</p>
 </div>
+
+Several steps below refer to holes in the Top plate by name (S2 and S3 for the stepper mount, I1 to I6 and O1 to O6 for the interface brackets). This map shows which hole is which:
+
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/top-plate-hole-map.756f0dae2288fdb2.jpg" alt="Hole map of the hexagonal top plate: three stepper holes S1 to S3 in a row left of the center opening, six inner-ring holes I1 to I6, six outer-ring holes O1 to O6, and five cable holes C1 to C5, colour-coded by group">
+  <figcaption>Top plate hole map. S = stepper trio, I = inner ring, O = outer ring, C = cable holes.</figcaption>
+</figure>
 
 
 {% include step.html n="1" title="Attach the interface ribs to the upper fixed section" %}

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -91,7 +91,7 @@ parts_needed:
     qty: 4
   - part: scr-m3-35-bhcs
     qty: 1
-  - part: scr-m3-10
+  - part: scr-m3-10-shcs
     qty: 2
   - part: tnut-m5-2020
     qty: 56
@@ -291,7 +291,7 @@ Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable
     loading="lazy"></iframe>
 </div>
 
-Place an M3 nut into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two M3 × 10 mm screws.
+Place an M3 nut into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two M3 × 10 mm socket head screws.
 
 Rotate the chute until it hits the limit switch.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -180,7 +180,7 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
     loading="lazy"></iframe>
 </div>
 
-Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with an M5 × 16 mm button head screw. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
+Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with a screw <span class="fastener-todo">fastener not recorded</span>. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
 
 Repeat with the 5 other prepared Interface brackets into the 5 other Interface ribs.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -304,19 +304,19 @@ After this step the chute should still rotate to each of its limits.
 Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with 4 screws into 4 T-nuts.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-1.fbda1317264f8eec.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-1.ae2ef835181f63bd.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">
 </figure>
 
 Slide an Interface spacer onto each piece of extrusion, with the lip at the top facing toward the center of the assembly.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-2.8a1bb7db57d76b85.jpg" alt="An interface spacer slid onto each vertical extrusion support, lips facing inward">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-2.b6e8241ef78d74d0.jpg" alt="An interface spacer slid onto each vertical extrusion support, lips facing inward">
 </figure>
 
 Follow the first two stages of a regular layer, then place the regular layer assembly onto the interface assembly.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.2a49c8f1de5726ed.jpg" alt="A regular layer assembly lowered onto the interface assembly">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.28f9d54d3c156c6b.jpg" alt="A regular layer assembly lowered onto the interface assembly">
 </figure>
 
 Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 M5 × 16 mm screws tapped into the holes at the base of the External bracket sides, bracing against the extrusion.
@@ -324,5 +324,5 @@ Attach an External bracket cover to each of the External bracket sides, then fas
 The top interface is now complete.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-4.103ce98e106b4312.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-4.e49b6ce3304489d5.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
 </figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -316,7 +316,7 @@ Slide an Interface spacer onto each piece of extrusion, with the lip at the top 
 Follow the first two stages of a regular layer, then place the regular layer assembly onto the interface assembly.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.28f9d54d3c156c6b.jpg" alt="A regular layer assembly lowered onto the interface assembly">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.e49b6ce3304489d5.jpg" alt="A regular layer assembly lowered onto the interface assembly">
 </figure>
 
 Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 M5 × 16 mm screws tapped into the holes at the base of the External bracket sides, bracing against the extrusion.
@@ -324,5 +324,5 @@ Attach an External bracket cover to each of the External bracket sides, then fas
 The top interface is now complete.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-4.e49b6ce3304489d5.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-4.28f9d54d3c156c6b.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
 </figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -180,7 +180,7 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
     loading="lazy"></iframe>
 </div>
 
-Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with a screw <span class="fastener-todo">fastener not recorded</span>. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
+Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with an M5 × 16 mm button head screw. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
 
 Repeat with the 5 other prepared Interface brackets into the 5 other Interface ribs.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -8,7 +8,92 @@ kicker: Distribution — Top interface
 lede: The interface between the feeder and the bin tower.
 permalink: /hardware/assembly/distribution/top-interface/
 author: zed0
+parts_needed:
+  - part: interface-upper-fixed-section
+    qty: 1
+  - part: interface-rib
+    qty: 5
+  - part: interface-rib-switch
+    qty: 1
+  - part: interface-bracket
+    qty: 6
+  - part: interface-spacer
+    qty: 6
+  - part: interface-nema23-bracket
+    qty: 1
+  - part: interface-big-spacer
+    qty: 1
+  - part: limit-switch-housing
+    qty: 1
+  - part: limit-switch-dowel-pin
+    qty: 1
+  - part: limit-switch-hammer
+    qty: 1
+  - part: top-interface-split-spur-gear-3
+    qty: 1
+  - part: top-interface-split-spur-gear-1
+    qty: 1
+  - part: top-interface-split-spur-gear-2
+    qty: 1
+  - part: interface-spur-gear
+    qty: 1
+  - part: interface-idler-gear
+    qty: 1
+  - part: interface-cage-bracket
+    qty: 5
+  - part: interface-cage-bracket-cable
+    qty: 1
+  - part: cable-cage-top
+    qty: 1
+  - part: cable-cage-bottom
+    qty: 1
+  - part: cable-clamp-outer
+    qty: 1
+  - part: cable-clamp-inner
+    qty: 1
+  - part: ribbon-cable-clamp
+    qty: 1
+  - part: ext-bracket-left
+    qty: 6
+  - part: ext-bracket-cover
+    qty: 6
+  - part: extrusion-e
+    qty: 6
+  - part: extrusion-f
+    qty: 6
+  - part: lazy-susan
+    qty: 1
+  - part: brg-608-2rs
+    qty: 1
+  - part: motor-nema23
+    qty: 1
+  - part: pulley-20t-8mm
+    qty: 1
+  - part: endstop-mechanical
+    qty: 1
+  - part: cable-idc-2x8-long
+    qty: 1
+  - part: scr-m5-16-shcs
+    qty: 24
+  - part: scr-m5-12-shcs
+    qty: 48
+  - part: m4-12mm-countersunk
+    qty: 8
+  - part: scr-m3-8-cs
+    qty: 20
+  - part: scr-m3-6-bhcs
+    qty: 1
+  - part: tnut-m5-2020
+    qty: 48
+  - part: nut-m5
+    qty: 6
 ---
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>The screws, T-nuts, and nuts in the parts list above, and all of the quantities, are a best guess and need checking before this page is published. The printed parts, extrusion, bearing, motor, and cabling are drawn from the assembly itself.</p>
+</div>
+
 
 {% include step.html n="1" title="Attach the interface ribs to the upper fixed section" %}
 
@@ -214,6 +299,30 @@ Place the Cable cage bottom over the Top interface chute mount. Use 6 nuts and b
 
 After this step the chute should still rotate to each of its limits.
 
----
+{% include step.html n="12" title="Attach the framing" %}
 
-_Steps for mounting the full interface frame are coming._
+Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with 4 screws into 4 T-nuts.
+
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-1.fbda1317264f8eec.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">
+</figure>
+
+Slide an Interface spacer onto each piece of extrusion, with the lip at the top facing toward the center of the assembly.
+
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-2.8a1bb7db57d76b85.jpg" alt="An interface spacer slid onto each vertical extrusion support, lips facing inward">
+</figure>
+
+Follow the first two stages of a regular layer, then place the regular layer assembly onto the interface assembly.
+
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.2a49c8f1de5726ed.jpg" alt="A regular layer assembly lowered onto the interface assembly">
+</figure>
+
+Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 M5 × 16 mm screws tapped into the holes at the base of the External bracket sides, bracing against the extrusion.
+
+The top interface is now complete.
+
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-4.103ce98e106b4312.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
+</figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -75,25 +75,35 @@ parts_needed:
     qty: 1
   - part: cable-idc-2x8-long
     qty: 1
-  - part: scr-m5-16-shcs
+  - part: scr-m5-35-shcs
+    qty: 6
+  - part: scr-m5-25-shcs
+    qty: 6
+  - part: scr-m5-22-cs
+    qty: 15
+  - part: scr-m5-20-bhcs
     qty: 24
+  - part: scr-m5-16-bhcs
+    qty: 36
+  - part: scr-m5-16-shcs
+    qty: 2
   - part: scr-m5-12-shcs
-    qty: 48
-  - part: m4-12mm-countersunk
-    qty: 8
-  - part: scr-m3-8-cs
-    qty: 20
-  - part: scr-m3-6-bhcs
+    qty: 4
+  - part: scr-m3-35-bhcs
     qty: 1
+  - part: scr-m3-10
+    qty: 2
   - part: tnut-m5-2020
-    qty: 48
+    qty: 56
   - part: nut-m5
     qty: 6
+  - part: nut-m3
+    qty: 1
 ---
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>The screws, T-nuts, and nuts in the parts list above, and all of the quantities, are a best guess and need checking before this page is published. The printed parts, extrusion, bearing, motor, and cabling are drawn from the assembly itself.</p>
+  <p>The fasteners and quantities in the parts list come from the build notes and are called out inline at each step. A few smaller screws are not recorded yet; those are marked <span class="fastener-todo">fastener not recorded</span> in the steps below. If you know one, please add its size.</p>
 </div>
 
 Several steps below refer to holes in the Top plate by name (S2 and S3 for the stepper mount, I1 to I6 and O1 to O6 for the interface brackets). This map shows which hole is which:
@@ -115,13 +125,13 @@ Several steps below refer to holes in the Top plate by name (S2 and S3 for the s
     loading="lazy"></iframe>
 </div>
 
-Attach the Interface rib (switch gap) to the Interface upper fixed section, two positions counterclockwise of the notch for the stepper mount. Use two screws tapping directly into the plastic.
+Attach the Interface rib (switch gap) to the Interface upper fixed section, two positions counterclockwise of the notch for the stepper mount. Use two M5 × 16 mm button head screws, tapping directly into the plastic.
 
-Attach the remaining 5 Interface ribs to the Interface upper fixed section, two screws each, again tapping into the plastic.
+Attach the remaining 5 Interface ribs to the Interface upper fixed section, two M5 × 16 mm button head screws each, again tapping into the plastic.
 
-Slot the Interface NEMA 23 bracket into the Interface upper fixed section and secure it with a screw from below.
+Slot the Interface NEMA 23 bracket into the Interface upper fixed section and secure it with a screw from below <span class="fastener-todo">fastener not recorded</span>.
 
-Attach the whole assembly to the bottom of the Top plate with screws through holes S2 and S3 into the Interface NEMA 23 bracket.
+Attach the whole assembly to the bottom of the Top plate with M5 × 22 mm countersunk screws through holes S2 and S3 into the Interface NEMA 23 bracket.
 
 {% include step.html n="2" title="Prepare the interface brackets" %}
 
@@ -138,7 +148,7 @@ Align an Interface bracket with piece E (Interface spoke, long) of aluminum extr
 
 Place T-nuts in the extrusion, lined up with the 4 holes on the side of the Interface bracket.
 
-Slide the extrusion into the Interface bracket, careful not to dislodge the T-nuts, and screw them in.
+Slide the extrusion into the Interface bracket, careful not to dislodge the T-nuts, and drive four M5 × 16 mm button head screws into them.
 
 Repeat for all 6 Interface brackets.
 
@@ -155,9 +165,9 @@ Repeat for all 6 Interface brackets.
 
 Push the Printed dowel pin into the Limit switch housing.
 
-Attach a Roller lever limit switch with 2 screws so the roller sits next to the dowel pin.
+Attach a Roller lever limit switch with 2 screws <span class="fastener-todo">fastener not recorded</span> so the roller sits next to the dowel pin.
 
-Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and screw the Limit switch housing to the extrusion. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
+Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two M5 × 16 mm socket head screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
 {% include step.html n="4" title="Install the brackets" %}
 
@@ -170,11 +180,11 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
     loading="lazy"></iframe>
 </div>
 
-Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with a screw. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
+Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with a screw <span class="fastener-todo">fastener not recorded</span>. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
 
 Repeat with the 5 other prepared Interface brackets into the 5 other Interface ribs.
 
-Flip the whole assembly and screw all 6 Interface brackets into place through holes I1 to I6 and O1 to O6.
+Flip the whole assembly and screw all 6 Interface brackets into place with M5 × 22 mm countersunk screws through holes I1 to I6 and O1 to O6.
 
 {% include step.html n="5" title="Prepare the interface chute gear and mount" %}
 
@@ -187,11 +197,11 @@ Flip the whole assembly and screw all 6 Interface brackets into place through ho
     loading="lazy"></iframe>
 </div>
 
-Slot the Limit switch hammer into the Top interface chute mount, then screw it in place from below.
+Slot the Limit switch hammer into the Top interface chute mount, then screw it in place from below <span class="fastener-todo">fastener not recorded</span>.
 
-Align the Chute gear on the Top interface chute mount with the notch by the screw for the Limit switch hammer. Attach it with 5 screws.
+Align the Chute gear on the Top interface chute mount with the notch by the screw for the Limit switch hammer. Attach it with 5 screws <span class="fastener-todo">fastener not recorded</span>.
 
-Align the Top interface lazy Susan washer with the 4 inner heat inserts on the Top interface chute mount. Align the inner ring of the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) with these 4 heat inserts too. Screw the Lazy Susan into position through the washer and into the Top interface chute mount.
+Align the Top interface lazy Susan washer with the 4 inner heat inserts on the Top interface chute mount. Align the inner ring of the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) with these 4 heat inserts too. Screw the Lazy Susan into position through the washer and into the Top interface chute mount <span class="fastener-todo">fastener not recorded</span>.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -213,9 +223,9 @@ Once complete, the free section of the Lazy Susan should rotate freely.
 
 Place the Interface big spacer on the Interface upper fixed section with its 4 holes lined up with the 4 heat inserts.
 
-Rotate the free part of the Lazy Susan on the assembled interface chute so that 3 of its holes line up with the holes in the Top interface chute mount. Place the assembly on top of the Interface big spacer with the 3 holes aligned with 3 of the heat inserts. Screw these together tightly.
+Rotate the free part of the Lazy Susan on the assembled interface chute so that 3 of its holes line up with the holes in the Top interface chute mount. Place the assembly on top of the Interface big spacer with the 3 holes aligned with 3 of the heat inserts. Screw these together tightly <span class="fastener-todo">fastener not recorded</span>.
 
-Rotate the Top interface chute mount 90 degrees relative to the Interface upper fixed section to reveal the 4th screw hole in the Lazy Susan (it should also line up with a hole in the Interface big spacer and a heat insert). Drive a screw tightly through this hole.
+Rotate the Top interface chute mount 90 degrees relative to the Interface upper fixed section to reveal the 4th screw hole in the Lazy Susan (it should also line up with a hole in the Interface big spacer and a heat insert). Drive a screw <span class="fastener-todo">fastener not recorded</span> tightly through this hole.
 
 Once done, check that the chute rotates freely relative to the Interface upper fixed section.
 
@@ -243,13 +253,13 @@ Loosen the screws attaching the Limit switch housing to the extrusion. Slide the
     loading="lazy"></iframe>
 </div>
 
-Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }}) over the shaft of the NEMA 23 stepper motor and tighten the two worm screws on its side. Slide the Interface spur gear onto the Timing pulley and secure it with 5 screws, half tapped into the Interface spur gear and half bracing against the Timing pulley.
+Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }}) over the shaft of the NEMA 23 stepper motor and tighten the two worm screws on its side. Slide the Interface spur gear onto the Timing pulley and secure it with 5 screws <span class="fastener-todo">fastener not recorded</span>, half tapped into the Interface spur gear and half bracing against the Timing pulley.
 
 Push a 608 2RS bearing into the Interface idler gear.
 
-Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards and secure it with a button head screw (the video uses a screw with a washer).
+Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards and secure it with a button head screw <span class="fastener-todo">fastener not recorded</span> (the video uses a screw with a washer).
 
-Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with 4 screws.
+Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four M5 × 12 mm screws.
 
 At this point the chute should still rotate, but you will now feel resistance from the stepper motor.
 
@@ -266,9 +276,9 @@ At this point the chute should still rotate, but you will now feel resistance fr
 
 Slot the Cable cage top over the Top interface chute mount, with the corners of the hexagon aligning with the Interface brackets.
 
-Place the Cable cage bracket (cable mount) on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable). Screw it into the Interface bracket, clamping down the Cable cage top.
+Place the Cable cage bracket (cable mount) on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable). Screw it into the Interface bracket with an M5 × 25 mm socket head screw and a T-nut, clamping down the Cable cage top.
 
-Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable cage top.
+Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable cage top with M5 × 25 mm socket head screws and T-nuts.
 
 {% include step.html n="10" title="Put the cable in the cable cage" %}
 
@@ -281,7 +291,7 @@ Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable
     loading="lazy"></iframe>
 </div>
 
-Place a nut into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with 2 screws.
+Place an M3 nut into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two M3 × 10 mm screws.
 
 Rotate the chute until it hits the limit switch.
 
@@ -289,9 +299,9 @@ Fold your IDC ribbon cable around the Cable clamp (inner), following the guides 
 
 Guide the rest of the ribbon cable around the side of the Top interface chute mount, in the direction the chute can rotate, back to the Cable cage bracket (cable mount).
 
-Screw the Ribbon cable clamp lightly to the Cable cage bracket (cable mount), clamping the ribbon cable between the two.
+Screw the Ribbon cable clamp <span class="fastener-todo">fastener not recorded</span> lightly to the Cable cage bracket (cable mount), clamping the ribbon cable between the two.
 
-Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long screw through the Cable clamp (inner) into the nut in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
+Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long M3 × 35 mm screw through the Cable clamp (inner) into the M3 nut in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
 
 {% include step.html n="11" title="Attach the cable cage bottom" %}
 
@@ -304,13 +314,13 @@ Check that the chute can rotate fully to the limit switch in both directions, th
     loading="lazy"></iframe>
 </div>
 
-Place the Cable cage bottom over the Top interface chute mount. Use 6 nuts and bolts to clamp the Cable cage bottom, Cable cage top, and Cable cage brackets together.
+Place the Cable cage bottom over the Top interface chute mount. Use 6 M5 × 35 mm socket head screws and M5 nuts to clamp the Cable cage bottom, Cable cage top, and Cable cage brackets together.
 
 After this step the chute should still rotate to each of its limits.
 
 {% include step.html n="12" title="Attach the framing" %}
 
-Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with 4 screws into 4 T-nuts.
+Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with four M5 × 20 mm button head screws into four T-nuts.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-1.ae2ef835181f63bd.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -34,6 +34,7 @@
 									<span class="part-card-name">
 										{#if part.page}<a href={part.page}>{part.name}</a>{:else}{part.name}{/if}
 									</span>
+									{#if part.caption}<span class="part-card-caption">{part.caption}</span>{/if}
 								{/if}
 							</li>
 						{/each}

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -224,6 +224,7 @@ export type ResolvedPart = {
 	page?: string;
 	qty?: number;
 	notes?: string;
+	caption?: string;
 	missing?: boolean;
 };
 export type PartsGroup = { category: string; parts: ResolvedPart[] };
@@ -241,6 +242,7 @@ function resolveParts(partsNeeded: any[]): { groups: PartsGroup[]; notes: Resolv
 			image: part.image,
 			page: part.page,
 			notes: part.notes,
+			caption: part.caption,
 			qty,
 			category: part.category ?? 'Other'
 		};

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -149,11 +149,13 @@ interface-idler-gear:
 
 cable-cage-top:
   name: Cable cage top
-  category: Printed parts
+  category: Laser-cut parts
+  image: https://img.basically.website/web/parts/top-interface/cable-cage-top.0856e376cd2b9238.jpg
 
 cable-cage-bottom:
   name: Cable cage bottom
-  category: Printed parts
+  category: Laser-cut parts
+  image: https://img.basically.website/web/parts/top-interface/cable-cage-bottom.72b2038544dec559.jpg
 
 interface-cage-bracket:
   name: Cable cage bracket

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -1,9 +1,11 @@
 # Catalog of known parts, keyed by id. An assembly page lists what it needs with
 # `parts_needed: [{part: id, qty: N}, ...]` and the "Parts needed" block renders
 # each entry — primary image + name (linked to its detail page when one exists),
-# grouped by `category`, with any `notes` surfaced below.
+# grouped by `category`, with any `notes` surfaced in a list below the cards.
 #
-# Fields: name (required), image, page, category, notes (all optional).
+# Fields: name (required), image, page, category, notes, caption (all optional).
+# `caption` is small text shown directly under a card (e.g. a cut length),
+# distinct from `notes`, which collects into the block beneath the whole group.
 #
 # ids, names, and render filenames mirror the sorter-v2-filament-calculator repo
 # so the two stay aligned for the eventual merge into this repo.

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -218,7 +218,6 @@ cable-idc-2x8-long:
   name: IDC ribbon cable, 16-pin (2x8), 1 m
   category: Electronics
   image: https://img.basically.website/web/parts/hardware/electronics/cable-idc-2x8-long.78c80cba0d300af0.jpg
-  notes: Length is a guess; could be the 30 cm variant.
 
 scr-m5-12-shcs:
   name: M5 x 12 mm socket head cap screw

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -186,13 +186,13 @@ extrusion-e:
   name: Interface spoke, long (extrusion E)
   category: Extrusion
   image: https://img.basically.website/web/parts/top-interface/extrusion-e.bce3a0752b0f99f5.png
-  notes: 2020 aluminum extrusion cut to 238 mm. Piece E on the framing cut list.
+  caption: 2020 aluminum extrusion, cut to 238 mm (piece E).
 
 extrusion-f:
   name: Interface vertical support (extrusion F)
   category: Extrusion
   image: https://img.basically.website/web/parts/top-interface/extrusion-f.7e1f6b2dc9e069f7.png
-  notes: 2020 aluminum extrusion cut to 274 mm. Piece F on the framing cut list.
+  caption: 2020 aluminum extrusion, cut to 274 mm (piece F).
 
 brg-608-2rs:
   name: 608 2RS bearing

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -232,15 +232,40 @@ scr-m5-12-shcs:
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
-scr-m3-8-cs:
-  name: M3 x 8 mm countersunk screw
+scr-m5-35-shcs:
+  name: M5 × 35 mm socket head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+
+scr-m5-25-shcs:
+  name: M5 × 25 mm socket head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+
+scr-m5-22-cs:
+  name: M5 × 22 mm countersunk screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
 
-scr-m3-6-bhcs:
-  name: M3 x 6 mm button head cap screw
+scr-m5-20-bhcs:
+  name: M5 × 20 mm button head cap screw
   category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/m3-button.87be93e901c86545.jpg
+  image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+
+scr-m5-16-bhcs:
+  name: M5 × 16 mm button head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+
+scr-m3-35-bhcs:
+  name: M3 × 35 mm button head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+
+scr-m3-10:
+  name: M3 × 10 mm screw
+  category: Screws
+  caption: Head type not yet recorded.
 
 tnut-m5-2020:
   name: M5 roll-in T-nut (2020)
@@ -249,5 +274,10 @@ tnut-m5-2020:
 
 nut-m5:
   name: M5 nut
+  category: Nuts
+  image: https://img.basically.website/web/parts/hardware/nuts/nut-m5.4a3db788bb1ca8a2.jpg
+
+nut-m3:
+  name: M3 nut
   category: Nuts
   image: https://img.basically.website/web/parts/hardware/nuts/nut-m5.4a3db788bb1ca8a2.jpg

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -68,3 +68,172 @@ ext-bracket-cover:
 scr-m5-16-shcs:
   name: M5 × 16 mm socket head cap screw
   category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/scr-m5-16-shcs.84fe29409130e7ab.png
+
+# --- Top interface assembly: parts for the framing step and the parts-needed section ---
+
+interface-upper-fixed-section:
+  name: Interface upper fixed section
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-upper-fixed-section.43022d76c3781bf3.png
+
+interface-rib:
+  name: Interface rib
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-rib.e1f78a4bb85ac058.png
+
+interface-rib-switch:
+  name: Interface rib (switch gap)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-rib-switch.228974f9f11bc476.png
+
+interface-bracket:
+  name: Interface bracket
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-bracket.06c0c5896cd8eada.png
+
+interface-spacer:
+  name: Interface spacer
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-spacer.6e705203cb9a28cc.png
+
+interface-nema23-bracket:
+  name: Interface NEMA 23 bracket
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-nema23-bracket.65680e73221cff98.png
+
+interface-big-spacer:
+  name: Interface big spacer
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-big-spacer.db6c33380531b205.png
+
+limit-switch-housing:
+  name: Limit switch housing
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/limit-switch-housing.6e5f8214b3702dbc.png
+
+limit-switch-dowel-pin:
+  name: Printed dowel pin
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/limit-switch-dowel-pin.1d9942a3d5b3d1cd.png
+
+limit-switch-hammer:
+  name: Limit switch hammer
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/limit-switch-hammer.e125ead0312a27d0.png
+
+top-interface-split-spur-gear-3:
+  name: Top interface chute mount
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/top-interface-split-spur-gear-3.38a5bd2da98bbe1a.png
+
+top-interface-split-spur-gear-1:
+  name: Chute gear
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/top-interface-split-spur-gear-1.53f641b54c0a2025.png
+
+top-interface-split-spur-gear-2:
+  name: Top interface lazy Susan washer
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/top-interface-split-spur-gear-2.3957a51534edf294.png
+
+interface-spur-gear:
+  name: Interface spur gear (2M 25T)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-spur-gear.4ac1e106d8a7814d.png
+
+interface-idler-gear:
+  name: Interface idler gear (2M 25T)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-idler-gear.bcf557482f5a061f.png
+
+cable-cage-top:
+  name: Cable cage top
+  category: Printed parts
+
+cable-cage-bottom:
+  name: Cable cage bottom
+  category: Printed parts
+
+interface-cage-bracket:
+  name: Cable cage bracket
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-cage-bracket.bd245c6306f15e5f.png
+
+interface-cage-bracket-cable:
+  name: Cable cage bracket (cable mount)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/interface-cage-bracket-cable.cc282a11d3fc5359.png
+
+cable-clamp-outer:
+  name: Cable clamp (outer)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/cable-clamp-outer.a6beadc0de7f26c7.png
+
+cable-clamp-inner:
+  name: Cable clamp (inner)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/cable-clamp-inner.05cabbf3bbc70448.png
+
+ribbon-cable-clamp:
+  name: Ribbon cable clamp
+  category: Printed parts
+  image: https://img.basically.website/web/parts/top-interface/ribbon-cable-clamp.5ff6e38d86a3ee4c.png
+
+extrusion-e:
+  name: Interface spoke, long (extrusion E)
+  category: Extrusion
+  image: https://img.basically.website/web/parts/top-interface/extrusion-e.bce3a0752b0f99f5.png
+  notes: 2020 aluminum extrusion cut to 238 mm. Piece E on the framing cut list.
+
+extrusion-f:
+  name: Interface vertical support (extrusion F)
+  category: Extrusion
+  image: https://img.basically.website/web/parts/top-interface/extrusion-f.7e1f6b2dc9e069f7.png
+  notes: 2020 aluminum extrusion cut to 274 mm. Piece F on the framing cut list.
+
+brg-608-2rs:
+  name: 608 2RS bearing
+  category: Bearings
+
+motor-nema23:
+  name: NEMA 23 stepper motor
+  category: Motors
+
+pulley-20t-8mm:
+  name: Timing pulley
+  category: Pulleys
+  notes: Best guess at the pulley; confirm before publishing.
+
+endstop-mechanical:
+  name: Roller lever limit switch (V-155-1C25)
+  category: Electronics
+
+cable-idc-2x8-long:
+  name: IDC ribbon cable, 16-pin (2x8), 1 m
+  category: Electronics
+  notes: Length is a guess; could be the 30 cm variant.
+
+scr-m5-12-shcs:
+  name: M5 x 12 mm socket head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/scr-m5-12-shcs.fccd5dad98a0d6ec.png
+
+scr-m3-8-cs:
+  name: M3 x 8 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/scr-m3-8-cs.c6bd5c001e587c04.png
+
+scr-m3-6-bhcs:
+  name: M3 x 6 mm button head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/scr-m3-6-bhcs.b497e4b8a7f059c9.png
+
+tnut-m5-2020:
+  name: M5 roll-in T-nut (2020)
+  category: Nuts
+  image: https://img.basically.website/web/parts/hardware/nuts/tnut-m5-2020.f0beef4bed1785f1.png
+
+nut-m5:
+  name: M5 nut
+  category: Nuts

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -68,7 +68,7 @@ ext-bracket-cover:
 scr-m5-16-shcs:
   name: M5 × 16 mm socket head cap screw
   category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/scr-m5-16-shcs.84fe29409130e7ab.png
+  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
 # --- Top interface assembly: parts for the framing step and the parts-needed section ---
 
@@ -195,45 +195,51 @@ extrusion-f:
 brg-608-2rs:
   name: 608 2RS bearing
   category: Bearings
+  image: https://img.basically.website/web/parts/hardware/bearings/brg-608-2rs.2a896b36c1da4ef2.jpg
 
 motor-nema23:
   name: NEMA 23 stepper motor
   category: Motors
+  image: https://img.basically.website/web/parts/hardware/motors/motor-nema23.0a18ad4145b45f71.jpg
 
 pulley-20t-8mm:
   name: Timing pulley
   category: Pulleys
+  image: https://img.basically.website/web/parts/hardware/pulleys/pulley-20t-8mm.75040004a32a0f14.jpg
   notes: Best guess at the pulley; confirm before publishing.
 
 endstop-mechanical:
   name: Roller lever limit switch (V-155-1C25)
   category: Electronics
+  image: https://img.basically.website/web/parts/hardware/electronics/endstop-mechanical.d54e0ccc62893dea.jpg
 
 cable-idc-2x8-long:
   name: IDC ribbon cable, 16-pin (2x8), 1 m
   category: Electronics
+  image: https://img.basically.website/web/parts/hardware/electronics/cable-idc-2x8-long.78c80cba0d300af0.jpg
   notes: Length is a guess; could be the 30 cm variant.
 
 scr-m5-12-shcs:
   name: M5 x 12 mm socket head cap screw
   category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/scr-m5-12-shcs.fccd5dad98a0d6ec.png
+  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
 scr-m3-8-cs:
   name: M3 x 8 mm countersunk screw
   category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/scr-m3-8-cs.c6bd5c001e587c04.png
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
 
 scr-m3-6-bhcs:
   name: M3 x 6 mm button head cap screw
   category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/scr-m3-6-bhcs.b497e4b8a7f059c9.png
+  image: https://img.basically.website/web/parts/hardware/screws/m3-button.87be93e901c86545.jpg
 
 tnut-m5-2020:
   name: M5 roll-in T-nut (2020)
   category: Nuts
-  image: https://img.basically.website/web/parts/hardware/nuts/tnut-m5-2020.f0beef4bed1785f1.png
+  image: https://img.basically.website/web/parts/hardware/nuts/tnut-m5-2020-photo.1bcc565052be1e9e.jpg
 
 nut-m5:
   name: M5 nut
   category: Nuts
+  image: https://img.basically.website/web/parts/hardware/nuts/nut-m5.4a3db788bb1ca8a2.jpg

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -149,6 +149,12 @@ interface-idler-gear:
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/interface-idler-gear.bcf557482f5a061f.png
 
+top-plate:
+  name: Top plate
+  category: Laser-cut parts
+  image: https://img.basically.website/web/parts/top-interface/top-plate.fb89181642abbe25.jpg
+  caption: The machine's hexagonal top plate; the interface mounts under it.
+
 cable-cage-top:
   name: Cable cage top
   category: Laser-cut parts

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -208,7 +208,6 @@ pulley-20t-8mm:
   name: Timing pulley
   category: Pulleys
   image: https://img.basically.website/web/parts/hardware/pulleys/pulley-20t-8mm.75040004a32a0f14.jpg
-  notes: Best guess at the pulley; confirm before publishing.
 
 endstop-mechanical:
   name: Roller lever limit switch (V-155-1C25)

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -262,10 +262,10 @@ scr-m3-35-bhcs:
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
 
-scr-m3-10:
-  name: M3 × 10 mm screw
+scr-m3-10-shcs:
+  name: M3 × 10 mm socket head cap screw
   category: Screws
-  caption: Head type not yet recorded.
+  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
 tnut-m5-2020:
   name: M5 roll-in T-nut (2020)

--- a/docs/src/liquid/_includes/page-requirements.html
+++ b/docs/src/liquid/_includes/page-requirements.html
@@ -50,6 +50,7 @@ Unknown ids render the raw id so a missing catalog entry is visible, not silent.
               <span class="part-card-name">
                 {% if part.page %}<a href="{{ part.page | relative_url }}">{{ part.name }}</a>{% else %}{{ part.name }}{% endif %}
               </span>
+              {% if part.caption %}<span class="part-card-caption">{{ part.caption }}</span>{% endif %}
             {% else %}
               <span class="part-card-name part-card-missing">{{ pid }}</span>
             {% endif %}

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -598,6 +598,16 @@ body {
 	color: var(--muted);
 }
 
+.fastener-todo {
+	display: inline-block;
+	padding: 0 6px;
+	font-size: 0.82em;
+	font-weight: 600;
+	color: var(--ink);
+	background: color-mix(in srgb, var(--color-warning) 16%, var(--surface));
+	border: 1px solid color-mix(in srgb, var(--color-warning) 45%, transparent);
+}
+
 .part-card-missing {
 	color: var(--muted);
 	font-family: var(--font-mono);

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -591,6 +591,13 @@ body {
 	text-decoration: underline;
 }
 
+.part-card-caption {
+	margin-top: 3px;
+	font-size: 0.72rem;
+	line-height: 1.35;
+	color: var(--muted);
+}
+
 .part-card-missing {
 	color: var(--muted);
 	font-family: var(--font-mono);


### PR DESCRIPTION
Completes the **Top interface** assembly page (`docs/`), built out from zed0's source doc and verified against the assembly videos with barthel.

### What's on it
- **New "Attach the framing" step** (the doc's final section), with the text and four full-resolution, auto-cropped photos.
- **Parts needed** block listing every component: the interface printed parts, the E/F extrusion pieces, the laser-cut top plate and cable cage top/bottom, the COTS hardware (bearing, motor, pulley, limit switch, ribbon cable) with real product photos, the heat inserts, and the fasteners.
- **Top plate hole map** so the S2/S3, I1-I6 and O1-O6 references in the steps are legible.
- **Preparation step** with a per-part row for each insert-bearing part (upper fixed section, NEMA 23 bracket, chute mount, interface bracket, limit switch housing, limit switch hammer), each grouped with its heat-insert photo pulled from the source videos.
- **Fasteners named inline** at each step where they're used, from barthel's build notes.

### Data corrections (barthel's frame-by-frame audit)
The heat-insert counts in `parts-calculator`'s `parts.json` were wrong for several parts and are corrected here: NEMA 23 bracket is 6×M5 + 1×M3 (not 5×M5), chute mount is 4×M4 + 7×M3 (not 9×M3), and the limit switch hammer's 1×M3 was undocumented. `parts.json` still needs the same fix upstream.

### Known remaining gap
Eight smaller screws are still marked `fastener not recorded` in the steps (chute gear, spur gear, idler, roller switch, and a few singles), flagged inline and disclosed in a callout at the top of the page.

Build passes on Node 20; `validate_frontmatter.py` and `validate_images.py` both clean.

Thanks to zed0 for the source doc and direction, and barthel for the fastener/insert audit and video timestamps.
