### PR TITLE
docs: credit hardware pages and expand Bottom interface

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -225,9 +225,13 @@ needed" block), `notes` (short, collected into a list under the whole block),
 ## Authors
 
 `src/liquid/_data/authors.yml` maps an id to `{name, url}`. A page sets
-`author: <id>`, or `authors: [id-one, id-two]` for multiple authors, and the
-byline renders under the page header. Add a contributor once here; every page
-crediting them updates automatically.
+`author: <id>`, or `authors: [id-one, id-two]` for multiple authors. Use
+`contributors: [id-one, id-two]` for people who supplied or materially
+corrected page content. The credits render under the page header. Add a person
+once here; every page crediting them updates automatically.
+
+Every page under `hardware/assembly/`, including landing and placeholder pages,
+must set `author` or `authors`. `scripts/validate_frontmatter.py` enforces this.
 
 ## Deploy and PR previews
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -230,8 +230,8 @@ needed" block), `notes` (short, collected into a list under the whole block),
 corrected page content. The credits render under the page header. Add a person
 once here; every page crediting them updates automatically.
 
-Every page under `hardware/assembly/`, including landing and placeholder pages,
-must set `author` or `authors`. `scripts/validate_frontmatter.py` enforces this.
+Every page under `hardware/`, including landing and placeholder pages, must set
+`author` or `authors`. `scripts/validate_frontmatter.py` enforces this.
 
 ## Deploy and PR previews
 

--- a/docs/scripts/validate_frontmatter.py
+++ b/docs/scripts/validate_frontmatter.py
@@ -41,6 +41,7 @@ ALLOWED_TYPES = (
 
 EXCLUDED_DIRS: set[str] = set()
 EXCLUDED_FILES = {"README.md", "AGENTS.md"}
+CREDIT_REQUIRED_PREFIXES = ("hardware/assembly/",)
 
 # Per-section frontmatter defaults, matched by path prefix (later, more
 # specific matches win). Mirrors FM_DEFAULTS in docs/src/lib/server/content.ts.
@@ -145,6 +146,14 @@ def validate_page(
                 errors.append(
                     f"{relative_path}: last_verified '{value}' is not a valid YYYY-MM-DD date"
                 )
+
+    if relative_path.startswith(CREDIT_REQUIRED_PREFIXES):
+        author = page_meta.get("author")
+        authors = page_meta.get("authors")
+        if not author and not authors:
+            errors.append(
+                f"{relative_path}: assembly page must list 'author' or 'authors'"
+            )
     return errors
 
 

--- a/docs/scripts/validate_frontmatter.py
+++ b/docs/scripts/validate_frontmatter.py
@@ -41,7 +41,7 @@ ALLOWED_TYPES = (
 
 EXCLUDED_DIRS: set[str] = set()
 EXCLUDED_FILES = {"README.md", "AGENTS.md"}
-CREDIT_REQUIRED_PREFIXES = ("hardware/assembly/",)
+CREDIT_REQUIRED_PREFIXES = ("hardware/",)
 
 # Per-section frontmatter defaults, matched by path prefix (later, more
 # specific matches win). Mirrors FM_DEFAULTS in docs/src/lib/server/content.ts.
@@ -152,7 +152,7 @@ def validate_page(
         authors = page_meta.get("authors")
         if not author and not authors:
             errors.append(
-                f"{relative_path}: assembly page must list 'author' or 'authors'"
+                f"{relative_path}: hardware page must list 'author' or 'authors'"
             )
     return errors
 

--- a/docs/src/content/hardware/BOM.md
+++ b/docs/src/content/hardware/BOM.md
@@ -6,6 +6,7 @@ slug: BOM
 kicker: Hardware — Bill of Materials
 lede: Parts you'll need to buy to build a machine
 permalink: /hardware/BOM
+author: jgadling
 ---
 
 ## Bill of Materials
@@ -34,6 +35,5 @@ Each bin layer:
 
 Vertical supports:
 - 6x 280mm + (160mm * number of bin layers): the interface layer is 280mm, and each bin layer adds 160mm
-
 
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -8,6 +8,7 @@ kicker: Bin frame — Bottom interface
 lede: The component the chute rests on top of.
 permalink: /hardware/assembly/distribution/bin-frame/bottom-interface/
 author: spencer
+contributors: [abrianbaker]
 parts_needed:
   - part: lazy-susan
   - part: ls-mount-to-chute

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -11,12 +11,22 @@ author: spencer
 contributors: [abrianbaker]
 parts_needed:
   - part: lazy-susan
+    qty: 1
   - part: ls-mount-to-chute
+    qty: 1
   - part: ls-bottom-static
+    qty: 1
   - part: ls-washer
+    qty: 1
+  - part: m4-ruthex-long
+    qty: 8
   - part: m4-12mm-countersunk
     qty: 8
 ---
+
+The fasteners and quantities in the parts list are called out inline at each step.
+
+{% include fastener-legend.html %}
 
 <div class="video-embed video-embed-wide">
   <iframe
@@ -28,8 +38,6 @@ parts_needed:
 </div>
 
 The bottom interface stacks the chute mount, a spacer ring, the Lazy Susan bearing, and the bottom static part. Here it is exploded into its components:
-
-{% include fastener-legend.html %}
 
 <div class="img-row">
   <figure>
@@ -49,7 +57,33 @@ Once assembled, it mounts into the machine frame:
   </figure>
 </div>
 
-{% include step.html n="1" title="Mount the Lazy Susan to the chute mount" %}
+{% include step.html n="1" title="Preparation" %}
+
+Before assembling anything, press the heat inserts into both printed parts while they are still loose. Installing them after the Lazy Susan is mounted is much harder. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Lazy Susan chute mount:</strong> 4 × M4</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/step1-line-up-hole.68efcd2365b95c9f.jpg" alt="Close-up of the Lazy Susan over the chute mount, with one of the four M4 heat inserts visible through a screw hole">
+    <figcaption>The four M4 inserts sit evenly around the circular mounting face.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Lazy Susan bottom static:</strong> 4 × M4</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/step2-place-chute-adapter.5d3dfd2a5794d4ef.jpg" alt="The chute mount lifted above the bottom static part, showing three of the four brass M4 heat inserts around the black ring">
+    <figcaption>The four M4 inserts sit evenly around the top face.</figcaption>
+  </figure>
+</div>
+
+{% include step.html n="2" title="Mount the Lazy Susan to the chute mount" %}
+
+**Heat inserts first:** press the 4 × M4 inserts into the Lazy Susan chute mount before placing the spacer and bearing.
 
 Set the spacer on the chute mount and the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) on top. You need to remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})). Line up a screw hole with a heat insert in the chute mount and drive the {% include fastener.html size="M4" variant="countersunk" length="12" %} screw. Repeat around the disc.
 
