### PR TITLE
docs: first-draft assembly pages from the parts calculator tree

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -9,6 +9,25 @@ lede: The chute assembly. Build one per layer.
 permalink: /hardware/assembly/distribution/chute/chute-core/
 author: spencer
 contributors: [barthel]
+parts_needed:
+  - part: chute-core
+    qty: 1
+  - part: funnel-bracket-left
+    qty: 1
+  - part: funnel-bracket-right
+    qty: 1
+  - part: layer-connector-1
+    qty: 1
+  - part: layer-connector-2
+    qty: 1
+  - part: layer-adapter-board-basically
+    qty: 1
+  - part: m3-ruthex-long
+    qty: 18
+  - part: scr-m3-12-cs
+    qty: 6
+  - part: scr-m3-8-cs
+    qty: 8
 ---
 
 <div class="callout callout-warning">
@@ -18,31 +37,41 @@ contributors: [barthel]
 
 The chute is what steers a part into the right bin. Build one per layer, plus two for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
 
-One chute is the chute core plus four things that bolt onto it:
-
-| Sub-assembly | Qty | Covered on |
-|---|---|---|
-| Chute core | 1 | this page |
-| Door module | 1 | [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}) |
-| Funnel bracket (left) and (right) | 1 each | [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}) |
-| Layer connector A and B | 1 each | [Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}) |
-| Layer adapter board | 1 | [PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) |
+The fasteners and quantities are in the parts list above and are called out inline at each step.
 
 {% include fastener-legend.html %}
 
-{% include step.html n="1" title="Press the heat inserts into the chute core" %}
+One chute is the chute core plus four things that bolt onto it:
 
-The chute core takes **18 × M3 heat inserts**, and every screw that lands on the chute core threads into one of them. Press them all in while the core is still bare. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+- **Door module**, one per chute: the door, the bearing assembly, the servo adapter and the servo in its bracket, built as a unit. See [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}).
+- **Funnel bracket (left)** and **Funnel bracket (right)**, one of each. See [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
+- **Layer connector A** and **Layer connector B**, one of each. See [Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
+- **Layer adapter board**, one per chute. See [PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}).
 
-The 18 split up as: 2 for the servo bracket arms, 4 for the layer adapter board, and the rest for the funnel brackets, the bearing assembly and the layer connectors.
+Every screw on this page lands in one of the chute core's own M3 heat inserts. Nothing here taps into bare plastic.
 
-<div class="img-placeholder">Image coming</div>
+{% include step.html n="1" title="Preparation" %}
+
+Press the heat inserts into the chute core before anything is mounted to it. Once the funnel brackets and the door module are on, several of the insert positions are hard to reach with an iron. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page. 2 for the servo bracket arms, 4 for the layer adapter board, and the rest for the funnel brackets, the bearing assembly and the layer connectors.</p>
+  </div>
+  <div class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </div>
+</div>
+
+The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists every part in the machine that needs inserts.
 
 {% include step.html n="2" title="Fit the funnel brackets" %}
 
 Fit the Funnel bracket (left) and the Funnel bracket (right) to the chute core. Together with the door module and the layer connectors these use the chute's 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, all into the core's inserts.
 
 Which screw goes in which hole is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
 
 {% include step.html n="3" title="Fit the door module" %}
 

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -8,8 +8,48 @@ kicker: Chute — Chute core
 lede: The chute assembly. Build one per layer.
 permalink: /hardware/assembly/distribution/chute/chute-core/
 author: spencer
+contributors: [barthel]
 ---
 
-Build one chute core per layer.
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=chute">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
+</div>
 
-_Content pending — the chute core is itself made of layers, documented here later._
+The chute is what steers a part into the right bin. Build one per layer, plus two for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
+
+One chute is the chute core plus four things that bolt onto it:
+
+| Sub-assembly | Qty | Covered on |
+|---|---|---|
+| Chute core | 1 | this page |
+| Door module | 1 | [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}) |
+| Funnel bracket (left) and (right) | 1 each | [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}) |
+| Layer connector A and B | 1 each | [Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}) |
+| Layer adapter board | 1 | [PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) |
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Press the heat inserts into the chute core" %}
+
+The chute core takes **18 × M3 heat inserts**, and every screw that lands on the chute core threads into one of them. Press them all in while the core is still bare. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+The 18 split up as: 2 for the servo bracket arms, 4 for the layer adapter board, and the rest for the funnel brackets, the bearing assembly and the layer connectors.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Fit the funnel brackets" %}
+
+Fit the Funnel bracket (left) and the Funnel bracket (right) to the chute core. Together with the door module and the layer connectors these use the chute's 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, all into the core's inserts.
+
+Which screw goes in which hole is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+{% include step.html n="3" title="Fit the door module" %}
+
+Build the [door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}) as a unit (door, bearing assembly, servo adapter, servo in its bracket) and bolt it to the chute core. The servo bracket lands on **two** of the core's M3 inserts.
+
+{% include step.html n="4" title="Fit the layer connectors and the PCB" %}
+
+Attach Layer connector A and Layer connector B, then the [layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) on its four PCB inserts.
+
+The chute is now complete. Repeat for every layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -9,6 +9,10 @@ lede: The chute assembly. Build one per layer.
 permalink: /hardware/assembly/distribution/chute/chute-core/
 author: spencer
 contributors: [barthel]
+warning: >-
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=chute), not from an
+  actual build. No step here has been checked against a machine. Correct it as you build.
 parts_needed:
   - part: chute-core
     qty: 1
@@ -29,11 +33,6 @@ parts_needed:
   - part: scr-m3-8-cs
     qty: 8
 ---
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=chute">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
-</div>
 
 The chute is what steers a part into the right bin. Build one per layer, plus two for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
 

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -9,6 +9,11 @@ lede: The funnel that guides parts through the door.
 permalink: /hardware/assembly/distribution/chute/funnel/
 author: spencer
 contributors: [barthel]
