### PR TITLE
docs(external-bracket): match Top Interface parts section, drop STL links

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/external-bracket.md
+++ b/docs/src/content/hardware/assembly/distribution/external-bracket.md
@@ -11,27 +11,22 @@ author: christoph
 last_verified: 2026-08-03
 parts_needed:
   - part: ext-bracket-left
+    qty: 1
   - part: ext-bracket-bottom-vertical
+    qty: 1
   - part: ext-bracket-cover
+    qty: 1
+  - part: ext-2020-c
+    qty: 1
   - part: scr-m5-16-shcs
     qty: 4
 ---
 
 Three printed parts that bolt together into one external bracket. **6 per distribution frame (per layer), plus one set per interface.**
 
+The fasteners and quantities are in the parts list above and are called out inline at each step.
+
 {% include fastener-legend.html %}
-
-| Part | Qty per bracket | Qty per machine (6 brackets/layer) | Weight | STL |
-|---|---|---|---|---|
-| External bracket — side | 1 | 6 | 48.5 g | [Download STL](https://sorter-v2-parts.nyc3.cdn.digitaloceanspaces.com/stl/da4b3abd3db72070484178ef5aa1d0906397c6a310bdf0e22f724940bd62dba2.stl) |
-| External bracket — bottom vertical | 1 | 6 | 50.6 g | [Download STL](https://sorter-v2-parts.nyc3.cdn.digitaloceanspaces.com/stl/313397afb08fc1943f045905b96131f73f1dc70c05d59fd2583c77da38318c36.stl) |
-| External bracket — cover | 1 | 6 | 12.4 g | [Download STL](https://sorter-v2-parts.nyc3.cdn.digitaloceanspaces.com/stl/f99e33cea11551b8222feac91c28015488ff2c239e632f5098322e7ea10fc96c.stl) |
-
-**Other parts**
-
-| Part | Qty per bracket | Notes |
-|---|---|---|
-| C-Layer vertical support (extrusion) | 1 | The vertical aluminum extrusion the bracket clamps onto. |
 
 - No heat inserts are used on this assembly. Joining is **self-tap**: the {% include fastener.html size="M5" variant="socket" length="16" %} screws thread directly into the printed plastic.
 - The most-used M5 in the machine, the same screw used on every external bracket, every bin bracket, every interface rib, and every lazy Susan extrusion mount.


### PR DESCRIPTION
Matches the External bracket page's parts section and screw specs to the Top Interface page, and removes the STL downloads, as requested.

**What changed**
- **Parts needed:** removed the two markdown parts tables. They duplicated the `parts_needed:` frontmatter card that already auto-renders at the top of the page (the same mechanism Top Interface uses), so the page now has a single Parts needed section instead of a table on top of it.
- **STL downloads:** gone, they lived in the removed table.
- **Frontmatter:** added the C-Layer vertical support extrusion (`ext-2020-c`) that the old "Other parts" table listed, plus explicit quantities, so nothing is lost from the parts list.
- **Screws:** the build prose already names each screw through the `fastener.html` include, which renders the M5 violet colour symbol + full name (`M5 × 16 mm socket head`), same as Top Interface. No plain-text screw specs remain except inside an image `alt` attribute, where the include must not go.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539216407521263758): "Take a look at https://docs.basically.website/hardware/assembly/distribution/external-bracket/ and adjust the 'need parts' section and the description of the screws (symbol including colour code) to match those on Top Interface. Remove the STL downloads."

request: https://discord.com/channels/1430279849171222682/1539216407521263758/1539507393577226310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
