### PR TITLE
docs: prepare timing pulley 20 tooth

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -225,8 +225,9 @@ needed" block), `notes` (short, collected into a list under the whole block),
 ## Authors
 
 `src/liquid/_data/authors.yml` maps an id to `{name, url}`. A page sets
-`author: <id>` and the byline renders under the page header. Add a
-contributor once here; every page crediting them updates automatically.
+`author: <id>`, or `authors: [id-one, id-two]` for multiple authors, and the
+byline renders under the page header. Add a contributor once here; every page
+crediting them updates automatically.
 
 ## Deploy and PR previews
 

--- a/docs/src/content/hardware/helpers/index.md
+++ b/docs/src/content/hardware/helpers/index.md
@@ -10,4 +10,4 @@ permalink: /hardware/helpers/
 ---
 
 - **[Preparing Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})**
-- **[Preparing pulley gear mod]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }})**
+- **[Prepare timing pulley 20 tooth]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }})**

--- a/docs/src/content/hardware/helpers/pulley-gear-mod.md
+++ b/docs/src/content/hardware/helpers/pulley-gear-mod.md
@@ -1,12 +1,21 @@
 ---
 layout: default
-title: Preparing pulley gear mod
+title: Prepare timing pulley 20 tooth
 type: how-to
 section: hardware
 slug: helper-pulley-gear-mod
-kicker: Helpers — Pulley gear mod
-lede: One-time prep for the pulley gear mod before it goes into an assembly.
+kicker: Helpers — Timing pulley
+lede: Remove the top flange from the 20-tooth timing pulley before assembly.
 permalink: /hardware/helpers/pulley-gear-mod/
+parts_needed:
+  - part: pulley-20t-8mm
+tools_needed: [Needle-nose pliers]
 ---
 
-_Content pending._
+The 20-tooth timing pulley needs its top flange removed before it fits into the Interface spur gear.
+
+## Remove the top flange
+
+Grip the top flange with needle-nose pliers and pry it upwards. It should pop off cleanly without damaging the pulley.
+
+Remove only the top flange. Leave the lower flange in place.

--- a/docs/src/content/hardware/helpers/pulley-gear-mod.md
+++ b/docs/src/content/hardware/helpers/pulley-gear-mod.md
@@ -7,6 +7,7 @@ slug: helper-pulley-gear-mod
 kicker: Helpers — Timing pulley
 lede: Remove the top flange from the 20-tooth timing pulley before assembly.
 permalink: /hardware/helpers/pulley-gear-mod/
+authors: [abrianbaker, spencer]
 parts_needed:
   - part: pulley-20t-8mm
 tools_needed: [Bottle opener, Needle-nose pliers]

--- a/docs/src/content/hardware/helpers/pulley-gear-mod.md
+++ b/docs/src/content/hardware/helpers/pulley-gear-mod.md
@@ -16,6 +16,11 @@ The 20-tooth timing pulley needs its top flange removed before it fits into the 
 
 ## Remove the top flange
 
+<div class="img-row">
+  <figure><img src="https://img.basically.website/web/helpers/timing-pulley/before-flange-removal.19deceb4e5706b6d.jpg" alt="20-tooth timing pulley before preparation, with the top flange attached"><figcaption>Before: top flange attached.</figcaption></figure>
+  <figure><img src="https://img.basically.website/web/helpers/timing-pulley/after-flange-removal.1dabaa6e3a0563d3.jpg" alt="20-tooth timing pulley after preparation, with the removed top flange beside it"><figcaption>After: top flange removed.</figcaption></figure>
+</div>
+
 Grip the top flange with needle-nose pliers and pry it upwards. It should pop off cleanly without damaging the pulley.
 
 You can also use a bottle opener together with the pliers to pop the top flange off.

--- a/docs/src/content/hardware/helpers/pulley-gear-mod.md
+++ b/docs/src/content/hardware/helpers/pulley-gear-mod.md
@@ -9,7 +9,7 @@ lede: Remove the top flange from the 20-tooth timing pulley before assembly.
 permalink: /hardware/helpers/pulley-gear-mod/
 parts_needed:
   - part: pulley-20t-8mm
-tools_needed: [Needle-nose pliers]
+tools_needed: [Bottle opener, Needle-nose pliers]
 ---
 
 The 20-tooth timing pulley needs its top flange removed before it fits into the Interface spur gear.
@@ -17,5 +17,7 @@ The 20-tooth timing pulley needs its top flange removed before it fits into the 
 ## Remove the top flange
 
 Grip the top flange with needle-nose pliers and pry it upwards. It should pop off cleanly without damaging the pulley.
