### PR TITLE
docs(top-interface): fastener specs, not-in-calc marker, more inserts

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -80,13 +80,15 @@ parts_needed:
   - part: m5-ruthex-long
     qty: 24
   - part: m3-ruthex-long
-    qty: 11
+    qty: 12
   - part: scr-m5-35-shcs
     qty: 6
-  - part: scr-m5-25-shcs
+  - part: scr-m5-30-shcs
     qty: 6
   - part: scr-m5-22-cs
     qty: 15
+  - part: scr-m5-8-cs
+    qty: 6
   - part: scr-m5-20-bhcs
     qty: 24
   - part: scr-m5-16-bhcs
@@ -101,8 +103,16 @@ parts_needed:
     qty: 1
   - part: scr-m3-10-shcs
     qty: 2
+  - part: scr-m3-12-cs
+    qty: 6
+  - part: scr-m3-16-shcs
+    qty: 2
+  - part: scr-m3-8-cs
+    qty: 5
+  - part: scr-m3-6-cs
+    qty: 1
   - part: tnut-m5-2020
-    qty: 56
+    qty: 50
   - part: nut-m5
     qty: 6
   - part: nut-m3
@@ -186,6 +196,16 @@ Before assembling anything, press the heat inserts into the parts that take them
   </figure>
 </div>
 
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Cable cage bracket (cable mount):</strong> 1 × M3</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-cable-cage-bracket-cable-inserts.72708f4941f1b0da.jpg" alt="The Cable cage bracket (cable mount) held up, showing a single brass M3 heat insert">
+    <figcaption>The one M3 insert in the Cable cage bracket (cable mount).</figcaption>
+  </figure>
+</div>
+
 The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists every part in the machine that needs inserts.
 
 {% include step.html n="2" title="Attach the interface ribs to the upper fixed section" %}
@@ -205,7 +225,7 @@ Attach the Interface rib (switch gap) to the Interface upper fixed section, two 
 
 Attach the remaining 5 Interface ribs to the Interface upper fixed section, two M5 × 16 mm button head screws each, again tapping into the plastic.
 
-Slot the Interface NEMA 23 bracket into the Interface upper fixed section and secure it with a screw from below <span class="fastener-todo">fastener not recorded</span>.
+Slot the Interface NEMA 23 bracket into the Interface upper fixed section and secure it from below with an M3 × 12 mm countersunk screw.
 
 Attach the whole assembly to the bottom of the Top plate with M5 × 22 mm countersunk screws through holes S2 and S3 into the Interface NEMA 23 bracket.
 
@@ -245,7 +265,7 @@ Repeat for all 6 Interface brackets.
 
 Push the Printed dowel pin into the Limit switch housing.
 
-Attach a Roller lever limit switch with 2 screws <span class="fastener-todo">fastener not recorded</span> so the roller sits next to the dowel pin.
+Attach a Roller lever limit switch with two M3 × 16 mm socket head screws (into the housing's 2 M3 inserts) so the roller sits next to the dowel pin.
 
 Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two M5 × 16 mm socket head screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
@@ -260,11 +280,18 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
     loading="lazy"></iframe>
 </div>
 
-Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with a screw <span class="fastener-todo">fastener not recorded</span>. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
+Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with an M5 × 8 mm countersunk screw. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>The M5 × 8 mm is a snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush.</p>
+</div>
 
 Repeat with the 5 other prepared Interface brackets into the 5 other Interface ribs.
 
 Flip the whole assembly and screw all 6 Interface brackets into place with M5 × 22 mm countersunk screws through holes I1 to I6 and O1 to O6.
+
+**Alternative:** the Top plate's laser-cut holes are not countersunk, so a countersunk head does not seat flush. M5 × 20 mm button head screws work here instead.
 
 {% include step.html n="6" title="Prepare the interface chute gear and mount" %}
 
@@ -279,9 +306,9 @@ Flip the whole assembly and screw all 6 Interface brackets into place with M5 ×
 
 **Heat inserts first:** the Top interface chute mount takes 4 × M4 and 7 × M3 inserts, and the Limit switch hammer takes 1 × M3. Press them in before assembling.
 
-Slot the Limit switch hammer into the Top interface chute mount, then screw it in place from below <span class="fastener-todo">fastener not recorded</span>.
+Slot the Limit switch hammer into the Top interface chute mount, then secure it from below with an M3 × 6 mm countersunk screw (into the hammer's M3 insert).
 
-Align the Chute gear on the Top interface chute mount with the notch by the screw for the Limit switch hammer. Attach it with 5 screws <span class="fastener-todo">fastener not recorded</span>.
+Align the Chute gear on the Top interface chute mount with the notch by the screw for the Limit switch hammer. Attach it with five M3 × 12 mm countersunk screws.
 
 Align the Top interface lazy Susan washer with the 4 inner heat inserts on the Top interface chute mount. Align the inner ring of the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) with these 4 heat inserts too. Screw the Lazy Susan into position through the washer and into the Top interface chute mount with four M4 × 12 mm countersunk screws.
 
@@ -335,7 +362,7 @@ Loosen the screws attaching the Limit switch housing to the extrusion. Slide the
     loading="lazy"></iframe>
 </div>
 
-Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }}) over the shaft of the NEMA 23 stepper motor and tighten the two worm screws on its side. Slide the Interface spur gear onto the Timing pulley and secure it with 5 screws <span class="fastener-todo">fastener not recorded</span>, half tapped into the Interface spur gear and half bracing against the Timing pulley.
+Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }}) over the shaft of the NEMA 23 stepper motor and tighten the two worm screws on its side. Slide the Interface spur gear onto the Timing pulley and secure it with five M3 × 8 mm countersunk screws, half tapped into the Interface spur gear and half bracing against the Timing pulley.
 
 Push a 608 2RS bearing into the Interface idler gear.
 
