### PR TITLE
docs(assembly): fastener icons + top-interface spec corrections + not-in-calc marker

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -28,6 +28,8 @@ parts_needed:
 
 The bottom interface stacks the chute mount, a spacer ring, the Lazy Susan bearing, and the bottom static part. Here it is exploded into its components:
 
+{% include fastener-legend.html %}
+
 <div class="img-row">
   <figure>
     <img src="https://img.basically.website/web/assembly/bottom-interface/exploded-view-cropped.1e520f8cdb04989d.jpg" alt="Exploded view of the bottom interface: chute mount on top, spacer ring, Lazy Susan bearing, and the corner mounting brackets below">
@@ -48,7 +50,7 @@ Once assembled, it mounts into the machine frame:
 
 {% include step.html n="1" title="Mount the Lazy Susan to the chute mount" %}
 
-Set the spacer on the chute mount and the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) on top. You need to remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})). Line up a screw hole with a heat insert in the chute mount and drive the screw. Repeat around the disc.
+Set the spacer on the chute mount and the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) on top. You need to remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})). Line up a screw hole with a heat insert in the chute mount and drive the {% include fastener.html size="M4" variant="countersunk" length="12" %} screw. Repeat around the disc.
 
 <div class="img-row">
   <figure>
@@ -63,7 +65,7 @@ The Lazy Susan is two discs, inner and outer, that spin independently. One disc'
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>The M4 × 12 mm countersunk screws must be very tight. Most electric screwdrivers won't tighten them enough. They're a hassle to reach if they come loose, and machine vibration can work them loose.</p>
+  <p>The {% include fastener.html size="M4" variant="countersunk" length="12" %} screws must be very tight. Most electric screwdrivers won't tighten them enough. They're a hassle to reach if they come loose, and machine vibration can work them loose.</p>
 </div>
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/lazy-susan-on-chute-mount.d478621b1f81e5ae.jpg" alt="Lazy Susan bearing mounted on the chute mount with the spacer between them">

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -43,7 +43,9 @@ This guide covers creating a regular layer. It's also the basis for creating the
 
 Note that some of the ordering in this guide may seem unusual, but it's written this way to avoid both putting unnecessary strain on pieces, and allowing for the use of slide-in T-nuts.
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The T-nut count above is the minimum you need if you tap directly into the printed parts where you can, and goes up if you fasten with T-nuts throughout instead.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The {% include fastener.html size="M5" variant="t-nut" %} count above is the minimum you need if you tap directly into the printed parts where you can, and goes up if you fasten with T-nuts throughout instead.
+
+{% include fastener-legend.html %}
 
 {% include step.html n="1" title="Assemble the frame brackets" %}
 
