### PR TITLE
public API: parts catalog reads, a de-identified fleet view, and a mass rollup

### DIFF
--- a/software/hive/agent-docs/auth.md
+++ b/software/hive/agent-docs/auth.md
@@ -1,6 +1,6 @@
 # Hive auth & permissions
 
-Last verified against the code: 2026-08-09. If you touch auth, re-verify and
+Last verified against the code: 2026-08-16. If you touch auth, re-verify and
 update this doc in the same change.
 
 ## The four credential types
@@ -27,11 +27,43 @@ Design philosophy: **a key grants exactly what its scopes say, nothing more.**
   grants nothing.
 - Scope vocabulary lives in `deps.py` (`VALID_API_KEY_SCOPES`): currently
   `models:read`, `models:write`, `samples:read`, `samples:write`,
-  `keys:manage`, `stats:read`.
-- `stats:read` (admin-owned, non-machine-constrained keys only) grants the
-  aggregate stats endpoint (`routers/public_stats.py`) — the replacement for
-  the legacy `PUBLIC_STATS_API_KEY` shared secret, which stays accepted only
-  until consumers cut over; then delete the env var and the legacy branch.
+  `keys:manage`, `stats:read`, `fleet:read`, `fleet:anon`,
+  `contributors:read`, `parts:read`, `parts:prices`.
+- The last six are the **service-to-service surface** —
+  `routers/public_stats.py` and `routers/public_catalog.py`. Every tier of it
+  additionally requires the key's owner to be an admin and the key to be
+  unconstrained, and both conditions live in `deps.resolve_public_scopes` so an
+  endpoint cannot forget one. Register a new endpoint there with
+  `require_public_scope(<scope>)`.
+
+  | Scope | Grants | Withheld because |
+  |---|---|---|
+  | `stats:read` | `/stats`, `/fleet/mass` — fleet-wide aggregates, no machine and no person | — (this is the tier safe for a public consumer) |
+  | `fleet:read` | `/fleet` — the roster with owner Discord where linked | names machine owners |
+  | `fleet:anon` | `/fleet/anon` — the same machines and counts, de-identified | — (safe to repeat aloud; see below) |
+  | `contributors:read` | `/contributors` — who has been labelling | names contributors |
+  | `parts:read` | the parts catalog: identity, category, geometry, weight, colors | — |
+  | `parts:prices` | adds the price block to every catalog row | market data is a licensed feed, not a fact about a brick |
+
+- `stats:read` is also the replacement for the legacy `PUBLIC_STATS_API_KEY`
+  shared secret, which stays accepted **on that tier only** until consumers cut
+  over; then delete the env var and the legacy branch. It has never opened any
+  tier above the aggregates, and must not: a shared secret cannot be revoked
+  for one consumer or narrowed to one tier.
+- **`fleet:anon` is a separate scope and not a flag on `fleet:read`.** The two
+  differ in who may hold them — the de-identified view is for a consumer that
+  repeats what it reads to strangers — so a consumer that should only ever see
+  that view must not hold a credential able to ask for the other. The
+  de-identification is in the payload (no owner, no owner-chosen name, no real
+  machine id, a date rather than a timestamp) rather than in a promise about
+  how the payload gets used. The reasoning for each dropped field is on
+  `get_public_fleet_anon`; the timestamp one is the non-obvious one.
+- **`parts:prices` shapes a payload rather than gating an endpoint.** A key
+  with `parts:read` alone gets every catalog row in full with the price block
+  absent — nothing 403s halfway through a batch. The stripping is by field-name
+  set (`_PRICE_FIELDS`), so a price field added upstream is excluded by default
+  instead of leaking until somebody notices; add its name there in the same
+  change.
 - Keys may carry an optional `expires_at`; expired keys 401.
 - Revocation is a tombstone (`revoked_at`), not a delete, so the UI can show
   history.

--- a/software/hive/backend/app/deps.py
+++ b/software/hive/backend/app/deps.py
@@ -35,6 +35,22 @@ API_KEY_SCOPE_FLEET_READ = "fleet:read"
 # anyone who has ever reviewed a sample — and a key that should see one has no
 # business seeing the other.
 API_KEY_SCOPE_CONTRIBUTORS_READ = "contributors:read"
+# The DE-IDENTIFIED fleet tier, for a consumer that repeats what it reads to
+# strangers. Same machines and the same counts as `fleet:read`, with every
+# handle back to a person removed rather than merely omitted from a template:
+# no owner identity, no owner-chosen machine name, and a last-seen date instead
+# of a timestamp. It is a separate scope and not a flag on `fleet:read` because
+# the two differ in who may hold them, and a consumer that should only ever see
+# the de-identified view must not hold a credential that can ask for the other.
+API_KEY_SCOPE_FLEET_ANON = "fleet:anon"
+# The parts catalog, split in two because the halves carry different risk.
+# `parts:read` is CATALOG FACT — what a part is, what it weighs, how big it is,
+# what colors it comes in. `parts:prices` is the market data, which is a
+# licensed feed rather than a fact about a brick and is the half worth being
+# able to withhold from a consumer that gets the rest. A key that should quote
+# a part's weight has no need to quote its price.
+API_KEY_SCOPE_PARTS_READ = "parts:read"
+API_KEY_SCOPE_PARTS_PRICES = "parts:prices"
 VALID_API_KEY_SCOPES = frozenset(
     {
         API_KEY_SCOPE_MODELS_READ,
@@ -44,7 +60,10 @@ VALID_API_KEY_SCOPES = frozenset(
         API_KEY_SCOPE_KEYS_MANAGE,
         API_KEY_SCOPE_STATS_READ,
         API_KEY_SCOPE_FLEET_READ,
+        API_KEY_SCOPE_FLEET_ANON,
         API_KEY_SCOPE_CONTRIBUTORS_READ,
+        API_KEY_SCOPE_PARTS_READ,
+        API_KEY_SCOPE_PARTS_PRICES,
     }
 )
 
@@ -279,5 +298,86 @@ def require_api_key_scopes(*required_scopes: str):
                 detail=f"API key is missing required scopes: {', '.join(missing)}",
             )
         return current_user
