### PR TITLE
docs: document the LED current-limiting resistor value

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -11,3 +11,8 @@ author: spencer
 ---
 
 _Content pending._
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>The C-channel COB light boards need a current-limiting resistor.</b> <b>220&#8486;, 1/4 W, in series, one per board.</b> Wired straight to 24V a 50 mm COB plate pulls about 0.5A and melts its printed mount. A board fed from a basically board v1.3 LED header already has one on the board. Full detail: <a href="{{ '/hardware/electronics/#43--leds-from-basically-board-v13' | relative_url }}">LEDs, on the wire harness page</a>.</p>
+</div>

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -188,16 +188,16 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>Every LED needs a current-limiting resistor in series, one per light.</b> The 50 mm COB plates and the LED strip have no current limiting of their own. Wired straight to 24V a COB plate pulls about 0.5A (12W), runs far hotter than it needs to, and melts its printed mount. Two lights sharing one resistor is not enough; give each its own (Jon, 2026-08-17).</p>
+  <p><b>Every COB board needs a current-limiting resistor in series, one per board.</b> The 50 mm COB plates have no current limiting of their own. Wired straight to 24V a plate pulls about 0.5A (12W), runs far hotter than it needs to, and melts its printed mount. Two boards sharing one resistor is not enough; give each its own. <b>This does not apply to the LED strip</b> (L3), which has current limiting built in (Jon, 2026-08-17 and 2026-08-19).</p>
 </div>
 
 <dl class="spec-list">
-  <dt>On basically board v1.3</dt><dd>Already fitted. <b>180&#8486;</b>, 1206, 250 mW, 1% (LCSC C17924) in series with the +24V feed to each of the four LED headers: R21 on J8, R22 on J9, R27 on J10, R28 on J11. Each has a solder jumper next to it (JP1-JP4) that bridges the resistor out, for a module that already limits its own current</dd>
-  <dt>Wiring an LED straight to the PSU</dt><dd>Fit your own: <b>220&#8486;</b> is what Spencer settled on for the C-channel COB plates and the classification chamber, and <b>200&#8486; is the ballpark</b> he gives people whose lights are overheating. <b>1/4 W</b> is enough at these currents</dd>
+  <dt>Fit your own</dt><dd><b>220&#8486;</b>, <b>1/4 W</b>, in series, one per COB board. That is what Spencer settled on for the C-channel plates and the classification chamber, and what Jon recommends. <b>200&#8486;</b> is the ballpark given to people whose lights are overheating</dd>
+  <dt>On basically board v1.3</dt><dd>Already fitted, so a COB board fed from the board needs nothing added. <b>180&#8486;</b>, 1206, 250 mW, 1% (LCSC C17924) in series with the +24V feed to each of the four LED headers: R21 on J8, R22 on J9, R27 on J10, R28 on J11. Each has a solder jumper next to it (JP1-JP4) that bridges the resistor out. On the strip channel the resistor is not strictly required, and brightness can be trimmed with PWM instead (Jon, 2026-08-19)</dd>
   <dt>Effect</dt><dd>Draw drops from ~0.5A to ~0.1A. Still bright enough for the camera, per the C-channel testing in Feb 2026</dd>
 </dl>
 
-<p>Sources, since this has been asked several times: Spencer in #c-channels 2026-02-13 (&ldquo;went for 220ohm resistor&rdquo;), in the classification chamber thread 2026-03-22 (&ldquo;220 ohm&rdquo;), and in #machine-setup-help 2026-05-13 (&ldquo;They need resistor. Ballpark of 200ohm is good&rdquo;, in series, 1/4 W) after a builder's C-channel COB mount started melting after a minute.</p>
+<p>Sources, since this has been asked several times: Spencer in #c-channels 2026-02-13 (&ldquo;went for 220ohm resistor&rdquo;), in the classification chamber thread 2026-03-22 (&ldquo;220 ohm&rdquo;), and in #machine-setup-help 2026-05-13 (&ldquo;They need resistor. Ballpark of 200ohm is good&rdquo;, in series, 1/4 W) after a builder's C-channel COB mount started melting after a minute; Jon in #electronics 2026-08-17 and 2026-08-19.</p>
 
 ### 4.4 &nbsp; Sensors and steppers (from basically board v1.3)
 