@@ -56,7 +58,7 @@ The aluminum extrusion is cut to length; the [framing cut list](https://parts-ca
   </figure>
 </div>
 
-Slide piece A/G (Outer horizontal / Horizontal interface frame) of aluminum extrusion into an External bracket — side. Use an M5 × 16 mm screw to tap directly through the outer of the two adjacent holes on the External bracket — side, bracing it against the extrusion. If you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes to fasten into them instead.
+Slide piece A/G (Outer horizontal / Horizontal interface frame) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side, bracing it against the extrusion. If you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes to fasten into them instead.
 
 If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2 into the innermost section of the extrusion and 4 into the outermost section before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
 
@@ -78,7 +80,7 @@ If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2
   </figure>
 </div>
 
-Repeat these steps to make two semi-circles of three sections of extrusion and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more M5 × 16 mm button head screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
+Repeat these steps to make two semi-circles of three sections of extrusion and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/two-half-hexagons.cfd5d241ba46d491.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
 
@@ -106,9 +108,9 @@ Prepare 12 Frame 90° brackets by drilling out the holes on the long side to all
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/spoke-brackets-attached.bdf5459b2c7f06bc.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">
 
-Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 M5 × 12 mm screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
+Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 {% include fastener.html size="M5" variant="button" length="12" %} screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
 
-Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the 2 Frame 90° brackets that you have just placed, and secure it with 2 M5 × 16 mm screws tapped directly into the Frame 90° brackets, bracing against the extrusion. You can now tighten up the M5 × 12 mm screws that were previously holding the Frame 90° brackets loosely in place.
+Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the 2 Frame 90° brackets that you have just placed, and secure it with 2 {% include fastener.html size="M5" variant="button" length="16" %} screws tapped directly into the Frame 90° brackets, bracing against the extrusion. You can now tighten up the {% include fastener.html size="M5" variant="button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
 
 <div class="img-row">
   <figure>
@@ -119,7 +121,7 @@ Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the
   </figure>
 </div>
 
-On each side of this B/H (Spoke / Interface spoke (short)) slide a Frame crossbeam into place until it is level with the end of the extrusion, and secure it with an M5 × 20 mm screw.
+On each side of this B/H (Spoke / Interface spoke (short)) slide a Frame crossbeam into place until it is level with the end of the extrusion, and secure it with an {% include fastener.html size="M5" variant="socket" length="20" %} screw.
 
 Perform these steps 2 more times, on every 2nd side of the hexagon.
 
@@ -134,7 +136,7 @@ Perform these steps 2 more times, on every 2nd side of the hexagon.
   </figure>
 </div>
 
-On each of the remaining 3 sides of the hexagon, use 2 M5 × 12 mm screws (either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts) to loosely fasten 2 Frame 90° brackets, aligning them with the gap in the Frame crossbeams. Slide the remaining B/H (Spoke / Interface spoke (short)) pieces into the slots, through both the Frame crossbeams and Frame 90° brackets.
+On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html size="M5" variant="button" length="12" %} screws (either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts) to loosely fasten 2 Frame 90° brackets, aligning them with the gap in the Frame crossbeams. Slide the remaining B/H (Spoke / Interface spoke (short)) pieces into the slots, through both the Frame crossbeams and Frame 90° brackets.
 
 <div class="img-row">
   <figure>
@@ -147,7 +149,7 @@ On each of the remaining 3 sides of the hexagon, use 2 M5 × 12 mm screws (eithe
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/spokes-complete-top.517a329e0407cb17.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
 
-Secure them in place with 2 M5 × 16 mm screws tapped into the Frame 90° brackets and 2 M5 × 20 mm screws through the Frame crossbeams. You can now tighten up the M5 × 12 mm screws that were previously holding the Frame 90° brackets loosely in place.
+Secure them in place with 2 {% include fastener.html size="M5" variant="button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
 
 <div class="callout">
   <p>If you are currently building the interface layer, stop here and return to the interface layer guide.</p>
@@ -164,7 +166,7 @@ Secure them in place with 2 M5 × 16 mm screws tapped into the Frame 90° bracke
   </figure>
 </div>
 
-On each corner of your hexagon, slot an External bracket — cover onto the External bracket — side (do this before attaching the extrusion, since it's tricky to get in place afterwards). Slot piece C (Layer vertical support) of aluminum extrusion between the External bracket — cover and the External bracket — side. At typical cut length you can leave this 3 mm short at either end, so try to align it about 3 mm above the bottom. Use 2 M5 × 16 mm screws tapped through the holes near the bottom of the External bracket — side to secure the extrusion.
+On each corner of your hexagon, slot an External bracket — cover onto the External bracket — side (do this before attaching the extrusion, since it's tricky to get in place afterwards). Slot piece C (Layer vertical support) of aluminum extrusion between the External bracket — cover and the External bracket — side. At typical cut length you can leave this 3 mm short at either end, so try to align it about 3 mm above the bottom. Use 2 {% include fastener.html size="M5" variant="button" length="16" %} screws tapped through the holes near the bottom of the External bracket — side to secure the extrusion.
 
 <div class="img-row">
   <figure>
@@ -175,12 +177,12 @@ On each corner of your hexagon, slot an External bracket — cover onto the Exte
   </figure>
 </div>
 
-On each corner, slide an External bracket — bottom vertical onto piece C (Layer vertical support), ensuring the angles of the External bracket — bottom vertical align at the bottom. Secure them with 2 M5 × 16 mm screws through the outer holes on the External bracket — bottom vertical. The extrusion will likely rest a few mm below the top.
+On each corner, slide an External bracket — bottom vertical onto piece C (Layer vertical support), ensuring the angles of the External bracket — bottom vertical align at the bottom. Secure them with 2 {% include fastener.html size="M5" variant="button" length="16" %} screws through the outer holes on the External bracket — bottom vertical. The extrusion will likely rest a few mm below the top.
 
 {% include step.html n="4" title="Add the bin retainers" %}
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/bin-retainers-installed.945ecff28147b1f1.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
 
-On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 M5 × 12 mm screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
+On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
 
 A regular layer is now complete. You will also need to construct a [Chute core]({{ '/hardware/assembly/distribution/chute/' | relative_url }}) for each layer you build.

--- a/docs/src/content/hardware/assembly/distribution/external-bracket.md
+++ b/docs/src/content/hardware/assembly/distribution/external-bracket.md
@@ -19,6 +19,8 @@ parts_needed:
 
 Three printed parts that bolt together into one external bracket. **6 per distribution frame (per layer), plus one set per interface.**
 
+{% include fastener-legend.html %}
+
 | Part | Qty per bracket | Qty per machine (6 brackets/layer) | Weight | STL |
 |---|---|---|---|---|
 | External bracket — side | 1 | 6 | 48.5 g | [Download STL](https://sorter-v2-parts.nyc3.cdn.digitaloceanspaces.com/stl/da4b3abd3db72070484178ef5aa1d0906397c6a310bdf0e22f724940bd62dba2.stl) |
@@ -31,14 +33,14 @@ Three printed parts that bolt together into one external bracket. **6 per distri
 |---|---|---|
 | C-Layer vertical support (extrusion) | 1 | The vertical aluminum extrusion the bracket clamps onto. |
 
-- No heat inserts are used on this assembly. Joining is **self-tap**: the M5 × 16 mm screws thread directly into the printed plastic.
+- No heat inserts are used on this assembly. Joining is **self-tap**: the {% include fastener.html size="M5" variant="socket" length="16" %} screws thread directly into the printed plastic.
 - The most-used M5 in the machine, the same screw used on every external bracket, every bin bracket, every interface rib, and every lazy Susan extrusion mount.
-- Of the four M5 × 16 mm screws: **2** join the bottom-vertical part to the side bracket, and **2** clamp the side bracket against the C-Layer vertical support to hold it in place. The **cover clips on**, it takes no screws.
+- Of the four {% include fastener.html size="M5" variant="socket" length="16" %} screws: **2** join the bottom-vertical part to the side bracket, and **2** clamp the side bracket against the C-Layer vertical support to hold it in place. The **cover clips on**, it takes no screws.
 - Matching parts from the same print run are embossed with a shared set code (e.g. **"b2"**) on both the side bracket and the bottom-vertical part, keep marked pairs together so brackets don't get mixed across sets.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/parts-laid-out.0a59300a73b4f6c2.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
-  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four M5 × 16 mm screws. The cover is fitted last, in Step 4.</figcaption>
+  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four {% include fastener.html size="M5" variant="socket" length="16" %} screws. The cover is fitted last, in Step 4.</figcaption>
 </figure>
 
 <div class="img-row">
@@ -48,17 +50,17 @@ Three printed parts that bolt together into one external bracket. **6 per distri
   </figure>
   <figure>
     <img src="https://img.basically.website/web/assembly/external-bracket/bottom-vertical-flange.4b9a511aea49346c.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
-    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two M5 × 16 mm screws in Step 1 go into.</figcaption>
+    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two {% include fastener.html size="M5" variant="socket" length="16" %} screws in Step 1 go into.</figcaption>
   </figure>
 </div>
 
 {% include step.html n="1" title="Mount the bottom-vertical leg to the side bracket" %}
 
-Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two M5 × 16 mm socket head screws down through the flange into the side bracket.
+Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two {% include fastener.html size="M5" variant="socket" length="16" %} screws down through the flange into the side bracket.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step1-screwed-underside.d3637471f50acb1b.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
-  <figcaption>Two M5 × 16 mm screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.</figcaption>
+  <figcaption>Two {% include fastener.html size="M5" variant="socket" length="16" %} screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.</figcaption>
 </figure>
 
 <div class="callout callout-warning">
@@ -77,7 +79,7 @@ Slide the C-Layer vertical support (the vertical aluminum extrusion) down throug
 
 {% include step.html n="3" title="Screw the bracket down onto the extrusion" %}
 
-Two more M5 × 16 mm screws clamp the side bracket against the C-Layer vertical support to hold it firmly in place.
+Two more {% include fastener.html size="M5" variant="socket" length="16" %} screws clamp the side bracket against the C-Layer vertical support to hold it firmly in place.
 
 <div class="img-row">
   <figure>
@@ -86,7 +88,7 @@ Two more M5 × 16 mm screws clamp the side bracket against the C-Layer vertical 
   </figure>
   <figure>
     <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-driven-in.259bbc4b6fdbb5b2.jpg" alt="Retention screw driven in, seated flush in the hex socket">
-    <figcaption>After: M5 × 16 mm screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
+    <figcaption>After: {% include fastener.html size="M5" variant="socket" length="16" %} screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -114,6 +114,8 @@ parts_needed:
   <p>The fasteners and quantities in the parts list come from the build notes and are called out inline at each step. A few smaller screws are not recorded yet; those are marked <span class="fastener-todo">fastener not recorded</span> in the steps below. If you know one, please add its size.</p>
 </div>
 
+{% include fastener-legend.html %}
+
 Several steps below refer to holes in the Top plate by name (S2 and S3 for the stepper mount, I1 to I6 and O1 to O6 for the interface brackets). This map shows which hole is which:
 
 <figure>
@@ -201,13 +203,13 @@ The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists ever
 
 **Heat inserts first:** press the 4 × M4 inserts into the Interface upper fixed section and the 6 × M5 and 1 × M3 inserts into the Interface NEMA 23 bracket before you assemble anything here.
 
-Attach the Interface rib (switch gap) to the Interface upper fixed section, two positions counterclockwise of the notch for the stepper mount. Use two M5 × 16 mm button head screws, tapping directly into the plastic.
+Attach the Interface rib (switch gap) to the Interface upper fixed section, two positions counterclockwise of the notch for the stepper mount. Use two {% include fastener.html size="M5" variant="button" length="16" %} screws, tapping directly into the plastic.
 
-Attach the remaining 5 Interface ribs to the Interface upper fixed section, two M5 × 16 mm button head screws each, again tapping into the plastic.
+Attach the remaining 5 Interface ribs to the Interface upper fixed section, two {% include fastener.html size="M5" variant="button" length="16" %} screws each, again tapping into the plastic.
 
 Slot the Interface NEMA 23 bracket into the Interface upper fixed section and secure it with a screw from below <span class="fastener-todo">fastener not recorded</span>.
 
-Attach the whole assembly to the bottom of the Top plate with M5 × 22 mm countersunk screws through holes S2 and S3 into the Interface NEMA 23 bracket.
+Attach the whole assembly to the bottom of the Top plate with {% include fastener.html size="M5" variant="countersunk" length="22" %} screws through holes S2 and S3 into the Interface NEMA 23 bracket.
 
 {% include step.html n="3" title="Prepare the interface brackets" %}
 
@@ -226,7 +228,7 @@ Align an Interface bracket with piece E (Interface spoke, long) of aluminum extr
 
 Place T-nuts in the extrusion, lined up with the 4 holes on the side of the Interface bracket.
 
-Slide the extrusion into the Interface bracket, careful not to dislodge the T-nuts, and drive four M5 × 16 mm button head screws into them.
+Slide the extrusion into the Interface bracket, careful not to dislodge the T-nuts, and drive four {% include fastener.html size="M5" variant="button" length="16" %} screws into them.
 
 Repeat for all 6 Interface brackets.
 
@@ -247,7 +249,7 @@ Push the Printed dowel pin into the Limit switch housing.
 
 Attach a Roller lever limit switch with 2 screws <span class="fastener-todo">fastener not recorded</span> so the roller sits next to the dowel pin.
 
-Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two M5 × 16 mm socket head screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
+Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two {% include fastener.html size="M5" variant="socket" length="16" %} screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
 {% include step.html n="5" title="Install the brackets" %}
 
@@ -264,7 +266,7 @@ Slide a T-nut just into the end of the extrusion of the limit switch interface b
 
 Repeat with the 5 other prepared Interface brackets into the 5 other Interface ribs.
 
-Flip the whole assembly and screw all 6 Interface brackets into place with M5 × 22 mm countersunk screws through holes I1 to I6 and O1 to O6.
+Flip the whole assembly and screw all 6 Interface brackets into place with {% include fastener.html size="M5" variant="countersunk" length="22" %} screws through holes I1 to I6 and O1 to O6.
 
 {% include step.html n="6" title="Prepare the interface chute gear and mount" %}
 
@@ -283,7 +285,7 @@ Slot the Limit switch hammer into the Top interface chute mount, then screw it i
 
 Align the Chute gear on the Top interface chute mount with the notch by the screw for the Limit switch hammer. Attach it with 5 screws <span class="fastener-todo">fastener not recorded</span>.
 
-Align the Top interface lazy Susan washer with the 4 inner heat inserts on the Top interface chute mount. Align the inner ring of the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) with these 4 heat inserts too. Screw the Lazy Susan into position through the washer and into the Top interface chute mount with four M4 × 12 mm countersunk screws.
+Align the Top interface lazy Susan washer with the 4 inner heat inserts on the Top interface chute mount. Align the inner ring of the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) with these 4 heat inserts too. Screw the Lazy Susan into position through the washer and into the Top interface chute mount with four {% include fastener.html size="M4" variant="countersunk" length="12" %} screws.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -305,9 +307,9 @@ Once complete, the free section of the Lazy Susan should rotate freely.
 
 Place the Interface big spacer on the Interface upper fixed section with its 4 holes lined up with the 4 heat inserts.
 
-Rotate the free part of the Lazy Susan on the assembled interface chute so that 3 of its holes line up with the holes in the Top interface chute mount. Place the assembly on top of the Interface big spacer with the 3 holes aligned with 3 of the heat inserts. Screw these together tightly with three M4 × 12 mm countersunk screws.
+Rotate the free part of the Lazy Susan on the assembled interface chute so that 3 of its holes line up with the holes in the Top interface chute mount. Place the assembly on top of the Interface big spacer with the 3 holes aligned with 3 of the heat inserts. Screw these together tightly with three {% include fastener.html size="M4" variant="countersunk" length="12" %} screws.
 
-Rotate the Top interface chute mount 90 degrees relative to the Interface upper fixed section to reveal the 4th screw hole in the Lazy Susan (it should also line up with a hole in the Interface big spacer and a heat insert). Drive a fourth M4 × 12 mm countersunk screw tightly through this hole.
+Rotate the Top interface chute mount 90 degrees relative to the Interface upper fixed section to reveal the 4th screw hole in the Lazy Susan (it should also line up with a hole in the Interface big spacer and a heat insert). Drive a fourth {% include fastener.html size="M4" variant="countersunk" length="12" %} screw tightly through this hole.
 
 Once done, check that the chute rotates freely relative to the Interface upper fixed section.
 
@@ -341,7 +343,7 @@ Push a 608 2RS bearing into the Interface idler gear.
 
 Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards and secure it with a button head screw <span class="fastener-todo">fastener not recorded</span> (the video uses a screw with a washer).
 
-Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four M5 × 12 mm screws.
+Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four {% include fastener.html size="M5" variant="socket" length="12" %} screws.
 
 At this point the chute should still rotate, but you will now feel resistance from the stepper motor.
 
@@ -358,9 +360,9 @@ At this point the chute should still rotate, but you will now feel resistance fr
 
 Slot the Cable cage top over the Top interface chute mount, with the corners of the hexagon aligning with the Interface brackets.
 
-Place the Cable cage bracket (cable mount) on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable). Screw it into the Interface bracket with an M5 × 25 mm socket head screw and a T-nut, clamping down the Cable cage top.
+Place the Cable cage bracket (cable mount) on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable). Screw it into the Interface bracket with an {% include fastener.html size="M5" variant="socket" length="25" %} screw and a T-nut, clamping down the Cable cage top.
 
-Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable cage top with M5 × 25 mm socket head screws and T-nuts.
+Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable cage top with {% include fastener.html size="M5" variant="socket" length="25" %} screws and T-nuts.
 
 {% include step.html n="11" title="Put the cable in the cable cage" %}
 
@@ -373,7 +375,7 @@ Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable
     loading="lazy"></iframe>
 </div>
 
-Place an M3 nut into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two M3 × 10 mm socket head screws.
+Place an {% include fastener.html size="M3" variant="nut" %} into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two {% include fastener.html size="M3" variant="socket" length="10" %} screws.
 
 Rotate the chute until it hits the limit switch.
 
@@ -383,7 +385,7 @@ Guide the rest of the ribbon cable around the side of the Top interface chute mo
 
 Screw the Ribbon cable clamp <span class="fastener-todo">fastener not recorded</span> lightly to the Cable cage bracket (cable mount), clamping the ribbon cable between the two.
 
-Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long M3 × 35 mm screw through the Cable clamp (inner) into the M3 nut in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
+Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long {% include fastener.html size="M3" variant="button" length="35" %} screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
 
 {% include step.html n="12" title="Attach the cable cage bottom" %}
 
@@ -396,13 +398,13 @@ Check that the chute can rotate fully to the limit switch in both directions, th
     loading="lazy"></iframe>
 </div>
 
-Place the Cable cage bottom over the Top interface chute mount. Use 6 M5 × 35 mm socket head screws and M5 nuts to clamp the Cable cage bottom, Cable cage top, and Cable cage brackets together.
+Place the Cable cage bottom over the Top interface chute mount. Use 6 {% include fastener.html size="M5" variant="socket" length="35" %} screws and {% include fastener.html size="M5" variant="nut" %}s to clamp the Cable cage bottom, Cable cage top, and Cable cage brackets together.
 
 After this step the chute should still rotate to each of its limits.
 
 {% include step.html n="13" title="Attach the framing" %}
 
-Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with four M5 × 20 mm button head screws into four T-nuts.
+Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with four {% include fastener.html size="M5" variant="button" length="20" %} screws into four T-nuts.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-1.ae2ef835181f63bd.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">
@@ -420,7 +422,7 @@ Follow the first two stages of a regular layer, then place the regular layer ass
   <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.e49b6ce3304489d5.jpg" alt="A regular layer assembly lowered onto the interface assembly">
 </figure>
 
-Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 M5 × 16 mm screws tapped into the holes at the base of the External bracket sides, bracing against the extrusion.
+Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 {% include fastener.html size="M5" variant="socket" length="16" %} screws tapped into the holes at the base of the External bracket sides, bracing against the extrusion.
 
 The top interface is now complete.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -80,13 +80,15 @@ parts_needed:
   - part: m5-ruthex-long
     qty: 24
   - part: m3-ruthex-long
-    qty: 11
+    qty: 12
   - part: scr-m5-35-shcs
     qty: 6
-  - part: scr-m5-25-shcs
+  - part: scr-m5-30-shcs
     qty: 6
   - part: scr-m5-22-cs
     qty: 15
+  - part: scr-m5-8-cs
+    qty: 6
   - part: scr-m5-20-bhcs
     qty: 24
   - part: scr-m5-16-bhcs
@@ -101,8 +103,16 @@ parts_needed:
     qty: 1
   - part: scr-m3-10-shcs
     qty: 2
+  - part: scr-m3-12-cs
+    qty: 6
+  - part: scr-m3-16-shcs
+    qty: 2
+  - part: scr-m3-8-cs
+    qty: 5
+  - part: scr-m3-6-cs
+    qty: 1
   - part: tnut-m5-2020
-    qty: 56
+    qty: 50
   - part: nut-m5
     qty: 6
   - part: nut-m3
@@ -188,6 +198,16 @@ Before assembling anything, press the heat inserts into the parts that take them
   </figure>
 </div>
 
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Cable cage bracket (cable mount):</strong> 1 × M3</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-cable-cage-bracket-cable-inserts.72708f4941f1b0da.jpg" alt="The Cable cage bracket (cable mount) held up, showing a single brass M3 heat insert">
+    <figcaption>The one M3 insert in the Cable cage bracket (cable mount).</figcaption>
+  </figure>
+</div>
+
 The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists every part in the machine that needs inserts.
 
 {% include step.html n="2" title="Attach the interface ribs to the upper fixed section" %}
@@ -207,7 +227,7 @@ Attach the Interface rib (switch gap) to the Interface upper fixed section, two 
 
 Attach the remaining 5 Interface ribs to the Interface upper fixed section, two {% include fastener.html size="M5" variant="button" length="16" %} screws each, again tapping into the plastic.
 
-Slot the Interface NEMA 23 bracket into the Interface upper fixed section and secure it with a screw from below <span class="fastener-todo">fastener not recorded</span>.
+Slot the Interface NEMA 23 bracket into the Interface upper fixed section and secure it from below with an {% include fastener.html size="M3" variant="countersunk" length="12" %} screw.
 
 Attach the whole assembly to the bottom of the Top plate with {% include fastener.html size="M5" variant="countersunk" length="22" %} screws through holes S2 and S3 into the Interface NEMA 23 bracket.
 
@@ -247,7 +267,7 @@ Repeat for all 6 Interface brackets.
 
 Push the Printed dowel pin into the Limit switch housing.
 
-Attach a Roller lever limit switch with 2 screws <span class="fastener-todo">fastener not recorded</span> so the roller sits next to the dowel pin.
+Attach a Roller lever limit switch with two {% include fastener.html size="M3" variant="socket" length="16" %} screws (into the housing's 2 M3 inserts) so the roller sits next to the dowel pin.
 
 Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two {% include fastener.html size="M5" variant="socket" length="16" %} screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
@@ -262,11 +282,18 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
     loading="lazy"></iframe>
 </div>
 
-Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with a screw <span class="fastener-todo">fastener not recorded</span>. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
+Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with an {% include fastener.html size="M5" variant="countersunk" length="8" %} screw. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>The M5 × 8 mm is a snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush.</p>
+</div>
 
 Repeat with the 5 other prepared Interface brackets into the 5 other Interface ribs.
 
 Flip the whole assembly and screw all 6 Interface brackets into place with {% include fastener.html size="M5" variant="countersunk" length="22" %} screws through holes I1 to I6 and O1 to O6.
+
+**Alternative:** the Top plate's laser-cut holes are not countersunk, so a countersunk head does not seat flush. {% include fastener.html size="M5" variant="button" length="20" %} screws work here instead.
 
 {% include step.html n="6" title="Prepare the interface chute gear and mount" %}
 
@@ -281,9 +308,9 @@ Flip the whole assembly and screw all 6 Interface brackets into place with {% in
 
 **Heat inserts first:** the Top interface chute mount takes 4 × M4 and 7 × M3 inserts, and the Limit switch hammer takes 1 × M3. Press them in before assembling.
 
-Slot the Limit switch hammer into the Top interface chute mount, then screw it in place from below <span class="fastener-todo">fastener not recorded</span>.
+Slot the Limit switch hammer into the Top interface chute mount, then secure it from below with an {% include fastener.html size="M3" variant="countersunk" length="6" %} screw (into the hammer's M3 insert).
 
-Align the Chute gear on the Top interface chute mount with the notch by the screw for the Limit switch hammer. Attach it with 5 screws <span class="fastener-todo">fastener not recorded</span>.
+Align the Chute gear on the Top interface chute mount with the notch by the screw for the Limit switch hammer. Attach it with five {% include fastener.html size="M3" variant="countersunk" length="12" %} screws.
 
 Align the Top interface lazy Susan washer with the 4 inner heat inserts on the Top interface chute mount. Align the inner ring of the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) with these 4 heat inserts too. Screw the Lazy Susan into position through the washer and into the Top interface chute mount with four {% include fastener.html size="M4" variant="countersunk" length="12" %} screws.
 
@@ -337,7 +364,7 @@ Loosen the screws attaching the Limit switch housing to the extrusion. Slide the
     loading="lazy"></iframe>
 </div>
 
-Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }}) over the shaft of the NEMA 23 stepper motor and tighten the two worm screws on its side. Slide the Interface spur gear onto the Timing pulley and secure it with 5 screws <span class="fastener-todo">fastener not recorded</span>, half tapped into the Interface spur gear and half bracing against the Timing pulley.
+Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }}) over the shaft of the NEMA 23 stepper motor and tighten the two worm screws on its side. Slide the Interface spur gear onto the Timing pulley and secure it with five {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, half tapped into the Interface spur gear and half bracing against the Timing pulley.
 
 Push a 608 2RS bearing into the Interface idler gear.
 
@@ -358,11 +385,13 @@ At this point the chute should still rotate, but you will now feel resistance fr
     loading="lazy"></iframe>
 </div>
 
+**Heat inserts first:** the Cable cage bracket (cable mount) takes 1 × M3 insert. Press it in before assembling.
+
 Slot the Cable cage top over the Top interface chute mount, with the corners of the hexagon aligning with the Interface brackets.
 
-Place the Cable cage bracket (cable mount) on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable). Screw it into the Interface bracket with an {% include fastener.html size="M5" variant="socket" length="25" %} screw and a T-nut, clamping down the Cable cage top.
+Screw the Cable cage bracket (cable mount), on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable), securely to the tail end of that Interface bracket with an {% include fastener.html size="M5" variant="socket" length="30" %} screw into the M5 heat insert, clamping the Cable cage top firmly in place.
 
-Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable cage top with {% include fastener.html size="M5" variant="socket" length="25" %} screws and T-nuts.
+Screw the remaining Cable cage brackets to the other 5 corners of the Cable cage top with {% include fastener.html size="M5" variant="socket" length="30" %} screws.
 
 {% include step.html n="11" title="Put the cable in the cable cage" %}
 
@@ -385,7 +414,7 @@ Guide the rest of the ribbon cable around the side of the Top interface chute mo
 
 Screw the Ribbon cable clamp <span class="fastener-todo">fastener not recorded</span> lightly to the Cable cage bracket (cable mount), clamping the ribbon cable between the two.
 
-Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long {% include fastener.html size="M3" variant="button" length="35" %} screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
+Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long M3 × 35 mm screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
 
 {% include step.html n="12" title="Attach the cable cage bottom" %}
 
@@ -422,7 +451,7 @@ Follow the first two stages of a regular layer, then place the regular layer ass
   <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.e49b6ce3304489d5.jpg" alt="A regular layer assembly lowered onto the interface assembly">
 </figure>
 
-Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 {% include fastener.html size="M5" variant="socket" length="16" %} screws tapped into the holes at the base of the External bracket sides, bracing against the extrusion.
+Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 M5 × 16 mm screws tapped into the holes at the base of the External bracket sides, bracing against the extrusion.
 
 The top interface is now complete.
 

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -30,6 +30,7 @@
 											<img class="part-card-img" src={part.image} alt={part.name} loading="lazy" />
 										{/if}
 										{#if part.qty}<span class="part-card-qty">{part.qty}×</span>{/if}
+										{#if part.not_in_calc}<span class="part-card-warn" title="Not currently in the parts calculator">!</span>{/if}
 									</div>
 									<span class="part-card-name">
 										{#if part.page}<a href={part.page}>{part.name}</a>{:else}{part.name}{/if}
@@ -46,6 +47,9 @@
 							<li><strong>{part.name}:</strong> {part.notes}</li>
 						{/each}
 					</ul>
+				{/if}
+				{#if parts.groups.some((g) => g.parts.some((p) => p.not_in_calc))}
+					<p class="parts-warn-legend"><span class="part-card-warn">!</span> not currently in the parts calculator.</p>
 				{/if}
 			</section>
 		{/if}

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -225,6 +225,7 @@ export type ResolvedPart = {
 	qty?: number;
 	notes?: string;
 	caption?: string;
+	not_in_calc?: boolean;
 	missing?: boolean;
 };
 export type PartsGroup = { category: string; parts: ResolvedPart[] };
@@ -243,6 +244,7 @@ function resolveParts(partsNeeded: any[]): { groups: PartsGroup[]; notes: Resolv
 			page: part.page,
 			notes: part.notes,
 			caption: part.caption,
+			not_in_calc: part.not_in_calc,
 			qty,
 			category: part.category ?? 'Other'
 		};

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -3,9 +3,11 @@
 # each entry — primary image + name (linked to its detail page when one exists),
 # grouped by `category`, with any `notes` surfaced in a list below the cards.
 #
-# Fields: name (required), image, page, category, notes, caption (all optional).
-# `caption` is small text shown directly under a card (e.g. a cut length),
-# distinct from `notes`, which collects into the block beneath the whole group.
+# Fields: name (required), image, page, category, notes, caption, not_in_calc
+# (all optional). `caption` is small text shown directly under a card (e.g. a
+# cut length), distinct from `notes`, which collects into the block beneath the
+# whole group. `not_in_calc: true` marks a card with a red "!" for a part that
+# is not (yet) in the parts calculator.
 #
 # ids, names, and render filenames mirror the sorter-v2-filament-calculator repo
 # so the two stay aligned for the eventual merge into this repo.
@@ -246,6 +248,9 @@ interface-cage-bracket-cable:
   name: Cable cage bracket (cable mount)
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/interface-cage-bracket-cable.cc282a11d3fc5359.png
+  heat_inserts:
+    - insert: m3-ruthex-long
+      qty: 1
 
 cable-clamp-outer:
   name: Cable clamp (outer)
@@ -308,9 +313,10 @@ scr-m5-35-shcs:
   name: M5 × 35 mm socket head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  not_in_calc: true
 
-scr-m5-25-shcs:
-  name: M5 × 25 mm socket head cap screw
+scr-m5-30-shcs:
+  name: M5 × 30 mm socket head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
@@ -323,16 +329,25 @@ scr-m5-22-cs:
   name: M5 × 22 mm countersunk screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+  not_in_calc: true
+
+scr-m5-8-cs:
+  name: M5 × 8 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+  not_in_calc: true
 
 scr-m5-20-bhcs:
   name: M5 × 20 mm button head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+  not_in_calc: true
 
 scr-m5-16-bhcs:
   name: M5 × 16 mm button head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+  not_in_calc: true
 
 scr-m3-35-bhcs:
   name: M3 × 35 mm button head cap screw
@@ -343,6 +358,28 @@ scr-m3-10-shcs:
   name: M3 × 10 mm socket head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  not_in_calc: true
+
+scr-m3-12-cs:
+  name: M3 × 12 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+
+scr-m3-16-shcs:
+  name: M3 × 16 mm socket head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+
+scr-m3-8-cs:
+  name: M3 × 8 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+
+scr-m3-6-cs:
+  name: M3 × 6 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+  not_in_calc: true
 
 tnut-m5-2020:
   name: M5 roll-in T-nut (2020)

--- a/docs/src/liquid/_includes/fastener-legend.html
+++ b/docs/src/liquid/_includes/fastener-legend.html
@@ -1,0 +1,7 @@
+{%- comment -%}
+Compact key for the inline fastener icons, mirroring the one on
+parts-calculator.basically.website/hardware: the icon silhouette is the head
+shape, its colour is the thread size. Drop it once near the top of any page
+that uses {% include fastener.html %}.
+{%- endcomment -%}
+<p class="fastener-legend"><span class="fastener-legend-lead">Fastener icons match the <a href="https://parts-calculator.basically.website/hardware">parts list</a>: the silhouette is the head shape, the colour is the thread size.</span> <span class="fastener-legend-swatch" style="--sw:#2f6fd0">M3</span> <span class="fastener-legend-swatch" style="--sw:#b8791b">M4</span> <span class="fastener-legend-swatch" style="--sw:#7a4ec2">M5</span> <span class="fastener-legend-swatch" style="--sw:#2c8a6b">M6</span></p>

--- a/docs/src/liquid/_includes/fastener.html
+++ b/docs/src/liquid/_includes/fastener.html
@@ -1,0 +1,47 @@
+{%- comment -%}
+Inline fastener reference: the same icon the parts calculator uses (head-shape
+silhouette, thread-size colour) followed by the part-list name, so a screw reads
+the same here as it does on parts-calculator.basically.website/hardware.
+
+Usage:
+  {% include fastener.html size="M5" variant="socket" length="20" %}  -> M5 × 20 mm socket head
+  {% include fastener.html size="M4" variant="countersunk" length="12" %}
+  {% include fastener.html size="M5" variant="t-nut" %}               -> M5 T-nut
+  {% include fastener.html size="M3" variant="nut" %}                 -> M3 nut
+
+Params:
+  size     M3 | M4 | M5 | M6            colour of the icon (thread size)
+  variant  socket | button | countersunk | flat | nut | t-nut | heat-insert
+  length   screw length in mm           omit for nuts / inserts
+  text     optional label override      when the auto-built name is not wanted
+
+Keep the whole rendered span on one line: it sits inline in prose, and a blank
+line inside it would end the HTML block for the markdown parser.
+{%- endcomment -%}
+{%- case include.size -%}
+  {%- when "M3" -%}{%- assign fill = "#2f6fd0" -%}
+  {%- when "M4" -%}{%- assign fill = "#b8791b" -%}
+  {%- when "M5" -%}{%- assign fill = "#7a4ec2" -%}
+  {%- when "M6" -%}{%- assign fill = "#2c8a6b" -%}
+  {%- else -%}{%- assign fill = "#7a7770" -%}
+{%- endcase -%}
+{%- assign hollow = false -%}
+{%- assign recess = "" -%}
+{%- case include.variant -%}
+  {%- when "socket" -%}{%- assign profile = "M7.5 3 h9 v7 h-9 z" -%}{%- assign word = "socket head" -%}{%- assign recess = '<circle cx="12" cy="6.6" r="1.9" fill="var(--bg)"/>' -%}
+  {%- when "button" -%}{%- assign profile = "M5 10 a7.6 7.6 0 0 1 14 0 z" -%}{%- assign word = "button head" -%}{%- assign recess = '<circle cx="12" cy="6.6" r="1.9" fill="var(--bg)"/>' -%}
+  {%- when "flat" -%}{%- assign profile = "M4 4.5 h16 v4 h-16 z" -%}{%- assign word = "flat head" -%}{%- assign recess = '<circle cx="12" cy="6.5" r="1.9" fill="var(--bg)"/>' -%}
+  {%- when "countersunk" -%}{%- assign profile = "M4 3 h16 v2.2 l-6.5 5.3 h-3 L4 5.2 z" -%}{%- assign word = "countersunk" -%}{%- assign recess = '<circle cx="12" cy="5.4" r="1.9" fill="var(--bg)"/>' -%}
+  {%- when "nut" -%}{%- assign profile = "M12 3 L20.4 7.8 v9.4 L12 22 L3.6 17.2 V7.8 z" -%}{%- assign word = "nut" -%}{%- assign hollow = true -%}{%- assign recess = '<circle cx="12" cy="12.5" r="3.6" fill="var(--bg)"/>' -%}
+  {%- when "t-nut" -%}{%- assign profile = "M4 5 h16 v5 h-5.5 v9 h-5 v-9 H4 z" -%}{%- assign word = "T-nut" -%}{%- assign hollow = true -%}
+  {%- when "heat-insert" -%}{%- assign profile = "M6.5 4 h11 v16 h-11 z" -%}{%- assign word = "heat-set insert" -%}{%- assign hollow = true -%}{%- assign recess = '<rect x="9.5" y="4" width="5" height="16" fill="var(--bg)"/>' -%}
+  {%- else -%}{%- assign profile = "" -%}{%- assign word = include.variant -%}
+{%- endcase -%}
+{%- if include.text -%}
+  {%- assign label = include.text -%}
+{%- elsif include.length -%}
+  {%- assign label = include.size | append: " × " | append: include.length | append: " mm " | append: word -%}
+{%- else -%}
+  {%- assign label = include.size | append: " " | append: word -%}
+{%- endif -%}
+<span class="fastener" title="{{ label }}"><svg class="fastener-icon" viewBox="0 0 24 24" width="15" height="15" fill="{{ fill }}" role="img" aria-label="{{ label }} icon"><path d="{{ profile }}"/>{%- unless hollow -%}<path d="M10.5 9 h3 v13 h-3 z"/>{%- endunless -%}{{ recess }}</svg><span class="fastener-name">{{ label }}</span></span>

--- a/docs/src/liquid/_includes/page-requirements.html
+++ b/docs/src/liquid/_includes/page-requirements.html
@@ -46,6 +46,7 @@ Unknown ids render the raw id so a missing catalog entry is visible, not silent.
               <div class="part-card-media">
                 {% if part.image %}<img class="part-card-img" src="{{ part.image }}" alt="{{ part.name }}">{% endif %}
                 {% if entry.qty %}<span class="part-card-qty">{{ entry.qty }}×</span>{% endif %}
+                {% if part.not_in_calc %}<span class="part-card-warn" title="Not currently in the parts calculator">!</span>{% endif %}
               </div>
               <span class="part-card-name">
                 {% if part.page %}<a href="{{ part.page | relative_url }}">{{ part.name }}</a>{% else %}{{ part.name }}{% endif %}
@@ -75,6 +76,17 @@ Unknown ids render the raw id so a missing catalog entry is visible, not silent.
         {% if part.notes %}<li><strong>{{ part.name }}:</strong> {{ part.notes }}</li>{% endif %}
       {% endfor %}
     </ul>
+    {% endif %}
+
+    {%- comment -%} Legend when any part is flagged as not in the parts calculator. {%- endcomment -%}
+    {% assign warncount = 0 %}
+    {% for entry in page.parts_needed %}
+      {% assign pid = entry.part | default: entry %}
+      {% assign part = site.data.parts[pid] %}
+      {% if part.not_in_calc %}{% assign warncount = warncount | plus: 1 %}{% endif %}
+    {% endfor %}
+    {% if warncount > 0 %}
+    <p class="parts-warn-legend"><span class="part-card-warn">!</span> not currently in the parts calculator.</p>
     {% endif %}
   </section>
   {% endif %}

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -562,6 +562,36 @@ body {
 	background: var(--ink);
 }
 
+/* Marker for a part that is not in the parts calculator */
+.part-card-warn {
+	position: absolute;
+	top: 0;
+	right: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 4px;
+	font-size: 0.78rem;
+	font-weight: 700;
+	line-height: 1;
+	color: var(--color-primary-contrast);
+	background: var(--color-danger);
+	cursor: help;
+}
+
+.parts-warn-legend {
+	margin: 10px 0 0;
+	font-size: 0.8rem;
+	color: var(--muted);
+}
+
+.parts-warn-legend .part-card-warn {
+	position: static;
+	margin-right: 5px;
+}
+
 .parts-notes {
 	margin: 14px 0 0;
 	padding-left: 1.1rem;

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -608,6 +608,54 @@ body {
 	border: 1px solid color-mix(in srgb, var(--color-warning) 45%, transparent);
 }
 
+/* Inline fastener reference: parts-calculator icon (head-shape silhouette in
+   thread-size colour) + the part-list name. See _includes/fastener.html. */
+.fastener {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 0.25em;
+	white-space: nowrap;
+}
+
+.fastener-icon {
+	align-self: center;
+	vertical-align: -0.18em;
+	flex-shrink: 0;
+}
+
+.fastener-name {
+	white-space: normal;
+}
+
+/* One-line key for the icons above, mirrors the parts-calculator legend. */
+.fastener-legend {
+	margin: 0 0 1rem;
+	font-size: 0.82rem;
+	line-height: 1.5;
+	color: var(--muted);
+}
+
+.fastener-legend-lead {
+	margin-right: 0.35em;
+}
+
+.fastener-legend-swatch {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3em;
+	margin-right: 0.5em;
+	font-weight: 600;
+	color: var(--ink);
+}
+
+.fastener-legend-swatch::before {
+	content: '';
+	width: 0.7em;
+	height: 0.7em;
+	border-radius: 2px;
+	background: var(--sw);
+}
+
 /* Grouped part + insert-photo rows in the Preparation step */
 .prep-item {
 	display: flex;


### PR DESCRIPTION
Combines two overlapping efforts into one self-contained PR (so there's no forced merge order between them): the fastener nomenclature + colour icons, and the fastener spec corrections + "not in the parts calculator" marker + extra inserts from #307.

### Fastener nomenclature + colour icons
Assembly steps reference each fastener with the same icon the parts calculator uses (head-shape silhouette in thread-size colour) via a `fastener.html` include, with a one-line legend per page. Applied across top-interface, external-bracket, bottom-interface and regular-layers.

### Top-interface fastener corrections (from #307, barthel's build audit)
The top-interface icons use the corrected specs, not the older ones:
- Cable cage brackets: **M5 × 30 socket into the M5 tail insert** (was M5 × 25 + T-nut), dropping 6 T-nuts
- Bracket securing screw: **M5 × 8 countersunk** (snug-fit callout)
- Hammer **M3 × 6 countersunk**, roller switch **2 × M3 × 16 socket**, NEMA + chute-gear **M3 × 12 countersunk**, spur gear **M3 × 8 countersunk** — down to 3 still-unrecorded screws

### "Not in the parts calculator" marker
A `not_in_calc` catalog field renders a small red **!** (tooltip + legend) on parts-list cards for the seven fasteners parts-calculator doesn't carry.

### More heat inserts
- **Cable cage bracket (cable mount): 1 × M3** — Preparation row with photo + a Step 10 note.

Supersedes #307 (closed). Build passes on Node 20; both validators clean.

Thanks to barthel for the fastener/insert audit and video timestamps, and zed0 for the source videos.