+
+    return dependency
+
+
+def presented_bearer_key(authorization: str | None, x_stats_key: str | None) -> str:
+    """The raw key off a service-to-service request, from either header."""
+    presented = x_stats_key
+    if not presented and authorization and authorization.startswith("Bearer "):
+        presented = authorization[7:]
+    return (presented or "").strip()
+
+
+def resolve_public_scopes(db: Session, presented: str) -> frozenset[str]:
+    """Authenticate an `hv_*` key for the service-to-service surface and return
+    what it grants.
+
+    The two conditions every tier of that surface shares, checked here so no
+    endpoint can forget one: the owner must be an admin, and the key must be
+    unconstrained. A machine-scoped key is deliberately *less* powerful than its
+    owner (see `services/access_window.py`), and fleet-wide or catalog-wide
+    reads are not per-machine data, so there is nothing for the constraint to
+    narrow — admitting one would silently hand it everything.
+
+    Raises 401 for anything that is not a well-formed live key.
+    """
+    if not presented.startswith(API_KEY_PREFIX):
+        raise HTTPException(status_code=401, detail="This endpoint requires an API key")
+    user, scopes, machine_ids = _resolve_api_key(db, presented)
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    if machine_ids is not None:
+        raise HTTPException(
+            status_code=403,
+            detail="Machine-scoped API keys cannot read fleet-wide or catalog-wide data",
+        )
+    return scopes
+
+
+def require_public_scope(scope: str):
+    """Dependency: admit a key carrying `scope` on the service-to-service surface.
+
+    Deny-by-default, exactly as `require_api_key_scopes` is for the user-facing
+    surface: holding a key is authentication and the scope is the authorization,
+    so a new endpoint here means a new scope rather than a reused neighbour.
+    """
+
+    def dependency(
+        db: Session = Depends(get_db),
+        authorization: str | None = Header(default=None),
+        x_stats_key: str | None = Header(default=None),
+    ) -> None:
+        presented = presented_bearer_key(authorization, x_stats_key)
+        granted = resolve_public_scopes(db, presented)
+        if scope not in granted:
+            raise HTTPException(
+                status_code=403, detail=f"API key is missing required scopes: {scope}"
+            )
+
+    return dependency
+
+
+def optional_public_scope(scope: str):
+    """Dependency: does this already-authenticated request's key carry `scope`?
+
+    For a payload whose SHAPE depends on a second scope — the catalog serves
+    market data only to a key that also holds `parts:prices`, and serves the
+    same part without it otherwise. Returns a bool rather than raising, so the
+    endpoint's own required scope decides admission and this only decides how
+    much of the row comes back.
+    """
+
+    def dependency(
+        db: Session = Depends(get_db),
+        authorization: str | None = Header(default=None),
+        x_stats_key: str | None = Header(default=None),
+    ) -> bool:
+        presented = presented_bearer_key(authorization, x_stats_key)
+        try:
+            return scope in resolve_public_scopes(db, presented)
+        except HTTPException:
+            return False
 
     return dependency

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -32,6 +32,7 @@ from app.routers import (
     models as models_router,
     piece_color_labels,
     profiles,
+    public_catalog,
     public_stats,
     review,
     samples,
@@ -113,6 +114,7 @@ app.include_router(piece_color_labels.router)
 app.include_router(color_models.router)
 app.include_router(color_predict.router)
 app.include_router(public_stats.router)
+app.include_router(public_catalog.router)
 app.include_router(link_models.router)
 app.include_router(api_keys.router)
 app.include_router(teacher.router)

--- a/software/hive/backend/app/routers/public_catalog.py
+++ b/software/hive/backend/app/routers/public_catalog.py
@@ -1,0 +1,187 @@
+"""Service-to-service reads of the parts catalog.
+
+The sibling of `routers/public_stats.py`: same credential model, same
+admin-owned unconstrained `hv_*` key, scope-gated the same way. Where that one
+serves what the fleet has DONE, this serves what a part IS.
+
+**Two scopes, because the halves carry different risk.** `parts:read` is
+catalog fact — identity, category, the colors it exists in, physical size,
+weight. `parts:prices` is market data, which is a licensed feed rather than a
+fact about a brick, and is the half worth being able to withhold from a
+consumer that gets the rest. A key with `parts:read` alone gets every part in
+full with the price block absent; nothing 403s halfway through a batch.
+
+**The batch endpoint is the one that matters.** A consumer doing arithmetic
+over the fleet's parts — what does this all weigh, how big is the average
+piece, which categories dominate — needs hundreds of parts per question, and
+doing that one HTTP request at a time is slow enough that it does not get done.
+`POST /parts/batch` takes up to MAX_BATCH ids and answers in one round trip and
+one pass over sqlite.
+
+The row shape comes from `profile_engine.db.pieceMetadata`, which the machines
+already use, rather than a second assembler built beside it. One place resolves
+a part id to a row, so a printed part or a minifig id behaves the same here as
+it does on a sorter.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, Query
+from pydantic import BaseModel, Field
+
+from app.deps import (
+    API_KEY_SCOPE_PARTS_PRICES,
+    API_KEY_SCOPE_PARTS_READ,
+    optional_public_scope,
+    require_public_scope,
+)
+from app.errors import APIError
+from app.services.profile_catalog import get_profile_catalog_service
+
+router = APIRouter(prefix="/api/public", tags=["public-catalog"])
+
+require_parts_key = require_public_scope(API_KEY_SCOPE_PARTS_READ)
+has_prices_scope = optional_public_scope(API_KEY_SCOPE_PARTS_PRICES)
+
+# One request, one sqlite pass. Well above what a question about the fleet's
+# part distribution needs (the distributions in /stats are fifteen deep) and
+# low enough that a caller cannot ask for the whole catalog a page at a time
+# and reassemble it. A consumer wanting bulk facts should say what it is
+# actually computing; that is a conversation, not a limit to raise quietly.
+MAX_BATCH = 250
+
+# Everything price-shaped in a pieceMetadata row. Stripped as a set rather than
+# by rebuilding the row field by field, so a new price field added upstream is
+# excluded by DEFAULT instead of leaking until somebody notices. If you add a
+# price field to pieceMetadata, add its name here in the same change.
+_PRICE_FIELDS = frozenset(
+    {
+        "price",
+        "moving_avg_price",
+        "price_currency",
+        "price_updated_at",
+        "price_color_specific",
+        "price_from_base_mold",
+        "price_from_base_name",
+    }
+)
+
+
+def _project(row: dict[str, Any] | None, *, with_prices: bool) -> dict[str, Any] | None:
+    """One catalog row as this API serves it.
+
+    Drops `source`, which pieceMetadata sets to the literal "hive" for the
+    machine's benefit and which is noise here, and drops the price block unless
+    the caller's key carries the scope for it.
+    """
+    if row is None:
+        return None
+    out = {k: v for k, v in row.items() if k != "source"}
+    if not with_prices:
+        out = {k: v for k, v in out.items() if k not in _PRICE_FIELDS}
+    return out
+
+
+@router.get("/parts/search", dependencies=[Depends(require_parts_key)])
+def search_public_parts(
+    q: str = Query(min_length=1, max_length=200),
+    category_id: int | None = None,
+    limit: int = Query(default=25, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+):
+    """Find parts by name or number.
+
+    The way in when the caller has words rather than ids — it does not know
+    "3001", it knows "2x4 brick". Returns catalog summaries, not full rows;
+    feed the part numbers to `/parts/batch` for the detail.
+    """
+    return get_profile_catalog_service().search_parts(
+        query=q, cat_id=category_id, limit=limit, offset=offset
+    )
+
+
+@router.get("/parts/{part_num}", dependencies=[Depends(require_parts_key)])
+def get_public_part(
+    part_num: str,
+    color_id: int | None = None,
+    with_prices: bool = Depends(has_prices_scope),
+):
+    """One part in full: identity, category, years, size, weight, image.
+
+    `part_num` may be a Rebrickable part number or a BrickLink item number —
+    the machines predict in the latter for printed parts and minifigs, so both
+    resolve here and the row that comes back names which is which.
+
+    `color_id` selects the color-specific price where one exists, and is inert
+    for a key without the price scope.
+    """
+    row = get_profile_catalog_service().piece_metadata(part_num, color_id)
+    if row is None:
+        raise APIError(404, f"No catalog entry for {part_num}", "PART_NOT_FOUND")
+    return _project(row, with_prices=with_prices)
+
+
+class BatchPartRef(BaseModel):
+    part_num: str = Field(min_length=1, max_length=64)
+    # Optional, and only meaningful for a caller that can see prices. A part is
+    # the same shape and weight in every color.
+    color_id: int | None = None
+
+
+class BatchPartsRequest(BaseModel):
+    parts: list[BatchPartRef] = Field(min_length=1, max_length=MAX_BATCH)
+
+
+@router.post("/parts/batch", dependencies=[Depends(require_parts_key)])
+def batch_public_parts(
+    payload: BatchPartsRequest = Body(...),
+    with_prices: bool = Depends(has_prices_scope),
+):
+    """Up to MAX_BATCH parts in one round trip.
+
+    Answers in request order with one entry per requested id, and an id the
+    catalog does not know comes back as `{"part_num": ..., "found": false}`
+    rather than being dropped. A caller doing arithmetic over a list needs the
+    answer to line up with what it asked; silently returning fewer rows than
+    were requested is how a total ends up wrong and nobody can see why.
+
+    Duplicate ids are resolved once and served to every position that asked.
+    """
+    catalog = get_profile_catalog_service()
+    resolved: dict[tuple[str, int | None], dict[str, Any] | None] = {}
+    out = []
+    for ref in payload.parts:
+        key = (ref.part_num, ref.color_id)
+        if key not in resolved:
+            resolved[key] = catalog.piece_metadata(ref.part_num, ref.color_id)
+        row = _project(resolved[key], with_prices=with_prices)
+        if row is None:
+            out.append({"part_num": ref.part_num, "found": False})
+        else:
+            out.append({**row, "found": True})
+    return {"parts": out, "count": len(out), "prices_included": with_prices}
+
+
+@router.get("/colors", dependencies=[Depends(require_parts_key)])
+def list_public_colors():
+    """The BrickLink color palette: id, name, swatch hex, transparency.
+
+    The id space `machine_pieces.color_id` and every distribution in `/stats`
+    are expressed in, so a consumer joining a color count to a color name wants
+    this list and not the Rebrickable one.
+    """
+    return {"colors": get_profile_catalog_service().list_bricklink_colors()}
+
+
+@router.get("/categories", dependencies=[Depends(require_parts_key)])
+def list_public_categories():
+    """Rebrickable part categories, with how many parts each holds."""
+    return {"categories": get_profile_catalog_service().admin_list_categories()}
+
+
+@router.get("/parts/{part_num}/colors", dependencies=[Depends(require_parts_key)])
+def public_part_colors(part_num: str, limit: int = Query(default=24, ge=1, le=100)):
+    """Which colors this part is actually sold in, commonest first."""
+    return get_profile_catalog_service().bricklink_part_colors(part_num, limit=limit)

--- a/software/hive/backend/app/routers/public_stats.py
+++ b/software/hive/backend/app/routers/public_stats.py
@@ -16,12 +16,29 @@ machines exist, how much each has sorted, and the owner's Discord where that
 owner linked one. Only for consumers whose credential is kept as well as the
 data is — the balloon box, Spencer's phone — never a public website.
 
+**`GET /fleet/anon` is the de-identified roster** (scope `fleet:anon`): the same
+machines and the same counts with every handle back to a person taken out — no
+owner, no owner-chosen name, no real machine id, and a date rather than a
+timestamp. For a consumer that repeats what it reads to strangers, where the
+safety has to be in the payload rather than in a promise about how the payload
+gets used. It is a scope of its own and not a flag on `fleet:read`, so a
+consumer that should only ever see this view cannot hold a credential that asks
+for the other one.
+
+**`GET /fleet/mass` is in the anonymous tier** (scope `stats:read`): what the
+fleet has sorted by weight rather than by count. No machine and no person in
+it, so it belongs beside `/stats` — the consumer drawing the headline counter is
+the one that wants this next to it.
+
 The split is enforced by SCOPE and not by convention, which is the whole point:
 a key minted for the website carries `stats:read` alone and is refused the
-roster, so leaking it costs aggregates rather than a list of owners. Both tiers
-additionally require the key's owner to be an admin and the key to be
+roster, so leaking it costs aggregates rather than a list of owners. Every tier
+additionally requires the key's owner to be an admin and the key to be
 unconstrained; a machine-scoped key is strictly less powerful than its owner
-and must not read fleet-wide anything.
+and must not read fleet-wide anything. Those two conditions live in
+`deps.resolve_public_scopes` so an endpoint here cannot forget one.
+
+The parts catalog is the sibling surface, in `routers/public_catalog.py`.
 
 Legacy: the `settings.PUBLIC_STATS_API_KEY` shared secret, presented as
 `Authorization: Bearer <key>` or `X-Stats-Key: <key>`. It opens the ANONYMOUS
@@ -31,6 +48,7 @@ every consumer holds a scoped key; delete the env var and the legacy branch
 below after cutover.
 """
 
+import hashlib
 import hmac
 from datetime import datetime, timedelta, timezone
 
@@ -42,17 +60,20 @@ from app.config import settings
 from app.deps import (
     API_KEY_PREFIX,
     API_KEY_SCOPE_CONTRIBUTORS_READ,
+    API_KEY_SCOPE_FLEET_ANON,
     API_KEY_SCOPE_FLEET_READ,
     API_KEY_SCOPE_STATS_READ,
-    _resolve_api_key,
     get_db,
+    presented_bearer_key,
+    require_public_scope,
+    resolve_public_scopes,
 )
 from app.models.machine import Machine
 from app.models.machine_daily_stats import MachineDailyStats
 from app.models.machine_piece import MachinePiece
 from app.models.user import User
 from app.models.user_identity import UserIdentity
-from app.services import analytics, leaderboard, machine_stats
+from app.services import analytics, fleet_mass, leaderboard, machine_stats
 
 router = APIRouter(prefix="/api/public", tags=["public-stats"])
 
@@ -79,39 +100,26 @@ PUBLIC_STATS_LOCAL_TZ = "America/Los_Angeles"
 ACTIVE_MACHINE_MIN_PIECES = 250
 
 
-def _presented_key(authorization: str | None, x_stats_key: str | None) -> str:
-    presented = x_stats_key
-    if not presented and authorization and authorization.startswith("Bearer "):
-        presented = authorization[7:]
-    return (presented or "").strip()
+def require_stats_key(
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(default=None),
+    x_stats_key: str | None = Header(default=None),
+) -> None:
+    """The anonymous tier: aggregates only, so the legacy secret still opens it.
 
-
-def _require_scope(db: Session, presented: str, scope: str, *, allow_legacy: bool) -> None:
-    """Admit an admin-owned, unconstrained `hv_*` key carrying `scope`.
-
-    `allow_legacy` says whether the shared secret is also accepted, and it is
-    false for every tier above the aggregates. A shared secret cannot be
-    revoked for one consumer or scoped to one tier, so letting it stand in for
-    a scope would undo the split it predates.
+    Every tier above this one is `require_public_scope` and nothing else — a
+    shared secret cannot be revoked for one consumer or narrowed to one tier, so
+    letting it stand in for a scope would undo the split it predates. This
+    endpoint keeps it only until the last consumer holds a scoped key.
     """
+    presented = presented_bearer_key(authorization, x_stats_key)
     if presented.startswith(API_KEY_PREFIX):
-        user, scopes, machine_ids = _resolve_api_key(db, presented)
-        if scope not in scopes:
+        if API_KEY_SCOPE_STATS_READ not in resolve_public_scopes(db, presented):
             raise HTTPException(
-                status_code=403, detail=f"API key is missing required scopes: {scope}"
-            )
-        if user.role != "admin":
-            raise HTTPException(status_code=403, detail="Insufficient permissions")
-        if machine_ids is not None:
-            raise HTTPException(
-                status_code=403, detail="Machine-scoped API keys cannot read fleet-wide stats"
+                status_code=403,
+                detail=f"API key is missing required scopes: {API_KEY_SCOPE_STATS_READ}",
             )
         return
-
-    if not allow_legacy:
-        raise HTTPException(
-            status_code=401, detail=f"This endpoint requires an API key with the {scope} scope"
-        )
     # Legacy shared secret — delete once every consumer holds a scoped key.
     configured = (settings.PUBLIC_STATS_API_KEY or "").strip()
     if not configured:
@@ -120,40 +128,9 @@ def _require_scope(db: Session, presented: str, scope: str, *, allow_legacy: boo
         raise HTTPException(status_code=401, detail="Invalid stats API key")
 
 
-def require_stats_key(
-    db: Session = Depends(get_db),
-    authorization: str | None = Header(default=None),
-    x_stats_key: str | None = Header(default=None),
-) -> None:
-    """The anonymous tier: aggregates only, so the legacy secret still opens it."""
-    _require_scope(
-        db, _presented_key(authorization, x_stats_key), API_KEY_SCOPE_STATS_READ, allow_legacy=True
-    )
-
-
-def require_contributors_key(
-    db: Session = Depends(get_db),
-    authorization: str | None = Header(default=None),
-    x_stats_key: str | None = Header(default=None),
-) -> None:
-    """The people tier: names and Discord ids, so a scoped key or nothing."""
-    _require_scope(
-        db,
-        _presented_key(authorization, x_stats_key),
-        API_KEY_SCOPE_CONTRIBUTORS_READ,
-        allow_legacy=False,
-    )
-
-
-def require_fleet_key(
-    db: Session = Depends(get_db),
-    authorization: str | None = Header(default=None),
-    x_stats_key: str | None = Header(default=None),
-) -> None:
-    """The identified tier: machines and owners, so a scoped key or nothing."""
-    _require_scope(
-        db, _presented_key(authorization, x_stats_key), API_KEY_SCOPE_FLEET_READ, allow_legacy=False
-    )
+require_contributors_key = require_public_scope(API_KEY_SCOPE_CONTRIBUTORS_READ)
+require_fleet_key = require_public_scope(API_KEY_SCOPE_FLEET_READ)
+require_fleet_anon_key = require_public_scope(API_KEY_SCOPE_FLEET_ANON)
 
 
 @router.get("/stats", dependencies=[Depends(require_stats_key)])
@@ -200,6 +177,17 @@ def get_public_fleet(db: Session = Depends(get_db)):
     would be the wrong call — a consumer that wants to know how many
     registrations exist can still ask — but `active_machine_count` is the
     number meant for people, and the balloon board says only that one.
+    """
+    return _roster(db)
+
+
+def _roster(db: Session) -> dict:
+    """The identified roster. `/fleet` serves this; `/fleet/anon` projects it.
+
+    One builder for both so the counts cannot drift apart: a de-identified view
+    assembled by its own query would eventually disagree with this one about
+    how many machines exist, and two endpoints disagreeing about the size of
+    the fleet is worse than either being slightly wrong.
     """
     rows = (
         db.query(Machine, UserIdentity)
@@ -267,6 +255,99 @@ def get_public_fleet(db: Session = Depends(get_db)):
         ),
         "active_discord_linked_count": sum(1 for m in active if m["owner_discord"] is not None),
     }