+warning: >-
+  **AI-generated first draft.** Written from the machine assembly tree and parts registry in
+  the [parts calculator](https://parts-calculator.basically.website/assembly?focus=chute), not
+  from an actual build. No step here has been checked against a machine. Correct it as you
+  build.
 parts_needed:
   - part: funnel-half
     qty: 1
@@ -23,11 +28,6 @@ parts_needed:
   - part: scr-m3-8-cs
     qty: 8
 ---
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree and parts registry in the <a href="https://parts-calculator.basically.website/assembly?focus=chute">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
-</div>
 
 The funnel catches what the door releases and guides it into the bin below. It hangs off two printed brackets that are part of the chute.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -8,6 +8,35 @@ kicker: Chute — Funnel
 lede: The funnel that guides parts through the door.
 permalink: /hardware/assembly/distribution/chute/funnel/
 author: spencer
+contributors: [barthel]
 ---
 
-_Content pending._
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree and parts registry in the <a href="https://parts-calculator.basically.website/assembly?focus=chute">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
+</div>
+
+The funnel catches what the door releases and guides it into the bin below. It hangs off two printed brackets that are part of the chute.
+
+{% include step.html n="1" title="Pick the funnel size for the layer" %}
+
+**One funnel per layer**, and the size is chosen per layer rather than once for the whole machine. The choice also sets that layer's bins:
+
+| Funnel | Bins on that layer |
+|---|---|
+| Funnel (half size) | 12, six Bin (half, left) and six Bin (half, right) |
+| Funnel (third size) | 18, six each of Bin (third, left), (center) and (right-back) |
+
+Decide before printing, since it changes both the funnel and the bin set. The [parts calculator](https://parts-calculator.basically.website/) takes a size per layer and totals the print for whatever mix you pick.
+
+{% include step.html n="2" title="Fit the funnel brackets to the chute core" %}
+
+Every chute carries a **Funnel bracket (left)** and a **Funnel bracket (right)**, one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, using screws from the chute's set of 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %}.
+
+Which of those go into the funnel brackets is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="3" title="Hang the funnel" %}
+
+How the funnel itself attaches to the brackets is not recorded yet.

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -9,6 +9,19 @@ lede: The funnel that guides parts through the door.
 permalink: /hardware/assembly/distribution/chute/funnel/
 author: spencer
 contributors: [barthel]
+parts_needed:
+  - part: funnel-half
+    qty: 1
+  - part: funnel-third
+    qty: 1
+  - part: funnel-bracket-left
+    qty: 1
+  - part: funnel-bracket-right
+    qty: 1
+  - part: scr-m3-12-cs
+    qty: 6
+  - part: scr-m3-8-cs
+    qty: 8
 ---
 
 <div class="callout callout-warning">
@@ -18,20 +31,26 @@ contributors: [barthel]
 
 The funnel catches what the door releases and guides it into the bin below. It hangs off two printed brackets that are part of the chute.
 
+The fasteners and quantities are in the parts list above and are called out inline at each step.
+
+{% include fastener-legend.html %}
+
+- **One funnel per layer**, in one of two sizes. Print the size that matches that layer's bins.
+- The 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws in the list are the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s whole set, shared between the funnel brackets, the door module and the layer connectors. Only some of them land here.
+- The brackets screw into the chute core's M3 heat inserts, so there is nothing to tap.
+
 {% include step.html n="1" title="Pick the funnel size for the layer" %}
 
-**One funnel per layer**, and the size is chosen per layer rather than once for the whole machine. The choice also sets that layer's bins:
+The size is chosen per layer rather than once for the whole machine, and it sets that layer's bins with it:
 
-| Funnel | Bins on that layer |
-|---|---|
-| Funnel (half size) | 12, six Bin (half, left) and six Bin (half, right) |
-| Funnel (third size) | 18, six each of Bin (third, left), (center) and (right-back) |
+- **Funnel (half size):** 12 bins on that layer, six Bin (half, left) and six Bin (half, right).
+- **Funnel (third size):** 18 bins on that layer, six each of Bin (third, left), Bin (third, center) and Bin (third, right-back).
 
 Decide before printing, since it changes both the funnel and the bin set. The [parts calculator](https://parts-calculator.basically.website/) takes a size per layer and totals the print for whatever mix you pick.
 
 {% include step.html n="2" title="Fit the funnel brackets to the chute core" %}
 
-Every chute carries a **Funnel bracket (left)** and a **Funnel bracket (right)**, one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, using screws from the chute's set of 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %}.
+Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, using screws from the chute's set.
 
 Which of those go into the funnel brackets is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -9,6 +9,15 @@ lede: The connectors that chain layers together.
 permalink: /hardware/assembly/distribution/chute/layer-connectors/
 author: spencer
 contributors: [barthel]
+parts_needed:
+  - part: layer-connector-1
+    qty: 1
+  - part: layer-connector-2
+    qty: 1
+  - part: scr-m3-12-cs
+    qty: 6
+  - part: scr-m3-8-cs
+    qty: 8
 ---
 
 <div class="callout callout-warning">
@@ -16,17 +25,21 @@ contributors: [barthel]
   <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=layer-connector">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
 </div>
 
-The layer connectors are a pair of printed parts, **Layer connector A** and **Layer connector B**, that join one layer's chute to the next one down so parts pass from chute to chute without a gap.
+The layer connectors are a pair of printed parts, Layer connector A and Layer connector B, that join one layer's chute to the next one down so parts pass from chute to chute without a gap.
 
-**How many:** 1 of each per distribution layer, plus 1 of each for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) and 1 of each for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
+The fasteners and quantities are in the parts list above and are called out inline at each step.
 
 {% include fastener-legend.html %}
 
+- **How many:** 1 of each per distribution layer, plus 1 of each for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) and 1 of each for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
+- The screws in the list are the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s whole set of 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %}, shared with the funnel brackets and the door module. Only some of them land here.
+- Both connectors go into the chute core's M3 heat inserts.
+
 {% include step.html n="1" title="Fit the connectors to the chute core" %}
 
-Both connectors fasten to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), into its M3 heat inserts, using screws from the chute's own set of 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %}.
+Both connectors fasten to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), into its M3 heat inserts.
 
