### PR TITLE
harness: keep the project and the company out of the supplier package

### DIFF
--- a/electronics/wire_harness/board-power.yml
+++ b/electronics/wire_harness/board-power.yml
@@ -1,6 +1,6 @@
 metadata:
-  title: Sorter V2 - 24V to basically board v1.3
-  description: "The board's 24V feed. The buildable sub-harness for W1 on\nthe 24V power distribution drawing. From Jon's\nDC_basicallyV1_3_Harness (2026-08-08)."
+  title: 24V to controller board v1.3
+  description: "The board's 24V feed. The buildable sub-harness for W1 on\nthe 24V power distribution drawing. From the\ncontroller-board reference drawing (2026-08-08)."
 
 connectors:
   P1:
@@ -11,7 +11,7 @@ connectors:
     type: JST VH 2-pin (VHR-2)
     subtype: female
     pinlabels: [+24V, GND]
-    notes: "basically board v1.3 24V input\nPin 1 = +24V, pin 2 = GND"
+    notes: "controller board v1.3 24V input\nPin 1 = +24V, pin 2 = GND"
     additional_components:
       - type: Terminal - SVH-21T-P1.1
         qty: 1

--- a/electronics/wire_harness/leds.yml
+++ b/electronics/wire_harness/leds.yml
@@ -1,12 +1,12 @@
 metadata:
-  title: Sorter V2 - LED drops and limit switch
-  description: "LED feeds L1-L3 (board to unplug point), pigtails L1p-L3p,\nand the limit switch cable. Jon's 2026-08-08 drawings do not\ncover the LED drops, so apart from the limit switch\nterminals everything here is still Spencer's July 12th\nnotes. Values marked GUESS are guesses, not measurements."
+  title: LED drops and limit switch
+  description: "LED feeds L1-L3 (board to unplug point), pigtails L1p-L3p,\nand the limit switch cable. The 2026-08-08 reference drawings\ndo not cover the LED drops, so apart from the limit switch\nterminals everything here is still from earlier engineering\nnotes. Values marked GUESS are guesses, not measurements."
 
 connectors:
   BOARD_L1: &dupont
     type: Dupont 1x2 female, 2.54 mm
     pinlabels: [+24V, GND]
-    notes: "On basically board v1.3. GUESS - verify which\npin is +."
+    notes: "On controller board v1.3. GUESS - verify which\npin is +."
   BOARD_L2: *dupont
   BOARD_L3: *dupont
   LJ1: &ledjack
@@ -33,7 +33,7 @@ connectors:
     type: Dupont 1x3 female, 2.54 mm
     pincount: 3
     pinlabels: [SIG, GND, n/c]
-    notes: "On basically board v1.3. Position 3 is\ndeliberately unpopulated so the plug cannot go\non backwards. GUESS - verify pin order."
+    notes: "On controller board v1.3. Position 3 is\ndeliberately unpopulated so the plug cannot go\non backwards. GUESS - verify pin order."
   SW:
     type: "Quick-connect receptacle, #187 (4.75 x 0.5 mm tab)"
     pinlabels: [SIG, GND]
@@ -44,21 +44,21 @@ cables:
     gauge: 22 AWG
     length: 36 in
     colors: [RD, BK]
-    notes: "LED feed. Gauge = GUESS, not covered by Jon's\ndrawings."
+    notes: "LED feed. Gauge = GUESS, not covered by the\nreference drawings."
   L2: *feed
   L3: *feed
   L1P: &pig
     gauge: 22 AWG
     length: 6 in
     colors: [RD, BK]
-    notes: "LED pigtail. Gauge = GUESS, not covered by\nJon's drawings."
+    notes: "LED pigtail. Gauge = GUESS, not covered by\nthe reference drawings."
   L2P: *pig
   L3P: *pig
   LIM:
     gauge: 22 AWG
     length: 24 in
     colors: [WH, BK]
-    notes: "Limit switch. Gauge = GUESS, not covered by\nJon's drawings."
+    notes: "Limit switch. Gauge = GUESS, not covered by\nthe reference drawings."
 
 connections:
   -

--- a/electronics/wire_harness/power.yml
+++ b/electronics/wire_harness/power.yml
@@ -1,6 +1,6 @@
 metadata:
-  title: Sorter V2 - 24V power distribution
-  description: "PSU box pigtails PJ1-PJ3 and load cables W1-W3. The PSU end\nand the board end follow Jon's DC_PSU_Harness and\nDC_basicallyV1_3_Harness drawings (2026-08-08), which are\nthe source of truth for those. Values marked GUESS are\nguesses, not measurements."
+  title: 24V power distribution
+  description: "PSU box pigtails PJ1-PJ3 and load cables W1-W3. The PSU end\nand the board end follow the DC_PSU_Harness and\ncontroller-board reference drawings (2026-08-08),\nwhich are the source of truth for those. Values marked GUESS\nare guesses, not measurements."
 
 connectors:
   PSU:
@@ -22,7 +22,7 @@ connectors:
     type: JST VH 2-pin (VHR-2)
     subtype: female
     pinlabels: [+24V, GND]
-    notes: "basically board v1.3 24V input\nPin 1 = +24V, pin 2 = GND"
+    notes: "controller board v1.3 24V input\nPin 1 = +24V, pin 2 = GND"
     additional_components:
       - type: Terminal - SVH-21T-P1.1
         qty: 1
@@ -55,12 +55,12 @@ cables:
     gauge: 22 AWG
     length: 12 in
     colors: [RD, BK]
