### PR TITLE
docs: M5×16 as one socket/button screw with a green "A" tag

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -29,7 +29,7 @@ parts_needed:
     qty: 6
   - part: ext-2020-c
     qty: 6
-  - part: scr-m5-16-bhcs
+  - part: scr-m5-16-shcs
     qty: 36
   - part: scr-m5-20-shcs
     qty: 12
@@ -58,7 +58,7 @@ The aluminum extrusion is cut to length; the [framing cut list](https://parts-ca
   </figure>
 </div>
 
-Slide piece A/G (Outer horizontal / Horizontal interface frame) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side, bracing it against the extrusion. If you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes to fasten into them instead.
+Slide piece A/G (Outer horizontal / Horizontal interface frame) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side, bracing it against the extrusion. If you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes to fasten into them instead.
 
 If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2 into the innermost section of the extrusion and 4 into the outermost section before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
 
@@ -80,7 +80,7 @@ If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2
   </figure>
 </div>
 
-Repeat these steps to make two semi-circles of three sections of extrusion and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
+Repeat these steps to make two semi-circles of three sections of extrusion and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/two-half-hexagons.cfd5d241ba46d491.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
 
@@ -110,7 +110,7 @@ Prepare 12 Frame 90° brackets by drilling out the holes on the long side to all
 
 Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 {% include fastener.html size="M5" variant="button" length="12" %} screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
 
-Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the 2 Frame 90° brackets that you have just placed, and secure it with 2 {% include fastener.html size="M5" variant="button" length="16" %} screws tapped directly into the Frame 90° brackets, bracing against the extrusion. You can now tighten up the {% include fastener.html size="M5" variant="button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
+Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the 2 Frame 90° brackets that you have just placed, and secure it with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped directly into the Frame 90° brackets, bracing against the extrusion. You can now tighten up the {% include fastener.html size="M5" variant="button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
 
 <div class="img-row">
   <figure>
@@ -149,7 +149,7 @@ On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html 
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/spokes-complete-top.517a329e0407cb17.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
 
-Secure them in place with 2 {% include fastener.html size="M5" variant="button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
+Secure them in place with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
 
 <div class="callout">
   <p>If you are currently building the interface layer, stop here and return to the interface layer guide.</p>
@@ -166,7 +166,7 @@ Secure them in place with 2 {% include fastener.html size="M5" variant="button" 
   </figure>
 </div>
 
-On each corner of your hexagon, slot an External bracket — cover onto the External bracket — side (do this before attaching the extrusion, since it's tricky to get in place afterwards). Slot piece C (Layer vertical support) of aluminum extrusion between the External bracket — cover and the External bracket — side. At typical cut length you can leave this 3 mm short at either end, so try to align it about 3 mm above the bottom. Use 2 {% include fastener.html size="M5" variant="button" length="16" %} screws tapped through the holes near the bottom of the External bracket — side to secure the extrusion.
+On each corner of your hexagon, slot an External bracket — cover onto the External bracket — side (do this before attaching the extrusion, since it's tricky to get in place afterwards). Slot piece C (Layer vertical support) of aluminum extrusion between the External bracket — cover and the External bracket — side. At typical cut length you can leave this 3 mm short at either end, so try to align it about 3 mm above the bottom. Use 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped through the holes near the bottom of the External bracket — side to secure the extrusion.
 
 <div class="img-row">
   <figure>
@@ -177,7 +177,7 @@ On each corner of your hexagon, slot an External bracket — cover onto the Exte
   </figure>
 </div>
 
-On each corner, slide an External bracket — bottom vertical onto piece C (Layer vertical support), ensuring the angles of the External bracket — bottom vertical align at the bottom. Secure them with 2 {% include fastener.html size="M5" variant="button" length="16" %} screws through the outer holes on the External bracket — bottom vertical. The extrusion will likely rest a few mm below the top.
+On each corner, slide an External bracket — bottom vertical onto piece C (Layer vertical support), ensuring the angles of the External bracket — bottom vertical align at the bottom. Secure them with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through the outer holes on the External bracket — bottom vertical. The extrusion will likely rest a few mm below the top.
 
 {% include step.html n="4" title="Add the bin retainers" %}
 

--- a/docs/src/content/hardware/assembly/distribution/external-bracket.md
+++ b/docs/src/content/hardware/assembly/distribution/external-bracket.md
@@ -28,14 +28,14 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 {% include fastener-legend.html %}
 
-- No heat inserts are used on this assembly. Joining is **self-tap**: the {% include fastener.html size="M5" variant="socket" length="16" %} screws thread directly into the printed plastic.
+- No heat inserts are used on this assembly. Joining is **self-tap**: the {% include fastener.html size="M5" variant="socket-button" length="16" %} screws thread directly into the printed plastic.
 - The most-used M5 in the machine, the same screw used on every external bracket, every bin bracket, every interface rib, and every lazy Susan extrusion mount.
-- Of the four {% include fastener.html size="M5" variant="socket" length="16" %} screws: **2** join the bottom-vertical part to the side bracket, and **2** clamp the side bracket against the C-Layer vertical support to hold it in place. The **cover clips on**, it takes no screws.
+- Of the four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws: **2** join the bottom-vertical part to the side bracket, and **2** clamp the side bracket against the C-Layer vertical support to hold it in place. The **cover clips on**, it takes no screws.
 - Matching parts from the same print run are embossed with a shared set code (e.g. **"b2"**) on both the side bracket and the bottom-vertical part, keep marked pairs together so brackets don't get mixed across sets.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/parts-laid-out.0a59300a73b4f6c2.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
-  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four {% include fastener.html size="M5" variant="socket" length="16" %} screws. The cover is fitted last, in Step 4.</figcaption>
+  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. The cover is fitted last, in Step 4.</figcaption>
 </figure>
 
 <div class="img-row">
@@ -45,17 +45,17 @@ The fasteners and quantities are in the parts list above and are called out inli
   </figure>
   <figure>
     <img src="https://img.basically.website/web/assembly/external-bracket/bottom-vertical-flange.4b9a511aea49346c.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
-    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two {% include fastener.html size="M5" variant="socket" length="16" %} screws in Step 1 go into.</figcaption>
+    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws in Step 1 go into.</figcaption>
   </figure>
 </div>
 
 {% include step.html n="1" title="Mount the bottom-vertical leg to the side bracket" %}
 
-Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two {% include fastener.html size="M5" variant="socket" length="16" %} screws down through the flange into the side bracket.
+Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws down through the flange into the side bracket.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step1-screwed-underside.d3637471f50acb1b.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
-  <figcaption>Two {% include fastener.html size="M5" variant="socket" length="16" %} screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.</figcaption>
+  <figcaption>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.</figcaption>
 </figure>
 
 <div class="callout callout-warning">
@@ -74,7 +74,7 @@ Slide the C-Layer vertical support (the vertical aluminum extrusion) down throug
 
 {% include step.html n="3" title="Screw the bracket down onto the extrusion" %}
 
-Two more {% include fastener.html size="M5" variant="socket" length="16" %} screws clamp the side bracket against the C-Layer vertical support to hold it firmly in place.
+Two more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws clamp the side bracket against the C-Layer vertical support to hold it firmly in place.
 
 <div class="img-row">
   <figure>
@@ -83,7 +83,7 @@ Two more {% include fastener.html size="M5" variant="socket" length="16" %} scre
   </figure>
   <figure>
     <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-driven-in.259bbc4b6fdbb5b2.jpg" alt="Retention screw driven in, seated flush in the hex socket">
-    <figcaption>After: {% include fastener.html size="M5" variant="socket" length="16" %} screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
+    <figcaption>After: {% include fastener.html size="M5" variant="socket-button" length="16" %} screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -91,10 +91,8 @@ parts_needed:
     qty: 6
   - part: scr-m5-20-bhcs
     qty: 24
-  - part: scr-m5-16-bhcs
-    qty: 36
   - part: scr-m5-16-shcs
-    qty: 2
+    qty: 38
   - part: scr-m5-12-shcs
     qty: 4
   - part: m4-12mm-countersunk
@@ -228,9 +226,9 @@ The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists ever
 
 **Heat inserts first:** press the 4 × M4 inserts into the Interface upper fixed section and the 6 × M5 and 1 × M3 inserts into the Interface NEMA 23 bracket before you assemble anything here.
 
-Attach the Interface rib (switch gap) to the Interface upper fixed section, two positions counterclockwise of the notch for the stepper mount. Use two {% include fastener.html size="M5" variant="button" length="16" %} screws, tapping directly into the plastic.
+Attach the Interface rib (switch gap) to the Interface upper fixed section, two positions counterclockwise of the notch for the stepper mount. Use two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws, tapping directly into the plastic.
 
-Attach the remaining 5 Interface ribs to the Interface upper fixed section, two {% include fastener.html size="M5" variant="button" length="16" %} screws each, again tapping into the plastic.
+Attach the remaining 5 Interface ribs to the Interface upper fixed section, two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws each, again tapping into the plastic.
 
 Slot the Interface NEMA 23 bracket into the Interface upper fixed section and secure it from below with an {% include fastener.html size="M3" variant="countersunk" length="12" %} screw.
 
@@ -253,7 +251,7 @@ Align an Interface bracket with piece E (Interface spoke, long) of aluminum extr
 
 Place T-nuts in the extrusion, lined up with the 4 holes on the side of the Interface bracket.
 
-Slide the extrusion into the Interface bracket, careful not to dislodge the T-nuts, and drive four {% include fastener.html size="M5" variant="button" length="16" %} screws into them.
+Slide the extrusion into the Interface bracket, careful not to dislodge the T-nuts, and drive four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into them.
 
 Repeat for all 6 Interface brackets.
 
@@ -274,7 +272,7 @@ Push the Printed dowel pin into the Limit switch housing.
 
 Attach a Roller lever limit switch with two {% include fastener.html size="M3" variant="socket" length="16" %} screws (into the housing's 2 M3 inserts) so the roller sits next to the dowel pin.
 
-Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two {% include fastener.html size="M5" variant="socket" length="16" %} screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
+Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
 {% include step.html n="5" title="Install the brackets" %}
 
@@ -456,7 +454,7 @@ Follow the first two stages of [a regular layer]({{ '/hardware/assembly/distribu
   <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.e49b6ce3304489d5.jpg" alt="A regular layer assembly lowered onto the interface assembly">
 </figure>
 
-Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 {% include fastener.html size="M5" variant="socket" length="16" %} screws into the holes at the base of the External bracket sides, bracing against the extrusion. These holes run parallel to the extrusion profile, and the screws are self-tapping. See the [external bracket]({{ '/hardware/assembly/distribution/external-bracket/' | relative_url }}) instructions for building the bracket itself.
+Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the holes at the base of the External bracket sides, bracing against the extrusion. These holes run parallel to the extrusion profile, and the screws are self-tapping. See the [external bracket]({{ '/hardware/assembly/distribution/external-bracket/' | relative_url }}) instructions for building the bracket itself.
 
 The top interface is now complete.
 

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -31,6 +31,12 @@
 										{/if}
 										{#if part.qty}<span class="part-card-qty">{part.qty}×</span>{/if}
 										{#if part.not_in_calc}<span class="part-card-warn" title="Not currently in the parts calculator">!</span>{/if}
+										{#if part.alternative}<span
+												class="part-card-alt"
+												title={typeof part.alternative === 'string'
+													? part.alternative
+													: 'Interchangeable alternative'}>A</span
+											>{/if}
 									</div>
 									<span class="part-card-name">
 										{#if part.page}<a href={part.page}>{part.name}</a>{:else}{part.name}{/if}
@@ -50,6 +56,9 @@
 				{/if}
 				{#if parts.groups.some((g) => g.parts.some((p) => p.not_in_calc))}
 					<p class="parts-warn-legend"><span class="part-card-warn">!</span> not currently in the parts calculator.</p>
+				{/if}
+				{#if parts.groups.some((g) => g.parts.some((p) => p.alternative))}
+					<p class="parts-warn-legend"><span class="part-card-alt">A</span> an interchangeable alternative works (hover for what).</p>
 				{/if}
 			</section>
 		{/if}

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -226,6 +226,9 @@ export type ResolvedPart = {
 	notes?: string;
 	caption?: string;
 	not_in_calc?: boolean;
+	// Interchangeable alternative (e.g. socket vs button head): true for a bare
+	// tag, or a string naming the alternative. Renders the green "A" badge.
+	alternative?: string | boolean;
 	missing?: boolean;
 };
 export type PartsGroup = { category: string; parts: ResolvedPart[] };
@@ -245,6 +248,7 @@ function resolveParts(partsNeeded: any[]): { groups: PartsGroup[]; notes: Resolv
 			notes: part.notes,
 			caption: part.caption,
 			not_in_calc: part.not_in_calc,
+			alternative: part.alternative,
 			qty,
 			category: part.category ?? 'Other'
 		};

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -123,8 +123,9 @@ scr-m5-12-bhcs:
   image: https://img.basically.website/web/parts/hardware/screws/m5-button-head.87be93e901c86545.jpg
 
 scr-m5-16-shcs:
-  name: M5 × 16 mm socket head cap screw
+  name: M5 × 16 mm socket / button head
   category: Screws
+  alternative: Socket or button head
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
 # --- Top interface assembly: parts for the framing step and the parts-needed section ---
@@ -342,12 +343,6 @@ scr-m5-8-cs:
 
 scr-m5-20-bhcs:
   name: M5 × 20 mm button head cap screw
-  category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
-  not_in_calc: true
-
-scr-m5-16-bhcs:
-  name: M5 × 16 mm button head cap screw
   category: Screws
   image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
   not_in_calc: true

--- a/docs/src/liquid/_includes/fastener.html
+++ b/docs/src/liquid/_includes/fastener.html
@@ -29,6 +29,7 @@ line inside it would end the HTML block for the markdown parser.
 {%- assign recess = "" -%}
 {%- case include.variant -%}
   {%- when "socket" -%}{%- assign profile = "M7.5 3 h9 v7 h-9 z" -%}{%- assign word = "socket head" -%}{%- assign recess = '<circle cx="12" cy="6.6" r="1.9" fill="var(--bg)"/>' -%}
+  {%- when "socket-button" -%}{%- assign profile = "M7.5 3 h9 v7 h-9 z" -%}{%- assign word = "socket / button head" -%}{%- assign recess = '<circle cx="12" cy="6.6" r="1.9" fill="var(--bg)"/>' -%}
   {%- when "button" -%}{%- assign profile = "M5 10 a7.6 7.6 0 0 1 14 0 z" -%}{%- assign word = "button head" -%}{%- assign recess = '<circle cx="12" cy="6.6" r="1.9" fill="var(--bg)"/>' -%}
   {%- when "flat" -%}{%- assign profile = "M4 4.5 h16 v4 h-16 z" -%}{%- assign word = "flat head" -%}{%- assign recess = '<circle cx="12" cy="6.5" r="1.9" fill="var(--bg)"/>' -%}
   {%- when "countersunk" -%}{%- assign profile = "M4 3 h16 v2.2 l-6.5 5.3 h-3 L4 5.2 z" -%}{%- assign word = "countersunk" -%}{%- assign recess = '<circle cx="12" cy="5.4" r="1.9" fill="var(--bg)"/>' -%}

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -592,6 +592,36 @@ body {
 	margin-right: 5px;
 }
 
+/* Marker for a part that has an interchangeable alternative (e.g. socket vs
+   button head). Same footprint as the "!" but green, "A" for alternative. */
+.part-card-alt {
+	position: absolute;
+	top: 0;
+	right: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 4px;
+	font-size: 0.78rem;
+	font-weight: 700;
+	line-height: 1;
+	color: var(--color-primary-contrast);
+	background: var(--color-success);
+	cursor: help;
+}
+
+/* if a card carries both markers, sit the "A" left of the "!" */
+.part-card-warn + .part-card-alt {
+	right: 20px;
+}
+
+.parts-warn-legend .part-card-alt {
+	position: static;
+	margin-right: 5px;
+}
+
 .parts-notes {
 	margin: 14px 0 0;
 	padding-left: 1.1rem;


### PR DESCRIPTION
Makes the docs treat the **M5×16** as one interchangeable screw, using the socket-head symbol and the correct name, matching the change going into the parts calculator.

### Changes
- **`socket-button` fastener variant** (socket silhouette + "socket / button head" name). All M5×16 inline references now use it (they were a mix of socket and button symbols); the socket symbol is the most legible for the pair.
- **One M5×16 "Parts needed" card** (`scr-m5-16-shcs`): correct name "M5 × 16 mm socket / button head", keeps the product photo. The separate button-head card and its red **"!"** ("not in the parts calculator") are gone, M5×16 is in the calculator now. Its counts fold into the socket card.
- **Reusable green "A" "alternative" tag**: an `alternative` field on a part (resolved in `content.ts`, rendered by `Requirements.svelte`), mirroring the red "!". If a card ever carries both, the "A" sits just left of the "!" (no overlap).
- Countersunk symbols unchanged.

`npm run check` and `npm run build` pass; the M5×16 card renders the "A" (tooltip "Socket or button head") and the correct name, "!" gone.

Screw cards keep the **photo + correct name** (not the symbol); the head-shape symbol is for the inline step references. Per barthel.

The same treatment can extend to the other socket/button pairs (M5×20, M5×12) as a follow-up.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1539089324275146812/1539574828657279096): "Let's go back to the symbols for screw types. Use the original symbol for countersunk screws. For socket/button head screws, use the current socket head symbol."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
request: https://discord.com/channels/1430279849171222682/1539089324275146812/1539578934021333112
-->