-The split between the two lengths is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+The split between the two screw lengths is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -9,6 +9,11 @@ lede: The connectors that chain layers together.
 permalink: /hardware/assembly/distribution/chute/layer-connectors/
 author: spencer
 contributors: [barthel]
+warning: >-
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=layer-connector), not
+  from an actual build. No step here has been checked against a machine. Correct it as you
+  build.
 parts_needed:
   - part: layer-connector-1
     qty: 1
@@ -19,11 +24,6 @@ parts_needed:
   - part: scr-m3-8-cs
     qty: 8
 ---
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=layer-connector">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
-</div>
 
 The layer connectors are a pair of printed parts, Layer connector A and Layer connector B, that join one layer's chute to the next one down so parts pass from chute to chute without a gap.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -8,6 +8,28 @@ kicker: Chute — Layer connectors
 lede: The connectors that chain layers together.
 permalink: /hardware/assembly/distribution/chute/layer-connectors/
 author: spencer
+contributors: [barthel]
 ---
 
-_Content pending._
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=layer-connector">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
+</div>
+
+The layer connectors are a pair of printed parts, **Layer connector A** and **Layer connector B**, that join one layer's chute to the next one down so parts pass from chute to chute without a gap.
+
+**How many:** 1 of each per distribution layer, plus 1 of each for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) and 1 of each for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Fit the connectors to the chute core" %}
+
+Both connectors fasten to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), into its M3 heat inserts, using screws from the chute's own set of 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %}.
+
+The split between the two lengths is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Check the alignment against the layer below" %}
+
+Build the layers up first and check that A on one layer lines up with B on the layer below before tightening. Nothing here is adjustable once the tower is stacked.

--- a/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
@@ -9,6 +9,23 @@ lede: The mount the servo bolts into.
 permalink: /hardware/assembly/distribution/chute/mg995-servo/servo-mount/
 author: spencer
 contributors: [barthel]
+parts_needed:
+  - part: servo-bracket-housing
+    qty: 1
+  - part: servo-bracket-lower-arm
+    qty: 1
+  - part: servo-bracket-side-arm
+    qty: 1
+  - part: servo-bracket-cover
+    qty: 1
+  - part: servo-mg995
+    qty: 1
+  - part: m3-ruthex-long
+    qty: 6
+  - part: scr-m3-12-cs
+    qty: 4
+  - part: scr-m3-8-cs
+    qty: 2
 ---
 
 <div class="callout callout-warning">
@@ -18,31 +35,36 @@ contributors: [barthel]
 
 The MG995 sits in a four-part printed bracket, and the whole bracket goes onto the chute core as one unit. Build it on the bench, then bolt it on.
 
-**Parts, per chute:**
-
-| Part | Qty |
-|---|---|
-| Servo bracket, housing | 1 |
-| Servo bracket, lower arm | 1 |
-| Servo bracket, side arm | 1 |
-| Servo bracket, cover | 1 |
-| MG995 servo | 1 |
-| M3 × 12 mm countersunk | 4 |
-| M3 × 8 mm countersunk | 2 |
+The fasteners and quantities are in the parts list above and are called out inline at each step.
 
 {% include fastener-legend.html %}
 
-{% include step.html n="1" title="Press the heat inserts into the housing" %}
+- **One per chute**, so one per layer.
+- Everything on this page threads into the housing's own inserts or the servo's mounting ears. The two screws that hold the finished bracket to the chute core come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s set, not this one.
+- The cover clips on and takes no screws.
 
-The Servo bracket housing takes **6 × M3 heat inserts**. Press them in while the housing is loose. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}).
+{% include step.html n="1" title="Preparation" %}
 
-<div class="img-placeholder">Image coming</div>
+Press the inserts into the housing while it is still bare. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Servo bracket (housing):</strong> 6 × M3</p>
+  </div>
+  <div class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </div>
+</div>
+
+The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists every part in the machine that needs inserts.
 
 {% include step.html n="2" title="Seat the servo in the housing" %}
 
 Drop the MG995 into the housing and fasten it with 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the servo's own mounting ears.
 
 Clock the horn before you commit to a position. The MG995 only rotates 180°, and the door has to reach both fully open and fully closed inside that range, see [how to install]({{ '/hardware/assembly/distribution/chute/mg995-servo/how-to-install/' | relative_url }}).
+
+<div class="img-placeholder">Image coming</div>
 
 {% include step.html n="3" title="Add the arms and the cover" %}
 

--- a/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
@@ -8,6 +8,46 @@ kicker: MG995 servo — Servo mount
 lede: The mount the servo bolts into.
 permalink: /hardware/assembly/distribution/chute/mg995-servo/servo-mount/
 author: spencer
+contributors: [barthel]
 ---
 
-_Content pending._
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=servo-bracket">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
+</div>
+
+The MG995 sits in a four-part printed bracket, and the whole bracket goes onto the chute core as one unit. Build it on the bench, then bolt it on.
+
+**Parts, per chute:**
+
+| Part | Qty |
+|---|---|
+| Servo bracket, housing | 1 |
+| Servo bracket, lower arm | 1 |
+| Servo bracket, side arm | 1 |
+| Servo bracket, cover | 1 |
+| MG995 servo | 1 |
+| M3 × 12 mm countersunk | 4 |
+| M3 × 8 mm countersunk | 2 |
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Press the heat inserts into the housing" %}
+
+The Servo bracket housing takes **6 × M3 heat inserts**. Press them in while the housing is loose. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}).
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Seat the servo in the housing" %}
+
+Drop the MG995 into the housing and fasten it with 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the servo's own mounting ears.
+
+Clock the horn before you commit to a position. The MG995 only rotates 180°, and the door has to reach both fully open and fully closed inside that range, see [how to install]({{ '/hardware/assembly/distribution/chute/mg995-servo/how-to-install/' | relative_url }}).
+
+{% include step.html n="3" title="Add the arms and the cover" %}
+
+Fit the lower arm and the side arm to the housing and fasten them with the 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws into the housing's inserts. Clip the cover on last.
+
+{% include step.html n="4" title="Bolt the bracket to the chute core" %}
+
+The finished bracket mounts to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) on **two** of the core's M3 inserts, as one unit. The servo output then couples to the door through the two-piece servo adapter (servo side and flap side), which is part of the [door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}).