@@ -356,11 +383,13 @@ At this point the chute should still rotate, but you will now feel resistance fr
     loading="lazy"></iframe>
 </div>
 
+**Heat inserts first:** the Cable cage bracket (cable mount) takes 1 × M3 insert. Press it in before assembling.
+
 Slot the Cable cage top over the Top interface chute mount, with the corners of the hexagon aligning with the Interface brackets.
 
-Place the Cable cage bracket (cable mount) on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable). Screw it into the Interface bracket with an M5 × 25 mm socket head screw and a T-nut, clamping down the Cable cage top.
+Screw the Cable cage bracket (cable mount), on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable), securely to the tail end of that Interface bracket with an M5 × 30 mm socket head screw into the M5 heat insert, clamping the Cable cage top firmly in place.
 
-Screw the other 5 Cable cage brackets down over the other 5 corners of the Cable cage top with M5 × 25 mm socket head screws and T-nuts.
+Screw the remaining Cable cage brackets to the other 5 corners of the Cable cage top with M5 × 30 mm socket head screws.
 
 {% include step.html n="11" title="Put the cable in the cable cage" %}
 

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -30,6 +30,7 @@
 											<img class="part-card-img" src={part.image} alt={part.name} loading="lazy" />
 										{/if}
 										{#if part.qty}<span class="part-card-qty">{part.qty}×</span>{/if}
+										{#if part.not_in_calc}<span class="part-card-warn" title="Not currently in the parts calculator">!</span>{/if}
 									</div>
 									<span class="part-card-name">
 										{#if part.page}<a href={part.page}>{part.name}</a>{:else}{part.name}{/if}
@@ -46,6 +47,9 @@
 							<li><strong>{part.name}:</strong> {part.notes}</li>
 						{/each}
 					</ul>
+				{/if}
+				{#if parts.groups.some((g) => g.parts.some((p) => p.not_in_calc))}
+					<p class="parts-warn-legend"><span class="part-card-warn">!</span> not currently in the parts calculator.</p>
 				{/if}
 			</section>
 		{/if}

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -225,6 +225,7 @@ export type ResolvedPart = {
 	qty?: number;
 	notes?: string;
 	caption?: string;
+	not_in_calc?: boolean;
 	missing?: boolean;
 };
 export type PartsGroup = { category: string; parts: ResolvedPart[] };
@@ -243,6 +244,7 @@ function resolveParts(partsNeeded: any[]): { groups: PartsGroup[]; notes: Resolv
 			page: part.page,
 			notes: part.notes,
 			caption: part.caption,
+			not_in_calc: part.not_in_calc,
 			qty,
 			category: part.category ?? 'Other'
 		};

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -3,9 +3,11 @@
 # each entry — primary image + name (linked to its detail page when one exists),
 # grouped by `category`, with any `notes` surfaced in a list below the cards.
 #
-# Fields: name (required), image, page, category, notes, caption (all optional).
-# `caption` is small text shown directly under a card (e.g. a cut length),
-# distinct from `notes`, which collects into the block beneath the whole group.
+# Fields: name (required), image, page, category, notes, caption, not_in_calc
+# (all optional). `caption` is small text shown directly under a card (e.g. a
+# cut length), distinct from `notes`, which collects into the block beneath the
+# whole group. `not_in_calc: true` marks a card with a red "!" for a part that
+# is not (yet) in the parts calculator.
 #
 # ids, names, and render filenames mirror the sorter-v2-filament-calculator repo
 # so the two stay aligned for the eventual merge into this repo.
@@ -246,6 +248,9 @@ interface-cage-bracket-cable:
   name: Cable cage bracket (cable mount)
   category: Printed parts
   image: https://img.basically.website/web/parts/top-interface/interface-cage-bracket-cable.cc282a11d3fc5359.png
+  heat_inserts:
+    - insert: m3-ruthex-long
+      qty: 1
 
 cable-clamp-outer:
   name: Cable clamp (outer)
@@ -308,9 +313,10 @@ scr-m5-35-shcs:
   name: M5 × 35 mm socket head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  not_in_calc: true
 
-scr-m5-25-shcs:
-  name: M5 × 25 mm socket head cap screw
+scr-m5-30-shcs:
+  name: M5 × 30 mm socket head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
@@ -323,16 +329,25 @@ scr-m5-22-cs:
   name: M5 × 22 mm countersunk screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+  not_in_calc: true
+
+scr-m5-8-cs:
+  name: M5 × 8 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+  not_in_calc: true
 
 scr-m5-20-bhcs:
   name: M5 × 20 mm button head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+  not_in_calc: true
 
 scr-m5-16-bhcs:
   name: M5 × 16 mm button head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+  not_in_calc: true
 
 scr-m3-35-bhcs:
   name: M3 × 35 mm button head cap screw
@@ -343,6 +358,28 @@ scr-m3-10-shcs:
   name: M3 × 10 mm socket head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  not_in_calc: true
+
+scr-m3-12-cs:
+  name: M3 × 12 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+
+scr-m3-16-shcs:
+  name: M3 × 16 mm socket head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+
+scr-m3-8-cs:
+  name: M3 × 8 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+
+scr-m3-6-cs:
+  name: M3 × 6 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
+  not_in_calc: true
 
 tnut-m5-2020:
   name: M5 roll-in T-nut (2020)

--- a/docs/src/liquid/_includes/page-requirements.html
+++ b/docs/src/liquid/_includes/page-requirements.html
@@ -46,6 +46,7 @@ Unknown ids render the raw id so a missing catalog entry is visible, not silent.
               <div class="part-card-media">
                 {% if part.image %}<img class="part-card-img" src="{{ part.image }}" alt="{{ part.name }}">{% endif %}
                 {% if entry.qty %}<span class="part-card-qty">{{ entry.qty }}×</span>{% endif %}
+                {% if part.not_in_calc %}<span class="part-card-warn" title="Not currently in the parts calculator">!</span>{% endif %}
               </div>
               <span class="part-card-name">
                 {% if part.page %}<a href="{{ part.page | relative_url }}">{{ part.name }}</a>{% else %}{{ part.name }}{% endif %}
@@ -75,6 +76,17 @@ Unknown ids render the raw id so a missing catalog entry is visible, not silent.
         {% if part.notes %}<li><strong>{{ part.name }}:</strong> {{ part.notes }}</li>{% endif %}
       {% endfor %}
     </ul>
+    {% endif %}
+
+    {%- comment -%} Legend when any part is flagged as not in the parts calculator. {%- endcomment -%}
+    {% assign warncount = 0 %}
+    {% for entry in page.parts_needed %}
+      {% assign pid = entry.part | default: entry %}
+      {% assign part = site.data.parts[pid] %}
+      {% if part.not_in_calc %}{% assign warncount = warncount | plus: 1 %}{% endif %}
+    {% endfor %}
+    {% if warncount > 0 %}
+    <p class="parts-warn-legend"><span class="part-card-warn">!</span> not currently in the parts calculator.</p>
     {% endif %}
   </section>
   {% endif %}

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -562,6 +562,36 @@ body {
 	background: var(--ink);
 }
 
+/* Marker for a part that is not in the parts calculator */
+.part-card-warn {
+	position: absolute;
+	top: 0;
+	right: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 4px;
+	font-size: 0.78rem;
+	font-weight: 700;
+	line-height: 1;
+	color: var(--color-primary-contrast);
+	background: var(--color-danger);
+	cursor: help;
+}
+
+.parts-warn-legend {
+	margin: 10px 0 0;
+	font-size: 0.8rem;
+	color: var(--muted);
+}
+
+.parts-warn-legend .part-card-warn {
+	position: static;
+	margin-right: 5px;
+}
+
 .parts-notes {
 	margin: 14px 0 0;
 	padding-left: 1.1rem;


### PR DESCRIPTION
Follow-up to #303 (which added the heat-insert Preparation step) and #299 (framing step + parts list). Rebuilt on current main after #303 was squash-merged part-way through, so this carries the fastener and insert work barthel and I did afterwards.

### Fasteners recorded (inline + parts list)
From barthel's build, called out at the step they're used:
- NEMA bracket to upper section: **M3 × 12 countersunk**
- Roller lever limit switch: **2 × M3 × 16 socket head**
- Limit switch hammer: **M3 × 6 countersunk**
- Chute gear: **5 × M3 × 12 countersunk**
- Interface spur gear: **5 × M3 × 8 countersunk**
- Bracket securing screw: **M5 × 8 countersunk** (with a snug-fit callout: open the countersink slightly, tighten firm to sit flush)
- Step 10 reworked: cable cage brackets fasten with **M5 × 30 socket head into the M5 tail insert** (was M5 × 25 + T-nut), dropping 6 T-nuts

### "Not in the parts calculator" marker
A reusable `not_in_calc` catalog field renders a small red **!** (tooltip + legend) on cards for parts parts-calculator doesn't carry — the seven fasteners the cross-check turned up. Wired into the shared Requirements component, the Liquid include, the type and CSS.

### More heat inserts
- **Cable cage bracket (cable mount): 1 × M3** — Preparation row with a photo from the cable-cage-top video, plus a Step 10 note.
- "button head" used consistently (was mixed with "pan head"), and the M5 × 20 pan-head top-plate alternative noted.

Build passes on Node 20; `validate_frontmatter.py` and `validate_images.py` both clean.

Thanks to barthel for the fastener/insert audit and video timestamps, and zed0 for the source videos.