+
+
+# Domain separator for the machine pseudonym. Machine ids are v4 UUIDs, so the
+# hash is not brute-forceable back to one; the separator is belt-and-braces so
+# a digest from here can never collide with a digest of the same id computed
+# for some other purpose.
+_ANON_LABEL_SALT = b"hive/public/fleet-anon/v1"
+
+
+def _anon_label(machine_id: str) -> str:
+    """A stable opaque handle for one machine.
+
+    Stable so a consumer can hold a conversation about the same machine across
+    two questions, and opaque so the handle says nothing about whose it is. A
+    fresh random label per request would be safer by a hair and useless: the
+    thing asking is answering follow-up questions.
+    """
+    digest = hashlib.sha256(_ANON_LABEL_SALT + machine_id.encode()).hexdigest()
+    return "m-" + digest[:6]
+
+
+@router.get("/fleet/anon", dependencies=[Depends(require_fleet_anon_key)])
+def get_public_fleet_anon(db: Session = Depends(get_db)):
+    """The roster with every handle back to a person removed.
+
+    For a consumer that REPEATS WHAT IT READS TO STRANGERS. `/fleet` is for one
+    that keeps its data as well as it keeps its credential; this is for one that
+    by design does not, so the safety has to be in the payload rather than in a
+    promise about how the payload gets used.
+
+    What is dropped, and why each one is a handle and not just a nicety:
+
+    * **`owner_discord`** — the obvious one. A named owner is a named person.
+    * **`name`** — the owner picked it, and people name a machine after
+      themselves, their shop, or their town. It reads like a label and behaves
+      like an identifier.
+    * **`id`** — the real machine UUID appears in hive URLs and in support
+      threads, so it correlates this row with anywhere else it has been seen.
+      Replaced by a stable pseudonym, which supports a follow-up question
+      without being a join key on anything else.
+    * **`last_seen_at`'s time of day** — the non-obvious one, and the reason
+      this endpoint exists rather than `/fleet` minus two fields. A timestamp
+      per machine, sampled over a fleet, is a daily activity pattern; a daily
+      activity pattern is a working-hours schedule; and a schedule is a
+      timezone, which is a rough location. Served as a UTC DATE, which still
+      answers "has this one run recently" and no longer draws a clock.
+
+    What is kept is what the fleet is: how many machines, how much each has
+    sorted, how fast, and whether it is running now — the last as a boolean off
+    the trailing-hour count rather than as a time.
+    """
+    full = _roster(db)
+    machines = [
+        {
+            "label": _anon_label(m["id"]),
+            "is_active": m["is_active"],
+            "pieces_seen": m["pieces_seen"],
+            "distributed": m["distributed"],
+            "overall_ppm": m["overall_ppm"],
+            "last_24h_pieces": m["last_24h_pieces"],
+            "last_30d_pieces": m["last_30d_pieces"],
+            # A boolean, not the hour it happened. Same question answered,
+            # nothing to plot against a clock.
+            "sorting_within_the_hour": m["last_hour_pieces"] > 0,
+            "last_seen_date": (m["last_seen_at"] or "")[:10] or None,
+            "first_seen_date": (m["created_at"] or "")[:10] or None,
+        }
+        for m in full["machines"]
+    ]
+    return {
+        "machines": machines,
+        "active_threshold_pieces": full["active_threshold_pieces"],
+        "active_machine_count": full["active_machine_count"],
+        # Deliberately no registered_machine_count: it counts benches that never
+        # sorted a piece, and this tier's whole audience is people being told a
+        # number out loud. See the note on /fleet.
+    }
+
+
+@router.get("/fleet/mass", dependencies=[Depends(require_stats_key)])
+def get_public_fleet_mass(db: Session = Depends(get_db)):
+    """How much the fleet has sorted, by mass rather than by count.
+
+    An aggregate with no machine and no person in it, so it sits in the
+    anonymous tier alongside `/stats` — the consumer that draws the headline
+    counter is exactly the one that wants this next to it.
+
+    Read `services/fleet_mass.py` before quoting a field: the honest number
+    depends on coverage, and the payload carries both a measured sum and an
+    extrapolation because neither alone is the answer.
+    """
+    ids = [mid for (mid,) in db.query(Machine.id).filter(Machine.archived_at.is_(None)).all()]
+    return fleet_mass.get_fleet_mass(db, ids)
 
 
 def _pieces_by_machine_since(db: Session, ids: list, *, hours: int) -> dict[str, int]:

--- a/software/hive/backend/app/services/fleet_mass.py
+++ b/software/hive/backend/app/services/fleet_mass.py
@@ -1,0 +1,156 @@
+"""How much the fleet has sorted, by mass.
+
+The piece counter answers "how many"; this answers "how much", which is the
+number people actually have intuition for — nobody knows whether 4 million
+pieces is a lot, and everybody knows what a tonne is.
+
+**It is a join across two databases and cannot be done in SQL.** The piece
+histogram lives in Postgres (`machine_pieces`) and the weights live in the
+parts catalog, which is a separate SQLite file (`parts.db`, see
+`services/profile_engine/db.py`). So: one grouped scan in Postgres, one batched
+weight lookup in SQLite, multiplied in Python.
+
+**Coverage is part of the answer, not a footnote.** A piece contributes mass
+only if it was identified AND its part has a weight on file, and neither is
+guaranteed — an unidentified piece has no part id at all, and plenty of catalog
+entries have no weight. Reporting only the sum would understate the truth by
+however much is missing and would silently drift as coverage changed. So the
+payload carries the measured sum, how many pieces are behind it, and an
+estimate that extends the mean matched piece over the unmatched remainder.
+A consumer says "at least X" from the first or "about Y" from the second, and
+`coverage` is what tells it which claim it can defend.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.machine_piece import MachinePiece
+
+logger = logging.getLogger(__name__)
+
+# The whole-table group-by behind this is one sequential scan of machine_pieces,
+# which is seconds at fleet scale and grows with the fleet. Nothing downstream
+# needs it fresher than this: it is a lifetime total, so a ten-minute-old answer
+# differs from a live one in a digit nobody reads.
+CACHE_TTL_S = 600.0
+
+_cache: dict[str, Any] | None = None
+_cache_key: tuple | None = None
+_cache_at: float = 0.0
+_lock = threading.Lock()
+
+
+def get_fleet_mass(db: Session, machine_ids: list) -> dict[str, Any]:
+    """Total mass sorted across these machines, with its coverage."""
+    global _cache, _cache_key, _cache_at
+
+    key = tuple(sorted(str(m) for m in machine_ids))
+    with _lock:
+        if _cache is not None and _cache_key == key and (time.monotonic() - _cache_at) < CACHE_TTL_S:
+            return _cache
+
+    # Computed outside the lock: it is a multi-second scan, and two concurrent
+    # callers doing it twice is cheaper than every caller queueing behind one.
+    computed = _compute(db, machine_ids)
+
+    with _lock:
+        _cache, _cache_key, _cache_at = computed, key, time.monotonic()
+    return computed
+
+
+def reset_cache() -> None:
+    """Drop the memo. For tests, which sync pieces and re-ask within the TTL."""
+    global _cache, _cache_key, _cache_at
+    with _lock:
+        _cache, _cache_key, _cache_at = None, None, 0.0
+
+
+def _compute(db: Session, machine_ids: list) -> dict[str, Any]:
+    if not machine_ids:
+        return _empty()
+
+    # Every piece, identified or not, so `total_pieces` is the real denominator
+    # and the estimate below extrapolates over the right population.
+    total_pieces = int(
+        db.query(func.count())
+        .select_from(MachinePiece)
+        .filter(MachinePiece.machine_id.in_(machine_ids))
+        .scalar()
+        or 0
+    )
+
+    counts = (
+        db.query(MachinePiece.part_id, func.count())
+        .filter(MachinePiece.machine_id.in_(machine_ids))
+        .filter(MachinePiece.part_id.isnot(None))
+        .group_by(MachinePiece.part_id)
+        .all()
+    )
+    by_part = {str(pid): int(n) for pid, n in counts}
+    if not by_part:
+        return _empty(total_pieces=total_pieces)
+
+    try:
+        from app.services.profile_catalog import get_profile_catalog_service
+
+        weights = get_profile_catalog_service().batch_part_weights(list(by_part))
+    except Exception:
+        # A box without the catalog loaded should still answer the piece
+        # question rather than 500 — mass comes back as unknown coverage.
+        logger.exception("fleet mass: catalog unavailable")
+        return _empty(total_pieces=total_pieces)
+
+    grams = 0.0
+    matched_pieces = 0
+    for part_num, n in by_part.items():
+        w = weights.get(part_num)
+        if w is None:
+            continue
+        grams += w * n
+        matched_pieces += n
+
+    mean_g = (grams / matched_pieces) if matched_pieces else None
+    estimated = (mean_g * total_pieces) if mean_g is not None else None
+
+    return {
+        "known_grams": round(grams, 1),
+        "known_kg": round(grams / 1000.0, 2),
+        # The pieces actually behind known_grams, and the two ways they fall
+        # short: never identified, or identified as a part with no weight.
+        "matched_pieces": matched_pieces,
+        "total_pieces": total_pieces,
+        "identified_pieces": sum(by_part.values()),
+        "coverage": round(matched_pieces / total_pieces, 4) if total_pieces else 0.0,
+        "mean_piece_grams": round(mean_g, 3) if mean_g is not None else None,
+        # The mean matched piece extended over every piece. Sound only if the
+        # unmatched pieces resemble the matched ones; they skew small and odd
+        # (that is partly WHY they are unmatched), so read it as an upper-ish
+        # estimate rather than a measurement.
+        "estimated_total_grams": round(estimated, 1) if estimated is not None else None,
+        "estimated_total_kg": round(estimated / 1000.0, 2) if estimated is not None else None,
+        "distinct_parts": len(by_part),
+        "distinct_parts_weighed": sum(1 for p in by_part if p in weights),
+    }
+
+
+def _empty(total_pieces: int = 0) -> dict[str, Any]:
+    return {
+        "known_grams": 0.0,
+        "known_kg": 0.0,
+        "matched_pieces": 0,
+        "total_pieces": total_pieces,
+        "identified_pieces": 0,
+        "coverage": 0.0,
+        "mean_piece_grams": None,
+        "estimated_total_grams": None,
+        "estimated_total_kg": None,
+        "distinct_parts": 0,
+        "distinct_parts_weighed": 0,
+    }

--- a/software/hive/backend/app/services/profile_catalog.py
+++ b/software/hive/backend/app/services/profile_catalog.py
@@ -381,6 +381,16 @@ class ProfileCatalogService:
         with self._lock:
             return profile_db.batchPieceMovingAvg(self._conn, pairs)
 
+    def batch_part_weights(self, part_nums: list[str]) -> dict[str, float]:
+        """Catalog weight in grams, keyed by part id, for the ids that have one.
+
+        Absent means no weight on file. Used to turn a piece-count histogram
+        into a mass, which is a couple of queries here and would be thousands
+        through `piece_metadata`.
+        """
+        with self._lock:
+            return profile_db.batchPartWeights(self._conn, part_nums)
+
     def admin_list_categories(self) -> list[dict[str, Any]]:
         return profile_db.adminListCategories(self._conn)
 

--- a/software/hive/backend/app/services/profile_engine/db.py
+++ b/software/hive/backend/app/services/profile_engine/db.py
@@ -1498,6 +1498,60 @@ def pieceMetadata(conn, part_num, color_key):
     return metadata
 
 
+# SQLite's default host-parameter ceiling is 999. Bind well under it and chunk,
+# so a caller can pass the fleet's whole distinct-part list without knowing.
+_IN_CHUNK = 500
+
+
+def _chunked(items, size=_IN_CHUNK):
+    items = list(items)
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def batchPartWeights(conn, part_nums):
+    # Catalog weight in grams for many parts in one pass, as {part_num: grams}.
+    # A part with no weight on file is simply absent rather than present as None,
+    # so a caller can tell "weighs nothing recorded" from "weighs zero".
+    #
+    # Same two-step resolution as pieceMetadata, for the same reason: an id here
+    # is whatever the machine recorded, which is a Rebrickable part_num for most
+    # pieces and a BrickLink item number for the printed and minifig ones. Doing
+    # only the first step silently drops those, which is a quiet undercount
+    # rather than a visible failure.
+    wanted = [p for p in dict.fromkeys(part_nums) if p]
+    if not wanted:
+        return {}
+
+    out = {}
+    for chunk in _chunked(wanted):
+        marks = ",".join("?" * len(chunk))
+        # ORDER BY is_primary last so the primary item's weight is the one that
+        # survives the dict assignment for a part mapping to several items.
+        rows = conn.execute(
+            f"SELECT pbi.part_num, bi.weight FROM part_bricklink_ids pbi "
+            f"JOIN bricklink_items bi ON bi.item_no = pbi.item_no "
+            f"WHERE pbi.part_num IN ({marks}) AND bi.weight IS NOT NULL "
+            f"ORDER BY pbi.is_primary ASC",
+            chunk,
+        ).fetchall()
+        for part_num, weight in rows:
+            out[part_num] = float(weight)
+
+    missing = [p for p in wanted if p not in out]
+    for chunk in _chunked(missing):
+        marks = ",".join("?" * len(chunk))
+        rows = conn.execute(
+            f"SELECT item_no, weight FROM bricklink_items "
+            f"WHERE item_no IN ({marks}) AND weight IS NOT NULL",
+            chunk,
+        ).fetchall()
+        for item_no, weight in rows:
+            out[item_no] = float(weight)
+
+    return out
+
+
 def batchPieceMovingAvg(conn, pairs):
     # Resolve just the moving-average price for many (part_num, color_id) pairs in
     # one call — the machine revalues its whole piece history this way. color_id is

--- a/software/hive/backend/tests/test_public_catalog.py
+++ b/software/hive/backend/tests/test_public_catalog.py
@@ -1,0 +1,343 @@
+"""The service-to-service parts catalog: the scope split, and the batch shape.
+
+The catalog here is a REAL ProfileCatalogService over a temp parts.db rather
+than a stub, so these exercise the same id-resolution the machines use — the
+BrickLink-vs-Rebrickable fallback is the part most likely to break and a fake
+would not have it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import settings
+from app.services import profile_catalog as pc
+from app.services.profile_engine import db as profile_db
+
+CATEGORIES = [{"id": 1, "name": "Bricks"}, {"id": 2, "name": "Plates"}]
+PARTS = [
+    {"part_num": "3001", "name": "Brick 2 x 4", "part_cat_id": 1,
+     "external_ids": {"BrickLink": ["3001"]}},
+    {"part_num": "3020", "name": "Plate 2 x 4", "part_cat_id": 2,
+     "external_ids": {"BrickLink": ["3020"]}},
+    # The base mold behind the printed item below. Rebrickable carries the mold;
+    # the print exists only as a BrickLink item number.
+    {"part_num": "973", "name": "Torso", "part_cat_id": 1, "external_ids": {}},
+    # No BrickLink mapping at all, so no weight — the coverage case.
+    {"part_num": "99999", "name": "Mystery Thing", "part_cat_id": 1, "external_ids": {}},
+]
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def catalog(tmp_path, monkeypatch):
+    """A live catalog service backed by a seeded temp parts.db."""
+    monkeypatch.setattr(settings, "SORTING_PROFILE_PARTS_DB_PATH", str(tmp_path / "parts.db"))
+    monkeypatch.setattr(pc, "_catalog_service", None)
+    svc = pc.get_profile_catalog_service()
+    conn = svc._conn
+
+    profile_db.upsertCategories(conn, CATEGORIES)
+    profile_db.upsertParts(conn, PARTS)
+    for part_num, item_no in (("3001", "3001"), ("3020", "3020")):
+        conn.execute(
+            "INSERT OR REPLACE INTO part_bricklink_ids (part_num, item_no, is_primary) "
+            "VALUES (?, ?, 1)",
+            (part_num, item_no),
+        )
+    conn.execute(
+        "INSERT INTO bricklink_items (item_no, part_num, name, weight, dim_x_studs, "
+        "dim_y_studs, year_released) VALUES ('3001', '3001', 'Brick 2 x 4', 2.5, 4, 2, 1979)"
+    )
+    conn.execute(
+        "INSERT INTO bricklink_items (item_no, part_num, name, weight, dim_x_studs, "
+        "dim_y_studs, year_released) VALUES ('3020', '3020', 'Plate 2 x 4', 1.2, 4, 2, 1979)"
+    )
+    # A BrickLink-only id: no Rebrickable part row, which is how printed parts
+    # and minifigs arrive off a machine.
+    conn.execute(
+        "INSERT INTO bricklink_items (item_no, part_num, name, weight) "
+        "VALUES ('973pb1234', '973', 'Torso with Print', 1.9)"
+    )
+    conn.execute(
+        "INSERT INTO price_guides (item_no, bl_color_id, rb_color_id, ord_new_wavg, "
+        "inv_new_qty, inv_new_lots) VALUES ('3001', 5, 4, 1.20, 500, 9)"
+    )
+    profile_db.upsertPartGeometry(
+        conn, "3001",
+        {"ldraw_id": "3001", "geometry_source": "direct", "bbox_x_mm": 31.8,
+         "bbox_y_mm": 15.8, "bbox_z_mm": 11.4, "max_extent_mm": 35.5, "volume_mm3": 4200.0},
+        "2026-01-01T00:00:00Z",
+    )
+    conn.commit()
+    profile_db.reloadPartsData(conn, svc._parts_data)
+    yield svc
+
+
+def _admin_login(client, db):
+    """Register an admin and leave the client logged in AS THEM.
+
+    A function and not a fixture on purpose. Every login mutates the one
+    TestClient cookie jar, so a fixture that logs in is order-dependent on any
+    other fixture that also logs in — `test_machine` registers its own owner and
+    would silently leave a member holding the session. Called explicitly, the
+    order is on the page.
+    """
+    from app.models.user import User
+    from tests.conftest import _auth_headers, _login_user, _register_user
+
+    _register_user(client, "catalog-admin@test.com", "Password123!", "Catalog Admin")
+    _login_user(client, "catalog-admin@test.com", "Password123!")
+    user = db.query(User).filter(User.email == "catalog-admin@test.com").first()
+    user.role = "admin"
+    db.commit()
+    _login_user(client, "catalog-admin@test.com", "Password123!")
+    return _auth_headers(client)
+
+
+def _mint(client, headers, scopes, machine_ids=None):
+    payload = {"name": "catalog-key", "scopes": scopes}
+    if machine_ids is not None:
+        payload["machine_ids"] = machine_ids
+    r = client.post("/api/auth/api-keys", json=payload, headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()["raw_token"]
+
+
+class TestCatalogAuth:
+    def test_no_key_is_refused(self, client, catalog):
+        assert client.get("/api/public/parts/3001").status_code == 401
+
+    def test_the_legacy_shared_secret_does_not_open_the_catalog(
+        self, client, catalog, monkeypatch
+    ):
+        """The stats secret predates every scope and must not stand in for one."""
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "legacy-secret")
+        r = client.get("/api/public/parts/3001", headers={"X-Stats-Key": "legacy-secret"})
+        assert r.status_code == 401
+
+    def test_a_stats_key_cannot_read_the_catalog(self, client, db, catalog):
+        headers = _admin_login(client, db)
+        token = _mint(client, headers, ["stats:read"])
+        r = client.get("/api/public/parts/3001", headers=_bearer(token))
+        assert r.status_code == 403
+        assert "parts:read" in r.json()["error"]
+
+    def test_machine_scoped_key_is_refused(self, client, db, catalog, test_machine):
+        """A key narrowed to one machine is strictly less powerful than its
+        owner, and the catalog is not per-machine data for it to narrow."""
+        import uuid
+
+        from app.models.machine import Machine
+        from app.models.user import User
+
+        headers = _admin_login(client, db)
+        # Minting a machine-scoped key validates the ids against machines the
+        # creator owns, so the admin has to own this one for the test to reach
+        # the guard under test rather than stopping at that check.
+        admin = db.query(User).filter(User.email == "catalog-admin@test.com").first()
+        machine = db.query(Machine).filter(Machine.id == uuid.UUID(test_machine["id"])).first()
+        machine.owner_id = admin.id
+        db.commit()
+
+        token = _mint(client, headers, ["parts:read"], machine_ids=[test_machine["id"]])
+        r = client.get("/api/public/parts/3001", headers=_bearer(token))
+        assert r.status_code == 403
+
+
+class TestPartsRead:
+    @pytest.fixture
+    def token(self, client, db):
+        return _mint(client, _admin_login(client, db), ["parts:read"])
+
+    def test_serves_identity_weight_and_ldraw_dimensions(self, client, catalog, token):
+        r = client.get("/api/public/parts/3001", headers=_bearer(token))
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["part_num"] == "3001"
+        assert body["name"] == "Brick 2 x 4"
+        assert body["category"] == "Bricks"
+        assert body["bricklink"]["weight_g"] == 2.5
+        assert body["dimensions"]["bbox_x_mm"] == 31.8
+        assert body["dimensions"]["source"] == "ldraw_direct"
+        assert body["dimensions"]["confidence"] == "exact"
+
+    def test_resolves_a_bricklink_only_id(self, client, catalog, token):
+        """A machine predicts printed parts in BrickLink ids; they must resolve."""
+        r = client.get("/api/public/parts/973pb1234", headers=_bearer(token))
+        assert r.status_code == 200, r.text
+        assert r.json()["bricklink"]["weight_g"] == 1.9
+
+    def test_unknown_part_is_404(self, client, catalog, token):
+        assert client.get("/api/public/parts/nope-not-real", headers=_bearer(token)).status_code == 404
+
+    def test_prices_are_absent_without_the_price_scope(self, client, catalog, token):
+        body = client.get("/api/public/parts/3001?color_id=5", headers=_bearer(token)).json()
+        for field in ("price", "moving_avg_price", "price_currency", "price_updated_at"):
+            assert field not in body, f"{field} leaked to a key without parts:prices"
+
+    def test_prices_appear_with_the_price_scope(self, client, db, catalog):
+        token = _mint(client, _admin_login(client, db), ["parts:read", "parts:prices"])
+        body = client.get("/api/public/parts/3001?color_id=5", headers=_bearer(token)).json()
+        assert body["moving_avg_price"] == 1.20
+
+    def test_search_and_colors_and_categories(self, client, catalog, token):
+        r = client.get("/api/public/parts/search?q=brick", headers=_bearer(token))
+        assert r.status_code == 200, r.text
+        assert any(p["part_num"] == "3001" for p in r.json()["results"])
+
+        assert client.get("/api/public/colors", headers=_bearer(token)).status_code == 200
+        cats = client.get("/api/public/categories", headers=_bearer(token))
+        assert cats.status_code == 200
+        assert any(c["name"] == "Bricks" for c in cats.json()["categories"])
+
+
+class TestPartsBatch:
+    @pytest.fixture
+    def token(self, client, db):
+        return _mint(client, _admin_login(client, db), ["parts:read"])
+
+    def test_answers_in_request_order_with_one_entry_per_id(self, client, catalog, token):
+        r = client.post(
+            "/api/public/parts/batch",
+            headers=_bearer(token),
+            json={"parts": [{"part_num": "3020"}, {"part_num": "3001"}, {"part_num": "3020"}]},
+        )
+        assert r.status_code == 200, r.text
+        parts = r.json()["parts"]
+        assert [p["part_num"] for p in parts] == ["3020", "3001", "3020"]
+        assert r.json()["count"] == 3
+
+    def test_an_unknown_id_holds_its_place(self, client, catalog, token):
+        """A caller doing arithmetic needs the answer to line up with the ask."""
+        r = client.post(
+            "/api/public/parts/batch",
+            headers=_bearer(token),
+            json={"parts": [{"part_num": "3001"}, {"part_num": "ghost"}, {"part_num": "3020"}]},
+        )
+        parts = r.json()["parts"]
+        assert len(parts) == 3
+        assert parts[1] == {"part_num": "ghost", "found": False}
+        assert parts[0]["found"] is True
+
+    def test_batch_respects_the_price_scope(self, client, catalog, token):
+        r = client.post(
+            "/api/public/parts/batch",
+            headers=_bearer(token),
+            json={"parts": [{"part_num": "3001", "color_id": 5}]},
+        )
+        assert r.json()["prices_included"] is False
+        assert "moving_avg_price" not in r.json()["parts"][0]
+
+    def test_over_the_cap_is_refused(self, client, catalog, token):
+        from app.routers.public_catalog import MAX_BATCH
+
+        r = client.post(
+            "/api/public/parts/batch",
+            headers=_bearer(token),
+            json={"parts": [{"part_num": "3001"}] * (MAX_BATCH + 1)},
+        )
+        assert r.status_code == 422
+
+
+class TestBatchPartWeights:
+    """The lookup behind the fleet mass rollup."""
+
+    def test_maps_both_id_spaces_and_omits_the_unweighed(self, catalog):
+        weights = catalog.batch_part_weights(["3001", "3020", "973pb1234", "99999", "ghost"])
+        assert weights["3001"] == 2.5
+        assert weights["3020"] == 1.2
+        # BrickLink-only id resolves through the direct fallback.
+        assert weights["973pb1234"] == 1.9
+        # A part with no weight on file is ABSENT, not present as None, so a
+        # caller can tell "nothing recorded" from "weighs zero".
+        assert "99999" not in weights
+        assert "ghost" not in weights
+
+    def test_empty_input(self, catalog):
+        assert catalog.batch_part_weights([]) == {}
+
+
+class TestFleetMass:
+    """The weight rollup: the two-database join, and honest coverage.
+
+    Lives here rather than beside the other fleet tests because the half most
+    likely to be wrong is the catalog half — the piece scan is a group-by.
+    """
+
+    def _sync(self, client, machine_token, records):
+        r = client.post(
+            "/api/machine/sync/piece-records",
+            headers=_bearer(machine_token),
+            json={"records": records},
+        )
+        assert r.status_code == 200, r.text
+
+    def _mass(self, client, db, catalog, machine_token, records):
+        import time
+
+        from app.services import fleet_mass
+
+        fleet_mass.reset_cache()
+        self._sync(client, machine_token, [
+            {"piece_uuid": f"p{i}", "local_id": i + 1, "seen_at": time.time() - 60,
+             "classification_status": "classified", **rec}
+            for i, rec in enumerate(records)
+        ])
+        token = _mint(client, _admin_login(client, db), ["stats:read"])
+        r = client.get("/api/public/fleet/mass", headers=_bearer(token))
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    def test_sums_catalog_weights_over_the_piece_histogram(
+        self, client, db, catalog, machine_token
+    ):
+        # 3 × 2.5g + 2 × 1.2g = 9.9g
+        body = self._mass(client, db, catalog, machine_token, [
+            {"part_id": "3001", "color_id": "5"},
+            {"part_id": "3001", "color_id": "5"},
+            {"part_id": "3001", "color_id": "11"},
+            {"part_id": "3020", "color_id": "5"},
+            {"part_id": "3020", "color_id": "5"},
+        ])
+        assert body["known_grams"] == 9.9
+        assert body["matched_pieces"] == 5
+        assert body["total_pieces"] == 5
+        assert body["coverage"] == 1.0
+        assert body["distinct_parts"] == 2
+
+    def test_coverage_reports_what_could_not_be_weighed(
+        self, client, db, catalog, machine_token
+    ):
+        """A piece with no part id, and a part with no weight, both count
+        against coverage — the estimate is what extends over them."""
+        body = self._mass(client, db, catalog, machine_token, [
+            {"part_id": "3001", "color_id": "5"},   # 2.5g, weighed
+            {"part_id": "99999", "color_id": "5"},  # in the catalog, no weight
+            {"color_id": "5"},                      # never identified at all
+        ])
+        assert body["known_grams"] == 2.5
+        assert body["matched_pieces"] == 1
+        assert body["total_pieces"] == 3
+        assert body["identified_pieces"] == 2
+        assert body["coverage"] == pytest.approx(1 / 3, abs=1e-4)
+        assert body["mean_piece_grams"] == 2.5
+        # The mean matched piece extended over every piece, including the two
+        # that could not be weighed.
+        assert body["estimated_total_grams"] == 7.5
+
+    def test_requires_the_stats_scope(self, client, db, catalog, monkeypatch):
+        """Mass is an aggregate, so it sits in the anonymous tier with /stats —
+        same scope, and the same legacy secret, until that secret is deleted."""
+        monkeypatch.setattr(settings, "PUBLIC_STATS_API_KEY", "legacy-secret")
+        assert client.get("/api/public/fleet/mass").status_code == 401
+        assert client.get(
+            "/api/public/fleet/mass", headers={"X-Stats-Key": "legacy-secret"}
+        ).status_code == 200
+
+        token = _mint(client, _admin_login(client, db), ["parts:read"])
+        r = client.get("/api/public/fleet/mass", headers=_bearer(token))
+        assert r.status_code == 403