--- a/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
@@ -9,6 +9,11 @@ lede: The mount the servo bolts into.
 permalink: /hardware/assembly/distribution/chute/mg995-servo/servo-mount/
 author: spencer
 contributors: [barthel]
+warning: >-
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=servo-bracket), not
+  from an actual build. No step here has been checked against a machine. Correct it as you
+  build.
 parts_needed:
   - part: servo-bracket-housing
     qty: 1
@@ -27,11 +32,6 @@ parts_needed:
   - part: scr-m3-8-cs
     qty: 2
 ---
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=servo-bracket">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
-</div>
 
 The MG995 sits in a four-part printed bracket, and the whole bracket goes onto the chute core as one unit. Build it on the bench, then bolt it on.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -8,6 +8,26 @@ kicker: Chute — PCB
 lede: The board that drives the servo.
 permalink: /hardware/assembly/distribution/chute/pcb/
 author: spencer
+contributors: [barthel]
 ---
 
-_Content pending._
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=chute-pcb">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
+</div>
+
+Each layer carries one **basically Layer Adapter Board**, the in-house board that breaks out the control board's ribbon connectors for that distribution layer and drives the layer's servo. One per layer.
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Screw the board onto the chute core" %}
+
+The board mounts on **four M3 inserts** in the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), which are part of the core's 18. Press those inserts in before the chute is assembled.
+
+Seat the board over the four inserts and fasten it with 4 {% include fastener.html size="M3" variant="button" length="6" %} screws. Do not overtighten, the board is standing on printed plastic.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Connect the ribbon cable" %}
+
+The board takes the ribbon connection that chains this layer to the control board. How the layers chain is covered under [electronics]({{ '/hardware/electronics/' | relative_url }}) and in the [WireViz drawings]({{ '/hardware/electronics/wireviz/' | relative_url }}).

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -9,6 +9,13 @@ lede: The board that drives the servo.
 permalink: /hardware/assembly/distribution/chute/pcb/
 author: spencer
 contributors: [barthel]
+parts_needed:
+  - part: layer-adapter-board-basically
+    qty: 1
+  - part: m3-ruthex-long
+    qty: 4
+  - part: scr-m3-6-bhcs
+    qty: 4
 ---
 
 <div class="callout callout-warning">
@@ -16,18 +23,25 @@ contributors: [barthel]
   <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=chute-pcb">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
 </div>
 
-Each layer carries one **basically Layer Adapter Board**, the in-house board that breaks out the control board's ribbon connectors for that distribution layer and drives the layer's servo. One per layer.
+Each layer carries one basically Layer Adapter Board, the in-house board that breaks out the control board's ribbon connectors for that distribution layer and drives the layer's servo. One per layer.
+
+The fasteners and quantities are in the parts list above and are called out inline at each step.
 
 {% include fastener-legend.html %}
 
-{% include step.html n="1" title="Screw the board onto the chute core" %}
+- The 4 M3 inserts the board sits on are part of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s 18, not extra ones.
+- The board is the only thing on the chute that uses a {% include fastener.html size="M3" variant="button" length="6" %} screw.
 
-The board mounts on **four M3 inserts** in the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), which are part of the core's 18. Press those inserts in before the chute is assembled.
+{% include step.html n="1" title="Preparation" %}
+
+Press the chute core's inserts before the chute is assembled, the four PCB inserts among them. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique, and the [Preparation]({{ '/hardware/preparation/' | relative_url }}) page for every part in the machine that takes inserts.
+
+{% include step.html n="2" title="Screw the board onto the chute core" %}
 
 Seat the board over the four inserts and fasten it with 4 {% include fastener.html size="M3" variant="button" length="6" %} screws. Do not overtighten, the board is standing on printed plastic.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="2" title="Connect the ribbon cable" %}
+{% include step.html n="3" title="Connect the ribbon cable" %}
 
 The board takes the ribbon connection that chains this layer to the control board. How the layers chain is covered under [electronics]({{ '/hardware/electronics/' | relative_url }}) and in the [WireViz drawings]({{ '/hardware/electronics/wireviz/' | relative_url }}).

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -9,6 +9,10 @@ lede: The board that drives the servo.
 permalink: /hardware/assembly/distribution/chute/pcb/
 author: spencer
 contributors: [barthel]
+warning: >-
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=chute-pcb), not from
+  an actual build. No step here has been checked against a machine. Correct it as you build.
 parts_needed:
   - part: layer-adapter-board-basically
     qty: 1
@@ -17,11 +21,6 @@ parts_needed:
   - part: scr-m3-6-bhcs
     qty: 4
 ---
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=chute-pcb">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
-</div>
 
 Each layer carries one basically Layer Adapter Board, the in-house board that breaks out the control board's ribbon connectors for that distribution layer and drives the layer's servo. One per layer.
 

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -8,11 +8,63 @@ kicker: Feeder — C-Channel
 lede: The C-channel stage itself.
 permalink: /hardware/assembly/feeder/c-channel/
 author: spencer
+contributors: [barthel]
 ---
 