@@ -71,7 +105,9 @@ The Lazy Susan is two discs, inner and outer, that spin independently. One disc'
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/lazy-susan-on-chute-mount.d478621b1f81e5ae.jpg" alt="Lazy Susan bearing mounted on the chute mount with the spacer between them">
 
-{% include step.html n="2" title="Mount the Lazy Susan to the bottom static part" %}
+{% include step.html n="3" title="Mount the Lazy Susan to the bottom static part" %}
+
+**Heat inserts first:** press the 4 × M4 inserts into the Lazy Susan bottom static before placing the chute mount and bearing assembly.
 
 The Lazy Susan's other disc screws down into the bottom static part. You reach those screws through a pass-through hole in the chute mount.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -7,6 +7,7 @@ slug: assembly-bottom-two-layers
 kicker: Bin frame — Bottom two layers
 lede: The paired base layers. Built together on the long vertical extrusions.
 permalink: /hardware/assembly/distribution/bin-frame/bottom-two-layers/
+author: spencer
 ---
 
 The bottom two layers are paired. The long vertical extrusion that the bottom wheel mounts to runs through both layers, so the wheel can take more force. The extrusion does not continue up the whole tower — slotting modular layers onto six extrusions at once is impractical, so the run stops after two layers.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
@@ -7,6 +7,7 @@ slug: assembly-bin-frame
 kicker: Distribution — Bin frame
 lede: The stacked layers of bins. Layer count is N; build in this order.
 permalink: /hardware/assembly/distribution/bin-frame/
+author: spencer
 ---
 
 1. **[Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }})** — the base the frame builds up from.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -8,6 +8,7 @@ kicker: Bin frame — Regular layers
 lede: The repeating bin layers above the base. Build N−2 for an N-layer machine.
 permalink: /hardware/assembly/distribution/bin-frame/regular-layers/
 author: zed0
