### PR TITLE
docs(parts): add product photo for the M3×15 mm washer card

### DIFF
--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -402,5 +402,5 @@ nut-m3:
 washer-m3-15:
   name: M3 × 15 mm washer
   category: Washers
-  image: https://img.basically.website/web/parts/hardware/washers/washer-m3-15.b254c98220245c2e.jpg
+  image: https://img.basically.website/web/parts/hardware/washers/washer-m3-15.0308d4e5b19bb5e4.jpg
   not_in_calc: true

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -402,4 +402,5 @@ nut-m3:
 washer-m3-15:
   name: M3 × 15 mm washer
   category: Washers
+  image: https://img.basically.website/web/parts/hardware/washers/washer-m3-15.b254c98220245c2e.jpg
   not_in_calc: true


### PR DESCRIPTION
The **M3 × 15 mm washer** card in the top-interface Parts needed list had no image. Adds a stainless fender-washer photo on a white background, in the same style as the scattered screw and nut shots already in the catalog.

Requested by uwe_barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1537170859633156116/1539127345993097327): "The washer does not yet have an image in the "Need Parts" tab. Please add an image in the same style as the other images in the tabs for screws and nuts."
