### PR TITLE
docs: link all helper pages from landing page

### DIFF
--- a/docs/src/content/hardware/helpers/index.md
+++ b/docs/src/content/hardware/helpers/index.md
@@ -11,3 +11,4 @@ permalink: /hardware/helpers/
 
 - **[Preparing Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})**
 - **[Prepare timing pulley 20 tooth]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }})**
+- **[Installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }})**


### PR DESCRIPTION
Adds the missing Installing heat inserts link to the Helpers landing page so all three helper pages are listed together.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539593692082348033): "Check to make sure that all helper pages (https://docs.basically.website/hardware/helpers/) are linked in the documentation."

Follow-up [from Discord](https://discord.com/channels/1430279849171222682/1539593692082348033/1539595115356618822): "Create a PR to sove this."

Validation:
- Image validation passes for all 126 immutable assets.
- Frontmatter validation reports only the same five pre-existing errors on main.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1539593692082348033
request: https://discord.com/channels/1430279849171222682/1539593692082348033/1539595115356618822
preview: /hardware/helpers/
-->