@@ -231,7 +231,7 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
 - MEAN WELL LRS-350-24, 350.4W 24V 14.6A single output &middot; [link](https://www.amazon.com/dp/B013ETVO12)
 - 3Dman fused mains inlet switch, 15A 250V rocker + 10A fuse, 3-pin, 18 AWG &middot; [link](https://www.amazon.com/dp/B07RQV2NPN)
 - DC 12V/24V to 5V USB-C buck converter, 5A 25W, powers Orange Pi 5 &middot; [link](https://www.amazon.com/dp/B0FV3P6KLS)
-- Current-limiting resistor for any LED not fed through basically board v1.3: 220&#8486;, 1/4 W, one per light. The board's own LED headers already have theirs (see 4.3)
+- Current-limiting resistor for any COB board not fed through basically board v1.3: 220&#8486;, 1/4 W, one per board. The board's own LED headers already have theirs (see 4.3). The LED strip does not need one
 - Cooling fan, 40mm. Not on the 24V bus: it runs off the Orange Pi or the board, so the voltage follows whichever pin header it ends up on. 5V is likely sufficient.
 - uxcell 16-pin IDC flat ribbon cable, FC/FC, 2.54 mm, 1 m, gray &middot; [link](https://www.amazon.com/dp/B07S2W4N9T)
 - Waveshare 4-port USB hub, 24V model (USB 3.2 version, not the 5V industrial one, which cannot take 24V in)

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -186,6 +186,19 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
   <p>LED strip for the classification channel is <b>6000K</b>. Length: 2× revolutions around the classification channel inner tube = 108.400 mm × 2, so roughly 220 mm.</p>
 </div>
 
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>Every LED needs a current-limiting resistor in series, one per light.</b> The 50 mm COB plates and the LED strip have no current limiting of their own. Wired straight to 24V a COB plate pulls about 0.5A (12W), runs far hotter than it needs to, and melts its printed mount. Two lights sharing one resistor is not enough; give each its own (Jon, 2026-08-17).</p>
+</div>
+
+<dl class="spec-list">
+  <dt>On basically board v1.3</dt><dd>Already fitted. <b>180&#8486;</b>, 1206, 250 mW, 1% (LCSC C17924) in series with the +24V feed to each of the four LED headers: R21 on J8, R22 on J9, R27 on J10, R28 on J11. Each has a solder jumper next to it (JP1-JP4) that bridges the resistor out, for a module that already limits its own current</dd>
+  <dt>Wiring an LED straight to the PSU</dt><dd>Fit your own: <b>220&#8486;</b> is what Spencer settled on for the C-channel COB plates and the classification chamber, and <b>200&#8486; is the ballpark</b> he gives people whose lights are overheating. <b>1/4 W</b> is enough at these currents</dd>
+  <dt>Effect</dt><dd>Draw drops from ~0.5A to ~0.1A. Still bright enough for the camera, per the C-channel testing in Feb 2026</dd>
+</dl>
+
+<p>Sources, since this has been asked several times: Spencer in #c-channels 2026-02-13 (&ldquo;went for 220ohm resistor&rdquo;), in the classification chamber thread 2026-03-22 (&ldquo;220 ohm&rdquo;), and in #machine-setup-help 2026-05-13 (&ldquo;They need resistor. Ballpark of 200ohm is good&rdquo;, in series, 1/4 W) after a builder's C-channel COB mount started melting after a minute.</p>
+
 ### 4.4 &nbsp; Sensors and steppers (from basically board v1.3)
 
 <table>
@@ -218,6 +231,7 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
 - MEAN WELL LRS-350-24, 350.4W 24V 14.6A single output &middot; [link](https://www.amazon.com/dp/B013ETVO12)
 - 3Dman fused mains inlet switch, 15A 250V rocker + 10A fuse, 3-pin, 18 AWG &middot; [link](https://www.amazon.com/dp/B07RQV2NPN)
 - DC 12V/24V to 5V USB-C buck converter, 5A 25W, powers Orange Pi 5 &middot; [link](https://www.amazon.com/dp/B0FV3P6KLS)
+- Current-limiting resistor for any LED not fed through basically board v1.3: 220&#8486;, 1/4 W, one per light. The board's own LED headers already have theirs (see 4.3)
 - Cooling fan, 40mm. Not on the 24V bus: it runs off the Orange Pi or the board, so the voltage follows whichever pin header it ends up on. 5V is likely sufficient.
 - uxcell 16-pin IDC flat ribbon cable, FC/FC, 2.54 mm, 1 m, gray &middot; [link](https://www.amazon.com/dp/B07S2W4N9T)
 - Waveshare 4-port USB hub, 24V model (USB 3.2 version, not the 5V industrial one, which cannot take 24V in)

--- a/docs/src/content/hardware/electronics/order.md
+++ b/docs/src/content/hardware/electronics/order.md
@@ -107,7 +107,7 @@ Some parts come with their own fixed leads or solder pads, so the harness can't 
 
 - **24V to 5V USB-C buck** (W3): converter has fixed input leads, so splice.
 - **Chute stepper** (CH): flying leads out of the motor, so splice.
-- **COB boards** (L1p, L2p): solder pads, so solder direct.
+- **COB boards** (L1p, L2p): solder pads, so solder direct. Each COB board also needs a **220&#8486;, 1/4 W current-limiting resistor in series**, one per board, unless it is fed from a basically board v1.3 LED header (which has its own). Without one the plate pulls about 0.5A and melts its mount. See [LEDs]({{ '/hardware/electronics/#43--leds-from-basically-board-v13' | relative_url }}).
 - **LED strip** (L3p): a solderless clamp-on connector bites onto the cut strip, so no soldering. Pick the variant with IDC crimp points on both sides and it takes the pigtail wire too.
 
 <div class="callout">


### PR DESCRIPTION
The wire harness page describes the LED drops but never says the COB boards need a current-limiting resistor, or what value. It has been asked at least four times in Discord and answered from memory each time, most recently in #electronics today.

Adds to **4.3 LEDs** on the wire harness page:

- a warning that each COB board needs its own series resistor, and what happens without one (~0.5A / 12W per plate, melted mounts). The LED strip is called out as **not** needing one, it has current limiting built in
- what to fit: **220Ω, 1/4 W**, one per board
- what is already on basically board v1.3: 180Ω 1206 250mW 1% (LCSC C17924) as R21/R22/R27/R28 in series with the +24V feed to J8-J11, each with a bypass solder jumper JP1-JP4. Read straight off `electronics/KiCad/1_Distribution_Board/1_Distribution_Board.kicad_pcb` on `main`. On the strip channel it is not strictly required and brightness can be trimmed with PWM instead
- the sources, so it does not have to be re-derived

And links to it from the two places Jon asked for:

- **Order spec**, section 4, the COB boards bullet
- **Feeder → C-Channel** assembly page (still a stub otherwise)

Plus one line in the parts list in section 5 of the harness page.

Sourced from:

- Spencer, #c-channels 2026-02-13: "went for 220ohm resistor" (after 30Ω, having measured 0.5A unrestricted and 0.1A with the resistor)
- Spencer, in the classification chamber thread 2026-03-22: "220 ohm"
- Spencer, #machine-setup-help 2026-05-13: "They need resistor. Ballpark of 200ohm is good", "In series", and 1/4 W when Phoxtane asked the wattage, replying to a builder whose C-channel COB mount melted after a minute
- Jon, #electronics 2026-08-17: each light should have its own, not one shared between two
- Jon, 2026-08-19: "Go 220"; 180 is on the PCB but can be PWM'd down; and the LED strip does have its own current limiting, so this applies to the COB/LED boards only

Requested by Jon ⚡ (@effreek) [from Discord](https://discord.com/channels/1430279849171222682/1437436041685631129/1539692772938883243): "can you find the resistor value for current limiting the LEDs listed in the instructions? If it isn’t there can you add a note and pull this info from the discussions? If that isn’t clear tag me and let me know so I can pull it from the PCB design. (It’s included on the basically board)", and [from Discord](https://discord.com/channels/1430279849171222682/1539692772938883243/1539694869256347768): "the LED strip lighting DOES have a current limiting LED. The board still has one on but its not strictly required. This only applies to the COB/ LED boards". Originally asked by zed0 (@zed0) [from Discord](https://discord.com/channels/1430279849171222682/1437436041685631129/1539683876593475684): "What value resistors are people using with their LED COB boards?"

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1437436041685631129/1539692772938883243
request: https://discord.com/channels/1430279849171222682/1539692772938883243/1539694869256347768
request: https://discord.com/channels/1430279849171222682/1437436041685631129/1539683876593475684
preview: /hardware/electronics/
preview: /hardware/electronics/order/
preview: /hardware/assembly/feeder/c-channel/
-->
