### PR TITLE
docs(top-interface): grey-part photos for limit switch housing and chute mount inserts

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -162,8 +162,9 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Top interface chute mount:</strong> 4 × M4 and 7 × M3</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside-grey.f48d2c86ebeb1716.jpg" alt="The underside of the grey Top interface chute mount, showing two of the brass M3 heat inserts on the ring beside the recess for the Limit switch hammer screw">
-    <figcaption>Underside: two of the M3 inserts on the ring, next to the recess for the Limit switch hammer screw. All 4 M4 and 7 M3 go around this face.</figcaption>
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside.d9429f336757fc52.jpg" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside-grey.f48d2c86ebeb1716.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
+    <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. Right: a closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -164,7 +164,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside.d9429f336757fc52.jpg" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
     <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside-grey.f48d2c86ebeb1716.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
-    <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. Right: a closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw.</figcaption>
+    <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. The grey shot is a closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -161,11 +161,16 @@ Before assembling anything, press the heat inserts into the parts that take them
   <div class="prep-item-body">
     <p><strong>Top interface chute mount:</strong> 4 × M4 and 7 × M3</p>
   </div>
-  <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside.d9429f336757fc52.jpg" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside-grey.f48d2c86ebeb1716.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
-    <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. The grey shot is a closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw.</figcaption>
-  </figure>
+  <div class="prep-item-figure prep-item-figure-split">
+    <figure>
+      <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside.d9429f336757fc52.jpg" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
+      <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face.</figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside-grey.f48d2c86ebeb1716.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
+      <figcaption>A closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw.</figcaption>
+    </figure>
+  </div>
 </div>
 
 <div class="prep-item">

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -162,8 +162,8 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Top interface chute mount:</strong> 4 × M4 and 7 × M3</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside.d9429f336757fc52.jpg" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
-    <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face.</figcaption>
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside-grey.f48d2c86ebeb1716.jpg" alt="The underside of the grey Top interface chute mount, showing two of the brass M3 heat inserts on the ring beside the recess for the Limit switch hammer screw">
+    <figcaption>Underside: two of the M3 inserts on the ring, next to the recess for the Limit switch hammer screw. All 4 M4 and 7 M3 go around this face.</figcaption>
   </figure>
 </div>
 
@@ -182,7 +182,7 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Limit switch housing:</strong> 2 × M3</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-limit-switch-housing-inserts.0284a86a83e37af7.jpg" alt="The Limit switch housing held up, showing two brass M3 heat inserts on the face where the roller lever limit switch mounts">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-limit-switch-housing-inserts-grey.285c56f517498819.jpg" alt="The grey Limit switch housing, showing two brass M3 heat inserts on the angled face where the roller lever limit switch mounts, with the dowel pin hole above them">
     <figcaption>The two M3 inserts, where the roller lever limit switch mounts.</figcaption>
   </figure>
 </div>

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -717,6 +717,24 @@ body {
 .prep-item-figure img + img {
 	margin-top: 8px;
 }
+/* Stacked photos that each carry their own caption directly beneath them */
+.prep-item-figure-split {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+.prep-item-figure-split > figure {
+	margin: 0;
+}
+.prep-item-figure-split img.doc-figure {
+	margin-bottom: 0;
+}
+.prep-item-figure-split figcaption {
+	margin-top: 6px;
+	font-size: 0.875rem;
+	line-height: 1.4;
+	color: var(--muted);
+}
 
 .part-card-missing {
 	color: var(--muted);


### PR DESCRIPTION
Updates two heat-insert prep photos on the top-interface assembly page to show the current grey parts.

- **Limit switch housing:** the black part swapped for the grey one, cropped. The two M3 inserts and the part orientation read much more clearly.
- **Top interface chute mount:** the grey underside shot is **added alongside** the existing white underside photo (not a replacement), as a closer view of two of the M3 inserts and the recess for the Limit switch hammer screw. Each of the two photos now carries its own caption directly beneath it (a small scoped `.prep-item-figure-split` helper in `layout.css`).

Images uploaded content-addressed via `docs/scripts/upload_image.py`; `validate_images.py` passes and `validate_frontmatter.py` shows only the pre-existing errors already on `main`.

Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539212532101943376): "I've got two photos for you to put in the assembly docs. First for the limit switch housing, replace the photo of the black part with the photos of the grey grey one, it's much easier to see orientation of the part." The second photo (chute-mount underside), the crop/rotate note, and the layout tweaks followed in the same thread.

request: https://discord.com/channels/1430279849171222682/1539212864236290148/1539510021040377948

🤖 Generated with [Claude Code](https://claude.com/claude-code)