+contributors: [brickcyclealice, barthel]
 parts_needed:
   - part: ext-bracket-left
     qty: 6

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -7,6 +7,7 @@ slug: assembly-chute-core
 kicker: Chute — Chute core
 lede: The chute assembly. Build one per layer.
 permalink: /hardware/assembly/distribution/chute/chute-core/
+author: spencer
 ---
 
 Build one chute core per layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -7,6 +7,7 @@ slug: assembly-door-module
 kicker: Chute — Door module
 lede: The per-layer door mechanism that releases parts into a bin.
 permalink: /hardware/assembly/distribution/chute/door-module/
+author: spencer
 ---
 
 The door module is made up of:

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -7,6 +7,7 @@ slug: assembly-funnel
 kicker: Chute — Funnel
 lede: The funnel that guides parts through the door.
 permalink: /hardware/assembly/distribution/chute/funnel/
+author: spencer
 ---
 
 _Content pending._

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -7,6 +7,7 @@ slug: assembly-chute
 kicker: Distribution — Chute
 lede: The rotating chute that aims parts at the correct bin.
 permalink: /hardware/assembly/distribution/chute/
+author: spencer
 ---
 
 1. **[Chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})** — build one per layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -7,6 +7,7 @@ slug: assembly-layer-connectors
 kicker: Chute — Layer connectors
 lede: The connectors that chain layers together.
 permalink: /hardware/assembly/distribution/chute/layer-connectors/
+author: spencer
 ---
 
 _Content pending._

--- a/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/index.md
@@ -7,6 +7,7 @@ slug: assembly-mg995-servo
 kicker: Chute — MG995 servo
 lede: The servo that drives the door. Mount it, then install it.
 permalink: /hardware/assembly/distribution/chute/mg995-servo/
+author: spencer
 ---
 
 1. **[Servo mount]({{ '/hardware/assembly/distribution/chute/mg995-servo/servo-mount/' | relative_url }})** — the mount the servo bolts into.

--- a/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
@@ -7,6 +7,7 @@ slug: assembly-servo-mount
 kicker: MG995 servo — Servo mount
 lede: The mount the servo bolts into.
 permalink: /hardware/assembly/distribution/chute/mg995-servo/servo-mount/
+author: spencer
 ---
 
 _Content pending._

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -7,6 +7,7 @@ slug: assembly-pcb
 kicker: Chute — PCB
 lede: The board that drives the servo.
 permalink: /hardware/assembly/distribution/chute/pcb/
+author: spencer
 ---
 
 _Content pending._

--- a/docs/src/content/hardware/assembly/distribution/external-bracket.md
+++ b/docs/src/content/hardware/assembly/distribution/external-bracket.md
@@ -8,6 +8,7 @@ kicker: Distribution — External bracket
 lede: The bracket that mounts a distribution-frame vertical extrusion to the frame and gives it a mounting point.
 permalink: /hardware/assembly/distribution/external-bracket/
 author: christoph
+contributors: [barthel]
 last_verified: 2026-08-03
 parts_needed:
   - part: ext-bracket-left

--- a/docs/src/content/hardware/assembly/distribution/index.md
+++ b/docs/src/content/hardware/assembly/distribution/index.md
@@ -7,6 +7,7 @@ slug: assembly-distribution
 kicker: Assembly — Distribution
 lede: The bin tower and the chute that steers parts into it. Build in this order.
 permalink: /hardware/assembly/distribution/
+author: spencer
 ---
 
 Distribution and the interface layer are assembled as one unit.

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -8,6 +8,7 @@ kicker: Distribution — Top interface
 lede: The interface between the feeder and the bin tower.
 permalink: /hardware/assembly/distribution/top-interface/
 author: zed0
+contributors: [barthel, brickcyclealice]
 parts_needed:
   - part: interface-upper-fixed-section
     qty: 1

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -7,6 +7,7 @@ slug: assembly-arranging-c-channels
 kicker: Feeder — Arranging C-Channels
 lede: How the C-channels are laid out together.
 permalink: /hardware/assembly/feeder/arranging-c-channels/
+author: spencer
 ---
 
 _Content pending._

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -7,6 +7,7 @@ slug: assembly-c-channel
 kicker: Feeder — C-Channel
 lede: The C-channel stage itself.
 permalink: /hardware/assembly/feeder/c-channel/