--- a/software/hive/backend/tests/test_public_stats.py
+++ b/software/hive/backend/tests/test_public_stats.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 
 from app.config import settings
@@ -335,3 +336,120 @@ class TestContributors:
                 assert "avatar_url" not in e
                 assert "user_id" not in e
                 assert "email" not in e
+
+
+class TestFleetAnonTier:
+    """The de-identified roster: what it drops, and that a key for it cannot
+    ask for the identified one."""
+
+    def _admin_headers(self, client, db):
+        from app.models.user import User
+        from tests.conftest import _auth_headers, _login_user, _register_user
+
+        _register_user(client, "anon-admin@test.com", "Password123!", "Anon Admin")
+        _login_user(client, "anon-admin@test.com", "Password123!")
+        user = db.query(User).filter(User.email == "anon-admin@test.com").first()
+        user.role = "admin"
+        db.commit()
+        _login_user(client, "anon-admin@test.com", "Password123!")
+        return _auth_headers(client)
+
+    def _mint(self, client, headers, scopes):
+        r = client.post(
+            "/api/auth/api-keys", json={"name": "anon-key", "scopes": scopes}, headers=headers
+        )
+        assert r.status_code == 200, r.text
+        return r.json()["raw_token"]
+
+    def _link_discord(self, db, email):
+        """Give the machine owner a linked Discord identity, so the identified
+        tier has something to serve and the anonymous one has something to drop."""
+        from app.models.machine import Machine
+        from app.models.user_identity import UserIdentity
+
+        owner_id = db.query(Machine.owner_id).first()[0]
+        db.add(UserIdentity(
+            user_id=owner_id, provider="discord",
+            provider_user_id="1234567890", provider_login="someowner",
+        ))
+        db.commit()
+
+    def test_scope_is_separate_from_fleet_read_in_both_directions(
+        self, client, db, machine_token
+    ):
+        """The whole point of a third scope: neither key can ask for the other's
+        tier, so a consumer that should only see the de-identified view cannot
+        hold a credential that reaches the roster."""
+        headers = self._admin_headers(client, db)
+        anon_only = self._mint(client, headers, ["fleet:anon"])
+        full_only = self._mint(client, headers, ["fleet:read"])
+
+        assert client.get("/api/public/fleet", headers=_bearer(anon_only)).status_code == 403
+        assert client.get("/api/public/fleet/anon", headers=_bearer(full_only)).status_code == 403
+        assert client.get("/api/public/fleet/anon", headers=_bearer(anon_only)).status_code == 200
+
+    def test_drops_every_handle_back_to_a_person(self, client, db, machine_token):
+        _sync(client, machine_token, [
+            {"piece_uuid": "a", "local_id": 1, "seen_at": time.time() - 60,
+             "classification_status": "classified", "part_id": "3001", "color_id": "5"},
+        ])
+        self._link_discord(db, "anon-admin@test.com")
+        headers = self._admin_headers(client, db)
+
+        full = client.get(
+            "/api/public/fleet", headers=_bearer(self._mint(client, headers, ["fleet:read"]))
+        ).json()
+        anon = client.get(
+            "/api/public/fleet/anon", headers=_bearer(self._mint(client, headers, ["fleet:anon"]))
+        ).json()
+
+        # The identified tier really does carry the things being dropped, so
+        # this test fails if the roster stops serving them rather than passing
+        # vacuously.
+        assert full["machines"][0]["owner_discord"]["id"] == "1234567890"
+        assert full["machines"][0]["name"]
+        assert ":" in full["machines"][0]["last_seen_at"]  # a timestamp, with a clock in it
+
+        row = anon["machines"][0]
+        for gone in ("owner_discord", "name", "id", "last_seen_at", "last_hour_pieces"):
+            assert gone not in row, f"{gone} survived into the de-identified roster"
+        # And nothing anywhere in the payload spells the owner's Discord id.
+        assert "1234567890" not in json.dumps(anon)
+
+    def test_keeps_the_counts_and_a_stable_pseudonym(self, client, db, machine_token):
+        _sync(client, machine_token, [
+            {"piece_uuid": f"p{i}", "local_id": i + 1, "seen_at": time.time() - 60,
+             "classification_status": "classified", "part_id": "3001", "color_id": "5"}
+            for i in range(3)
+        ])
+        # Lifetime counters are served out of machine_stats_cache, which an
+        # hourly worker fills and which is therefore empty in a test.
+        from app.services import machine_stats
+
+        machine_stats.refresh_cache(db)
+
+        headers = self._admin_headers(client, db)
+        token = self._mint(client, headers, ["fleet:anon"])
+
+        first = client.get("/api/public/fleet/anon", headers=_bearer(token)).json()
+        again = client.get("/api/public/fleet/anon", headers=_bearer(token)).json()
+
+        row = first["machines"][0]
+        assert row["pieces_seen"] == 3
+        assert row["sorting_within_the_hour"] is True
+        # A DATE, not a timestamp: no clock to plot a working day against.
+        assert len(row["last_seen_date"]) == 10
+        assert row["label"].startswith("m-")
+        # Stable across calls, so a consumer can hold a follow-up conversation
+        # about the same machine.
+        assert row["label"] == again["machines"][0]["label"]
+
+    def test_does_not_serve_the_registration_count(self, client, db, machine_token):
+        """The number that counts benches which never sorted a piece. This tier's
+        audience is people being told a number out loud."""
+        headers = self._admin_headers(client, db)
+        body = client.get(
+            "/api/public/fleet/anon", headers=_bearer(self._mint(client, headers, ["fleet:anon"]))
+        ).json()
+        assert "registered_machine_count" not in body
+        assert "active_machine_count" in body


