### PR TITLE
docs: roll the socket/button "A" tag out to the rest of the screws

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -34,7 +34,7 @@ parts_needed:
     qty: 36
   - part: scr-m5-20-shcs
     qty: 12
-  - part: scr-m5-12-bhcs
+  - part: scr-m5-12-shcs
     qty: 12
   - part: tnut-m5-2020
     qty: 36
@@ -109,9 +109,9 @@ Prepare 12 Frame 90° brackets by drilling out the holes on the long side to all
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/spoke-brackets-attached.bdf5459b2c7f06bc.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">
 
-Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 {% include fastener.html size="M5" variant="button" length="12" %} screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
+Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
 
-Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the 2 Frame 90° brackets that you have just placed, and secure it with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped directly into the Frame 90° brackets, bracing against the extrusion. You can now tighten up the {% include fastener.html size="M5" variant="button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
+Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the 2 Frame 90° brackets that you have just placed, and secure it with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped directly into the Frame 90° brackets, bracing against the extrusion. You can now tighten up the {% include fastener.html size="M5" variant="socket-button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
 
 <div class="img-row">
   <figure>
@@ -122,7 +122,7 @@ Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the
   </figure>
 </div>
 
-On each side of this B/H (Spoke / Interface spoke (short)) slide a Frame crossbeam into place until it is level with the end of the extrusion, and secure it with an {% include fastener.html size="M5" variant="socket" length="20" %} screw.
+On each side of this B/H (Spoke / Interface spoke (short)) slide a Frame crossbeam into place until it is level with the end of the extrusion, and secure it with an {% include fastener.html size="M5" variant="socket-button" length="20" %} screw.
 
 Perform these steps 2 more times, on every 2nd side of the hexagon.
 
@@ -137,7 +137,7 @@ Perform these steps 2 more times, on every 2nd side of the hexagon.
   </figure>
 </div>
 
-On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html size="M5" variant="button" length="12" %} screws (either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts) to loosely fasten 2 Frame 90° brackets, aligning them with the gap in the Frame crossbeams. Slide the remaining B/H (Spoke / Interface spoke (short)) pieces into the slots, through both the Frame crossbeams and Frame 90° brackets.
+On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws (either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts) to loosely fasten 2 Frame 90° brackets, aligning them with the gap in the Frame crossbeams. Slide the remaining B/H (Spoke / Interface spoke (short)) pieces into the slots, through both the Frame crossbeams and Frame 90° brackets.
 
 <div class="img-row">
   <figure>
@@ -150,7 +150,7 @@ On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html 
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/spokes-complete-top.517a329e0407cb17.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
 
-Secure them in place with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
+Secure them in place with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket-button" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="socket-button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
 
 <div class="callout">
   <p>If you are currently building the interface layer, stop here and return to the interface layer guide.</p>
@@ -184,6 +184,6 @@ On each corner, slide an External bracket — bottom vertical onto piece C (Laye
 
 <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/bin-retainers-installed.945ecff28147b1f1.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
 
-On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
+On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
 
 A regular layer is now complete. You will also need to construct a [Chute core]({{ '/hardware/assembly/distribution/chute/' | relative_url }}) for each layer you build.

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -90,7 +90,7 @@ parts_needed:
     qty: 15
   - part: scr-m5-8-cs
     qty: 6
-  - part: scr-m5-20-bhcs
+  - part: scr-m5-20-shcs
     qty: 24
   - part: scr-m5-16-shcs
     qty: 38
@@ -282,7 +282,7 @@ Repeat for all 6 Interface brackets.
 
 Push the Printed dowel pin into the Limit switch housing.
 
-Attach a Roller lever limit switch with two {% include fastener.html size="M3" variant="socket" length="16" %} screws (into the housing's 2 M3 inserts) so the roller sits next to the dowel pin.
+Attach a Roller lever limit switch with two {% include fastener.html size="M3" variant="socket-button" length="16" %} screws (into the housing's 2 M3 inserts) so the roller sits next to the dowel pin.
 
 Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
@@ -308,7 +308,7 @@ Repeat with the 5 other prepared Interface brackets into the 5 other Interface r
 
 Flip the whole assembly and screw all 6 Interface brackets into place with {% include fastener.html size="M5" variant="countersunk" length="22" %} screws through holes I1 to I6 and O1 to O6.
 
-**Alternative:** the Top plate's laser-cut holes are not countersunk, so a countersunk head does not seat flush. {% include fastener.html size="M5" variant="button" length="20" %} screws work here instead.
+**Alternative:** the Top plate's laser-cut holes are not countersunk, so a countersunk head does not seat flush. {% include fastener.html size="M5" variant="socket-button" length="20" %} screws work here instead.
 
 {% include step.html n="6" title="Prepare the interface chute gear and mount" %}
 
@@ -399,9 +399,9 @@ Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | rel
 
 Push a 608 2RS bearing into the Interface idler gear.
 
-Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards and secure it with an {% include fastener.html size="M3" variant="button" length="35" %} screw and an M3 × 15 mm washer.
+Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards and secure it with an {% include fastener.html size="M3" variant="socket-button" length="35" %} screw and an M3 × 15 mm washer.
 
-Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four {% include fastener.html size="M5" variant="socket" length="12" %} screws.
+Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four {% include fastener.html size="M5" variant="socket-button" length="12" %} screws.
 
 At this point the chute should still rotate, but you will now feel resistance from the stepper motor.
 
@@ -435,9 +435,9 @@ At this point the chute should still rotate, but you will now feel resistance fr
 
 Slot the Cable cage top over the Top interface chute mount, with the corners of the hexagon aligning with the Interface brackets.
 
-Screw the Cable cage bracket (cable mount), on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable), securely to the tail end of that Interface bracket with an {% include fastener.html size="M5" variant="socket" length="30" %} screw into the M5 heat insert, clamping the Cable cage top firmly in place.
+Screw the Cable cage bracket (cable mount), on the Interface bracket opposite the Limit switch housing (this minimises the maximum travel of the cable), securely to the tail end of that Interface bracket with an {% include fastener.html size="M5" variant="socket-button" length="30" %} screw into the M5 heat insert, clamping the Cable cage top firmly in place.
 
-Screw the remaining Cable cage brackets to the other 5 corners of the Cable cage top with {% include fastener.html size="M5" variant="socket" length="30" %} screws.
+Screw the remaining Cable cage brackets to the other 5 corners of the Cable cage top with {% include fastener.html size="M5" variant="socket-button" length="30" %} screws.
 
 {% include step.html n="11" title="Put the cable in the cable cage" %}
 
@@ -450,7 +450,7 @@ Screw the remaining Cable cage brackets to the other 5 corners of the Cable cage
     loading="lazy"></iframe>
 </div>
 
-Place an {% include fastener.html size="M3" variant="nut" %} into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two {% include fastener.html size="M3" variant="socket" length="10" %} screws.
+Place an {% include fastener.html size="M3" variant="nut" %} into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two {% include fastener.html size="M3" variant="socket-button" length="10" %} screws.
 
 Rotate the chute until it hits the limit switch.
 
@@ -458,9 +458,9 @@ Fold your IDC ribbon cable around the Cable clamp (inner), following the guides 
 
 Guide the rest of the ribbon cable around the side of the Top interface chute mount, in the direction the chute can rotate, back to the Cable cage bracket (cable mount).
 
-Screw the Ribbon cable clamp lightly to the Cable cage bracket (cable mount) with one {% include fastener.html size="M3" variant="socket" length="10" %} screw, clamping the ribbon cable between the two.
+Screw the Ribbon cable clamp lightly to the Cable cage bracket (cable mount) with one {% include fastener.html size="M3" variant="socket-button" length="10" %} screw, clamping the ribbon cable between the two.
 
-Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long {% include fastener.html size="M3" variant="button" length="35" %} screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end.
+Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long {% include fastener.html size="M3" variant="socket-button" length="35" %} screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end.
 
 {% include step.html n="12" title="Attach the cable cage bottom" %}
 
@@ -479,7 +479,7 @@ After this step the chute should still rotate to each of its limits.
 
 {% include step.html n="13" title="Attach the framing" %}
 
-Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with four {% include fastener.html size="M5" variant="button" length="20" %} screws into four T-nuts.
+Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with four {% include fastener.html size="M5" variant="socket-button" length="20" %} screws into four T-nuts.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-1.ae2ef835181f63bd.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -115,11 +115,6 @@ ext-2020-c:
   image: https://img.basically.website/web/parts/extrusion/extrusion-2020.0691a894c8154731.png
   caption: 2020 aluminum extrusion, cut to 154 mm (piece C).
 
-scr-m5-12-bhcs:
-  name: M5 × 12 mm button head screw
-  category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/m5-button-head.87be93e901c86545.jpg
-
 scr-m5-16-shcs:
   name: M5 × 16 mm socket / button head
   category: Screws
@@ -307,8 +302,9 @@ cable-idc-2x8-long:
   image: https://img.basically.website/web/parts/hardware/electronics/cable-idc-2x8-long.78c80cba0d300af0.jpg
 
 scr-m5-12-shcs:
-  name: M5 x 12 mm socket head cap screw
+  name: M5 × 12 mm socket / button head
   category: Screws
+  alternative: Socket or button head
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
 scr-m5-35-shcs:
@@ -318,13 +314,15 @@ scr-m5-35-shcs:
   not_in_calc: true
 
 scr-m5-30-shcs:
-  name: M5 × 30 mm socket head cap screw
+  name: M5 × 30 mm socket / button head
   category: Screws
+  alternative: Socket or button head
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
 scr-m5-20-shcs:
-  name: M5 × 20 mm socket head cap screw
+  name: M5 × 20 mm socket / button head
   category: Screws
+  alternative: Socket or button head
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
 scr-m5-22-cs:
@@ -339,22 +337,17 @@ scr-m5-8-cs:
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
   not_in_calc: true
 
-scr-m5-20-bhcs:
-  name: M5 × 20 mm button head cap screw
-  category: Screws
-  image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
-  not_in_calc: true
-
 scr-m3-35-bhcs:
-  name: M3 × 35 mm button head cap screw
+  name: M3 × 35 mm socket / button head
   category: Screws
+  alternative: Socket or button head
   image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
 
 scr-m3-10-shcs:
-  name: M3 × 10 mm socket head cap screw
+  name: M3 × 10 mm socket / button head
   category: Screws
+  alternative: Socket or button head
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
-  not_in_calc: true
 
 scr-m3-12-cs:
   name: M3 × 12 mm countersunk screw
@@ -362,8 +355,9 @@ scr-m3-12-cs:
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
 
 scr-m3-16-shcs:
-  name: M3 × 16 mm socket head cap screw
+  name: M3 × 16 mm socket / button head
   category: Screws
+  alternative: Socket or button head
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
 
 scr-m3-8-cs:

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -305,7 +305,7 @@ scr-m5-12-shcs:
   name: M5 × 12 mm socket / button head
   category: Screws
   alternative: Socket or button head
-  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m5-35-shcs:
   name: M5 × 35 mm socket head cap screw
@@ -317,13 +317,13 @@ scr-m5-30-shcs:
   name: M5 × 30 mm socket / button head
   category: Screws
   alternative: Socket or button head
-  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m5-20-shcs:
   name: M5 × 20 mm socket / button head
   category: Screws
   alternative: Socket or button head
-  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m5-22-cs:
   name: M5 × 22 mm countersunk screw
@@ -341,13 +341,13 @@ scr-m3-35-bhcs:
   name: M3 × 35 mm socket / button head
   category: Screws
   alternative: Socket or button head
-  image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+  image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m3-10-shcs:
   name: M3 × 10 mm socket / button head
   category: Screws
   alternative: Socket or button head
-  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m3-12-cs:
   name: M3 × 12 mm countersunk screw
@@ -358,7 +358,7 @@ scr-m3-16-shcs:
   name: M3 × 16 mm socket / button head
   category: Screws
   alternative: Socket or button head
-  image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
+  image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m3-8-cs:
   name: M3 × 8 mm countersunk screw


### PR DESCRIPTION
Rolls the socket/button **"A"** tag and naming out to the rest of the interchangeable screws, matching what went in for M5×16 (#319/#321).

- **Consolidate** the M5×12 and M5×20 socket/button card pairs into one card each: correct "socket / button head" name, green "A" tag, the separate button card removed and its `parts_needed` refs repointed.
- **Tag + rename** the M5×30, M3×10, M3×16 and M3×35 cards; drop the stale "!" on M3×10 (it's in the calculator).
- **Inline symbol:** those sizes' step references now use the socket-head symbol (`socket-button` variant), consistent with M5×16.

Countersunk screws untouched (distinct head). M5×35 left as-is (it's a flat/pancake head, and the two repos disagree on it — separate cleanup). `npm run build` passes; the "A" badge and names render on the assembly pages.

Pairs with parts-calculator #27 (the same tag rollout on the calculator side).

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1539089324275146812/1539841643304460359): "distribute the green 'A' and the description/name adjustments to all relevant screws in the part calculator and in the assembly documentation (needed parts cards and texts)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
request: https://discord.com/channels/1430279849171222682/1539089324275146812/1539843114393542656
-->
