### PR TITLE
docs(top-interface): record final fasteners (idler M3×35+washer, ribbon clamp M3×10), clear all flags

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -102,7 +102,7 @@ parts_needed:
   - part: scr-m3-35-bhcs
     qty: 2
   - part: scr-m3-10-shcs
-    qty: 2
+    qty: 3
   - part: scr-m3-12-cs
     qty: 6
   - part: scr-m3-16-shcs
@@ -121,10 +121,7 @@ parts_needed:
     qty: 1
 ---
 
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>The fasteners and quantities in the parts list come from the build notes and are called out inline at each step. A few smaller screws are not recorded yet; those are marked <span class="fastener-todo">fastener not recorded</span> in the steps below. If you know one, please add its size.</p>
-</div>
+The fasteners and quantities in the parts list come from the build notes and are called out inline at each step.
 
 {% include fastener-legend.html %}
 
@@ -414,7 +411,7 @@ Fold your IDC ribbon cable around the Cable clamp (inner), following the guides 
 
 Guide the rest of the ribbon cable around the side of the Top interface chute mount, in the direction the chute can rotate, back to the Cable cage bracket (cable mount).
 
-Screw the Ribbon cable clamp <span class="fastener-todo">fastener not recorded</span> lightly to the Cable cage bracket (cable mount), clamping the ribbon cable between the two.
+Screw the Ribbon cable clamp lightly to the Cable cage bracket (cable mount) with one {% include fastener.html size="M3" variant="socket" length="10" %} screw, clamping the ribbon cable between the two.
 
 Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long M3 × 35 mm screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -100,7 +100,7 @@ parts_needed:
   - part: m4-12mm-countersunk
     qty: 8
   - part: scr-m3-35-bhcs
-    qty: 1
+    qty: 2
   - part: scr-m3-10-shcs
     qty: 2
   - part: scr-m3-12-cs
@@ -116,6 +116,8 @@ parts_needed:
   - part: nut-m5
     qty: 6
   - part: nut-m3
+    qty: 1
+  - part: washer-m3-15
     qty: 1
 ---
 
@@ -368,7 +370,7 @@ Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | rel
 
 Push a 608 2RS bearing into the Interface idler gear.
 
-Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards and secure it with a button head screw <span class="fastener-todo">fastener not recorded</span> (the video uses a screw with a washer).
+Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards and secure it with an {% include fastener.html size="M3" variant="button" length="35" %} screw and an M3 × 15 mm washer.
 
 Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four {% include fastener.html size="M5" variant="socket" length="12" %} screws.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -413,7 +413,7 @@ Guide the rest of the ribbon cable around the side of the Top interface chute mo
 
 Screw the Ribbon cable clamp lightly to the Cable cage bracket (cable mount) with one {% include fastener.html size="M3" variant="socket" length="10" %} screw, clamping the ribbon cable between the two.
 
-Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long M3 × 35 mm screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end (the video uses a different type of screw here).
+Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long {% include fastener.html size="M3" variant="button" length="35" %} screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end.
 
 {% include step.html n="12" title="Attach the cable cage bottom" %}
 

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -395,3 +395,8 @@ nut-m3:
   name: M3 nut
   category: Nuts
   image: https://img.basically.website/web/parts/hardware/nuts/nut-m5.4a3db788bb1ca8a2.jpg
+
+washer-m3-15:
+  name: M3 × 15 mm washer
+  category: Washers
+  not_in_calc: true


### PR DESCRIPTION
Records the last two unrecorded fasteners on the top-interface page, clearing every `fastener not recorded` flag.

**Idler gear (Step 9):**
- Button head screw is **M3 × 35 mm** (already in catalog + parts calc), paired with an **M3 × 15 mm washer**.
- Washer added to the catalog under a new **Washers** category, flagged not in the parts calculator (red `!`). M3 × 35 mm button head qty bumped to 2.

**Ribbon cable clamp (Step 10):**
- Fastened with one **M3 × 10 mm socket head** screw (already in catalog + parts calc); that part's qty bumped to 3.

With no flags left, the callout that explained them is removed; the fastener icon legend stays.

Requested by uwe_barthel (@uwe_barthel):
- Idler [from Discord](https://discord.com/channels/1430279849171222682/1537170859633156116/1538975087162560615): "I use a M3 x 35mm button head screw and a M3 x 15mm washer."
- Ribbon clamp [from Discord](https://discord.com/channels/1430279849171222682/1537170859633156116/1538982533725687839): "With one M3 x 10mm socket head screw."
- Cable clamp [from Discord](https://discord.com/channels/1430279849171222682/1537170859633156116/1538983860476452874): "It's a M3 x 35 mm button head screw".
