### PR TITLE
docs(electronics): PSU output pigtail photo + make-your-own page

### DIFF
--- a/docs/src/content/hardware/electronics/psu-pigtail.md
+++ b/docs/src/content/hardware/electronics/psu-pigtail.md
@@ -1,0 +1,54 @@
+---
+layout: default
+title: Make your own PSU output pigtail
+type: reference
+section: hardware
+slug: electronics-psu-pigtail
+kicker: Electronics — PSU output pigtail
+lede: Build one of the three DC output pigtails for the PSU box: a panel-mount barrel jack and two crimp spade terminals.
+permalink: /hardware/electronics/psu-pigtail/
+last_verified: 2026-07-12
+---
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>Not validated against a built machine.</b> This is the current spec off the harness drawings, not a checked build procedure. Values marked <b>GUESS</b> in the <a href="{{ '/hardware/electronics/wireviz/' | n }}">WireViz drawing</a> are guesses.</p>
+</div>
+
+The PSU box has three DC outputs, and each one is a short pigtail: two crimp spade terminals onto the PSU terminal block at one end, a panel-mount barrel jack on the other. You need **three per PSU build**, one for each 24V load (the basically board, the USB hub, and the Orange Pi buck).
+
+<div class="callout">
+  <p><b>You usually don't have to make these.</b> The panel-mount jacks are commonly sold with the pigtail leads already attached, so buying the jacks with leads and crimping the spade terminals on is less work than building from bare wire. This page is for when you want to make your own.</p>
+</div>
+
+<figure class="harness-figure">
+  <img src="https://img.basically.website/web/harness/psu-pigtail-built.dc73ad657b30cce2.jpg" alt="An assembled PSU output pigtail: a panel-mount barrel jack with red and black 18 AWG leads, each ending in an insulated spade terminal">
+  <figcaption>One assembled pigtail: panel-mount barrel jack, red +24V and black ground leads, an insulated spade terminal crimped on each.</figcaption>
+</figure>
+
+## Parts, per pigtail
+
+<dl class="spec-list">
+  <dt>DC barrel jack</dt><dd>5.5 × 2.1 mm female, panel-mount, center-positive, rated ≥ 5 A. <b>2.1 mm pin, not 2.5 mm</b> — the two do not mate.</dd>
+  <dt>Spade terminals (×2)</dt><dd>Insulated fork/spade, 18 AWG, M3.5 stud, <b>8 mm wide max</b>. Molex <code>0191310031</code> or equivalent. The 8 mm limit matters: wider terminals will not fit between the LRS-350-24 output screws.</dd>
+  <dt>Wire</dt><dd>~4 in of 18 AWG, one red and one black. Skip this if your jack already ships with leads.</dd>
+</dl>
+
+<p class="download-line">
+  <span>Where to buy:</span>
+  <span><b>Amazon links for the jack and the crimp terminals are being added here.</b></span>
+</p>
+
+## Build it
+
+1. Start from ~4 in of 18 AWG red and black wire, or from a panel-mount jack that already has its leads.
+2. Wire the jack **center-positive**: red to the tip (+24V), black to the sleeve (GND). If your jack came with unlabeled leads, check tip vs sleeve with a multimeter before you trust the colors.
+3. Crimp an insulated spade terminal onto the free end of each wire — one on red, one on black.
+4. At the PSU terminal block, the red terminal lands on a <b>+V</b> screw and the black on the matching <b>−V</b> screw. MEAN WELL numbers the LRS-350-24 block so that <b>4–6 are −V</b> and <b>7–9 are +V</b>: pair <b>7 with 4, 8 with 5, 9 with 6</b>, one pigtail per pair.
+5. Panel-mount the jack into the PSU enclosure.
+
+Repeat for all three outputs.
+
+## Reference
+
+The full drawing, BOM and downloads for this pigtail are on the [WireViz drawings]({{ '/hardware/electronics/wireviz/' | n }}) page, under **PSU output pigtail**.

--- a/docs/src/content/hardware/electronics/psu-pigtail.md
+++ b/docs/src/content/hardware/electronics/psu-pigtail.md
@@ -49,6 +49,29 @@ The PSU box has three DC outputs, and each one is a short pigtail: two crimp spa
 
 Repeat for all three outputs.
 
