### PR TITLE
docs: add soldering-iron method to heat inserts page

### DIFF
--- a/docs/src/content/hardware/helpers/heat-inserts.md
+++ b/docs/src/content/hardware/helpers/heat-inserts.md
@@ -22,4 +22,20 @@ Easiest with a {% include affiliate-link.html url="https://www.amazon.com/Vertic
     loading="lazy"></iframe>
 </div>
 
+## Using a soldering iron
+
+<div class="img-row">
+  <figure><img src="https://img.basically.website/web/assembly/heat-inserts/soldering-iron-insert-placed.79c096bde443b732.jpg" alt="Brass heat insert standing over its hole in a printed part, thinner end down, next to an insert already installed flush"><figcaption>Set each insert over its hole, thinner section first.</figcaption></figure>
+  <figure><img src="https://img.basically.website/web/assembly/heat-inserts/soldering-iron-pressing-insert.b9467173b8056483.jpg" alt="Soldering iron tip centered on a heat insert, pressing it straight down into the part"><figcaption>Center the tip and press gently while it heats.</figcaption></figure>
+</div>
+
+Place each insert above its cavity, straight and centered, with the thinner section going in first. Line the soldering iron tip up with the center of the insert and apply slight pressure while it heats up, about 20 seconds. Once the insert passes the plastic's melt temperature it starts to descend into the part. Push it down straight into the hole, not at an angle.
+
+It travels faster as it gets hotter, so keep a steady hand. Larger inserts take longer to heat up before they sink. Keep the iron on the insert until it is flush with the top of the part, and make sure it is square before you remove the heat, or it will not align.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Needle-nose pliers help hold the smaller inserts still. They get hot, so do not use your hands.</p>
+</div>
+
 {% include affiliate-footnotes.html %}

--- a/docs/src/content/hardware/helpers/heat-inserts.md
+++ b/docs/src/content/hardware/helpers/heat-inserts.md
@@ -9,18 +9,7 @@ lede: Pressing brass heat-set inserts into printed parts.
 permalink: /hardware/helpers/heat-inserts/
 ---
 
-<img class="doc-figure" src="https://img.basically.website/web/tools/heat-insert-press.3890a976bbb772d5.jpg" alt="Benchtop heat-set insert press with a set of tips">
-
-Easiest with a {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-Heat-Insertion-Threaded-Components/dp/B0FRXF1ZH6" text="heat-set insert press" %}. You can also use a regular soldering iron.
-
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/dnUfhQ9JohU"
-    title="Installing heat-set inserts"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+You can install the brass inserts with a soldering iron or a dedicated heat-set insert press.
 
 ## Using a soldering iron
 
@@ -36,6 +25,21 @@ It travels faster as it gets hotter, so keep a steady hand. Larger inserts take 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p>Needle-nose pliers help hold the smaller inserts still. They get hot, so do not use your hands.</p>
+</div>
+
+## Using a heat press
+
+<img class="doc-figure" src="https://img.basically.website/web/tools/heat-insert-press.3890a976bbb772d5.jpg" alt="Benchtop heat-set insert press with a set of tips">
+
+A {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-Heat-Insertion-Threaded-Components/dp/B0FRXF1ZH6" text="heat-set insert press" %} is the easiest way to install them: it holds the insert square and drives it straight down, so you just line it up over the hole and lower the arm. The video below shows the process.
+
+<div class="video-embed video-embed-wide">
+  <iframe
+    src="https://www.youtube.com/embed/dnUfhQ9JohU"
+    title="Installing heat-set inserts"
+    allow="encrypted-media; picture-in-picture; web-share"
+    allowfullscreen
+    loading="lazy"></iframe>
 </div>
 
 {% include affiliate-footnotes.html %}


### PR DESCRIPTION
Adds a "Using a soldering iron" section to the heat inserts helper page, with the step-by-step method and two contributor photos (insert placed over its hole, and the iron pressing it in), plus a warning callout about hot pliers.

Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539216049151680642): "here is some details for the heat inserts page. For people using a soldering iron. When using a soldering iron to install a heat insert. Place each insert above its cavity, making sure it is straight and centered. The thinner section goes in first. Line the tip of the soldering iron up with the center of the insert, and apply slight pressure while the insert heats up. Wait about 20seconds. Once the insert exceeds the plastic melt temperature, the insert will start to descend into the part. Be careful to push the insert down straight into the hole, and not at an angle. It travels faster as it gets hotter so have a steady hand. Larger inserts may take longer to heat up before they sink into the part. Keep the iron on the insert until it is flush with the top of your part. Make sure the inserts is square before removing heat or it won’t align. Note: needle nose pliers can help holding the smaller inserts still. They get hot, don’t use your hands."

request: https://discord.com/channels/1430279849171222682/1539216049151680642/1539507283409502250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Follow-up (reorder + heat press heading) requested by barthel (@uwe_barthel):
request: https://discord.com/channels/1430279849171222682/1539216049151680642/1539509608996020287