-_Content pending._
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=c-channel">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
+</div>
+
+A C-channel is one drive unit: a stator, the NEMA bracket bolted under it, a gear train, and a NEMA 17 stepper. **Build 4 per machine**, three in the feeder and one for the classification channel.
+
+**Parts, per C-channel:**
+
+| Part | Qty |
+|---|---|
+| Stator | 1 |
+| NEMA bracket | 1 |
+| Output gear (130T) | 1, with a 6806-2RS bearing pressed in |
+| Idler gear (24T) | 1, with a 608-2RS bearing pressed in |
+| Input gear (12T, screw) | 1 |
+| NEMA 17 stepper motor | 1 |
+| M3 × 12 mm countersunk | 4 |
+| M3 × 16 mm socket head | 3 |
+| M3 × 8 mm countersunk | 5 |
+
+The rotor is **not** part of this unit, because it differs by where the C-channel goes: the three feeder channels take a faceted rotor, the classification channel takes the finned one. Colour differs too, the feeder parts are charcoal and the classification-channel parts are ash grey.
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Press the gear bearings" %}
+
+Press a 6806-2RS bearing into the Output gear (130T) and a 608-2RS bearing into the Idler gear (24T). Both are press fits, no screws and no adhesive.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Bolt the NEMA bracket to the stator" %}
+
+Fasten the NEMA bracket to the underside of the stator with 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws.
+
+{% include step.html n="3" title="Mount the stepper" %}
+
+Fasten the NEMA 17 to the NEMA bracket with 3 {% include fastener.html size="M3" variant="socket" length="16" %} screws. Three, not four: one corner of the motor face is left free.
+
+Fit the Input gear (12T, screw) onto the motor shaft. It has a vertical screw hole for the grub screw that clamps it to the flat of the shaft.
+
+{% include step.html n="4" title="Fit the gear train and the output gear" %}
+
+Set the Idler gear (24T) between the input gear and the output gear, then attach the Output gear (130T) to the rotor with 5 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws.
+
+Turn the stage by hand before wiring it. The train should run without a tight spot anywhere in a full revolution.
+
+{% include step.html n="5" title="Fit the light post, on the channels that take one" %}
+
+Two of the C-channels carry a light post, which bolts to this unit's NEMA bracket with 2 {% include fastener.html size="M3" variant="countersunk" length="20" %} screws that thread straight into the printed post. Those screws belong to the light post, not to the parts list above.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p><b>The C-channel COB light boards need a current-limiting resistor.</b> <b>220&#8486;, 1/4 W, in series, one per board.</b> Wired straight to 24V a 50 mm COB plate pulls about 0.5A and melts its printed mount. A board fed from a basically board v1.3 LED header already has one on the board. Full detail: <a href="{{ '/hardware/electronics/#43--leds-from-basically-board-v13' | relative_url }}">LEDs, on the wire harness page</a>.</p>
 </div>
+
+Once all four are built, see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for how they sit together.

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -9,6 +9,29 @@ lede: The C-channel stage itself.
 permalink: /hardware/assembly/feeder/c-channel/
 author: spencer
 contributors: [barthel]
+parts_needed:
+  - part: stator
+    qty: 1
+  - part: nema-bracket
+    qty: 1
+  - part: output-gear
+    qty: 1
+  - part: idler-gear
+    qty: 1
+  - part: input-gear
+    qty: 1
+  - part: motor-nema17
+    qty: 1
+  - part: brg-6806-2rs
+    qty: 1
+  - part: brg-608-2rs
+    qty: 1
+  - part: scr-m3-12-cs
+    qty: 4
+  - part: scr-m3-16-shcs
+    qty: 3
+  - part: scr-m3-8-cs
+    qty: 5
 ---
 
 <div class="callout callout-warning">
@@ -16,25 +39,16 @@ contributors: [barthel]
   <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=c-channel">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
 </div>
 
-A C-channel is one drive unit: a stator, the NEMA bracket bolted under it, a gear train, and a NEMA 17 stepper. **Build 4 per machine**, three in the feeder and one for the classification channel.
+A C-channel is one drive unit: a stator, the NEMA bracket bolted under it, a gear train, and a NEMA 17 stepper.
 
-**Parts, per C-channel:**
-
-| Part | Qty |
-|---|---|
-| Stator | 1 |
-| NEMA bracket | 1 |
-| Output gear (130T) | 1, with a 6806-2RS bearing pressed in |
-| Idler gear (24T) | 1, with a 608-2RS bearing pressed in |
-| Input gear (12T, screw) | 1 |
-| NEMA 17 stepper motor | 1 |
-| M3 × 12 mm countersunk | 4 |
-| M3 × 16 mm socket head | 3 |
-| M3 × 8 mm countersunk | 5 |
-
-The rotor is **not** part of this unit, because it differs by where the C-channel goes: the three feeder channels take a faceted rotor, the classification channel takes the finned one. Colour differs too, the feeder parts are charcoal and the classification-channel parts are ash grey.
+The fasteners and quantities are in the parts list above and are called out inline at each step.
 
 {% include fastener-legend.html %}
+
+- **Build 4 per machine**, three in the feeder and one for the classification channel.
+- The rotor is **not** part of this unit, because it differs by where the C-channel goes: the three feeder channels take the faceted rotor, the classification channel takes the finned one. Colour differs too, the feeder parts are charcoal and the classification-channel parts are ash grey.
+- No heat inserts on this assembly. The screws thread into the printed parts and into the stepper's own tapped holes.
+- Two of the four channels also carry a light post, whose screws belong to the light post rather than to the list above.
 
 {% include step.html n="1" title="Press the gear bearings" %}
 
@@ -60,7 +74,7 @@ Turn the stage by hand before wiring it. The train should run without a tight sp
 
 {% include step.html n="5" title="Fit the light post, on the channels that take one" %}
 
-Two of the C-channels carry a light post, which bolts to this unit's NEMA bracket with 2 {% include fastener.html size="M3" variant="countersunk" length="20" %} screws that thread straight into the printed post. Those screws belong to the light post, not to the parts list above.
+Two of the C-channels carry a light post, which bolts to this unit's NEMA bracket with 2 {% include fastener.html size="M3" variant="countersunk" length="20" %} screws that thread straight into the printed post.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -9,6 +9,10 @@ lede: The C-channel stage itself.
 permalink: /hardware/assembly/feeder/c-channel/
 author: spencer
 contributors: [barthel]
+warning: >-
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=c-channel), not from
+  an actual build. No step here has been checked against a machine. Correct it as you build.
 parts_needed:
   - part: stator
     qty: 1
