### PR TITLE
docs: use composite socket/button tile as the M5 × 16 card image

### DIFF
--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -124,7 +124,7 @@ scr-m5-16-shcs:
   name: M5 × 16 mm socket / button head
   category: Screws
   alternative: Socket or button head
-  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 # --- Top interface assembly: parts for the framing step and the parts-needed section ---
 


### PR DESCRIPTION
Points the **M5 × 16 mm socket / button head** "Parts needed" card at the **composite socket/button tile** (one socket + one button screw, head-on and threads) that barthel designed, so the card shows both heads instead of a single-head socket photo.

**Image:** https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg — uploaded with `docs/scripts/upload_image.py`, so it is a canonical content-addressed object on the docs bucket (original kept at `originals/parts/scr-m5-16-shcs/socket-button-tile.26e52d7d5bcd2268.png`).

This supersedes the earlier draft of this PR, which used an interim Discord-mirror URL because the hosting step was believed to need a maintainer's credentials (issue #320). That premise was wrong: the upload script runs fine in the bot's own environment, so #320 is being closed. The branch has been rebuilt on current `main` (the rest of the M5 × 16 card work landed in #319), leaving this as a one-line change.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1539089324275146812/1539585549487185992): "Open an issue so Spencer or someone else knows about this. And after that create a PR for use the composited Image."

Follow-up from Spencer (@spencerhubert) [from Discord](https://discord.com/channels/1430279849171222682/1500946960817848330/1539769128745832448): "there was a github issue made about like uploading issues. i had someone investigate this is what they said can you address and like update the pr that is relevant"

The conflict this PR showed was its base: it was still targeting `docs-m5x16-socket-symbol`, which was squash-merged as #319, so GitHub was trying to merge all of `main` back into a dead branch. Retargeted to `main`, where the head branch is a clean one-line change on top of `fc64657`.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1539089324275146812/1539585549487185992
request: https://discord.com/channels/1430279849171222682/1500946960817848330/1539769128745832448
request: https://discord.com/channels/1430279849171222682/1539770062750228541/1539834442003251340
preview: /hardware/assembly/distribution/external-bracket/
-->