### PR DESCRIPTION
Three additions to the service-to-service API (`/api/public/*`), each behind its own scope.

### Parts catalog — `parts:read`

New `routers/public_catalog.py`:

| Endpoint | |
|---|---|
| `GET /parts/{part_num}` | one part: identity, category, years, dimensions, weight, image |
| `POST /parts/batch` | up to 250 ids in one round trip |
| `GET /parts/search` | by name or number |
| `GET /parts/{part_num}/colors` | colors the part is sold in |
| `GET /colors`, `GET /categories` | the palette and the category list |

Rows come from the same `pieceMetadata` the machines already use rather than a
second assembler beside it, so a BrickLink item number (which is how printed
parts and minifigs arrive off a sorter) resolves here exactly as it does there.

The batch endpoint is the one that matters: a consumer computing over a set of
parts needs hundreds per question, and doing that one HTTP request at a time is
slow enough that it does not get done. It answers in request order with one
entry per requested id, and an unknown id holds its place as `{"found": false}`
rather than being dropped — a caller doing arithmetic needs the answer to line
up with the ask.

### Prices split under `parts:prices`

Market data is a licensed feed rather than a fact about a brick, so it is worth
being able to withhold from a consumer that gets the rest. The scope shapes the
payload rather than gating an endpoint: `parts:read` alone returns every row in
full with the price block absent, so nothing 403s halfway through a batch.
Stripping is by field-name set, so a price field added upstream is excluded by
default instead of leaking until somebody notices.