@@ -33,11 +37,6 @@ parts_needed:
   - part: scr-m3-8-cs
     qty: 5
 ---
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>AI-generated first draft.</strong> Written from the machine assembly tree in the <a href="https://parts-calculator.basically.website/assembly?focus=c-channel">parts calculator</a>, not from an actual build. No step here has been checked against a machine. Correct it as you build.</p>
-</div>
 
 A C-channel is one drive unit: a stator, the NEMA bracket bolted under it, a gear train, and a NEMA 17 stepper.
 

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -1,13 +1,43 @@
 ---
 layout: default
 title: Classification chamber
-type: landing
+type: how-to
 section: hardware
 slug: assembly-classification-chamber
 kicker: Feeder — Classification chamber
 lede: Where parts are imaged for classification.
 permalink: /hardware/assembly/feeder/classification-chamber/
 author: spencer
+contributors: [barthel]
 ---
 
-_Content pending._
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>AI-generated first draft.</strong> Written from the parts registry in the <a href="https://parts-calculator.basically.website/assembly?focus=classification-chamber">parts calculator</a>, not from an actual build. The assembly order is not recorded anywhere yet, so this page lists what the chamber is made of rather than how it goes together. Correct it as you build.</p>
+</div>
+
+The classification chamber is where a part is lit and photographed on its way through. It sits on the fourth [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), the classification-channel one, and its printed parts are white rather than charcoal, so they bounce light onto the part instead of absorbing it.
+
+**Parts, one machine's worth:**
+
+| Part | Qty | Notes |
+|---|---|---|
+| Classification dome | 1 | Large, roughly a full print bed. White |
+| Rotor (finned) | 1 | White. The classification channel's rotor, in place of the feeder's faceted one |
+| Camera and LED insert | 1 | White. Carries the camera and the light |
+
+The camera itself is on its own extension: a 50 mm extension tube and a clamp ring hold the 4K camera module, one per machine. The overhead camera mount that hangs off the C-channels is a different part.
+
+{% include step.html n="1" title="Build the classification C-channel" %}
+
+Build the classification channel as a normal [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), but with the finned rotor rather than a faceted one, and in ash grey rather than charcoal.
+
+{% include step.html n="2" title="Fit the insert, the camera and the dome" %}
+
+Fit the camera and LED insert, then the camera on its extension tube and mount ring, then close the chamber with the dome.
+
+The fasteners for this stage are not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
+
+The chamber is lit by a 24 V white/daylight LED strip, not by the 50 mm COB plate the feeder light posts use. Even, passive light is the point: the camera has to expose every part of the disc the same way. See [electronics]({{ '/hardware/electronics/' | relative_url }}) for how it is driven and for the current-limiting resistor.

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -9,6 +9,19 @@ lede: Where parts are imaged for classification.
 permalink: /hardware/assembly/feeder/classification-chamber/
 author: spencer
 contributors: [barthel]
+parts_needed:
+  - part: classification-dome
+    qty: 1
+  - part: rotor-finned
+    qty: 1
+  - part: camera-led-insert
+    qty: 1
+  - part: camera-extension
+    qty: 1
+  - part: camera-extension-mount
+    qty: 1
+  - part: cam-imx415
+    qty: 1
 ---
 
 <div class="callout callout-warning">
@@ -16,17 +29,16 @@ contributors: [barthel]
   <p><strong>AI-generated first draft.</strong> Written from the parts registry in the <a href="https://parts-calculator.basically.website/assembly?focus=classification-chamber">parts calculator</a>, not from an actual build. The assembly order is not recorded anywhere yet, so this page lists what the chamber is made of rather than how it goes together. Correct it as you build.</p>
 </div>
 
-The classification chamber is where a part is lit and photographed on its way through. It sits on the fourth [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), the classification-channel one, and its printed parts are white rather than charcoal, so they bounce light onto the part instead of absorbing it.
+The classification chamber is where a part is lit and photographed on its way through. It sits on the fourth [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), the classification-channel one.
 
-**Parts, one machine's worth:**
+The parts are in the list above. No fasteners are recorded for this stage yet.
 
-| Part | Qty | Notes |
-|---|---|---|
-| Classification dome | 1 | Large, roughly a full print bed. White |
-| Rotor (finned) | 1 | White. The classification channel's rotor, in place of the feeder's faceted one |
-| Camera and LED insert | 1 | White. Carries the camera and the light |
+{% include fastener-legend.html %}
 
-The camera itself is on its own extension: a 50 mm extension tube and a clamp ring hold the 4K camera module, one per machine. The overhead camera mount that hangs off the C-channels is a different part.
+- **One per machine.**
+- The three chamber parts print **white** rather than charcoal, so the chamber bounces light onto the part instead of absorbing it.
+- The Classification dome is large, roughly a full print bed.
+- The camera sits on its own extension: a 50 mm extension tube and a clamp ring hold the 4K camera module. The overhead camera mount that hangs off the C-channels is a different part.
 
 {% include step.html n="1" title="Build the classification C-channel" %}
 