-    notes: "USB hub, double-male. Gauge = GUESS, not\ncovered by Jon's drawings."
+    notes: "USB hub, double-male. Gauge = GUESS, not\ncovered by the reference drawings."
   W3:
     gauge: 22 AWG
     length: 6 in
     colors: [RD, BK]
-    notes: "Orange Pi buck. Gauge = GUESS, not covered by\nJon's drawings."
+    notes: "Orange Pi buck. Gauge = GUESS, not covered by\nthe reference drawings."
 
 connections:
   -

--- a/electronics/wire_harness/psu-pigtail.yml
+++ b/electronics/wire_harness/psu-pigtail.yml
@@ -1,6 +1,6 @@
 metadata:
-  title: Sorter V2 - PSU output pigtail
-  description: "One PSU output pigtail, x3 per PSU build. The buildable sub-\nharness for PJ1-PJ3 on the 24V power distribution drawing.\nScrew numbers are MeanWell's own (LRS-350-SPEC): 4-6 are DC\nOUTPUT -V, 7-9 are DC OUTPUT +V. From Jon's DC_PSU_Harness\n(2026-08-08)."
+  title: PSU output pigtail
+  description: "One PSU output pigtail, x3 per PSU build. The buildable sub-\nharness for PJ1-PJ3 on the 24V power distribution drawing.\nScrew numbers are MeanWell's own (LRS-350-SPEC): 4-6 are DC\nOUTPUT -V, 7-9 are DC OUTPUT +V. From the PSU reference\ndrawing (2026-08-08)."
 
 connectors:
   F1:

--- a/electronics/wire_harness/rfq.txt
+++ b/electronics/wire_harness/rfq.txt
@@ -1,4 +1,4 @@
-RFQ - Sorter V2 wire harness
+RFQ - custom wire harness
 =============================================================
 STATUS: DRAFT - NOT VALIDATED. Values marked GUESS in the
 drawings are engineering guesses, not measurements. Do not
@@ -6,7 +6,7 @@ start production without a confirmed revision.
 =============================================================
 
 1. WHAT THIS IS
-Custom cable assemblies for one machine (a parts sorter).
+Custom cable assemblies for one machine.
 3 drawing sets are attached (PDF/PNG/SVG/HTML, generated with
 WireViz), each with its own BOM (TSV):
   - power     : PSU pigtails PJ1-PJ3, load cables W1-W3

--- a/electronics/wire_harness/steppers.yml
+++ b/electronics/wire_harness/steppers.yml
@@ -1,13 +1,13 @@
 metadata:
-  title: Sorter V2 - stepper cables
-  description: "Channel stepper cable S (x4) and chute stepper cable CH. S\nfollows Jon's Stepper_Harness drawing (2026-08-08), which is\nthe source of truth for the channel cable. Values marked\nGUESS are guesses, not measurements."
+  title: Stepper cables
+  description: "Channel stepper cable S (x4) and chute stepper cable CH. S\nfollows the stepper reference drawing (2026-08-08),\nwhich is the source of truth for the channel cable. Values\nmarked GUESS are guesses, not measurements."
 
 connectors:
   BOARD_S:
     type: JST PH 4-pin (PHR-4)
     subtype: 2.0mm pitch, female
     pinlabels: [A2, A1, B1, B2]
-    notes: "basically board v1.3 J23/J27/J31/J35. One\ncable per jack, x4 identical."
+    notes: "controller board v1.3 J23/J27/J31/J35. One\ncable per jack, x4 identical."
     additional_components:
       - type: Terminal - SPH-002T-P0.5S
         qty: 1
@@ -29,7 +29,7 @@ connectors:
     type: JST PH 4-pin (PHR-4)
     subtype: female
     pinlabels: [A2, A1, B1, B2]
-    notes: basically board v1.3 J39
+    notes: controller board v1.3 J39
   CH_LEADS:
     type: Bare tinned leads, labeled 1-4
     pinlabels: [A2, A1, B1, B2]
@@ -52,7 +52,7 @@ cables:
     gauge: 24 AWG
     length: 40 in
     colors: [BK, GN, RD, BU]
-    notes: "qty 1. Straight-through. Not covered by Jon's\ndrawing, so unlike S both Gauge and Length\nhere are still GUESS."
+    notes: "qty 1. Straight-through. Not covered by the\nreference drawing, so unlike S both Gauge and\nLength here are still GUESS."
 
 connections:
   -


### PR DESCRIPTION
The RFQ zip goes to cable vendors we have no relationship with, and it was carrying enough to identify the machine and who builds it:

  - every drawing titled "Sorter V2 - ..."
  - "basically board v1.3" on connector notes across four drawings
  - "DC_basicallyV1_3_Harness" cited as a source drawing
  - rfq.txt headed "RFQ - Sorter V2 wire harness", describing the job as cable assemblies for "a parts sorter"

All of that is baked into the rendered PNG/SVG/PDF, not just the yml, so it reached everyone we sent the zip to. Titles now describe the drawing, the board is "controller board v1.3", and rfq.txt asks for cables for "one machine". Personal names sitting in the same descriptions went with them.

No dimensions, part numbers, colors, pinouts or wiring changed. The diff is titles and descriptions only, and out/ regenerates clean: no "sorter", "basically", "lego" or "brick" in any shipped artifact.

The zip is still named sorter-v2-harness-rfq.zip. Renaming it would touch build-harness.sh, upload-harness.py, the docs page and the content-addressed URL in _data/harness.yml, and it is served from a public project URL regardless, so rename the file when sending it rather than here.