+
+You can also use a bottle opener together with the pliers to pop the top flange off.
 
 Remove only the top flange. Leave the lower flange in place.

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -265,6 +265,7 @@ export type Page = {
 	fm: Frontmatter;
 	html: string;
 	author?: { name: string; url?: string };
+	authors?: Array<{ name: string; url?: string }>;
 	parts?: { groups: PartsGroup[]; notes: ResolvedPart[] };
 	tools?: string[];
 	ogImage?: string;
@@ -326,9 +327,13 @@ export async function getPage(pathParam: string): Promise<Page | null> {
 
 	const page: Page = { url, fm, html };
 
-	if (fm.author) {
-		const a = data.authors?.[fm.author];
-		page.author = a ? { name: a.name, url: a.url } : { name: fm.author };
+	const authorIds = Array.isArray(fm.authors) ? fm.authors : fm.author ? [fm.author] : [];
+	if (authorIds.length) {
+		page.authors = authorIds.map((id: string) => {
+			const a = data.authors?.[id];
+			return a ? { name: a.name, url: a.url } : { name: id };
+		});
+		page.author = page.authors[0];
 	}
 	if (fm.parts_needed) page.parts = resolveParts(fm.parts_needed);
 	if (fm.tools_needed) page.tools = fm.tools_needed;

--- a/docs/src/liquid/_data/authors.yml
+++ b/docs/src/liquid/_data/authors.yml
@@ -8,6 +8,9 @@ spencer:
   name: Spencer
   url: https://github.com/spencerhhubert
 
+abrianbaker:
+  name: Abrianbaker
+
 zed0:
   name: zed0
 

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -87,7 +87,7 @@ sections:
         children:
           - title: Preparing Lazy Susan
             url: /hardware/helpers/lazy-susan/
-          - title: Preparing pulley gear mod
+          - title: Prepare timing pulley 20 tooth
             url: /hardware/helpers/pulley-gear-mod/
           - title: Installing heat inserts
             url: /hardware/helpers/heat-inserts/

--- a/docs/src/liquid/_includes/page-author.html
+++ b/docs/src/liquid/_includes/page-author.html
@@ -2,10 +2,18 @@
 Renders the page author as a byline directly below the page header. Moved out
 of the bottom page-meta box so attribution shows at the top of the page.
 
-Reads page.author, resolved against _data/authors.yml (falling back to the raw
-id when the author is not in the catalog).
+Reads page.authors or page.author, resolved against _data/authors.yml (falling
+back to the raw id when an author is not in the catalog).
 {%- endcomment -%}
-{% if page.author %}
+{% if page.authors %}
+<p class="page-author">
+  <span class="page-author-label">Authors</span>
+  {% for author_id in page.authors %}
+    {% assign author = site.data.authors[author_id] %}
+    {% if author %}{% if author.url %}<a href="{{ author.url }}" target="_blank" rel="noopener">{{ author.name }}</a>{% else %}{{ author.name }}{% endif %}{% else %}{{ author_id }}{% endif %}{% unless forloop.last %}{% if forloop.rindex == 2 %} and {% else %}, {% endif %}{% endunless %}
+  {% endfor %}
+</p>
+{% elsif page.author %}
 {% assign author = site.data.authors[page.author] %}
 <p class="page-author">
   <span class="page-author-label">Author</span>

--- a/docs/src/routes/[...path]/+page.svelte
+++ b/docs/src/routes/[...path]/+page.svelte
@@ -138,14 +138,17 @@
 	<p class="lede">{fm.lede}</p>
 {/if}
 
-{#if p.author}
+{#if p.authors?.length}
 	<p class="page-author">
-		<span class="page-author-label">Author</span>
-		{#if p.author.url}
-			<a href={p.author.url} target="_blank" rel="noopener">{p.author.name}</a>
-		{:else}
-			{p.author.name}
-		{/if}
+		<span class="page-author-label">{p.authors.length === 1 ? 'Author' : 'Authors'}</span>
+		{#each p.authors as author, i}
+			{#if i > 0}{i === p.authors.length - 1 ? ' and ' : ', '}{/if}
+			{#if author.url}
+				<a href={author.url} target="_blank" rel="noopener">{author.name}</a>
+			{:else}
+				{author.name}
+			{/if}
+		{/each}
 	</p>
 {/if}
 


### PR DESCRIPTION
Adds the missing timing-pulley preparation instructions.

- Renames the helper to “Prepare timing pulley 20 tooth” in the page title, helper index, and navigation.
- Lists the 20-tooth timing pulley, a bottle opener, and needle-nose pliers.
- Explains how to pry off the top flange while leaving the lower flange in place.
- Credits Abrianbaker and Spencer as page authors.

Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1539576899280572416/1539580117624291410): "Third one was what I was after.

https://discord.com/channels/1430279849171222682/1503528472818094220/1511947340527833108

can you load as an instruction into ‘prepare pulley gear mod’
Plus change the name to ‘prepare timing pulley 20 tooth’"

Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1539576899280572416/1539580954551656468): "include Spencer’s suggestion of using a bottle opener."

Requested by zed0 (@zed0) [from Discord](https://discord.com/channels/1430279849171222682/1539576899280572416/1539583438066163794): "Can you add both of these images as a before and after".

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1539576899280572416/1539591590358548520): "Add the Author(s) on this page".

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1539576899280572416/1539580117624291410
request: https://discord.com/channels/1430279849171222682/1539576899280572416/1539580954551656468
request: https://discord.com/channels/1430279849171222682/1539576899280572416/1539583438066163794
request: https://discord.com/channels/1430279849171222682/1539576899280572416/1539591590358548520
preview: /hardware/helpers/pulley-gear-mod/
-->