### PR TITLE
feeder: per-channel pulse move speeds; vision: detect degraded USB camera links

### DIFF
--- a/software/sorter/backend/scripts/jitter_channel_speeds.py
+++ b/software/sorter/backend/scripts/jitter_channel_speeds.py
@@ -1,0 +1,126 @@
+"""Prove the per-channel feeder move speeds are actually wired through.
+
+Writes a random ±1-10% perturbation to each of C1/C2/C3's move speed, holds it
+so you can watch the sorter log, then puts the original values back. It only
+ever touches config — it never commands a motor. Start sorting from the UI (so
+you keep the stop button) and run this alongside it.
+
+The point is that each channel gets a DIFFERENT jitter, so the log lines prove
+the speeds are independent rather than all reading one shared value:
+
+    python3 scripts/jitter_channel_speeds.py --hold 60
+
+Then watch, in another shell:
+
+    journalctl -u sorter -f | grep -o 'PulsePerception: ch[0-9_a-z]* pulse ch=[0-9] speed=[0-9]*'
+
+Each channel's pulses must report the jittered number printed below, and the
+three numbers must differ. If every channel logs the same speed, the per-channel
+plumbing is not live.
+
+Restores the original speeds on exit, including on Ctrl-C.
+"""
+
+import argparse
+import atexit
+import os
+import random
+import signal
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from subsystems.feeder.pulse_perception.autotune import TUNABLE_PARAMS
+from subsystems.feeder.pulse_perception.config import CHANNEL_MOVE_SPEED_KEYS
+from toml_config import getPulsePerceptionConfig, setPulsePerceptionConfig
+
+# Keep the jitter inside the same envelope auto-tune is allowed to search, so
+# this can never write a speed the tuner itself would refuse to try.
+_BOUNDS = {
+    meta["key"]: (meta["min"], meta["max"])
+    for meta in TUNABLE_PARAMS
+    if meta["key"] in set(CHANNEL_MOVE_SPEED_KEYS.values())
+}
+
+_MIN_JITTER_PCT = 1.0
+_MAX_JITTER_PCT = 10.0
+
+
+def jitteredSpeed(current: int, rng: random.Random, key: str) -> tuple[int, float]:
+    """One channel's perturbed speed and the signed percentage applied. The
+    magnitude is always >= 1% so the change is unambiguous in the log, and the
+    sign is random per channel so the three channels diverge."""
+    pct = rng.uniform(_MIN_JITTER_PCT, _MAX_JITTER_PCT) * rng.choice((-1.0, 1.0))
+    value = int(round(current * (1.0 + pct / 100.0)))
+    lo, hi = _BOUNDS.get(key, (1, 100000))
+    value = min(int(hi), max(int(lo), value))
+    if value == current:
+        # Clamped back onto the original (channel already at a bound) — nudge it
+        # off by a step so the log still shows a distinct number.
+        value = current - 1 if current > int(lo) else current + 1
+    applied_pct = (value - current) / current * 100.0 if current else 0.0
+    return value, applied_pct
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--hold",
+        type=float,
+        default=60.0,
+        help="seconds to hold the jittered speeds before restoring (default 60)",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=None, help="RNG seed, for a reproducible run"
+    )
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    config = getPulsePerceptionConfig()
+    original = {key: int(config[key]) for key in CHANNEL_MOVE_SPEED_KEYS.values()}
+
+    restored = False
+
+    def restore(*_a) -> None:
+        nonlocal restored
+        if restored:
+            return
+        restored = True
+        setPulsePerceptionConfig(original)
+        print("\nrestored original speeds:")
+        for channel, key in sorted(CHANNEL_MOVE_SPEED_KEYS.items()):
+            print(f"  C{channel}  {original[key]}")
+
+    # Any exit path puts the machine back — a half-finished run must never leave
+    # a tuned machine on a random speed.
+    atexit.register(restore)
+    signal.signal(signal.SIGINT, lambda *_a: sys.exit(0))
+    signal.signal(signal.SIGTERM, lambda *_a: sys.exit(0))
+
+    updates: dict[str, int] = {}
+    print("jittering per-channel move speeds (±1-10%):\n")
+    print(f"  {'channel':<9}{'before':>8}{'after':>8}{'delta':>9}")
+    for channel, key in sorted(CHANNEL_MOVE_SPEED_KEYS.items()):
+        before = original[key]
+        after, pct = jitteredSpeed(before, rng, key)
+        updates[key] = after
+        print(f"  C{channel:<8}{before:>8}{after:>8}{pct:>8.1f}%")
+
+    setPulsePerceptionConfig(updates)
+    print(
+        "\napplied. The feeder re-reads config on a ~1s TTL, so the next pulse on "
+        "each channel should log its new speed.\n"
+    )
+    print("watch with:")
+    print(
+        "  journalctl -u sorter -f | grep -o "
+        "'PulsePerception: ch[0-9_a-z]* pulse ch=[0-9] speed=[0-9]*'\n"
+    )
+    print(f"holding {args.hold:.0f}s — Ctrl-C to restore early.")
+    time.sleep(args.hold)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/software/sorter/backend/server/routers/cameras.py
+++ b/software/sorter/backend/server/routers/cameras.py
@@ -3304,6 +3304,39 @@ def get_camera_health() -> Dict[str, Any]:
     return shared_state.camera_service.get_health_status()
 
 
+@router.get("/api/cameras/{role}/recovery")
+def get_camera_recovery_status(role: str) -> Dict[str, Any]:
+    """Return what the capture thread negotiated versus what it asked for,
+    plus the USB link state behind it. A `degraded` camera is streaming at a
+    frame size the machine did not request."""
+    import server.shared_state as shared_state
+
+    if shared_state.camera_service is None:
+        raise HTTPException(status_code=500, detail="Camera service not initialized")
+    status = shared_state.camera_service.get_recovery_status_for_role(role)
+    if status is None:
+        raise HTTPException(status_code=404, detail=f"Unknown camera role '{role}'")
+    return {"role": role, **status}
+
+
+@router.post("/api/cameras/{role}/recover")
+def recover_camera(role: str) -> Dict[str, Any]:
+    """Kick the escalating reset ladder for one camera by hand. The automatic
+    path runs the same rungs; this exists so an operator never has to reach for
+    the USB cable while we are still chasing the underlying hub fault."""
+    import server.shared_state as shared_state
+
+    if shared_state.camera_service is None:
+        raise HTTPException(status_code=500, detail="Camera service not initialized")
+    if not shared_state.camera_service.request_recovery_for_role(role):
+        raise HTTPException(status_code=404, detail=f"Unknown camera role '{role}'")
+    return {
+        "ok": True,
+        "role": role,
+        "message": "Camera reset requested; the feed will drop out while it re-enumerates.",
+    }
+
+
 @router.get("/api/cameras/config")
 def get_camera_config() -> Dict[str, Any]:
     """Return current camera assignments from TOML."""