### De-identified roster — `fleet:anon`

`GET /fleet/anon`: the same machines and the same counts as `/fleet`, with the
owner identity, the owner-chosen machine name and the real machine id removed,
and last-seen served as a UTC date rather than a timestamp.

The timestamp is the non-obvious one and the reason this is an endpoint rather
than `/fleet` minus two fields — per-machine timestamps sampled across a fleet
are a daily activity pattern, which is a working-hours schedule, which is a
timezone. "Is it running now" is kept as a boolean off the trailing-hour count,
which answers the question without drawing a clock. Machines get a stable
pseudonym (a salted hash of the id) so a consumer can ask a follow-up about the
same one.

A separate scope rather than a flag on `fleet:read`: the two differ in who may
hold them, so a consumer that should only see this view must not hold a
credential able to ask for the other. Both tiers are built by one row builder,
so their counts cannot drift apart.

### Fleet mass — `GET /fleet/mass`, `stats:read`

What the fleet has sorted by weight rather than by count. It cannot be done in
SQL: the piece histogram is in Postgres and the weights are in the parts
catalog's sqlite, so it is one grouped scan, one batched weight lookup and a
multiply in Python, memoised for ten minutes.

Coverage is part of the answer rather than a footnote. Not every piece is
identified and not every part has a weight on file, so the payload carries the
measured sum, the pieces behind it, and an extrapolation of the mean matched
piece over the remainder — a caller says "at least X" or "about Y" and
`coverage` is what tells it which it can defend.

### Also

Extracts the admin-owned / unconstrained-key check every tier of this surface
shares into `deps.resolve_public_scopes`, so an endpoint here cannot forget one,
and replaces the three near-identical guards in `public_stats.py` with it. The
legacy `PUBLIC_STATS_API_KEY` shared secret still opens the aggregate tier only,
unchanged. `agent-docs/auth.md` updated in the same change.

### Tests

`tests/test_public_catalog.py` is new (the catalog, the scope split, the batch
shape, the weight lookup, the mass rollup) and `tests/test_public_stats.py`
gains the de-identified tier. The catalog tests run against a real
`ProfileCatalogService` over a temp `parts.db` rather than a stub, so they
exercise the actual id resolution. Full backend suite: 277 passed.