@@ -34,10 +46,12 @@ Build the classification channel as a normal [C-channel]({{ '/hardware/assembly/
 
 {% include step.html n="2" title="Fit the insert, the camera and the dome" %}
 
-Fit the camera and LED insert, then the camera on its extension tube and mount ring, then close the chamber with the dome.
+Fit the Camera & LED insert, then the camera on its extension tube and mount ring, then close the chamber with the dome.
 
 The fasteners for this stage are not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
 
 <div class="img-placeholder">Image coming</div>
+
+{% include step.html n="3" title="Light the chamber" %}
 
 The chamber is lit by a 24 V white/daylight LED strip, not by the 50 mm COB plate the feeder light posts use. Even, passive light is the point: the camera has to expose every part of the disc the same way. See [electronics]({{ '/hardware/electronics/' | relative_url }}) for how it is driven and for the current-limiting resistor.

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -9,6 +9,11 @@ lede: Where parts are imaged for classification.
 permalink: /hardware/assembly/feeder/classification-chamber/
 author: spencer
 contributors: [barthel]
+warning: >-
+  **AI-generated first draft.** Written from the parts registry in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=classification-chamber),
+  not from an actual build. The assembly order is not recorded anywhere yet, so this page
+  lists what the chamber is made of rather than how it goes together. Correct it as you build.
 parts_needed:
   - part: classification-dome
     qty: 1
@@ -23,11 +28,6 @@ parts_needed:
   - part: cam-imx415
     qty: 1
 ---
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>AI-generated first draft.</strong> Written from the parts registry in the <a href="https://parts-calculator.basically.website/assembly?focus=classification-chamber">parts calculator</a>, not from an actual build. The assembly order is not recorded anywhere yet, so this page lists what the chamber is made of rather than how it goes together. Correct it as you build.</p>
-</div>
 
 The classification chamber is where a part is lit and photographed on its way through. It sits on the fourth [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), the classification-channel one.
 

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -281,6 +281,9 @@ export type Page = {
 	contributors?: ResolvedPerson[];
 	parts?: { groups: PartsGroup[]; notes: ResolvedPart[] };
 	tools?: string[];
+	/** Rendered `warning:` front matter, shown above the parts block so a caveat
+	 *  about the whole page is read before its contents. */
+	warning?: string;
 	ogImage?: string;
 };
 
@@ -347,6 +350,10 @@ export async function getPage(pathParam: string): Promise<Page | null> {
 	);
 	if (fm.parts_needed) page.parts = resolveParts(fm.parts_needed);
 	if (fm.tools_needed) page.tools = fm.tools_needed;
+	if (fm.warning) {
+		const warned = await liquid.parseAndRender(String(fm.warning), { site, page: { ...fm, url } });
+		page.warning = String(await markdown.process(warned));
+	}
 
 	const img = html.match(/<img[^>]*src="([^"]+)"/);
 	if (img) page.ogImage = img[1].startsWith('http') ? img[1] : site.url + img[1];

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -397,3 +397,172 @@ washer-m3-15:
   category: Washers
   image: https://img.basically.website/web/parts/hardware/washers/washer-m3-15.0308d4e5b19bb5e4.jpg
   not_in_calc: true
+
+# --- Chute (per distribution layer) ---
+
+chute-core:
+  name: Chute core
+  category: Printed parts
+  image: https://img.basically.website/web/parts/chute-core.6528cf58bca4dd42.png
+  heat_inserts:
+    - insert: m3-ruthex-long
+      qty: 18
+
+chute-door:
+  name: Chute door
+  category: Printed parts
+  image: https://img.basically.website/web/parts/chute-door.b7a2393df1326488.png
+
+funnel-bracket-left:
+  name: Funnel bracket (left)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/funnel-bracket-left.be239d2c8847ae18.png
+
+funnel-bracket-right:
+  name: Funnel bracket (right)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/funnel-bracket-right.4e570798cac70277.png
+
+funnel-half:
+  name: Funnel (half size)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/funnel-half.ab98cf9404cbd671.png
+  caption: For a layer of 12 half bins.
+
+funnel-third:
+  name: Funnel (third size)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/funnel-third.da78903c014558d7.png
+  caption: For a layer of 18 third bins.
+
+layer-connector-1:
+  name: Layer connector A
+  category: Printed parts
+  image: https://img.basically.website/web/parts/layer-connector-1.28b737ed089139ae.png
+
+layer-connector-2:
+  name: Layer connector B
+  category: Printed parts
+  image: https://img.basically.website/web/parts/layer-connector-2.ca61a28acae60a8f.png
+
+servo-bracket-housing:
+  name: Servo bracket (housing)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/servo-bracket-housing.4243eb15a96c647b.png
+  heat_inserts:
+    - insert: m3-ruthex-long
+      qty: 6
+
+servo-bracket-lower-arm:
+  name: Servo bracket (lower arm)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/servo-bracket-lower-arm.310718b45e12c6f8.png
+
+servo-bracket-side-arm:
+  name: Servo bracket (side arm)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/servo-bracket-side-arm.055da0e4076d450a.png
+
+servo-bracket-cover:
+  name: Servo bracket (cover)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/servo-bracket-cover.e87993d672aefbd3.png
+
+# --- Feeder: C-channel and classification chamber ---
+
+stator:
+  name: Stator
+  category: Printed parts
+  image: https://img.basically.website/web/parts/stator.17bc4dcb603a3b87.png
+
+nema-bracket:
+  name: NEMA bracket
+  category: Printed parts
+  image: https://img.basically.website/web/parts/nema-bracket.3b2938ece10d01a2.png
+
+output-gear:
+  name: Output gear (130T)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/output-gear.52becc7a3135a501.png
+
+idler-gear:
+  name: Idler gear (24T)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/idler-gear.4fde9b2daa3a18a6.png
+
+input-gear:
+  name: Input gear (12T, screw)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/input-gear.4e9611093bce0c25.png
+
+rotor-faceted:
+  name: Rotor (faceted)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/rotor-faceted.e5a96a41bf032410.png
+  caption: The feeder channels' rotor.
+
+rotor-finned:
+  name: Rotor (finned)
+  category: Printed parts
+  image: https://img.basically.website/web/parts/rotor-finned.b8b8baef2b3d6e46.png
+  caption: The classification channel's rotor. Printed white.
+
+classification-dome:
+  name: Classification dome
+  category: Printed parts
+  image: https://img.basically.website/web/parts/classification-dome.6f6be14db10079b5.png
+  caption: Roughly a full print bed. Printed white.
+
+camera-led-insert:
+  name: Camera & LED insert
+  category: Printed parts
+  image: https://img.basically.website/web/parts/camera-led-insert.f2c6d2f256bbadbf.png
+  caption: Printed white.
+
+camera-extension:
+  name: Camera extension
+  category: Printed parts
+  image: https://img.basically.website/web/parts/camera-extension.b68be261bb4feb13.png
+  caption: 50 mm extension tube for the 4K camera module.
+
+camera-extension-mount:
+  name: Camera extension mount
+  category: Printed parts
+  image: https://img.basically.website/web/parts/camera-extension-mount.e19883debdbe1818.png
+
+# --- Chute and feeder hardware ---
+
+servo-mg995:
+  name: MG995 servo
+  category: Motors
+  image: https://img.basically.website/web/parts/hardware/motors/servo-mg995.dc4efa0fab427440.jpg
+
+motor-nema17:
+  name: NEMA 17 stepper motor
+  category: Motors
+  image: https://img.basically.website/web/parts/hardware/motors/motor-nema17.c23957d721c4fe3a.jpg
+
+brg-6806-2rs:
+  name: 6806-2RS bearing
+  category: Bearings
+  image: https://img.basically.website/web/parts/hardware/bearings/brg-6806-2rs.0ad458391ad1d0eb.jpg
+
+cam-imx415:
+  name: IMX415 4K camera module
+  category: Electronics
+  image: https://img.basically.website/web/parts/hardware/cameras/cam-imx415.ccca3eafc3ef8069.jpg
+
+layer-adapter-board-basically:
+  name: basically Layer Adapter Board
+  category: Electronics
+  image: https://img.basically.website/web/parts/hardware/pcbs/layer-adapter-board-basically.74d26e5babb055d6.jpg
+
+scr-m3-6-bhcs:
+  name: M3 × 6 mm button head cap screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/button.87be93e901c86545.jpg
+
+scr-m3-20-cs:
+  name: M3 × 20 mm countersunk screw
+  category: Screws
+  image: https://img.basically.website/web/parts/hardware/screws/countersunk.707eba7998554ea6.jpg

--- a/docs/src/routes/[...path]/+page.svelte
+++ b/docs/src/routes/[...path]/+page.svelte
@@ -169,6 +169,15 @@
 	</div>
 {/if}
 
+<!-- A caveat about the whole page (frontmatter `warning:`) goes above the parts
+     block, so it is read before the contents rather than after them. -->
+{#if p.warning}
+	<div class="callout callout-warning page-warning">
+		<span class="callout-icon" aria-hidden="true">⚠</span>
+		<div class="page-warning-body">{@html p.warning}</div>
+	</div>
+{/if}
+
 <Requirements parts={p.parts} tools={p.tools} />
 
 <div class="md-content" bind:this={contentEl}>

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -832,6 +832,15 @@ body {
 	margin: 0;
 }
 
+.page-warning {
+	margin-top: 1.6rem;
+}
+
+/* Multi-paragraph warnings keep the callout's tight paragraph spacing. */
+.page-warning-body p + p {
+	margin-top: 0.5rem;
+}
+
 .callout-warning {
 	border-color: color-mix(in srgb, var(--color-warning) 40%, transparent);
 	background: color-mix(in srgb, var(--color-warning) 6%, var(--surface));

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1089,6 +1089,7 @@ li {
 
 .md-content a,
 .lede a,
+.page-warning-body a,
 .page-meta a {
 	color: var(--primary);
 	text-decoration: underline;
@@ -1098,6 +1099,7 @@ li {
 
 .md-content a:hover,
 .lede a:hover,
+.page-warning-body a:hover,
 .page-meta a:hover {
 	color: var(--primary-hover);
 }


### PR DESCRIPTION
Seven hardware assembly pages were `_Content pending_` stubs. This fills each of them with a first draft built from the machine assembly tree and parts registry that back [parts-calculator.basically.website/assembly](https://parts-calculator.basically.website/assembly):

- Chute core
- PCB
- Layer connectors
- Servo mount
- Funnel
- C-Channel (the existing COB resistor callout is kept)
- Classification chamber

Every page opens with a warning callout saying it is AI-generated, derived from the parts calculator rather than from a build, and unverified. Where the calculator does not record which fastener goes in which hole, the page says so with the existing `fastener-todo` span instead of guessing.

**Follow-up, at barthel's request:** every page now uses the layout, formatting and style of the [Top interface](https://docs.basically.website/hardware/assembly/distribution/top-interface/) page. A `parts_needed` block in the front matter renders the Parts needed cards, then the standing fasteners line, the fastener legend, the key facts as bullets, then numbered steps, starting with Preparation on the assemblies that take heat inserts. The markdown tables the drafts used for sub-assemblies and part lists are gone.

That needed the catalog filled in: 30 chute and feeder parts were added to `src/liquid/_data/parts.yml`, with the parts-calculator renders and hardware photos uploaded to the docs bucket. `chute-core` (18 × M3) and `servo-bracket-housing` (6 × M3) carry `heat_inserts`, so they also show up on the [Preparation](https://docs.basically.website/hardware/preparation/) page.

**Warning above the parts, at barthel's request:** the Parts needed block is rendered by the page template, before the markdown body, so a callout written into the body always landed underneath it. This adds a `warning:` front matter field, rendered through the same liquid and markdown pipeline and shown as the usual warning callout directly above the parts; the seven AI-draft notices now live there. Any page can use it for a caveat that applies to the whole page.

Authors are unchanged (these are existing pages), with barthel added as a contributor.

A companion PR on `parts-calculator` corrects three descriptions that disagree with the docs and links each assembly node to its page here.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539873564612759562): "Please take a look at the brief assembly instructions at https://parts-calculator.basically.website/assembly. Is there already an assembly description for the component group or component at https://docs.basically.website/hardware/? If so, review and, if necessary, adjust the text in the short assembly instruction in the part calculator so that it matches the assembly description in the assembly documentation, and add a link to this assembly description. If there is no assembly description in the assembly documentation yet, or if there is an empty assembly description or one marked "Content pending" or similar, use the short assembly instruction from part calculator to create a first draft of a assembly description in the assembly documentation. Mark this assembly description right at the top with a warning note indicating that it was generated by AI."

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1539873564612759562/1539885048818442290
request: https://discord.com/channels/1430279849171222682/1539873564612759562/1539879390106619974
preview: /hardware/assembly/distribution/chute/chute-core/
-->



Layout follow-up requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1539873564612759562/1539879390106619974): "Please use the page layout, formatting, and style of the Top Interface page."

Warning placement requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1539873564612759562/1539885048818442290): "Move the warning note before the needed parts."