--- a/software/sorter/backend/subsystems/feeder/pulse_perception/autotune.py
+++ b/software/sorter/backend/subsystems/feeder/pulse_perception/autotune.py
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
 # bounds. Bounds are deliberately tighter than the config's own clamps — a
 # candidate can be slow or double-feed-prone, but never physically wild.
 TUNABLE_PARAMS: list[dict[str, Any]] = [
-    {"key": "move_speed_usteps_per_s", "type": "int", "min": 800, "max": 5000, "label": "Move speed (µsteps/s)"},
+    {"key": "ch1_move_speed_usteps_per_s", "type": "int", "min": 800, "max": 5000, "label": "C1 move speed (µsteps/s)"},
+    {"key": "ch2_move_speed_usteps_per_s", "type": "int", "min": 800, "max": 5000, "label": "C2 move speed (µsteps/s)"},
+    {"key": "ch3_move_speed_usteps_per_s", "type": "int", "min": 800, "max": 5000, "label": "C3 move speed (µsteps/s)"},
     {"key": "drop_pulse_output_deg", "type": "float", "min": 5.0, "max": 90.0, "label": "Drop-zone pulse distance (deg)"},
     {"key": "drop_pulse_pause_ms", "type": "int", "min": 0, "max": 600, "label": "Drop-zone pause (ms)"},
     {"key": "exit_pulse_output_deg", "type": "float", "min": 0.5, "max": 12.0, "label": "Exit pulse distance (deg)"},

--- a/software/sorter/backend/subsystems/feeder/pulse_perception/config.py
+++ b/software/sorter/backend/subsystems/feeder/pulse_perception/config.py
@@ -6,7 +6,15 @@ class PulsePerceptionConfig:
     # +1 carries pieces toward the exit (camera-clockwise = forward motor
     # direction). Flip to -1 if a channel's stepper is wired the other way.
     forward_direction_sign: int = 1
-    move_speed_usteps_per_s: int = 2000
+    # Move speed per channel. Each channel drives a different mass — C1 pushes a
+    # whole bulk hopper, C3 meters single pieces into classification — so they
+    # want different speeds. These are independent: nothing phase-locks the
+    # channels to each other (each channel's pulse cooldown is keyed on its own
+    # stepper and derived from its own move time), so changing one never desyncs
+    # another.
+    ch1_move_speed_usteps_per_s: int = 2000
+    ch2_move_speed_usteps_per_s: int = 2000
+    ch3_move_speed_usteps_per_s: int = 2000
     # Ignore moves smaller than this (noise) and clamp any single move to the
     # max so a bad config value can never spin a channel wildly.
     min_move_output_deg: float = 0.1
@@ -86,7 +94,9 @@ _DEFAULTS = PulsePerceptionConfig()
 # within a section is preserved; sections appear in first-seen order.
 FIELD_META: list[dict] = [
     {"section": "Motion", "key": "forward_direction_sign", "label": "Forward direction sign (+1/-1)", "type": "int", "default": _DEFAULTS.forward_direction_sign, "description": "Which way the motor turns to carry pieces toward the exit. Leave at +1; use -1 only if this channel's stepper is wired backwards and pieces move the wrong way."},
-    {"section": "Motion", "key": "move_speed_usteps_per_s", "label": "Move speed (µsteps/s)", "type": "int", "default": _DEFAULTS.move_speed_usteps_per_s, "description": "Motor speed used for every pulse on this page (microsteps per second). Higher = snappier moves."},
+    {"section": "Motion", "key": "ch1_move_speed_usteps_per_s", "label": "C1 move speed (µsteps/s)", "type": "int", "default": _DEFAULTS.ch1_move_speed_usteps_per_s, "description": "Motor speed used for every C1 (bulk) pulse, in microsteps per second. Higher = snappier moves. C1 shifts the whole bulk pile, so it usually wants a different speed than the metering channels."},
+    {"section": "Motion", "key": "ch2_move_speed_usteps_per_s", "label": "C2 move speed (µsteps/s)", "type": "int", "default": _DEFAULTS.ch2_move_speed_usteps_per_s, "description": "Motor speed used for every C2 pulse, in microsteps per second. Higher = snappier moves."},
+    {"section": "Motion", "key": "ch3_move_speed_usteps_per_s", "label": "C3 move speed (µsteps/s)", "type": "int", "default": _DEFAULTS.ch3_move_speed_usteps_per_s, "description": "Motor speed used for every C3 pulse, in microsteps per second. C3 meters single pieces into the classification channel, so a slower speed here trades throughput for fewer double-drops."},
     {"section": "Motion", "key": "min_move_output_deg", "label": "Min move (output deg)", "type": "float", "default": _DEFAULTS.min_move_output_deg, "description": "Moves smaller than this are treated as noise and skipped."},
     {"section": "Motion", "key": "max_move_output_deg", "label": "Max move clamp (output deg)", "type": "float", "default": _DEFAULTS.max_move_output_deg, "description": "Hard cap on any single pulse, so a bad value can never spin a channel wildly."},
     {"section": "Drop-zone pulse", "key": "drop_pulse_output_deg", "label": "Drop-zone pulse distance (output deg)", "type": "float", "default": _DEFAULTS.drop_pulse_output_deg, "description": "How far a piece is nudged per pulse while it is still back in the drop zone (not yet at the exit edge)."},
@@ -112,8 +122,47 @@ FIELD_META: list[dict] = [
 ]
 
 
+# Move speed used to be a single machine-wide value; it is now per channel.
+# Machines that were tuned before the split still have the old key in their
+# machine.toml, so it is migrated (see migrateLegacyKeys) rather than dropped —
+# silently reverting a tuned machine to the 2000 default would change its
+# behaviour on upgrade with nothing in the UI to explain it.
+LEGACY_MOVE_SPEED_KEY = "move_speed_usteps_per_s"
+
+CHANNEL_MOVE_SPEED_KEYS: dict[int, str] = {
+    1: "ch1_move_speed_usteps_per_s",
+    2: "ch2_move_speed_usteps_per_s",
+    3: "ch3_move_speed_usteps_per_s",
+}
+
+
+def channelMoveSpeed(cfg: PulsePerceptionConfig, channel: int) -> int:
+    """Move speed for one feeder channel (1-3). Unknown channels fall back to
+    C2's speed — the middle of the chain — so a caller that grows a new channel
+    still gets a sane pulse rather than a zero-speed move (which wedges the
+    firmware, see MIN_MOVE_SPEED_USTEPS_PER_S in flow.py)."""
+    key = CHANNEL_MOVE_SPEED_KEYS.get(channel, CHANNEL_MOVE_SPEED_KEYS[2])
+    return int(getattr(cfg, key))
+
+
+def migrateLegacyKeys(section: dict) -> dict:
+    """Upgrade a stored config section in place-safe fashion (returns a copy).
+
+    Seeds all three per-channel speeds from the retired single ``move_speed_usteps_per_s``
+    when that is what the machine has. Per-channel values already present always
+    win, so this is a no-op once a machine has been tuned since the split."""
+    migrated = dict(section)
+    legacy = migrated.pop(LEGACY_MOVE_SPEED_KEY, None)
+    if not isinstance(legacy, (int, float)) or isinstance(legacy, bool):
+        return migrated
+    for key in CHANNEL_MOVE_SPEED_KEYS.values():
+        migrated.setdefault(key, int(legacy))
+    return migrated
+
+
 def configFromDict(d: dict) -> PulsePerceptionConfig:
     cfg = PulsePerceptionConfig()
+    d = migrateLegacyKeys(d)
     for meta in FIELD_META:
         k = meta["key"]
         if k not in d:

--- a/software/sorter/backend/subsystems/feeder/pulse_perception/flow.py
+++ b/software/sorter/backend/subsystems/feeder/pulse_perception/flow.py
@@ -10,7 +10,7 @@ from global_config import GlobalConfig
 from vision import VisionManager
 
 from ..states import FeederState
-from .config import PulsePerceptionConfig
+from .config import PulsePerceptionConfig, channelMoveSpeed
 from .stuck_watchdog import FeederStuckWatchdog
 from subsystems.feeder.incidents import feeder_jam_incident_active
 
@@ -120,6 +120,7 @@ class PulsePerceptionFeeding(BaseState):
     def _move(
         self,
         label: str,
+        channel: int,
         stepper: "StepperMotor",
         output_deg: float,
         pause_ms: int,
@@ -128,7 +129,7 @@ class PulsePerceptionFeeding(BaseState):
     ) -> bool:
         if self._busy(stepper):
             return False
-        speed = int(cfg.move_speed_usteps_per_s)
+        speed = channelMoveSpeed(cfg, channel)
         output_deg = abs(output_deg)
         if enforce_min:
             output_deg = max(cfg.min_move_output_deg, output_deg)
@@ -147,7 +148,8 @@ class PulsePerceptionFeeding(BaseState):
         cooldown_ms = (max(0, exec_ms) + max(0, pause_ms)) if success else 500
         self._busy_until[stepper._name] = time.monotonic() + cooldown_ms / 1000.0
         self.gc.logger.info(
-            f"PulsePerception: {label} pulse output={output_deg:.1f}° motor={motor_deg:.1f}° "
+            f"PulsePerception: {label} pulse ch={channel} speed={speed} "
+            f"output={output_deg:.1f}° motor={motor_deg:.1f}° "
             f"success={success} exec_ms={exec_ms} pause_ms={pause_ms}"
         )
         return success
@@ -245,6 +247,7 @@ class PulsePerceptionFeeding(BaseState):
                 channel_id=3,
                 channel_label="C3",
                 upstream_label="C2",
+                upstream_channel_id=2,
                 upstream_stepper=self.irl.c_channel_2_rotor_stepper,
                 upstream_enabled=bool(cfg.enable_ch2),
                 leading_pos_deg=_leading_com(c3),
@@ -254,7 +257,7 @@ class PulsePerceptionFeeding(BaseState):
             )
             if not feeder_jam_incident_active(self.gc, channel_label="C3"):
                 self._apply_action(
-                    "ch3", action, self.irl.c_channel_3_rotor_stepper, c3, cfg
+                    "ch3", 3, action, self.irl.c_channel_3_rotor_stepper, c3, cfg
                 )
             # A piece counts as delivered the moment it clears C3's exit zone
             # (the precise pulses stop on their own once perception no longer
@@ -277,6 +280,7 @@ class PulsePerceptionFeeding(BaseState):
                 channel_id=2,
                 channel_label="C2",
                 upstream_label="C1",
+                upstream_channel_id=1,
                 upstream_stepper=self.irl.c_channel_1_rotor_stepper,
                 upstream_enabled=bool(cfg.enable_ch1),
                 leading_pos_deg=_leading_com(c2),
@@ -286,7 +290,7 @@ class PulsePerceptionFeeding(BaseState):
             )
             if not feeder_jam_incident_active(self.gc, channel_label="C2"):
                 self._apply_action(
-                    "ch2", action, self.irl.c_channel_2_rotor_stepper, c2, cfg
+                    "ch2", 2, action, self.irl.c_channel_2_rotor_stepper, c2, cfg
                 )
 
         if cfg.enable_ch1:
@@ -296,6 +300,7 @@ class PulsePerceptionFeeding(BaseState):
             if c1Action(c2) == Action.ADVANCE and not self._busy(stepper):
                 self._move(
                     "ch1",
+                    1,
                     stepper,
                     cfg.ch1_pulse_output_deg,
                     cfg.ch1_pulse_pause_ms,
@@ -307,6 +312,7 @@ class PulsePerceptionFeeding(BaseState):
     def _apply_action(
         self,
         label: str,
+        channel: int,
         action,
         stepper: "StepperMotor",
         state,
@@ -340,6 +346,7 @@ class PulsePerceptionFeeding(BaseState):
                 enforce_min = False
             self._move(
                 move_label,
+                channel,
                 stepper,
                 output_deg,
                 pause_ms,
@@ -349,6 +356,7 @@ class PulsePerceptionFeeding(BaseState):
         elif action == Action.PRECISE:
             self._move(
                 f"{label}_exit",
+                channel,
                 stepper,
                 cfg.exit_pulse_output_deg,
                 cfg.exit_pulse_pause_ms,

--- a/software/sorter/backend/subsystems/feeder/pulse_perception/stuck_watchdog.py
+++ b/software/sorter/backend/subsystems/feeder/pulse_perception/stuck_watchdog.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional
 
-from .config import PulsePerceptionConfig
+from .config import PulsePerceptionConfig, channelMoveSpeed
 from subsystems.feeder.incidents import (
     clear_feeder_jam_incident,
     feeder_jam_incident_active,
@@ -72,6 +72,7 @@ class FeederStuckWatchdog:
         channel_id: int,
         channel_label: str,
         upstream_label: str,
+        upstream_channel_id: int,
         upstream_stepper: Any,
         upstream_enabled: bool,
         leading_pos_deg: Optional[float],
@@ -156,7 +157,7 @@ class FeederStuckWatchdog:
         if automatic and upstream_enabled and tracker.nudge_attempts < int(
             cfg.stuck_max_nudge_attempts
         ):
-            moved = self._nudge_upstream(upstream_stepper, cfg)
+            moved = self._nudge_upstream(upstream_stepper, upstream_channel_id, cfg)
             if tracker.nudge_attempts == 0:
                 # First nudge of this stall: remember when it started (monotonic)
                 # so an auto-freed jam records its real duration.
@@ -224,13 +225,15 @@ class FeederStuckWatchdog:
         )
 
     def _nudge_upstream(
-        self, upstream_stepper: Any, cfg: PulsePerceptionConfig
+        self, upstream_stepper: Any, upstream_channel_id: int, cfg: PulsePerceptionConfig
     ) -> bool:
         if upstream_stepper is None:
             return False
         sign = 1 if cfg.forward_direction_sign >= 0 else -1
         motor_deg = sign * abs(float(cfg.stuck_nudge_output_deg)) * CHANNEL_OUTPUT_GEAR_RATIO
-        speed = int(cfg.move_speed_usteps_per_s)
+        # The nudge turns the UPSTREAM rotor, so it runs at that channel's speed,
+        # not the stalled channel's.
+        speed = channelMoveSpeed(cfg, upstream_channel_id)
         try:
             upstream_stepper.enabled = True
         except Exception:

--- a/software/sorter/backend/tests/test_camera_recovery_ladder.py
+++ b/software/sorter/backend/tests/test_camera_recovery_ladder.py
@@ -1,0 +1,67 @@
+import unittest
+
+import vision.camera_recovery as camera_recovery
+
+
+class RecoveryLadderOrderTests(unittest.TestCase):
+    def test_camera_local_rungs_come_before_any_shared_bus_rung(self) -> None:
+        # The control board's serial port shares the hub with the cameras, so a
+        # shared-bus rung costs motion control. Every reset that cannot do that
+        # must be tried first, or a recoverable camera glitch escalates straight
+        # into dropping the machine's control board.
+        flags = [step.disrupts_shared_bus for step in camera_recovery.RECOVERY_LADDER]
+        first_shared = flags.index(True) if True in flags else len(flags)
+        self.assertNotIn(False, flags[first_shared:])
+        self.assertGreater(first_shared, 0, "at least one camera-local rung must lead")
+
+    def test_the_rungs_that_re_enumerate_the_hub_are_marked(self) -> None:
+        marked = {
+            step.name
+            for step in camera_recovery.RECOVERY_LADDER
+            if step.disrupts_shared_bus
+        }
+        self.assertEqual(
+            marked,
+            {"usb_hub_reset", "upstream_port_power_cycle", "host_controller_rebind"},
+        )
+
+    def test_settle_times_are_positive_and_non_decreasing(self) -> None:
+        settles = [step.settle_s for step in camera_recovery.RECOVERY_LADDER]
+        self.assertTrue(all(s > 0 for s in settles))
+        self.assertEqual(settles, sorted(settles))
+
+
+class LinkSpeedTests(unittest.TestCase):
+    def test_full_speed_link_reads_as_degraded(self) -> None:
+        # 12 Mbit/s is the OHCI companion fallback that strips the cameras' high
+        # resolution modes; 480 is the high-speed link we need.
+        device = _device(speed_mbps=12.0)
+        self.assertTrue(camera_recovery.isLinkSpeedDegraded(device))
+
+    def test_high_speed_and_faster_links_are_not_degraded(self) -> None:
+        for speed in (480.0, 5000.0):
+            self.assertFalse(camera_recovery.isLinkSpeedDegraded(_device(speed_mbps=speed)))
+
+    def test_unknown_speed_is_not_reported_as_degraded(self) -> None:
+        # Absent evidence is not evidence of a fault — never escalate on it.
+        self.assertFalse(camera_recovery.isLinkSpeedDegraded(_device(speed_mbps=None)))
+        self.assertFalse(camera_recovery.isLinkSpeedDegraded(None))
+
+
+def _device(*, speed_mbps: float | None) -> camera_recovery.CameraUsbDevice:
+    return camera_recovery.CameraUsbDevice(
+        sysfs_path="/sys/bus/usb/devices/5-1.1",
+        devpath="1.1",
+        busnum=5,
+        devnum=3,
+        speed_mbps=speed_mbps,
+        parent_sysfs_path="/sys/bus/usb/devices/5-1",
+        port_sysfs_path=None,
+        parent_port_sysfs_path=None,
+        controller_name="5101c00.usb",
+        controller_driver="ohci-platform",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/sorter/backend/tests/test_feeder_stuck_watchdog.py
+++ b/software/sorter/backend/tests/test_feeder_stuck_watchdog.py
@@ -70,6 +70,7 @@ class FeederStuckWatchdogTests(unittest.TestCase):
             channel_id=2,
             channel_label="C2",
             upstream_label="C1",
+            upstream_channel_id=1,
             upstream_stepper=up,
             upstream_enabled=True,
             leading_pos_deg=pos,

--- a/software/sorter/backend/tests/test_pulse_perception_config.py
+++ b/software/sorter/backend/tests/test_pulse_perception_config.py
@@ -1,0 +1,66 @@
+import unittest
+
+from subsystems.feeder.pulse_perception.config import (
+    CHANNEL_MOVE_SPEED_KEYS,
+    LEGACY_MOVE_SPEED_KEY,
+    PulsePerceptionConfig,
+    channelMoveSpeed,
+    configFromDict,
+    configToDict,
+    migrateLegacyKeys,
+)
+
+
+class ChannelMoveSpeedTests(unittest.TestCase):
+    def test_resolves_each_channel_independently(self) -> None:
+        cfg = configFromDict(
+            {
+                "ch1_move_speed_usteps_per_s": 1200,
+                "ch2_move_speed_usteps_per_s": 2400,
+                "ch3_move_speed_usteps_per_s": 3600,
+            }
+        )
+        self.assertEqual(
+            [channelMoveSpeed(cfg, ch) for ch in (1, 2, 3)], [1200, 2400, 3600]
+        )
+
+    def test_unknown_channel_falls_back_to_a_nonzero_speed(self) -> None:
+        # A 0 speed wedges the firmware distance move (see
+        # MIN_MOVE_SPEED_USTEPS_PER_S in flow.py), so the fallback must be a real
+        # channel's speed rather than a missing-attribute zero.
+        cfg = PulsePerceptionConfig()
+        cfg.ch2_move_speed_usteps_per_s = 2400
+        self.assertEqual(channelMoveSpeed(cfg, 9), 2400)
+
+
+class LegacyMoveSpeedMigrationTests(unittest.TestCase):
+    def test_seeds_all_channels_from_the_retired_shared_key(self) -> None:
+        migrated = migrateLegacyKeys(
+            {LEGACY_MOVE_SPEED_KEY: 2600, "drop_pulse_pause_ms": 120}
+        )
+        self.assertNotIn(LEGACY_MOVE_SPEED_KEY, migrated)
+        for key in CHANNEL_MOVE_SPEED_KEYS.values():
+            self.assertEqual(migrated[key], 2600)
+        self.assertEqual(migrated["drop_pulse_pause_ms"], 120)
+
+    def test_existing_per_channel_values_win_over_the_legacy_key(self) -> None:
+        migrated = migrateLegacyKeys(
+            {LEGACY_MOVE_SPEED_KEY: 2600, "ch2_move_speed_usteps_per_s": 900}
+        )
+        self.assertEqual(migrated["ch2_move_speed_usteps_per_s"], 900)
+        self.assertEqual(migrated["ch1_move_speed_usteps_per_s"], 2600)
+        self.assertEqual(migrated["ch3_move_speed_usteps_per_s"], 2600)
+
+    def test_migration_is_a_noop_without_the_legacy_key(self) -> None:
+        section = {"ch1_move_speed_usteps_per_s": 1500}
+        self.assertEqual(migrateLegacyKeys(section), section)
+
+    def test_does_not_leave_the_legacy_key_in_the_serialized_config(self) -> None:
+        serialized = configToDict(PulsePerceptionConfig())
+        self.assertNotIn(LEGACY_MOVE_SPEED_KEY, serialized)
+        for key in CHANNEL_MOVE_SPEED_KEYS.values():
+            self.assertIn(key, serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/sorter/backend/toml_config.py
+++ b/software/sorter/backend/toml_config.py
@@ -306,12 +306,15 @@ def setClassificationProviders(updates: dict[str, Any]) -> dict[str, str]:
 
 def getPulsePerceptionConfig() -> dict[str, Any]:
     from subsystems.feeder.pulse_perception.config import (
-        PulsePerceptionConfig, configToDict,
+        PulsePerceptionConfig, configToDict, migrateLegacyKeys,
     )
     config = _read_toml()
     section = config.get("feeder_pulse_perception")
     defaults = configToDict(PulsePerceptionConfig())
     if isinstance(section, dict):
+        # Migrate before filtering: retired keys are not in ``defaults``, so an
+        # unmigrated section would have its old tuned value dropped on the floor.
+        section = migrateLegacyKeys(section)
         return {**defaults, **{k: v for k, v in section.items() if k in defaults}}
     return defaults
 

--- a/software/sorter/backend/vision/camera.py
+++ b/software/sorter/backend/vision/camera.py
@@ -26,11 +26,28 @@ from irl.config import (
     clampCameraPictureSettings,
     parseCameraDeviceSettings,
 )
+from . import camera_recovery
 from .types import CameraFrame
 
 CAPTURE_MODE_SETTLE_S = 2.0
 CAPTURE_EXPECTED_FRAME_FALLBACK_S = 10.0
 AUTO_CAMERA_CONTROL_KEYS = ("auto_exposure", "auto_white_balance", "autofocus")
+
+# How long frames may keep arriving at the wrong geometry before we treat the
+# camera as broken rather than still settling. Must exceed
+# CAPTURE_EXPECTED_FRAME_FALLBACK_S so a mode change in progress is never
+# mistaken for the stuck state.
+CAPTURE_WRONG_SIZE_CONFIRM_S = 15.0
+# Floor between ladder rungs. Re-enumeration plus reopen plus the exposure
+# settle is several seconds on its own; anything tighter just stacks resets on
+# a bus that has not finished coming back yet.
+CAPTURE_RECOVERY_COOLDOWN_S = 30.0
+# Once every rung has been tried the cause is almost certainly physical (bad
+# cable, hub browning out). Keep retrying the last rung anyway so the machine
+# heals itself if the hardware recovers, but stop hammering the bus.
+CAPTURE_RECOVERY_EXHAUSTED_COOLDOWN_S = 300.0
+# Re-check beat while a bus-disrupting rung is held back for an active sort.
+CAPTURE_RECOVERY_DEFERRED_COOLDOWN_S = 60.0
 
 if platform.system() == "Darwin":
     try:
@@ -750,6 +767,17 @@ class CaptureThread:
         self._color_profile_lock = threading.Lock()
         self._config_lock = threading.Lock()
         self._cap_lock = threading.Lock()
+        # Recovery bookkeeping. Written only by the capture thread; read by the
+        # health poller and the HTTP handlers, hence the lock on the snapshot.
+        self._recovery_lock = threading.Lock()
+        self._recovery_manual_request = threading.Event()
+        self._recovery_state: dict[str, object] = {
+            "degraded": False,
+            "attempts": 0,
+            "last_action": None,
+            "last_action_at": None,
+            "negotiated_size": None,
+        }
 
     def drain_ring_buffer(self, max_frames: int) -> list[CameraFrame]:
         """Return up to ``max_frames`` most-recent frames from the ring buffer.
@@ -970,6 +998,179 @@ class CaptureThread:
                 "fourcc": getattr(self._config, "fourcc", None),
             }
 
+    def getRecoveryStatus(self) -> dict[str, object]:
+        with self._recovery_lock:
+            status = dict(self._recovery_state)
+        source = self.getCameraSource()
+        if isinstance(source, int):
+            status.update(camera_recovery.describeCameraUsbState(source))
+        mode = self.getCaptureMode()
+        status["expected_size"] = (mode["width"], mode["height"])
+        return status
+
+    def isDegraded(self) -> bool:
+        with self._recovery_lock:
+            return bool(self._recovery_state["degraded"])
+
+    def requestRecovery(self) -> None:
+        # The USB resets have to run with the capture handle closed, so the
+        # request is handed to the capture thread instead of executed inline.
+        self._recovery_manual_request.set()
+        self._requestReopen()
+
+    def _setRecoveryState(self, **fields: object) -> None:
+        with self._recovery_lock:
+            self._recovery_state.update(fields)
+
+    def _clearDegraded(self) -> None:
+        # Runs once per good frame, so take the lock only when there is actually
+        # something to clear. Dict reads are atomic under the GIL.
+        if not self._recovery_state["degraded"] and not self._recovery_state["attempts"]:
+            return
+        with self._recovery_lock:
+            self._recovery_state.update(
+                {"degraded": False, "attempts": 0, "last_action": None}
+            )
+        log.warning("CaptureThread[%s] recovered — capture geometry matches request", self.name)
+
+    def _machineIsSorting(self) -> bool:
+        # Best-effort: if we cannot tell, assume it IS sorting. A deferred reset
+        # costs a degraded feed for a while longer; a reset taken mid-sort drops
+        # the control board's serial port along with the camera.
+        try:
+            from server import shared_state
+
+            controller = shared_state.controller_ref
+            if controller is None:
+                return False
+            return getattr(controller.state, "value", None) == "running"
+        except Exception:
+            return True
+
+    def _runRecoveryAttempt(
+        self,
+        source: int,
+        attempt: int,
+        width: int,
+        height: int,
+        fourcc: str | None,
+    ) -> tuple[int, bool]:
+        """Run one rung of the ladder. Returns the device index to reopen on
+        (which can differ from ``source`` because a USB reset re-mints
+        /dev/videoN) and whether the attempt was actually consumed — a rung
+        deferred because the machine is sorting must not advance the ladder.
+        Frame geometry, not the rung's own return value, is what decides
+        whether the camera actually came back."""
+        device = camera_recovery.resolveCameraUsbDevice(source)
+        negotiated = camera_recovery.readNegotiatedCaptureFormat(source)
+        log.error(
+            "CaptureThread[%s] degraded: want %dx%d, device negotiated %s, usb=%s "
+            "speed=%sMbps — recovery attempt %d",
+            self.name,
+            width,
+            height,
+            f"{negotiated[0]}x{negotiated[1]} {negotiated[2]}" if negotiated else "unknown",
+            device.devpath if device is not None else "unknown",
+            device.speed_mbps if device is not None else "unknown",
+            attempt,
+        )
+
+        if attempt == 0:
+            # Cheapest rung: close and reopen, which re-runs VIDIOC_S_FMT on the
+            # idle node. Skipped when the mode is missing from the descriptor
+            # altogether — at reduced link speed these cameras simply stop
+            # advertising their high-res modes, and no amount of reopening
+            # conjures one back.
+            supported = camera_recovery.supportsCaptureSize(source, width, height)
+            if supported is not False:
+                camera_recovery.forceCaptureFormat(source, width, height, fourcc)
+                self._setRecoveryState(
+                    last_action="reopen", last_action_at=time.time(), attempts=attempt + 1
+                )
+                return source, True
+            log.error(
+                "CaptureThread[%s] %dx%d is no longer in the device's format list — "
+                "skipping reopen, escalating to USB reset",
+                self.name,
+                width,
+                height,
+            )
+            attempt = 1
+
+        if device is None:
+            self._setRecoveryState(
+                last_action="no_usb_device", last_action_at=time.time(), attempts=attempt + 1
+            )
+            return source, True
+
+        ladder_index = min(attempt - 1, len(camera_recovery.RECOVERY_LADDER) - 1)
+        if ladder_index >= len(camera_recovery.RECOVERY_LADDER) - 1 and (
+            camera_recovery.isLikelyPhysicalLinkFault(device)
+        ):
+            # Verified on kitbash: with the link below high speed, every rung
+            # (and an EHCI-companion rebind beyond them) fails the handshake at
+            # the physical layer. Stop pretending a reset will help and tell the
+            # operator what actually needs doing.
+            log.error(
+                "CaptureThread[%s] USB link is %s Mbps, not %d — the high-speed handshake is "
+                "failing in hardware, which no reset can fix. Reseat or replace the USB cable "
+                "to the hub and check its power. Resets exhausted; holding.",
+                self.name,
+                device.speed_mbps,
+                camera_recovery.HIGH_SPEED_MBPS,
+            )
+            self._setRecoveryState(
+                last_action="physical_link_fault", last_action_at=time.time()
+            )
+            return source, True
+        step = camera_recovery.RECOVERY_LADDER[ladder_index]
+        if step.disrupts_shared_bus and self._machineIsSorting():
+            # This rung re-enumerates the hub the control board is also on, so
+            # running it mid-sort would drop motion control to fix a camera.
+            # Hold here without consuming the attempt: the ladder resumes from
+            # this rung as soon as sorting stops.
+            log.error(
+                "CaptureThread[%s] holding recovery step '%s' — it re-enumerates the "
+                "shared USB hub (control board included) and the machine is sorting. "
+                "It will run once sorting stops.",
+                self.name,
+                step.name,
+            )
+            self._setRecoveryState(
+                last_action=f"{step.name}_deferred_sorting", last_action_at=time.time()
+            )
+            return source, False
+        log.error("CaptureThread[%s] applying USB recovery step '%s'", self.name, step.name)
+        performed = False
+        try:
+            performed = bool(step.run(device))
+        except Exception as exc:
+            log.error("CaptureThread[%s] recovery step '%s' raised: %s", self.name, step.name, exc)
+        self._setRecoveryState(
+            last_action=step.name if performed else f"{step.name}_unavailable",
+            last_action_at=time.time(),
+            attempts=attempt + 1,
+        )
+        if not performed:
+            return source, True
+
+        self._stop_event.wait(step.settle_s)
+        # /dev/videoN is re-minted by the reset; follow the camera by its hub
+        # port chain so we reopen the same physical device rather than whatever
+        # index happened to be reused.
+        reresolved = camera_recovery.resolveIndexForDevpath(device.devpath)
+        if reresolved is not None and reresolved != source:
+            log.error(
+                "CaptureThread[%s] device moved /dev/video%d -> /dev/video%d after '%s'",
+                self.name,
+                source,
+                reresolved,
+                step.name,
+            )
+            self.setCameraSource(reresolved)
+            return reresolved, True
+        return source, True
+
     def start(self) -> None:
         if self._thread is not None and self._thread.is_alive():
             return
@@ -1028,6 +1229,11 @@ class CaptureThread:
         # Re-apply after the first successful read so the settings actually stick.
         post_stream_settings: dict[str, int | float | bool] | None = None
         post_stream_source: int | None = None
+        # Wall time of the first wrong-geometry frame in the current run of
+        # them; 0.0 whenever the last frame matched the requested mode.
+        wrong_size_since = 0.0
+        recovery_attempt = 0
+        next_recovery_at = 0.0
 
         while not self._stop_event.is_set():
             source, is_url, width, height, fps, fourcc = self._get_config_snapshot()
@@ -1041,6 +1247,7 @@ class CaptureThread:
                 last_expected_frame_at = 0.0
                 post_stream_settings = None
                 post_stream_source = None
+                wrong_size_since = 0.0
 
             if self._reopen_event.is_set():
                 self._reopen_event.clear()
@@ -1055,6 +1262,23 @@ class CaptureThread:
                 last_expected_frame_at = 0.0
                 post_stream_settings = None
                 post_stream_source = None
+
+            if self._recovery_manual_request.is_set():
+                self._recovery_manual_request.clear()
+                if isinstance(source, int):
+                    if cap is not None:
+                        cap.release()
+                        cap = None
+                    self._cap = None
+                    self.latest_frame = None
+                    _, consumed = self._runRecoveryAttempt(
+                        source, recovery_attempt, width, height, fourcc
+                    )
+                    if consumed:
+                        recovery_attempt += 1
+                    next_recovery_at = time.time() + CAPTURE_RECOVERY_COOLDOWN_S
+                    wrong_size_since = 0.0
+                    continue
 
             if source is None:
                 self.latest_frame = None
@@ -1143,6 +1367,39 @@ class CaptureThread:
                             post_stream_settings = None
                             post_stream_source = None
 
+            if wrong_size_since != 0.0 and isinstance(source, int):
+                now = time.time()
+                if (
+                    now - wrong_size_since >= CAPTURE_WRONG_SIZE_CONFIRM_S
+                    and now >= next_recovery_at
+                ):
+                    # The USB-level rungs need the handle closed; a reset with an
+                    # open fd only invalidates it from under cv2.
+                    cap.release()
+                    cap = None
+                    self._cap = None
+                    self.latest_frame = None
+                    _, consumed = self._runRecoveryAttempt(
+                        source, recovery_attempt, width, height, fourcc
+                    )
+                    if consumed:
+                        recovery_attempt += 1
+                        next_recovery_at = time.time() + (
+                            CAPTURE_RECOVERY_COOLDOWN_S
+                            if recovery_attempt <= len(camera_recovery.RECOVERY_LADDER)
+                            else CAPTURE_RECOVERY_EXHAUSTED_COOLDOWN_S
+                        )
+                    else:
+                        # Held for an active sort. Re-check on a slower beat so a
+                        # long sort with a broken camera does not spam the log.
+                        next_recovery_at = time.time() + CAPTURE_RECOVERY_DEFERRED_COOLDOWN_S
+                    # Re-armed on the next wrong-size frame; if the reset worked
+                    # the matching frame clears the attempt counter instead.
+                    wrong_size_since = 0.0
+                    expected_frame_settle_until = 0.0
+                    last_expected_frame_at = 0.0
+                    continue
+
             # Do not hold _cap_lock while reading. AVFoundation can block inside
             # cap.read(); holding the lock there prevents stop/reopen requests
             # from releasing the handle and leaves the camera stuck until the
@@ -1164,8 +1421,26 @@ class CaptureThread:
                         )
                         if now < expected_frame_settle_until or has_recent_expected:
                             continue
+                        # Past the settle window the wrong geometry is not a mode
+                        # change in flight, it is what the device is actually
+                        # going to keep sending. Everything downstream rescales
+                        # zone polygons and arc centers by frame_w/saved_w, so a
+                        # silently-accepted 640x480 in place of 1280x720 does not
+                        # just look squished — it puts every perception angle and
+                        # mask in the wrong place. Flag it and let the ladder run.
+                        if wrong_size_since == 0.0:
+                            wrong_size_since = now
+                            self._setRecoveryState(
+                                degraded=True,
+                                negotiated_size=(int(frame_w), int(frame_h)),
+                            )
                     else:
                         last_expected_frame_at = time.time()
+                        if wrong_size_since != 0.0:
+                            wrong_size_since = 0.0
+                            recovery_attempt = 0
+                            next_recovery_at = 0.0
+                        self._clearDegraded()
                 if post_stream_settings is not None and post_stream_source is not None:
                     with self._cap_lock:
                         if cap is not None:

--- a/software/sorter/backend/vision/camera_device.py
+++ b/software/sorter/backend/vision/camera_device.py
@@ -124,6 +124,18 @@ class CameraDevice:
     def describe_device_controls(self) -> tuple[list[dict[str, Any]], dict[str, int | float | bool]]:
         return self._capture.describeDeviceControls()
 
+    # ---- Degraded-capture recovery ----
+
+    @property
+    def degraded(self) -> bool:
+        return self._capture.isDegraded()
+
+    def get_recovery_status(self) -> dict[str, object]:
+        return self._capture.getRecoveryStatus()
+
+    def request_recovery(self) -> None:
+        self._capture.requestRecovery()
+
     # ---- Capture mode ----
 
     def set_capture_mode(

--- a/software/sorter/backend/vision/camera_recovery.py
+++ b/software/sorter/backend/vision/camera_recovery.py
@@ -1,0 +1,463 @@
+"""Soft recovery for USB cameras that come back wrong without disconnecting.
+
+The failure this exists for: the powered USB hub the C-channel cameras hang off
+occasionally fails its high-speed handshake on the EHCI controller
+(``device descriptor read/64, error -71`` → ``unable to enumerate USB device``)
+and the kernel hands the port to the OHCI companion, where the whole tree
+re-enumerates at FULL speed (``not running at top speed; connect to a high
+speed hub``). Nothing disconnects — /dev/videoN still opens and still yields
+frames — but at 12 Mbit/s these UVC cameras only advertise 640x480@5,
+640x360@5, 352x288@20, 320x240@20, 160x120@30. A request for 1280x720@30
+silently lands on 640x480@5, which is why the feed shows up squished (4:3
+pixels stretched into a 16:9 layout), washed out (auto-exposure is free to use
+a 200 ms integration time at 5 fps) and smeared (5 fps of motion blur).
+
+Only a real electrical disconnect makes ehci-hcd reclaim port ownership from
+its companion, which is why replugging the cable is the only thing that has
+worked so far. The ladder below walks from the cheapest reset to the ones that
+actually produce that disconnect, and every rung is verified by re-reading the
+negotiated format rather than assumed to have worked.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+import platform
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+log = logging.getLogger(__name__)
+
+# _IO('U', 20) — the ioctl behind the `usbreset` utility.
+USBDEVFS_RESET = 0x5514
+
+HIGH_SPEED_MBPS = 480
+
+SYSFS_VIDEO_ROOT = "/sys/class/video4linux"
+SYSFS_USB_DEVICES = "/sys/bus/usb/devices"
+
+_PLATFORM_USB_DRIVERS = ("ehci-platform", "ohci-platform", "xhci-hcd", "dwc3")
+
+
+@dataclass
+class CameraUsbDevice:
+    sysfs_path: str
+    # `devpath` is the hub port chain ("1.1"), the only identifier that survives
+    # the controller move — bus number, device number, /dev/videoN and the
+    # by-path symlink all change when the tree lands on the companion.
+    devpath: str
+    busnum: int
+    devnum: int
+    speed_mbps: float | None
+    parent_sysfs_path: str | None
+    port_sysfs_path: str | None
+    parent_port_sysfs_path: str | None
+    controller_name: str | None
+    controller_driver: str | None
+
+
+def _readSysfsText(path: str) -> str | None:
+    try:
+        with open(path, "r") as handle:
+            return handle.read().strip()
+    except Exception:
+        return None
+
+
+def _writeSysfsText(path: str, value: str) -> bool:
+    try:
+        with open(path, "w") as handle:
+            handle.write(value)
+        return True
+    except Exception as exc:
+        log.warning("camera recovery: write %s=%s failed: %s", path, value, exc)
+        return False
+
+
+def _readSysfsInt(path: str) -> int | None:
+    raw = _readSysfsText(path)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except Exception:
+        return None
+
+
+def _usbDeviceDirForInterface(interface_dir: str) -> str | None:
+    # /sys/.../usb5/5-1/5-1.1/5-1.1:1.0 → /sys/.../5-1.1. The USB device dir is
+    # the first ancestor carrying idVendor; the UVC interface dir does not.
+    current = interface_dir
+    for _ in range(8):
+        if os.path.exists(os.path.join(current, "idVendor")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current or parent == "/":
+            return None
+        current = parent
+    return None
+
+
+def _controllerForUsbDevice(sysfs_path: str) -> tuple[str | None, str | None]:
+    # Walk up past usbN to the platform/PCI device that owns the bus, then find
+    # which driver currently has it bound so a rebind can target it.
+    current = sysfs_path
+    for _ in range(12):
+        parent = os.path.dirname(current)
+        if parent == current or parent == "/":
+            return None, None
+        base = os.path.basename(current)
+        if base.startswith("usb") and base[3:].isdigit():
+            controller_dir = parent
+            controller_name = os.path.basename(controller_dir)
+            driver_link = os.path.join(controller_dir, "driver")
+            driver = None
+            try:
+                driver = os.path.basename(os.path.realpath(driver_link))
+            except Exception:
+                driver = None
+            if driver not in _PLATFORM_USB_DRIVERS:
+                driver = None
+            return controller_name, driver
+        current = parent
+    return None, None
+
+
+def _resolvePortSysfsPath(device_sysfs_path: str) -> str | None:
+    # The `port` symlink points at the usbN-portM device that owns the
+    # disable/enable knob for the port this device is plugged into.
+    port_link = os.path.join(device_sysfs_path, "port")
+    if not os.path.exists(port_link):
+        return None
+    try:
+        resolved = os.path.realpath(port_link)
+    except Exception:
+        return None
+    if not os.path.exists(os.path.join(resolved, "disable")):
+        return None
+    return resolved
+
+
+def resolveCameraUsbDevice(index: int) -> CameraUsbDevice | None:
+    if platform.system() != "Linux" or not isinstance(index, int) or index < 0:
+        return None
+    interface_link = os.path.join(SYSFS_VIDEO_ROOT, f"video{index}", "device")
+    if not os.path.exists(interface_link):
+        return None
+    try:
+        interface_dir = os.path.realpath(interface_link)
+    except Exception:
+        return None
+
+    device_dir = _usbDeviceDirForInterface(interface_dir)
+    if device_dir is None:
+        return None
+
+    busnum = _readSysfsInt(os.path.join(device_dir, "busnum"))
+    devnum = _readSysfsInt(os.path.join(device_dir, "devnum"))
+    if busnum is None or devnum is None:
+        return None
+
+    speed_raw = _readSysfsText(os.path.join(device_dir, "speed"))
+    try:
+        speed_mbps = float(speed_raw) if speed_raw else None
+    except Exception:
+        speed_mbps = None
+
+    parent_dir = os.path.dirname(device_dir)
+    if not os.path.exists(os.path.join(parent_dir, "idVendor")):
+        parent_dir = None
+
+    controller_name, controller_driver = _controllerForUsbDevice(device_dir)
+
+    return CameraUsbDevice(
+        sysfs_path=device_dir,
+        devpath=_readSysfsText(os.path.join(device_dir, "devpath")) or "",
+        busnum=busnum,
+        devnum=devnum,
+        speed_mbps=speed_mbps,
+        parent_sysfs_path=parent_dir,
+        port_sysfs_path=_resolvePortSysfsPath(device_dir),
+        parent_port_sysfs_path=(
+            _resolvePortSysfsPath(parent_dir) if parent_dir is not None else None
+        ),
+        controller_name=controller_name,
+        controller_driver=controller_driver,
+    )
+
+
+def isLinkSpeedDegraded(device: CameraUsbDevice | None) -> bool:
+    if device is None or device.speed_mbps is None:
+        return False
+    return device.speed_mbps < HIGH_SPEED_MBPS
+
+
+# Measured on kitbash 2026-08-12, in the degraded state, with the full ladder
+# plus an EHCI-companion rebind (unbind OHCI -> cycle EHCI -> rebind OHCI):
+# ehci-platform re-probed and retried the high-speed handshake three times and
+# failed every time —
+#     usb 4-1: device descriptor read/64, error -71
+#     usb usb4-port1: Cannot enable. Maybe the USB cable is bad?
+#     usb 4-1: device not accepting address 5, error -71
+#     usb usb4-port1: unable to enumerate USB device
+# — before the kernel handed the port back to the OHCI companion at 12 Mbit/s.
+#
+# So a sub-high-speed link here is NOT recoverable in software: the fallback is
+# the kernel correctly reporting that 480 Mbit/s signalling does not survive the
+# current cable/connector, and 12 Mbit/s is simply tolerant enough to enumerate.
+# Re-seating the cable fixes it because it changes the physical contact, not
+# because it resets any state. The ladder is still worth running (it does fix a
+# camera that merely mis-set its format at a healthy link speed), but once it is
+# exhausted with the link still slow, the honest answer is to send someone to
+# the hardware rather than keep resetting a bus that is doing its best.
+def isLikelyPhysicalLinkFault(device: CameraUsbDevice | None) -> bool:
+    return isLinkSpeedDegraded(device)
+
+
+def resolveIndexForDevpath(devpath: str) -> int | None:
+    # After a reset the kernel re-mints /dev/videoN, and these cameras all ship
+    # the same USB serial ("200901010001"), so by-id collides and by-path
+    # encodes the controller that just changed. The hub port chain is what
+    # actually identifies the physical camera.
+    if platform.system() != "Linux" or not devpath:
+        return None
+    try:
+        names = sorted(os.listdir(SYSFS_VIDEO_ROOT))
+    except Exception:
+        return None
+    for name in names:
+        if not name.startswith("video"):
+            continue
+        try:
+            candidate_index = int(name[len("video") :])
+        except Exception:
+            continue
+        device = resolveCameraUsbDevice(candidate_index)
+        if device is None or device.devpath != devpath:
+            continue
+        # Both the capture node and its metadata sibling map to the same USB
+        # device; only the capture node reports a video-capture format.
+        if readNegotiatedCaptureFormat(candidate_index) is None:
+            continue
+        return candidate_index
+    return None
+
+
+def readNegotiatedCaptureFormat(index: int) -> tuple[int, int, str] | None:
+    if not isinstance(index, int) or index < 0:
+        return None
+    try:
+        result = subprocess.run(
+            ["v4l2-ctl", "-d", f"/dev/video{index}", "--get-fmt-video"],
+            capture_output=True,
+            timeout=3,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+    except Exception:
+        return None
+
+    width = height = 0
+    fourcc = ""
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Width/Height"):
+            _, _, raw = stripped.partition(":")
+            parts = raw.strip().split("/")
+            if len(parts) == 2:
+                try:
+                    width, height = int(parts[0]), int(parts[1])
+                except Exception:
+                    return None
+        elif stripped.startswith("Pixel Format"):
+            _, _, raw = stripped.partition(":")
+            fourcc = raw.strip().split()[0].strip("'\"") if raw.strip() else ""
+    if width <= 0 or height <= 0:
+        return None
+    return width, height, fourcc
+
+
+def supportsCaptureSize(index: int, width: int, height: int) -> bool | None:
+    # Returns None when the enumeration can't be read at all. A False here is
+    # the definitive "the device is not currently capable of what we asked for"
+    # signal — at full speed these cameras drop their high-res modes from the
+    # descriptor entirely, so this distinguishes a bus-speed regression from a
+    # merely mis-set format.
+    if not isinstance(index, int) or index < 0 or width <= 0 or height <= 0:
+        return None
+    try:
+        result = subprocess.run(
+            ["v4l2-ctl", "-d", f"/dev/video{index}", "--list-formats-ext"],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+    except Exception:
+        return None
+    needle = f"{int(width)}x{int(height)}"
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Size:") and stripped.endswith(needle):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Ladder rungs. Each returns True if the action was actually performed; the
+# caller decides whether it worked by re-reading the negotiated format.
+# ---------------------------------------------------------------------------
+
+
+def forceCaptureFormat(index: int, width: int, height: int, fourcc: str | None) -> bool:
+    fmt_arg = f"width={int(width)},height={int(height)}"
+    if isinstance(fourcc, str) and len(fourcc.strip()) >= 4:
+        fmt_arg = f"pixelformat={fourcc.strip()[:4].upper()}," + fmt_arg
+    try:
+        result = subprocess.run(
+            ["v4l2-ctl", "-d", f"/dev/video{index}", f"--set-fmt-video={fmt_arg}"],
+            capture_output=True,
+            timeout=3,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _resetUsbDeviceAt(busnum: int, devnum: int) -> bool:
+    node = f"/dev/bus/usb/{busnum:03d}/{devnum:03d}"
+    try:
+        fd = os.open(node, os.O_WRONLY)
+    except Exception as exc:
+        log.warning("camera recovery: cannot open %s for reset: %s", node, exc)
+        return False
+    try:
+        fcntl.ioctl(fd, USBDEVFS_RESET, 0)
+        return True
+    except Exception as exc:
+        log.warning("camera recovery: USBDEVFS_RESET on %s failed: %s", node, exc)
+        return False
+    finally:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+
+
+def resetUsbDevice(device: CameraUsbDevice) -> bool:
+    return _resetUsbDeviceAt(device.busnum, device.devnum)
+
+
+def resetParentHub(device: CameraUsbDevice) -> bool:
+    parent = device.parent_sysfs_path
+    if parent is None:
+        return False
+    busnum = _readSysfsInt(os.path.join(parent, "busnum"))
+    devnum = _readSysfsInt(os.path.join(parent, "devnum"))
+    if busnum is None or devnum is None:
+        return False
+    return _resetUsbDeviceAt(busnum, devnum)
+
+
+def _cyclePort(port_sysfs_path: str | None, *, off_s: float) -> bool:
+    if port_sysfs_path is None:
+        return False
+    disable_path = os.path.join(port_sysfs_path, "disable")
+    if not _writeSysfsText(disable_path, "1"):
+        return False
+    time.sleep(off_s)
+    return _writeSysfsText(disable_path, "0")
+
+
+def cycleDevicePort(device: CameraUsbDevice) -> bool:
+    return _cyclePort(device.port_sysfs_path, off_s=1.0)
+
+
+def cycleUpstreamPort(device: CameraUsbDevice) -> bool:
+    # Disabling the port the *hub* sits on is the closest software equivalent to
+    # pulling the cable: it drives a real disconnect on the root port, which is
+    # the event that makes ehci-hcd take the port back from the OHCI companion
+    # and retry the high-speed handshake. Everything downstream of the hub
+    # (including the control-board serial port) re-enumerates with it.
+    return _cyclePort(device.parent_port_sysfs_path, off_s=2.0)
+
+
+def rebindHostController(device: CameraUsbDevice) -> bool:
+    name = device.controller_name
+    driver = device.controller_driver
+    if not name or not driver:
+        return False
+    driver_dir = os.path.join("/sys/bus/platform/drivers", driver)
+    if not os.path.isdir(driver_dir):
+        return False
+    if not _writeSysfsText(os.path.join(driver_dir, "unbind"), name):
+        return False
+    time.sleep(1.0)
+    ok = _writeSysfsText(os.path.join(driver_dir, "bind"), name)
+    # Rebinding only the companion cannot itself hand the port back to the
+    # high-speed sibling controller — if this rung is being reached the port
+    # cycle above already failed, and the remaining fix is physical.
+    if not ok:
+        log.error("camera recovery: failed to rebind USB host controller %s (%s)", name, driver)
+    return ok
+
+
+@dataclass
+class RecoveryStep:
+    name: str
+    run: Callable[[CameraUsbDevice], bool]
+    # How long to wait for re-enumeration before the format is re-read.
+    settle_s: float
+    # True when the rung re-enumerates the whole hub or controller rather than
+    # just this camera. The control board's serial port lives on the same hub,
+    # so these rungs briefly take the machine's motion control with them — the
+    # caller holds them until the machine is not actively sorting.
+    disrupts_shared_bus: bool = False
+
+
+# Ordered cheapest → most disruptive, and within that, camera-local rungs before
+# anything that touches the shared bus: an operator mid-sort should get every
+# reset that cannot cost them the control board before one that can. The capture
+# thread walks one rung per attempt and re-verifies after each, so a mild reset
+# that happens to work never escalates into a bus-wide re-enumeration.
+RECOVERY_LADDER: tuple[RecoveryStep, ...] = (
+    RecoveryStep("usb_device_reset", resetUsbDevice, 3.0),
+    RecoveryStep("port_power_cycle", cycleDevicePort, 5.0),
+    RecoveryStep("usb_hub_reset", resetParentHub, 5.0, disrupts_shared_bus=True),
+    RecoveryStep(
+        "upstream_port_power_cycle", cycleUpstreamPort, 8.0, disrupts_shared_bus=True
+    ),
+    RecoveryStep(
+        "host_controller_rebind", rebindHostController, 8.0, disrupts_shared_bus=True
+    ),
+)
+
+
+def describeCameraUsbState(index: int) -> dict[str, object]:
+    device = resolveCameraUsbDevice(index)
+    negotiated = readNegotiatedCaptureFormat(index)
+    state: dict[str, object] = {}
+    if device is not None:
+        state["usb_devpath"] = device.devpath
+        state["usb_speed_mbps"] = device.speed_mbps
+        state["usb_link_degraded"] = isLinkSpeedDegraded(device)
+        state["usb_controller"] = device.controller_name
+        state["likely_physical_fault"] = isLikelyPhysicalLinkFault(device)
+        if isLikelyPhysicalLinkFault(device):
+            state["operator_action"] = (
+                f"This camera's USB link came up at {device.speed_mbps:.0f} Mbit/s instead of "
+                f"{HIGH_SPEED_MBPS} Mbit/s, so the camera can only offer low resolutions. "
+                "Software resets cannot fix this — reseat (or replace) the USB cable between "
+                "the hub and the board, and check the hub's power."
+            )
+    if negotiated is not None:
+        state["negotiated_width"] = negotiated[0]
+        state["negotiated_height"] = negotiated[1]
+        state["negotiated_fourcc"] = negotiated[2]
+    return state

--- a/software/sorter/backend/vision/camera_service.py
+++ b/software/sorter/backend/vision/camera_service.py
@@ -208,8 +208,28 @@ class CameraService:
             result[role] = {
                 "status": device.health.value,
                 "last_frame_at": device.last_frame_at,
+                # A camera can be "online" and still useless: if the USB link
+                # dropped to full speed the device silently negotiates a smaller
+                # frame size than we asked for, and frames keep flowing at the
+                # wrong geometry. Surfaced separately so the existing status
+                # enum keeps its meaning.
+                "degraded": device.degraded,
             }
         return result
+
+    def get_recovery_status_for_role(self, role: str) -> dict[str, object] | None:
+        device = self._device_for_role(role)
+        if device is None:
+            return None
+        return device.get_recovery_status()
+
+    def request_recovery_for_role(self, role: str) -> bool:
+        device = self._device_for_role(role)
+        if device is None:
+            return False
+        self._gc.logger.warning(f"camera '{role}': manual capture recovery requested")
+        device.request_recovery()
+        return True
 
     def get_health_map(self) -> dict[str, str]:
         return {role: feed.device.health.value for role, feed in self._feeds.items()}

--- a/software/sorter/frontend/src/routes/settings/tuning/feeder-pulse-perception/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/tuning/feeder-pulse-perception/+page.svelte
@@ -420,6 +420,33 @@
 	{/if}
 
 	<SectionCard
+		title="Parameters"
+		description="Pulse distance and pause time per region for the simple pulsing feeder."
+	>
+		{#if loading}
+			<div class="text-sm text-text-muted">Loading…</div>
+		{:else}
+			<div class="flex flex-col gap-8">
+				{#each sections as section}
+					<div class="flex flex-col gap-2">
+						<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+							{section.name}
+						</div>
+						{#each section.fields as field}
+							<TuningParamRow {field} bind:values />
+						{/each}
+					</div>
+				{/each}
+			</div>
+
+			<div class="mt-6 flex gap-3">
+				<Button variant="primary" onclick={save} loading={saving}>Save</Button>
+				<Button variant="secondary" onclick={load} disabled={saving}>Reset to saved</Button>
+			</div>
+		{/if}
+	</SectionCard>
+
+	<SectionCard
 		title="Auto-tune"
 		description="Searches for the fastest pulse parameters on this machine. Each trial applies a candidate config and measures pieces/min into the classification channel. A trial only counts as feasible if its double-drop rate stays under the cap below — among feasible trials, highest throughput wins. The trial clock only advances while sorting is running, so this runs on top of normal sorting."
 	>
@@ -760,33 +787,6 @@
 						</tbody>
 					</table>
 				</div>
-			</div>
-		{/if}
-	</SectionCard>
-
-	<SectionCard
-		title="Parameters"
-		description="Pulse distance and pause time per region for the simple pulsing feeder."
-	>
-		{#if loading}
-			<div class="text-sm text-text-muted">Loading…</div>
-		{:else}
-			<div class="flex flex-col gap-8">
-				{#each sections as section}
-					<div class="flex flex-col gap-2">
-						<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">
-							{section.name}
-						</div>
-						{#each section.fields as field}
-							<TuningParamRow {field} bind:values />
-						{/each}
-					</div>
-				{/each}
-			</div>
-
-			<div class="mt-6 flex gap-3">
-				<Button variant="primary" onclick={save} loading={saving}>Save</Button>
-				<Button variant="secondary" onclick={load} disabled={saving}>Reset to saved</Button>
 			</div>
 		{/if}
 	</SectionCard>


### PR DESCRIPTION
Two independent changes.

## 1. Per-channel feeder move speeds + auto-tune moved down

C1 shifts a whole bulk pile while C3 meters single pieces into classification, so one shared `move_speed_usteps_per_s` was always a compromise. Split into `ch1`/`ch2`/`ch3`, and auto-tune now searches each independently (9 → 11 params).

**On the "do the pulses go out of sync?" question — no.** Each channel's pulse cooldown is already keyed on its own stepper (`self._busy_until[stepper._name]`) and derived from its own move time, and channels coordinate through perception state (`downstream_clear`, the drop-zone latch, `classification_ready`), never through timing. `set_speed_limits` was already issued on every pulse, so this adds no bus traffic. The jam watchdog's recovery nudge turns the *upstream* rotor, so it now correctly uses that channel's speed rather than the stalled channel's.

**Migration matters here.** `getPulsePerceptionConfig` filters out keys it doesn't know, so a `machine.toml` tuned before the split would have silently reverted to the 2000 default on upgrade. `migrateLegacyKeys` seeds all three channels from the old key instead; per-channel values already present always win.

**How to verify it's really wired through.** The pulse log line now reports `ch=` and `speed=`. `scripts/jitter_channel_speeds.py` writes a random ±1–10% perturbation to each channel, holds it, and restores the originals (including on Ctrl-C), so the log can be checked against three known, distinct values:

```
python3 scripts/jitter_channel_speeds.py --hold 60
journalctl -u sorter -f | grep -o 'PulsePerception: ch[0-9_a-z]* pulse ch=[0-9] speed=[0-9]*'
```

If every channel logs the same speed, the plumbing isn't live. The script only writes config — it never commands a motor.

Auto-tune also moves below Parameters on the tuning page; it's the occasional-use panel and it was pushing the everyday fields off screen.

## 2. USB cameras: detect the degraded state, and name the real cause

Diagnosis, confirmed live on kitbash: the USB2 hub carrying the C-channel cameras loses its high-speed handshake on EHCI, the kernel hands the port to the OHCI companion, and everything re-enumerates at **12 Mbit/s**. Nothing disconnects. At full speed these cameras drop every high-res mode from their descriptor, so the 1280x720 request silently lands on **640x480@5** — which is precisely the squished (4:3 stretched into 16:9), washed-out (5fps lets auto-exposure integrate 200ms) and smeared feed. The USB3 classification camera on xhci is unaffected, making it a clean control.

**This was not cosmetic.** `buildChannelDef` rescales zone polygons and `arc_center` by `frame_w/saved_w` *anisotropically* while treating section angles as resolution-independent, so in this state every mask and angular decision was quietly wrong. The old code noticed the mismatch for a 10s grace window and then accepted it forever. That silent acceptance is the real bug fixed here.

**I could not make this software-recoverable, and the PR says so.** I ran the full reset ladder against kitbash in its degraded state, plus an EHCI-companion rebind beyond it. EHCI re-probed and retried the high-speed handshake three times, failing every time:

```
usb 4-1: device descriptor read/64, error -71
usb usb4-port1: Cannot enable. Maybe the USB cable is bad?
usb 4-1: device not accepting address 5, error -71
usb usb4-port1: unable to enumerate USB device
```

480 Mbit/s signalling doesn't survive the current cable; 12 Mbit/s is tolerant enough to enumerate. Reseating works because it changes the physical contact, not because it resets state. **The hub also dropped off five times in 65s before failing for good — this is a hardware fault.**

So the ladder is kept (it does fix the milder variant: a camera that mis-set its format at a healthy link speed), but once exhausted with the link still slow we stop resetting and say so, in the log and on the recovery endpoint: reseat or replace the cable, check hub power.

Rungs that re-enumerate the hub also take the control board's serial port with them (`5-1.4` is the Pico), so they're ordered after every camera-local rung and are **held entirely while the machine is sorting** — recovering a camera must never cost someone their in-progress sort.

## Testing

- Full backend suite compared against `origin/main` in clean worktrees: **zero regressions**, same 17 pre-existing failures, +12 new passing tests. (Note: in a dirty working tree, untracked local modules cause ~7 additional unrelated failures — these are not from this branch.)
- Frontend `svelte-check` clean on the touched page; `npm run build` passes.
- Camera recovery helpers verified read-only against kitbash in its live degraded state; the reset rungs were then executed for real, which is how the physical-fault conclusion was reached.
- kitbash left untouched: repo clean on `main`, temp files removed, control board back at `/dev/ttyACM0`.

**Not yet done:** the per-channel speed change hasn't been exercised on real hardware — kitbash's cameras need a cable reseat first, since a sort test with 640x480 perception wouldn't mean anything.
