### PR TITLE
docs: stamp screw length on the "Parts needed" cards

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -201,7 +201,8 @@ Adding a drawing: new YAML source, an entry in the data file, an entry in the
 
 `src/liquid/_data/parts.yml` is the catalog, keyed by id. Fields: `name`,
 `image`, `page` (detail page, optional), `category` (groups the "Parts
-needed" block), `notes` (short, collected into a list under the whole block),
+needed" block), `length_mm` (screw length, stamped on the card image),
+`notes` (short, collected into a list under the whole block),
 `caption` (small text under a single card, e.g. a cut length),
 `heat_inserts: [{insert, qty}]`. ids and render filenames mirror the
 `sorter-v2-filament-calculator` repo so the two merge cleanly later.
@@ -209,6 +210,10 @@ needed" block), `notes` (short, collected into a list under the whole block),
 - A page lists what it needs via `parts_needed` (see front matter). Cards render
   image + name, linked to the detail page when one exists, grouped by category,
   with a quantity badge and any notes.
+- **Every screw needs `length_mm`.** One photo stands in for a whole family of
+  screws (every M5 socket head cap screw shares one picture), so without the
+  length stamped on the card an M5 x 12 and an M5 x 35 are the same card. The
+  parts calculator's hardware list does the same thing for the same reason.
 - Part detail pages live under `src/content/hardware/parts/`. Only put a part
   in the nav if it has a detail page worth linking; the catalog can hold parts
   with no page.

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -30,6 +30,9 @@
 											<img class="part-card-img" src={part.image} alt={part.name} loading="lazy" />
 										{/if}
 										{#if part.qty}<span class="part-card-qty">{part.qty}×</span>{/if}
+										<!-- One screw photo stands in for every length in its family, so the
+										     length gets stamped on the corner, as on the parts calculator. -->
+										{#if part.length_mm}<span class="part-card-len">{part.length_mm}mm</span>{/if}
 										{#if part.not_in_calc}<span class="part-card-warn" title="Not currently in the parts calculator">!</span>{/if}
 										{#if part.alternative}<span
 												class="part-card-alt"

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -225,6 +225,10 @@ export type ResolvedPart = {
 	qty?: number;
 	notes?: string;
 	caption?: string;
+	// Screw length in mm, stamped on the corner of the card image. One photo
+	// stands in for a whole family of screws, so the length is the one thing it
+	// cannot show, the same reason the parts calculator's hardware list carries it.
+	length_mm?: number;
 	not_in_calc?: boolean;
 	// Interchangeable alternative (e.g. socket vs button head): true for a bare
 	// tag, or a string naming the alternative. Renders the green "A" badge.
@@ -256,6 +260,7 @@ function resolveParts(partsNeeded: any[]): { groups: PartsGroup[]; notes: Resolv
 			page: part.page,
 			notes: part.notes,
 			caption: part.caption,
+			length_mm: part.length_mm,
 			not_in_calc: part.not_in_calc,
 			alternative: part.alternative,
 			qty,

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -57,6 +57,7 @@ m3-ruthex-long:
 m4-12mm-countersunk:
   name: M4 × 12 mm countersunk screw
   category: Screws
+  length_mm: 12
   image: https://img.basically.website/web/parts/hardware/screws/m4-12mm-countersunk.eb3c4468cf87495d.jpg
 
 ext-bracket-left:
@@ -118,6 +119,7 @@ ext-2020-c:
 scr-m5-16-shcs:
   name: M5 × 16 mm socket / button head
   category: Screws
+  length_mm: 16
   alternative: Socket or button head
   image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
@@ -304,70 +306,82 @@ cable-idc-2x8-long:
 scr-m5-12-shcs:
   name: M5 × 12 mm socket / button head
   category: Screws
+  length_mm: 12
   alternative: Socket or button head
   image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m5-35-shcs:
   name: M5 × 35 mm socket head cap screw
   category: Screws
+  length_mm: 35
   image: https://img.basically.website/web/parts/hardware/screws/m5-shcs.f415c8d0a2ee3205.jpg
   not_in_calc: true
 
 scr-m5-30-shcs:
   name: M5 × 30 mm socket / button head
   category: Screws
+  length_mm: 30
   alternative: Socket or button head
   image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m5-20-shcs:
   name: M5 × 20 mm socket / button head
   category: Screws
+  length_mm: 20
   alternative: Socket or button head
   image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m5-22-cs:
   name: M5 × 22 mm countersunk screw
   category: Screws
+  length_mm: 22
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
   not_in_calc: true
 
 scr-m5-8-cs:
   name: M5 × 8 mm countersunk screw
   category: Screws
+  length_mm: 8
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
   not_in_calc: true
 
 scr-m3-35-bhcs:
   name: M3 × 35 mm socket / button head
   category: Screws
+  length_mm: 35
   alternative: Socket or button head
   image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m3-10-shcs:
   name: M3 × 10 mm socket / button head
   category: Screws
+  length_mm: 10
   alternative: Socket or button head
   image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m3-12-cs:
   name: M3 × 12 mm countersunk screw
   category: Screws
+  length_mm: 12
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
 
 scr-m3-16-shcs:
   name: M3 × 16 mm socket / button head
   category: Screws
+  length_mm: 16
   alternative: Socket or button head
   image: https://img.basically.website/web/parts/scr-m5-16-shcs/socket-button-tile.4997cae8bf08013c.jpg
 
 scr-m3-8-cs:
   name: M3 × 8 mm countersunk screw
   category: Screws
+  length_mm: 8
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
 
 scr-m3-6-cs:
   name: M3 × 6 mm countersunk screw
   category: Screws
+  length_mm: 6
   image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg
   not_in_calc: true
 

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -568,6 +568,24 @@ body {
 	background: var(--ink);
 }
 
+/* Screw length, stamped on the corner of the card image the way the parts
+   calculator's hardware list does it. One photo stands in for a whole family
+   of screws (every M5 socket head is the same picture), so the length is the
+   one thing the image cannot tell you apart by. */
+.part-card-len {
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	padding: 1px 5px;
+	font-size: 0.7rem;
+	font-weight: 600;
+	line-height: 1.35;
+	font-variant-numeric: tabular-nums;
+	color: var(--ink);
+	background: var(--bg);
+	border: 1px solid var(--line);
+}
+
 /* Marker for a part that is not in the parts calculator */
 .part-card-warn {
 	position: absolute;


### PR DESCRIPTION
The "Parts needed" cards reuse one photo per screw family (every M5 socket head cap screw shares `m5-shcs.jpg`, every countersunk shares `countersunk.jpg`), so an M5 x 12 and an M5 x 35 render as the same card. The parts calculator's hardware list has the same problem and solves it by stamping the length on the corner of the thumbnail, so this does the same on the docs cards.

- `parts.yml` gains a `length_mm` field, set on all 14 screws in the catalog.
- `Requirements.svelte` renders it as `part-card-len` in the bottom-right corner of the card image (qty is top-left, the "!" and "A" markers are top-right, so nothing moves).
- `AGENTS.md` documents the field and says every screw needs it.

Nothing else changes: no page frontmatter is touched, so all 7 pages with a `parts_needed` block pick the tags up automatically.

Rebased onto `main` after #332 merged. That PR consolidated the socket/button pairs and deleted the separate `scr-m5-12-bhcs` / `scr-m5-20-bhcs` entries, so the diff here is now purely 14 added `length_mm` lines on top of #332's `alternative:` tags, nothing of #332's is touched. The length stamp sits bottom-right and the green "A" top-right, so they render together.

Checked after the rebase with `validate_frontmatter.py` (only the 5 pre-existing errors on main), `validate_images.py` (132 assets OK) and a YAML parse confirming all 14 screws carry `length_mm`. `npm run check` / `npm run build` could not be re-run locally (the box is out of disk), so the Cloudflare preview is the build check for this revision; it passed both before the rebase.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539854023220535346): "Please add a length tag to the “needed parts screw” cards on all pages, just as it is used in the screw overview in the parts calculator."

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1539854023220535346
preview: /hardware/assembly/distribution/top-interface/
request: https://discord.com/channels/1430279849171222682/1539855847486787715/1539889153162874940
-->