+### Crimping the spade terminal
+
+The crimp is the fiddly part. Strip the wire, seat it fully in the terminal barrel, crimp it in the matching die, and check it does not pull out.
+
+<div class="photo-grid">
+  <figure>
+    <img src="https://img.basically.website/web/harness/psu-pigtail-step1-stripped.d4bb7664ad7ef113.png" alt="Stripped end of the 18 AWG wire showing bare strands">
+    <figcaption>1. Strip the wire back to bare strands.</figcaption>
+  </figure>
+  <figure>
+    <img src="https://img.basically.website/web/harness/psu-pigtail-step2-terminal.a6187f03935ad6ed.png" alt="Stripped wire seated in the spade terminal barrel, not yet crimped">
+    <figcaption>2. Seat the bare strands fully in the terminal barrel.</figcaption>
+  </figure>
+  <figure>
+    <img src="https://img.basically.website/web/harness/psu-pigtail-step3-crimping.13c6e57cff511a3a.png" alt="Crimping the terminal in the red 22 to 16 AWG die of a ratcheting crimp tool">
+    <figcaption>3. Crimp in the matching die — the red (22–16 AWG) jaw suits the 18 AWG wire.</figcaption>
+  </figure>
+  <figure>
+    <img src="https://img.basically.website/web/harness/psu-pigtail-step4-crimped.5988df4ada6c0bb2.png" alt="The finished crimp with the insulation grip closed on the wire jacket">
+    <figcaption>4. Finished: the grip is closed on the jacket and the wire will not pull out.</figcaption>
+  </figure>
+</div>
+
 ## Reference
 
 The full drawing, BOM and downloads for this pigtail are on the [WireViz drawings]({{ '/hardware/electronics/wireviz/' | n }}) page, under **PSU output pigtail**.

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -23,6 +23,15 @@ last_verified: 2026-07-12
 {% for d in site.data.harness.drawings %}
 {% if d.of %}### {{ d.title }}{% else %}## {{ d.title }}{% endif %}
 
+{% if d.photo %}
+<figure class="harness-figure harness-photo">
+  <a href="{{ d.guide | n }}">
+    <img src="{{ d.photo }}" alt="Assembled {{ d.title }}">
+  </a>
+  <figcaption>What it looks like built. <a href="{{ d.guide | n }}">{{ d.guide_label }} →</a></figcaption>
+</figure>
+{% endif %}
+
 <figure class="harness-figure">
   <a href="{{ d.png }}" target="_blank" rel="noopener">
     <img src="{{ d.png }}" alt="WireViz drawing: {{ d.title }}">

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -38,6 +38,9 @@ drawings:
       One output pigtail, x3 per PSU build. Spade terminals onto a +V/-V screw
       pair on the PSU terminal block (7 with 4, 8 with 5, 9 with 6),
       panel-mount jack on the other end.
+    photo: https://img.basically.website/web/harness/psu-pigtail-built.dc73ad657b30cce2.jpg
+    guide: /hardware/electronics/psu-pigtail/
+    guide_label: How to make your own
     png: https://img.basically.website/harness/psu-pigtail.e7a2cf6fc8.png
     svg: https://img.basically.website/harness/psu-pigtail.7cdf562b21.svg
     pdf: https://img.basically.website/harness/psu-pigtail.791cdb0604.pdf

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -80,6 +80,8 @@ sections:
             url: /hardware/electronics/order/
           - title: WireViz drawings
             url: /hardware/electronics/wireviz/
+          - title: Make your own PSU pigtail
+            url: /hardware/electronics/psu-pigtail/
       - title: Helpers
         url: /hardware/helpers/
         children:


### PR DESCRIPTION
Jon asked ("can you add the following picture under the wireviz for PSU output pigtail, or maybe place it right after the title. This should also point to a page on making your own") [here](https://discord.com/channels/1430279849171222682/1536088194557419660/1538643281968238742).

## What this does
- Adds the assembled-pigtail photo to the **PSU output pigtail** drawing on the WireViz page, right after the title, above the diagram.
- The photo links to a new page, **Make your own PSU output pigtail** (`/hardware/electronics/psu-pigtail/`), added under Electronics in the nav.
- The new page has the jack/terminal spec (5.5×2.1 barrel jack, Molex `0191310031` spade terminals, 18 AWG) and the build steps, pulled from `psu-pigtail.yml` and `rfq.txt`.

## Implementation
- `harness.yml` gains optional `photo` / `guide` / `guide_label` fields on the psu-pigtail entry; the WireViz template renders the photo only when a drawing has them, so it stays data-driven rather than special-casing one section.
- Photo uploaded to the assets bucket (content-addressed), not committed.

## Still to do
- **Amazon links for the DC jack and the crimp terminals** — Jon is providing these; the page has a placeholder line where they go.

Built clean on Node 22 (`npm run build`); the 5 `validate_frontmatter.py` errors are all pre-existing on `main`, none in the changed files.
