### PR TITLE
docs: point the hardware BOM link at the parts calculator

### DIFF
--- a/docs/src/content/hardware/index.md
+++ b/docs/src/content/hardware/index.md
@@ -11,4 +11,4 @@ permalink: /hardware/
 
 - **[Assembly]({{ '/hardware/assembly/' | relative_url }})**: the build order, structured like a set of instructions.
 - **[Electronics]({{ '/hardware/electronics/' | relative_url }})**: the wire harness, stepper connectors and polarity, the cable order spec, and the rendered WireViz drawings.
-- **[Bill of materials](https://docs.google.com/spreadsheets/d/1aoxcyK0xa0i3iWYlO4u3-vsruOGU8V_U9XT65YhMZmY/edit?gid=0#gid=0)**: every part, with sources and part numbers.
+- **[Bill of materials](https://parts-calculator.basically.website/hardware)**: every part, with sources and part numbers.


### PR DESCRIPTION
Changes the **Bill of materials** link on the Hardware landing page from the Google Sheets BOM to the Parts Calculator's Hardware page at https://parts-calculator.basically.website/hardware.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539609086830575707): "Could you please change the BOM link in https://docs.basically.website/hardware/ to the BOM/Hardware page of the Part Calculator at https://parts-calculator.basically.website/hardware?"

Note: `/hardware/BOM` still links to the Google Sheet in its body text; that page wasn't part of the request, so I left it alone.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1539609086830575707
preview: /hardware/
-->