+author: spencer
 ---
 
 _Content pending._

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -7,6 +7,7 @@ slug: assembly-classification-chamber
 kicker: Feeder — Classification chamber
 lede: Where parts are imaged for classification.
 permalink: /hardware/assembly/feeder/classification-chamber/
+author: spencer
 ---
 
 _Content pending._

--- a/docs/src/content/hardware/assembly/feeder/index.md
+++ b/docs/src/content/hardware/assembly/feeder/index.md
@@ -7,6 +7,7 @@ slug: assembly-feeder
 kicker: Assembly — Feeder
 lede: The C-channel stages that meter parts toward the distribution system.
 permalink: /hardware/assembly/feeder/
+author: spencer
 ---
 
 1. **[C-Channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }})** — the C-channel stage itself.

--- a/docs/src/content/hardware/assembly/index.md
+++ b/docs/src/content/hardware/assembly/index.md
@@ -7,6 +7,7 @@ slug: assembly
 kicker: Hardware — Assembly
 lede: Build order for the machine. Follow the sections top to bottom.
 permalink: /hardware/assembly/
+author: spencer
 ---
 
 ## Order of operations

--- a/docs/src/content/hardware/assembly/software-setup.md
+++ b/docs/src/content/hardware/assembly/software-setup.md
@@ -7,6 +7,7 @@ slug: assembly-software-setup
 kicker: Assembly — Software setup
 lede: Flash and configure the machine, then continue in the Sorter section.
 permalink: /hardware/assembly/software-setup/
+author: spencer
 ---
 
 Once the hardware is built, set up the software. This hands off to the [Sorter]({{ '/sorter/' | relative_url }}) section.

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -7,6 +7,8 @@ slug: electronics-wire-harness
 kicker: Electronics — Wire harness
 lede: 24V power distribution from the PSU, plus everything connected to basically board v1.3.
 permalink: /hardware/electronics/
+author: spencer
+contributors: [effreek]
 last_verified: 2026-07-12
 ---
 

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -7,6 +7,8 @@ slug: electronics-order-spec
 kicker: Electronics — Order spec
 lede: Order-ready cable build list for a custom harness vendor.
 permalink: /hardware/electronics/order/
+author: spencer
+contributors: [effreek]
 last_verified: 2026-07-12
 ---
 

--- a/docs/src/content/hardware/electronics/psu-pigtail.md
+++ b/docs/src/content/hardware/electronics/psu-pigtail.md
@@ -7,6 +7,7 @@ slug: electronics-psu-pigtail
 kicker: Electronics — PSU output pigtail
 lede: Build one of the three DC output pigtails for the PSU box: a panel-mount barrel jack and two crimp spade terminals.
 permalink: /hardware/electronics/psu-pigtail/
+author: effreek
 last_verified: 2026-07-12
 ---
 

--- a/docs/src/content/hardware/electronics/steppers.md
+++ b/docs/src/content/hardware/electronics/steppers.md
@@ -7,6 +7,8 @@ slug: electronics-stepper-connectors
 kicker: Electronics — Stepper connectors
 lede: basically board v1.3 stepper pinout, the connector-to-motor mapping, and the connector reference.
 permalink: /hardware/electronics/steppers/
+author: spencer
+contributors: [effreek]
 last_verified: 2026-07-12
 ---
 

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -7,6 +7,8 @@ slug: electronics-wireviz
 kicker: Electronics — WireViz
 lede: The harness drawings and the zip to send a cable vendor.
 permalink: /hardware/electronics/wireviz/
+author: spencer
+contributors: [effreek]
 last_verified: 2026-07-12
 ---
 

--- a/docs/src/content/hardware/helpers/heat-inserts.md
+++ b/docs/src/content/hardware/helpers/heat-inserts.md
@@ -7,6 +7,8 @@ slug: helper-heat-inserts
 kicker: Helpers — Heat inserts
 lede: Pressing brass heat-set inserts into printed parts.
 permalink: /hardware/helpers/heat-inserts/
+author: spencer
+contributors: [brickcyclealice, barthel]
 parts_needed:
   - part: m3-ruthex-long
   - part: m4-ruthex-long

--- a/docs/src/content/hardware/helpers/index.md
+++ b/docs/src/content/hardware/helpers/index.md
@@ -7,6 +7,8 @@ slug: helpers
 kicker: Hardware — Helpers
 lede: One-time prep for parts used in multiple places on the machine. The assembly steps link here instead of repeating the procedure.
 permalink: /hardware/helpers/
