### PR TITLE
hive: cap the backend's memory so a leak can't swap-thrash the box

### DIFF
--- a/software/hive/docker-compose.prod.yml
+++ b/software/hive/docker-compose.prod.yml
@@ -55,6 +55,19 @@ services:
       postgres:
         condition: service_healthy
     environment:
+      # Half the resident set is glibc, not Python. This process runs ~15
+      # threads (uvicorn plus five background daemons and the teacher pool) on a
+      # 2-core box, and glibc lets a threaded program open 8 arenas per core, so
+      # it had spread 625 MB across 14 per-thread arenas — memory Python has
+      # already freed but glibc will not hand back, because a single live
+      # allocation anywhere in a 64 MB arena pins the whole arena.
+      #
+      # Two arenas means allocation contends a little and stays compact instead.
+      # Measured on prod 2026-08-20: 14 arenas, 625 MB of a 1288 MB anon total.
+      # This bounds fragmentation, which is not the same thing as fixing the
+      # leak — whatever keeps allocating is still doing it. Expect a lower
+      # floor and a slower climb, not a flat line.
+      MALLOC_ARENA_MAX: "2"
       ENVIRONMENT: ${ENVIRONMENT}
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}

--- a/software/hive/docker-compose.prod.yml
+++ b/software/hive/docker-compose.prod.yml
@@ -30,6 +30,27 @@ services:
     image: ${HIVE_BACKEND_IMAGE:?HIVE_BACKEND_IMAGE not set - deploy via hive_release_agent.py}
     container_name: hive-backend
     restart: unless-stopped
+    # This process leaks. On 2026-08-20 it reached 2.2 GB, pushed the 3.9 GB box
+    # 2 GB into swap, and served 502/524s for six hours until someone restarted
+    # it by hand. Nothing self-healed because the healthcheck answered normally
+    # the entire time — a thrashing process is still a live one, so there was no
+    # unhealthy state for Docker to act on. The ceiling is the backstop.
+    #
+    # memswap_limit is the half that actually matters, and it only works pinned
+    # to the same value as mem_limit (that is how Docker spells "no swap for
+    # this container"). Swapping IS the failure: with swap available the kernel
+    # never kills anything, it just slows the whole box down, which is how one
+    # leaking service took Postgres and the frontend with it. Denied swap, the
+    # container is OOM-killed at the ceiling and `restart: unless-stopped`
+    # brings it back in seconds.
+    #
+    # 1800m is ~40% above the ~1.3 GB this settles at once its caches and the
+    # onnxruntime arenas fill, so ordinary bursts don't trip it and a recycle
+    # lands roughly every day and a half at the observed leak rate. Override
+    # HIVE_BACKEND_MEM_LIMIT in .env.prod if real work needs more headroom; that
+    # is a container recreate, not a release.
+    mem_limit: ${HIVE_BACKEND_MEM_LIMIT:-1800m}
+    memswap_limit: ${HIVE_BACKEND_MEM_LIMIT:-1800m}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## What happened

On 2026-08-20 `hive-backend` grew to 2.2 GB over ~3 days on a 3.9 GB box, pushed it 2 GB into swap, and served 502/524s for roughly six hours (peak ~60 errors/hour, 08:00–14:00 UTC). A manual `docker restart` fixed it instantly.

Nothing self-healed, and that is the part worth fixing. The container healthcheck answered normally the entire time — a thrashing process is still a live one — so Docker never saw an unhealthy container to act on. There was no ceiling anywhere: `docker inspect` showed `Memory=0`.

## The fix

A memory ceiling on the backend service, with swap denied.

`mem_limit` on its own would not have prevented this. With swap available the kernel never kills the offender, it just slows the whole box down, which is exactly how one leaking service took Postgres and the frontend with it. `memswap_limit` pinned to the same value is how Docker spells "no swap for this container" (on cgroup v2 it sets `memory.swap.max=0`), so the container is OOM-killed at the ceiling and the existing `restart: unless-stopped` brings it back in seconds. A few seconds of dropped requests every day or so beats six hours of 502s.

## Why 1800m

Measured on prod rather than guessed. After a restart the process ramps fast for ~10 minutes and then plateaus, oscillating between 1.21 and 1.30 GB of anon memory as its caches and the onnxruntime arenas fill:

```
15:24 anon=1188 MB    15:27 anon=1290 MB
15:25 anon=1251 MB    15:28 anon=1213 MB
15:26 anon=1302 MB    15:29 anon=1283 MB
```

1800m sits ~40% above that plateau, so ordinary bursts do not trip it, and at the observed leak rate (~300 MB/day) a recycle lands roughly every day and a half. It is also low enough to leave room for Postgres — including its 1 GB `shm_size` — on a 3.9 GB box.

`HIVE_BACKEND_MEM_LIMIT` in `.env.prod` overrides it if real work turns out to need more headroom, which is a container recreate rather than a release.

## Already live

The same limit is applied to the running container via `docker update` (no restart, `RestartCount` still 0, health still green), so prod is protected now rather than at the next deploy. This PR is what makes it survive a redeploy.

## What this is not

This is a backstop, not the fix — the leak is still there. Notes on where it likely lives, and on why `gunicorn --max-requests` is **not** a safe swap-in for this service, are in the review comments.