### PR TITLE
docs: show cut length on aluminium extrusion parts-needed cards

### DIFF
--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -103,16 +103,19 @@ ext-2020-ag:
   name: Outer horizontal / Horizontal interface frame (A/G)
   category: Aluminum extrusion (2020)
   image: https://img.basically.website/web/parts/extrusion/extrusion-2020.0691a894c8154731.png
+  caption: 2020 aluminum extrusion, cut to 320 mm (pieces A and G).
 
 ext-2020-bh:
   name: Spoke / Interface spoke, short (B/H)
   category: Aluminum extrusion (2020)
   image: https://img.basically.website/web/parts/extrusion/extrusion-2020.0691a894c8154731.png
+  caption: 2020 aluminum extrusion, cut to 158 mm (pieces B and H).
 
 ext-2020-c:
   name: Layer vertical support (C)
   category: Aluminum extrusion (2020)
   image: https://img.basically.website/web/parts/extrusion/extrusion-2020.0691a894c8154731.png
+  caption: 2020 aluminum extrusion, cut to 154 mm (piece C).
 
 scr-m5-12-bhcs:
   name: M5 × 12 mm button head screw

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -271,14 +271,14 @@ ribbon-cable-clamp:
   image: https://img.basically.website/web/parts/top-interface/ribbon-cable-clamp.5ff6e38d86a3ee4c.png
 
 extrusion-e:
-  name: Interface spoke, long (extrusion E)
-  category: Extrusion
+  name: Interface spoke, long (E)
+  category: Aluminum extrusion (2020)
   image: https://img.basically.website/web/parts/top-interface/extrusion-e.bce3a0752b0f99f5.png
   caption: 2020 aluminum extrusion, cut to 238 mm (piece E).
 
 extrusion-f:
-  name: Interface vertical support (extrusion F)
-  category: Extrusion
+  name: Interface vertical support (F)
+  category: Aluminum extrusion (2020)
   image: https://img.basically.website/web/parts/top-interface/extrusion-f.7e1f6b2dc9e069f7.png
   caption: 2020 aluminum extrusion, cut to 274 mm (piece F).
 


### PR DESCRIPTION
The **Aluminum extrusion (2020)** cards in the "Parts needed" section (regular-layers and elsewhere these pieces appear) showed only the piece name, so anyone who didn't letter their offcuts couldn't tell A/G from B/H from C. Adds a cut-length `caption` to each, matching how the interface pieces E and F already display theirs.

- **A/G** (Outer horizontal / Horizontal interface frame): 320 mm
- **B/H** (Spoke / Interface spoke, short): 158 mm
- **C** (Layer vertical support): 154 mm

Lengths taken from the framing cut list source (`parts-calculator` `src/lib/framing.ts`): A/G/B/H are untrimmed, C is 160 mm CAD minus the 6 mm clearance trim. Data-only change in `parts.yml`; docs build passes.

Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539082900878655548): "in the parts needed section, for the aluminium can you show the length. I didn't label mine A B etc, but I can measure them easily pre build."


---

Follow-up: standardized the naming/format of all five 2020-extrusion cards so they read the same across pages, previously the interface pieces were "(extrusion E/F)" under an "Extrusion" header while the frame pieces were "(A/G)" etc. under "Aluminum extrusion (2020)". Now all use role + bare letter in the name and share the "Aluminum extrusion (2020)" category.

Requested by Barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660): "Standardize the naming of the aluminum profiles used in the 'need parts' cards."