+author: spencer
+contributors: [barthel]
 ---
 
 - **[Preparing Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})**

--- a/docs/src/content/hardware/index.md
+++ b/docs/src/content/hardware/index.md
@@ -7,6 +7,7 @@ slug: hardware
 kicker: The Physical Machine
 lede: Parts, sourcing, and step-by-step assembly for the physical Sorter V2 machine.
 permalink: /hardware/
+author: spencer
 ---
 
 - **[Assembly]({{ '/hardware/assembly/' | relative_url }})**: the build order, structured like a set of instructions.

--- a/docs/src/content/hardware/orange-pi-5.md
+++ b/docs/src/content/hardware/orange-pi-5.md
@@ -7,6 +7,7 @@ slug: hardware-orange-pi-5
 kicker: Parts — Orange Pi 5
 lede: The Orange Pi 5 is the primary compute platform for Sorter. This page covers hardware selection, memory and storage requirements, and WiFi adapter options.
 permalink: /hardware/orange-pi-5/
+author: spencer
 audience: self-builder
 applies_to: hardware-v2
 last_verified: 2026-05-19

--- a/docs/src/content/hardware/parts/index.md
+++ b/docs/src/content/hardware/parts/index.md
@@ -7,6 +7,7 @@ slug: parts
 kicker: Hardware — Parts
 lede: Reference pages for individual parts — what they are, what we know about them, and where to source them. Not every part has a page.
 permalink: /hardware/parts/
+author: spencer
 ---
 
 - **[Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }})**

--- a/docs/src/content/hardware/preparation/index.md
+++ b/docs/src/content/hardware/preparation/index.md
@@ -7,6 +7,7 @@ slug: preparation
 kicker: Hardware — Preparation
 lede: Prep done to parts before assembly. Right now that means pressing heat inserts.
 permalink: /hardware/preparation/
+author: spencer
 ---
 
 ## Heat inserts

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -215,7 +215,7 @@ const markdown = unified()
 	.use(rehypeSlug)
 	.use(rehypeStringify, { allowDangerousHtml: true });
 
