### PR TITLE
docs(top-interface): heat-insert Preparation step + insert/fastener corrections

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -75,6 +75,12 @@ parts_needed:
     qty: 1
   - part: cable-idc-2x8-long
     qty: 1
+  - part: m4-ruthex-long
+    qty: 8
+  - part: m5-ruthex-long
+    qty: 24
+  - part: m3-ruthex-long
+    qty: 11
   - part: scr-m5-35-shcs
     qty: 6
   - part: scr-m5-25-shcs
@@ -89,6 +95,8 @@ parts_needed:
     qty: 2
   - part: scr-m5-12-shcs
     qty: 4
+  - part: m4-12mm-countersunk
+    qty: 8
   - part: scr-m3-35-bhcs
     qty: 1
   - part: scr-m3-10-shcs
@@ -113,8 +121,74 @@ Several steps below refer to holes in the Top plate by name (S2 and S3 for the s
   <figcaption>Top plate hole map. S = stepper trio, I = inner ring, O = outer ring, C = cable holes.</figcaption>
 </figure>
 
+{% include step.html n="1" title="Preparation" %}
 
-{% include step.html n="1" title="Attach the interface ribs to the upper fixed section" %}
+Before assembling anything, press the heat inserts into the parts that take them, while the parts are still loose. Fusing them in afterwards is much harder, for example once the Interface upper fixed section is mounted to the Top plate. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Interface upper fixed section:</strong> 4 × M4</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-upper-fixed-section-inserts-full.5f320973aa8f4976.jpg" alt="The Interface upper fixed section ring, underside with the NEMA 23 bracket attached, showing four brass M4 heat inserts around its face">
+    <figcaption>Underside, with the NEMA 23 bracket attached.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Interface NEMA 23 bracket:</strong> 6 × M5 (4 on the top edges, 2 underneath) and 1 × M3 (on the tail)</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-nema23-inserts.51e9fc75c2c3840c.jpg" alt="The Interface NEMA 23 bracket held up, showing four brass M5 inserts on the top edges and one M3 insert on the long tail">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-nema23-inserts-underside.a2c5f24a51e32932.jpg" alt="The underside of the Interface NEMA 23 bracket, showing the two remaining brass M5 heat inserts">
+    <figcaption>Top: four M5 on the edges and one M3 on the tail. Underside: the two remaining M5.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Top interface chute mount:</strong> 4 × M4 and 7 × M3</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside.d9429f336757fc52.jpg" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
+    <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Interface bracket:</strong> 3 × M5 (each of the 6)</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-interface-bracket-inserts.d4d01073358fa475.jpg" alt="An Interface bracket held up, showing three brass M5 heat inserts: one on each long side and one on the tail end">
+    <figcaption>One M5 on each long side and one on the tail end.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Limit switch housing:</strong> 2 × M3</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-limit-switch-housing-inserts.0284a86a83e37af7.jpg" alt="The Limit switch housing held up, showing two brass M3 heat inserts on the face where the roller lever limit switch mounts">
+    <figcaption>The two M3 inserts, where the roller lever limit switch mounts.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Limit switch hammer:</strong> 1 × M3</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-limit-switch-hammer-inserts.8f73ff6876cebff2.jpg" alt="The Limit switch hammer held up, showing a single brass M3 heat insert in its round disc">
+    <figcaption>One M3 insert in the round disc.</figcaption>
+  </figure>
+</div>
+
+The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists every part in the machine that needs inserts.
+
+{% include step.html n="2" title="Attach the interface ribs to the upper fixed section" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -125,6 +199,8 @@ Several steps below refer to holes in the Top plate by name (S2 and S3 for the s
     loading="lazy"></iframe>
 </div>
 
+**Heat inserts first:** press the 4 × M4 inserts into the Interface upper fixed section and the 6 × M5 and 1 × M3 inserts into the Interface NEMA 23 bracket before you assemble anything here.
+
 Attach the Interface rib (switch gap) to the Interface upper fixed section, two positions counterclockwise of the notch for the stepper mount. Use two M5 × 16 mm button head screws, tapping directly into the plastic.
 
 Attach the remaining 5 Interface ribs to the Interface upper fixed section, two M5 × 16 mm button head screws each, again tapping into the plastic.
@@ -133,7 +209,7 @@ Slot the Interface NEMA 23 bracket into the Interface upper fixed section and se
 
 Attach the whole assembly to the bottom of the Top plate with M5 × 22 mm countersunk screws through holes S2 and S3 into the Interface NEMA 23 bracket.
 
-{% include step.html n="2" title="Prepare the interface brackets" %}
+{% include step.html n="3" title="Prepare the interface brackets" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -144,6 +220,8 @@ Attach the whole assembly to the bottom of the Top plate with M5 × 22 mm counte
     loading="lazy"></iframe>
 </div>
 
+**Heat inserts first:** each Interface bracket takes 3 × M5 inserts. Press them in before fitting the extrusion.
+
 Align an Interface bracket with piece E (Interface spoke, long) of aluminum extrusion.
 
 Place T-nuts in the extrusion, lined up with the 4 holes on the side of the Interface bracket.
@@ -152,7 +230,7 @@ Slide the extrusion into the Interface bracket, careful not to dislodge the T-nu
 
 Repeat for all 6 Interface brackets.
 
-{% include step.html n="3" title="Prepare the limit switch interface bracket" %}
+{% include step.html n="4" title="Prepare the limit switch interface bracket" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -163,13 +241,15 @@ Repeat for all 6 Interface brackets.
     loading="lazy"></iframe>
 </div>
 
+**Heat inserts first:** the Limit switch housing takes 2 × M3 inserts. Press them in before assembling it.
+
 Push the Printed dowel pin into the Limit switch housing.
 
 Attach a Roller lever limit switch with 2 screws <span class="fastener-todo">fastener not recorded</span> so the roller sits next to the dowel pin.
 
 Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two M5 × 16 mm socket head screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
-{% include step.html n="4" title="Install the brackets" %}
+{% include step.html n="5" title="Install the brackets" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -186,7 +266,7 @@ Repeat with the 5 other prepared Interface brackets into the 5 other Interface r
 
 Flip the whole assembly and screw all 6 Interface brackets into place with M5 × 22 mm countersunk screws through holes I1 to I6 and O1 to O6.
 
-{% include step.html n="5" title="Prepare the interface chute gear and mount" %}
+{% include step.html n="6" title="Prepare the interface chute gear and mount" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -197,11 +277,13 @@ Flip the whole assembly and screw all 6 Interface brackets into place with M5 ×
     loading="lazy"></iframe>
 </div>
 
+**Heat inserts first:** the Top interface chute mount takes 4 × M4 and 7 × M3 inserts, and the Limit switch hammer takes 1 × M3. Press them in before assembling.
+
 Slot the Limit switch hammer into the Top interface chute mount, then screw it in place from below <span class="fastener-todo">fastener not recorded</span>.
 
 Align the Chute gear on the Top interface chute mount with the notch by the screw for the Limit switch hammer. Attach it with 5 screws <span class="fastener-todo">fastener not recorded</span>.
 
-Align the Top interface lazy Susan washer with the 4 inner heat inserts on the Top interface chute mount. Align the inner ring of the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) with these 4 heat inserts too. Screw the Lazy Susan into position through the washer and into the Top interface chute mount <span class="fastener-todo">fastener not recorded</span>.
+Align the Top interface lazy Susan washer with the 4 inner heat inserts on the Top interface chute mount. Align the inner ring of the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) with these 4 heat inserts too. Screw the Lazy Susan into position through the washer and into the Top interface chute mount with four M4 × 12 mm countersunk screws.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -210,7 +292,7 @@ Align the Top interface lazy Susan washer with the 4 inner heat inserts on the T
 
 Once complete, the free section of the Lazy Susan should rotate freely.
 
-{% include step.html n="6" title="Attach the interface chute to the assembly" %}
+{% include step.html n="7" title="Attach the interface chute to the assembly" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -223,13 +305,13 @@ Once complete, the free section of the Lazy Susan should rotate freely.
 
 Place the Interface big spacer on the Interface upper fixed section with its 4 holes lined up with the 4 heat inserts.
 
-Rotate the free part of the Lazy Susan on the assembled interface chute so that 3 of its holes line up with the holes in the Top interface chute mount. Place the assembly on top of the Interface big spacer with the 3 holes aligned with 3 of the heat inserts. Screw these together tightly <span class="fastener-todo">fastener not recorded</span>.
+Rotate the free part of the Lazy Susan on the assembled interface chute so that 3 of its holes line up with the holes in the Top interface chute mount. Place the assembly on top of the Interface big spacer with the 3 holes aligned with 3 of the heat inserts. Screw these together tightly with three M4 × 12 mm countersunk screws.
 
-Rotate the Top interface chute mount 90 degrees relative to the Interface upper fixed section to reveal the 4th screw hole in the Lazy Susan (it should also line up with a hole in the Interface big spacer and a heat insert). Drive a screw <span class="fastener-todo">fastener not recorded</span> tightly through this hole.
+Rotate the Top interface chute mount 90 degrees relative to the Interface upper fixed section to reveal the 4th screw hole in the Lazy Susan (it should also line up with a hole in the Interface big spacer and a heat insert). Drive a fourth M4 × 12 mm countersunk screw tightly through this hole.
 
 Once done, check that the chute rotates freely relative to the Interface upper fixed section.
 
-{% include step.html n="7" title="Adjust the limit switch" %}
+{% include step.html n="8" title="Adjust the limit switch" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -242,7 +324,7 @@ Once done, check that the chute rotates freely relative to the Interface upper f
 
 Loosen the screws attaching the Limit switch housing to the extrusion. Slide the housing so the Limit switch hammer rotates into place between the Roller lever limit switch and the Printed dowel pin in both directions of rotation. The switch clicks when it is being activated correctly. Avoid friction between the Limit switch hammer and the Printed dowel pin. Tighten the screws to keep the housing in this position.
 
-{% include step.html n="8" title="Install the chute stepper motor" %}
+{% include step.html n="9" title="Install the chute stepper motor" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -263,7 +345,7 @@ Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four M5 �
 
 At this point the chute should still rotate, but you will now feel resistance from the stepper motor.
 
-{% include step.html n="9" title="Attach the cable cage top" %}
+{% include step.html n="10" title="Attach the cable cage top" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -280,7 +362,7 @@ Place the Cable cage bracket (cable mount) on the Interface bracket opposite the
 
 Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable cage top with M5 × 25 mm socket head screws and T-nuts.
 
-{% include step.html n="10" title="Put the cable in the cable cage" %}
+{% include step.html n="11" title="Put the cable in the cable cage" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -303,7 +385,7 @@ Screw the Ribbon cable clamp <span class="fastener-todo">fastener not recorded</
 
 Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long M3 × 35 mm screw through the Cable clamp (inner) into the M3 nut in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
 
-{% include step.html n="11" title="Attach the cable cage bottom" %}
+{% include step.html n="12" title="Attach the cable cage bottom" %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -318,7 +400,7 @@ Place the Cable cage bottom over the Top interface chute mount. Use 6 M5 × 35 m
 
 After this step the chute should still rotate to each of its limits.
 
-{% include step.html n="12" title="Attach the framing" %}
+{% include step.html n="13" title="Attach the framing" %}
 
 Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with four M5 × 20 mm button head screws into four T-nuts.
 

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -44,6 +44,16 @@ m4-ruthex-long:
   category: Heat inserts
   image: https://img.basically.website/web/parts/hardware/heat-inserts/m4-ruthex-long/insert.aabba833ab98e7db.jpg
 
+m5-ruthex-long:
+  name: M5 Ruthex heat insert (long)
+  category: Heat inserts
+  image: https://img.basically.website/web/parts/hardware/heat-inserts/m5-ruthex-long.cb9fbbc0fed59e3b.jpg
+
+m3-ruthex-long:
+  name: M3 Ruthex heat insert (long)
+  category: Heat inserts
+  image: https://img.basically.website/web/parts/hardware/heat-inserts/m3-ruthex-long.3173f0ffeef63ca4.jpg
+
 m4-12mm-countersunk:
   name: M4 × 12 mm countersunk screw
   category: Screws
@@ -118,6 +128,9 @@ interface-upper-fixed-section:
   name: Interface upper fixed section
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/interface-upper-fixed-section.43022d76c3781bf3.png
+  heat_inserts:
+    - insert: m4-ruthex-long
+      qty: 4
 
 interface-rib:
   name: Interface rib
@@ -133,6 +146,9 @@ interface-bracket:
   name: Interface bracket
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/interface-bracket.06c0c5896cd8eada.png
+  heat_inserts:
+    - insert: m5-ruthex-long
+      qty: 3
 
 interface-spacer:
   name: Interface spacer
@@ -143,6 +159,11 @@ interface-nema23-bracket:
   name: Interface NEMA 23 bracket
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/interface-nema23-bracket.65680e73221cff98.png
+  heat_inserts:
+    - insert: m5-ruthex-long
+      qty: 6
+    - insert: m3-ruthex-long
+      qty: 1
 
 interface-big-spacer:
   name: Interface big spacer
@@ -153,6 +174,9 @@ limit-switch-housing:
   name: Limit switch housing
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/limit-switch-housing.6e5f8214b3702dbc.png
+  heat_inserts:
+    - insert: m3-ruthex-long
+      qty: 2
 
 limit-switch-dowel-pin:
   name: Printed dowel pin
@@ -163,11 +187,19 @@ limit-switch-hammer:
   name: Limit switch hammer
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/limit-switch-hammer.e125ead0312a27d0.png
+  heat_inserts:
+    - insert: m3-ruthex-long
+      qty: 1
 
 top-interface-split-spur-gear-3:
   name: Top interface chute mount
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/top-interface-split-spur-gear-3.38a5bd2da98bbe1a.png
+  heat_inserts:
+    - insert: m4-ruthex-long
+      qty: 4
+    - insert: m3-ruthex-long
+      qty: 7
 
 top-interface-split-spur-gear-1:
   name: Chute gear

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -608,6 +608,38 @@ body {
 	border: 1px solid color-mix(in srgb, var(--color-warning) 45%, transparent);
 }
 
+/* Grouped part + insert-photo rows in the Preparation step */
+.prep-item {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px 24px;
+	margin: 1.1rem 0;
+	padding-bottom: 1.1rem;
+	border-bottom: 1px solid var(--line);
+}
+.prep-item:last-of-type {
+	border-bottom: none;
+}
+.prep-item-body {
+	flex: 1 1 220px;
+	min-width: 200px;
+}
+.prep-item-body p {
+	margin: 0;
+}
+.prep-item-figure {
+	flex: 0 1 360px;
+	margin: 0;
+}
+.prep-item-figure img {
+	width: 100%;
+	display: block;
+}
+.prep-item-figure img + img {
+	margin-top: 8px;
+}
+
 .part-card-missing {
 	color: var(--muted);
 	font-family: var(--font-mono);


### PR DESCRIPTION
Follow-up to #299. That PR merged the framing step, the parts-needed list and the top-plate hole map. This one carries the **heat-insert half** of the work, which all landed on the branch *after* #299 was squash-merged, so it needs its own PR.

### What's here
- **A "Preparation" step** (new step 1) with a row per insert-bearing part, each grouped with a heat-insert photo pulled from the assembly source videos:
  - Interface upper fixed section — 4 × M4
  - Interface NEMA 23 bracket — 6 × M5 (4 top edges, 2 underside) + 1 × M3 (tail)
  - Top interface chute mount — 4 × M4 + 7 × M3
  - Interface bracket — 3 × M5
  - Limit switch housing — 2 × M3
  - Limit switch hammer — 1 × M3
- Heat inserts added to the catalog (M5/M3 long entries) and the parts list.
- **Data corrections** from barthel's frame-by-frame audit — `parts-calculator`'s `parts.json` had the NEMA bracket, chute mount and hammer insert counts wrong or missing; corrected here, and it needs the same fix upstream.
- Lazy Susan screws specified as **M4 × 12 mm countersunk**.

### Known remaining gap
Eight smaller screws are still marked `fastener not recorded` in the steps (chute gear, spur gear, idler, roller switch and a few singles), flagged inline and disclosed in a callout at the top.

Build passes on Node 20; `validate_frontmatter.py` and `validate_images.py` both clean.

Thanks to barthel for the insert/fastener audit and the video timestamps, and zed0 for the source doc.