-// ── Parts / authors resolution (page-requirements.html, page-author.html) ────
+// ── Parts / credits resolution (page-requirements.html, page-author.html) ────
 
 export type ResolvedPart = {
 	id: string;
@@ -232,6 +232,15 @@ export type ResolvedPart = {
 	missing?: boolean;
 };
 export type PartsGroup = { category: string; parts: ResolvedPart[] };
+export type ResolvedPerson = { name: string; url?: string };
+
+function resolvePeople(ids: unknown): ResolvedPerson[] {
+	const values = Array.isArray(ids) ? ids : ids ? [ids] : [];
+	return values.map((id) => {
+		const person = data.authors?.[id];
+		return person ? { name: person.name, url: person.url } : { name: String(id) };
+	});
+}
 
 function resolveParts(partsNeeded: any[]): { groups: PartsGroup[]; notes: ResolvedPart[] } {
 	const catalog = data.parts ?? {};
@@ -268,8 +277,8 @@ export type Page = {
 	url: string;
 	fm: Frontmatter;
 	html: string;
-	author?: { name: string; url?: string };
-	authors?: Array<{ name: string; url?: string }>;
+	authors?: ResolvedPerson[];
+	contributors?: ResolvedPerson[];
 	parts?: { groups: PartsGroup[]; notes: ResolvedPart[] };
 	tools?: string[];
 	ogImage?: string;
@@ -332,13 +341,10 @@ export async function getPage(pathParam: string): Promise<Page | null> {
 	const page: Page = { url, fm, html };
 
 	const authorIds = Array.isArray(fm.authors) ? fm.authors : fm.author ? [fm.author] : [];
-	if (authorIds.length) {
-		page.authors = authorIds.map((id: string) => {
-			const a = data.authors?.[id];
-			return a ? { name: a.name, url: a.url } : { name: id };
-		});
-		page.author = page.authors[0];
-	}
+	page.authors = resolvePeople(authorIds);
+	page.contributors = resolvePeople(fm.contributors).filter(
+		(contributor) => !page.authors?.some((author) => author.name === contributor.name)
+	);
 	if (fm.parts_needed) page.parts = resolveParts(fm.parts_needed);
 	if (fm.tools_needed) page.tools = fm.tools_needed;
 

--- a/docs/src/liquid/_data/authors.yml
+++ b/docs/src/liquid/_data/authors.yml
@@ -22,3 +22,11 @@ barthel:
 
 brickcyclealice:
   name: BrickCycleAlice
+
+effreek:
+  name: Jon
+  url: https://github.com/effreek
+
+jgadling:
+  name: Jessica Gadling
+  url: https://github.com/jgadling

--- a/docs/src/liquid/_data/authors.yml
+++ b/docs/src/liquid/_data/authors.yml
@@ -16,3 +16,9 @@ zed0:
 
 christoph:
   name: Christoph
+
+barthel:
+  name: barthel
+
+brickcyclealice:
+  name: BrickCycleAlice

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -22,7 +22,6 @@ ls-mount-to-chute:
   name: Lazy Susan chute mount
   category: Printed parts
   image: https://img.basically.website/web/parts/ls-mount-to-chute.6e5e37d01abc3ae2.png
-  notes: Prepared with 4× M4 Ruthex long heat inserts.
   heat_inserts:
     - insert: m4-ruthex-long
       qty: 4
@@ -31,7 +30,6 @@ ls-bottom-static:
   name: Lazy Susan bottom static
   category: Printed parts
   image: https://img.basically.website/web/parts/ls-bottom-static.4776c7617442386d.png
-  notes: Prepared with 4× M4 Ruthex long heat inserts.
   heat_inserts:
     - insert: m4-ruthex-long
       qty: 4

--- a/docs/src/liquid/_includes/page-author.html
+++ b/docs/src/liquid/_includes/page-author.html
@@ -1,13 +1,15 @@
 {%- comment -%}
-Renders the page author as a byline directly below the page header. Moved out
-of the bottom page-meta box so attribution shows at the top of the page.
+Renders page authors and contributors directly below the page header. Moved
+out of the bottom page-meta box so attribution shows at the top of the page.
 
-Reads page.authors or page.author, resolved against _data/authors.yml (falling
-back to the raw id when an author is not in the catalog).
+Reads page.authors or page.author plus page.contributors, resolved against
+_data/authors.yml (falling back to the raw id when a person is not cataloged).
 {%- endcomment -%}
+{% if page.authors or page.author or page.contributors %}
+<div class="page-credits">
 {% if page.authors %}
 <p class="page-author">
-  <span class="page-author-label">Authors</span>
+  <span class="page-author-label">{% if page.authors.size == 1 %}Author{% else %}Authors{% endif %}</span>
   {% for author_id in page.authors %}
     {% assign author = site.data.authors[author_id] %}
     {% if author %}{% if author.url %}<a href="{{ author.url }}" target="_blank" rel="noopener">{{ author.name }}</a>{% else %}{{ author.name }}{% endif %}{% else %}{{ author_id }}{% endif %}{% unless forloop.last %}{% if forloop.rindex == 2 %} and {% else %}, {% endif %}{% endunless %}
@@ -23,4 +25,15 @@ back to the raw id when an author is not in the catalog).
     {{ page.author }}
   {% endif %}
 </p>
+{% endif %}
+{% if page.contributors %}
+<p class="page-author">
+  <span class="page-author-label">{% if page.contributors.size == 1 %}Contributor{% else %}Contributors{% endif %}</span>
+  {% for contributor_id in page.contributors %}
+    {% assign contributor = site.data.authors[contributor_id] %}
+    {% if contributor %}{% if contributor.url %}<a href="{{ contributor.url }}" target="_blank" rel="noopener">{{ contributor.name }}</a>{% else %}{{ contributor.name }}{% endif %}{% else %}{{ contributor_id }}{% endif %}{% unless forloop.last %}{% if forloop.rindex == 2 %} and {% else %}, {% endif %}{% endunless %}
+  {% endfor %}
+</p>
+{% endif %}
+</div>
 {% endif %}

--- a/docs/src/routes/[...path]/+page.svelte
+++ b/docs/src/routes/[...path]/+page.svelte
@@ -138,18 +138,35 @@
 	<p class="lede">{fm.lede}</p>
 {/if}
 
-{#if p.authors?.length}
-	<p class="page-author">
-		<span class="page-author-label">{p.authors.length === 1 ? 'Author' : 'Authors'}</span>
-		{#each p.authors as author, i}
-			{#if i > 0}{i === p.authors.length - 1 ? ' and ' : ', '}{/if}
-			{#if author.url}
-				<a href={author.url} target="_blank" rel="noopener">{author.name}</a>
-			{:else}
-				{author.name}
-			{/if}
-		{/each}
-	</p>
+{#if p.authors?.length || p.contributors?.length}
+	<div class="page-credits">
+		{#if p.authors?.length}
+			<p class="page-author">
+				<span class="page-author-label">{p.authors.length === 1 ? 'Author' : 'Authors'}</span>
+				{#each p.authors as author, i}
+					{#if i > 0}{i === p.authors.length - 1 ? ' and ' : ', '}{/if}
+					{#if author.url}
+						<a href={author.url} target="_blank" rel="noopener">{author.name}</a>
+					{:else}
+						{author.name}
+					{/if}
+				{/each}
+			</p>
+		{/if}
+		{#if p.contributors?.length}
+			<p class="page-author">
+				<span class="page-author-label">{p.contributors.length === 1 ? 'Contributor' : 'Contributors'}</span>
+				{#each p.contributors as contributor, i}
+					{#if i > 0}{i === p.contributors.length - 1 ? ' and ' : ', '}{/if}
+					{#if contributor.url}
+						<a href={contributor.url} target="_blank" rel="noopener">{contributor.name}</a>
+					{:else}
+						{contributor.name}
+					{/if}
+				{/each}
+			</p>
+		{/if}
+	</div>
 {/if}
 
 <Requirements parts={p.parts} tools={p.tools} />

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -403,8 +403,14 @@ body {
 	font-weight: 600;
 }
 
-.page-author {
+.page-credits {
 	margin: -6px 0 20px;
+	display: grid;
+	gap: 4px;
+}
+
+.page-author {
+	margin: 0;
 	font-size: 0.875rem;
 	color: var(--ink);
 	font-weight: 500;


### PR DESCRIPTION
Audits every page under `hardware/` so the people behind the documentation are visible at the top of each page, and expands Bottom interface to match Top interface's preparation flow.

- Adds an author to all 37 hardware pages, including landing and placeholder pages.
- Adds separate contributor credits where people supplied or materially corrected page content.
- Credits Jessica Gadling on the BOM and Jon on the PSU pigtail from repository and request history.
- Supports `contributors:` alongside the existing `author:` and `authors:` fields.
- Makes missing authors on future hardware pages a frontmatter validation error.
- Lists all Bottom interface quantities, including 8 M4 heat inserts.
- Adds a numbered Bottom interface Preparation step with insert locations, photos, and per-step reminders.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539593084181020702): "Check all assembly documentation pages to make sure the current authors and contributors are always listed there."

Follow-up requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1539593084181020702/1539597865007972393): "Check all pages on https://docs.basically.website/hardware/ e.g. the helper pages too. Check open PRs for avoiding overlaps."

Follow-up requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1539600771497201745/1539601534554476576): "Expand the bottom interface page to match the style of the top interface page in terms of the layout of the ‘Needed Parts,’ ‘Preparation’ section, and the heat inserts."

Checks:
- All 37 generated hardware pages contain a rendered author byline.
- `npm run check` passes on Node 22 with zero errors or warnings.
- The production build passes and validates all 126 immutable image assets.
- The frontmatter validator reports only the five pre-existing errors on `main`, with no hardware credit errors.
- Open PRs were checked before editing. PR #321 changes a separate fastener entry in `parts.yml`; this change removes only the two now-redundant Bottom interface preparation notes.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1539593084181020702
request: https://discord.com/channels/1430279849171222682/1539593084181020702/1539595678743928913
request: https://discord.com/channels/1430279849171222682/1539593084181020702/1539597865007972393
request: https://discord.com/channels/1430279849171222682/1539600771497201745/1539601534554476576
preview: /hardware/
preview: /hardware/BOM
preview: /hardware/assembly/
preview: /hardware/assembly/distribution/bin-frame/bottom-interface/
preview: /hardware/electronics/
preview: /hardware/electronics/psu-pigtail/
preview: /hardware/helpers/
preview: /hardware/helpers/heat-inserts/
preview: /hardware/orange-pi-5/
preview: /hardware/parts/
preview: /hardware/preparation/
-->
