### PR TITLE
hive: keep one loaded model per predictor, not every one ever seen

### DIFF
--- a/software/hive/backend/app/services/color_predictor.py
+++ b/software/hive/backend/app/services/color_predictor.py
@@ -57,7 +57,14 @@ class _Loaded:
 
 
 _lock = threading.Lock()
-_session_cache: dict[tuple[str, str], _Loaded] = {}
+# Exactly one color model is active at a time — set_active() enforces it — so one
+# slot is all this ever needs. It used to be a dict keyed by (filename, sha256)
+# with no eviction, which meant every model version ever activated kept its ONNX
+# session resident for the life of the process. Replacing the slot drops the
+# previous session; an in-flight predict() holds its own reference and finishes
+# on the model it started with.
+_loaded_key: tuple[str, str] | None = None
+_loaded_model: _Loaded | None = None
 
 
 def _sha256_of(path: Path) -> str:
@@ -185,14 +192,14 @@ def set_active(db: Session, model_id, active: bool) -> ColorModel | None:
 
 
 def _load(row: ColorModel) -> _Loaded | None:
+    global _loaded_key, _loaded_model
     path = model_dir() / row.filename
     if not path.exists():
         return None
     key = (row.filename, row.sha256)
     with _lock:
-        cached = _session_cache.get(key)
-        if cached is not None:
-            return cached
+        if key == _loaded_key and _loaded_model is not None:
+            return _loaded_model
     meta = _read_metadata(path)
     if meta is None:
         return None
@@ -220,7 +227,8 @@ def _load(row: ColorModel) -> _Loaded | None:
         multiview=meta.get("hive.multiview") == "1",
     )
     with _lock:
-        _session_cache[key] = loaded
+        _loaded_key = key
+        _loaded_model = loaded
     return loaded
 
 
@@ -362,8 +370,3 @@ def predict_bytes(db: Session, images: list[bytes], channels: list[int]) -> dict
         "top": [e for i in order[:3] if (e := entry(int(i))) is not None],
         "sample_count": len(batch),
     }
-
-
-def clear_cache() -> None:
-    with _lock:
-        _session_cache.clear()

--- a/software/hive/backend/app/services/link_predictor.py
+++ b/software/hive/backend/app/services/link_predictor.py
@@ -61,7 +61,14 @@ class _Loaded:
 
 
 _lock = threading.Lock()
-_session_cache: dict[tuple[str, str], _Loaded] = {}
+# Exactly one link model is active at a time — set_active() enforces it — so one
+# slot is all this ever needs. It used to be a dict keyed by (name, sha256) with
+# no eviction, which meant every model version ever activated kept its two ONNX
+# sessions resident for the life of the process. Replacing the slot drops the
+# previous sessions; an in-flight predict() holds its own reference and finishes
+# on the model it started with.
+_loaded_key: tuple[str, str] | None = None
+_loaded_model: _Loaded | None = None
 
 
 def _sha256_of(path: Path) -> str:
@@ -210,6 +217,7 @@ def set_active(db: Session, model_id, active: bool) -> LinkModel | None:
 
 
 def _load(row: LinkModel) -> _Loaded | None:
+    global _loaded_key, _loaded_model
     directory = model_dir()
     enc_path = directory / row.encoder_filename
     head_path = directory / row.head_filename
@@ -217,9 +225,8 @@ def _load(row: LinkModel) -> _Loaded | None:
         return None
     key = (row.name, row.sha256)
     with _lock:
-        cached = _session_cache.get(key)
-        if cached is not None:
-            return cached
+        if key == _loaded_key and _loaded_model is not None:
+            return _loaded_model
     if row.input_size <= 0:
         log.warning("link model %s has no usable input_size", row.name)
         return None
@@ -238,7 +245,8 @@ def _load(row: LinkModel) -> _Loaded | None:
         input_size=row.input_size,
     )
     with _lock:
-        _session_cache[key] = loaded
+        _loaded_key = key
+        _loaded_model = loaded
     return loaded
 
 
@@ -375,8 +383,3 @@ def predict(db: Session, machine_id: UUID, piece_uuid: str, candidates: list[dic
         "threshold": PREDICT_THRESHOLD,
         "scores": {lid: float(p) for lid, p in zip(scored_ids, probs)},
     }
-
-
-def clear_cache() -> None:
-    with _lock:
-        _session_cache.clear()

--- a/software/hive/backend/tests/test_model_session_cache.py
+++ b/software/hive/backend/tests/test_model_session_cache.py
@@ -1,0 +1,104 @@
+"""Both predictors keep exactly one loaded model, not every one they have seen.
+
+Regression cover for the leak found on 2026-08-20: `_load` cached into a dict
+keyed by (name/filename, sha256) with no eviction, so every model version ever
+activated kept its ONNX session — two, for link models — resident for the life
+of the process. Only one model is ever active, so one slot is all there is.
+
+Sessions are stubbed. A real graph would need the `onnx` package to build (see
+test_color_predict.py), and none of this is about inference anyway.
+"""
+
+from __future__ import annotations
+
+import gc
+import types
+import weakref
+
+
+class _FakeSession:
+    """Stands in for ort.InferenceSession, and counts how many were built."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_inputs(self):
+        return [types.SimpleNamespace(name="input")]
+
+    def get_outputs(self):
+        return [types.SimpleNamespace(name="output")]
+
+
+def _counting_session(made: list):
+    class Counting(_FakeSession):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            made.append(1)  # a count, not the object — a strong ref here would
+            # defeat the weakref check below
+
+    return Counting
+
+
+def test_color_predictor_keeps_only_the_active_model(tmp_path, monkeypatch):
+    from app.services import color_predictor as cp
+
+    (tmp_path / "colorpred.onnx").write_bytes(b"stub")
+    made: list = []
+    monkeypatch.setattr(cp, "model_dir", lambda: tmp_path)
+    monkeypatch.setattr(cp, "_read_metadata", lambda path: {"hive.classes": "[1, 2]", "hive.input_size": "64"})
+    monkeypatch.setattr(cp.ort, "InferenceSession", _counting_session(made))
+    monkeypatch.setattr(cp, "_loaded_key", None)
+    monkeypatch.setattr(cp, "_loaded_model", None)
+
+    v1 = types.SimpleNamespace(filename="colorpred.onnx", sha256="aaa")
+    v2 = types.SimpleNamespace(filename="colorpred.onnx", sha256="bbb")
+
+    first = cp._load(v1)
+    assert first is not None
+    assert cp._load(v1) is first, "same sha should hit the slot, not rebuild"
+    assert len(made) == 1
+
+    # The point of the fix: activating a new version must release the old
+    # session, not park it in a dict forever.
+    released = weakref.ref(first.session)
+    del first
+    second = cp._load(v2)
+    assert len(made) == 2
+    assert cp._loaded_key == ("colorpred.onnx", "bbb")
+    assert cp._loaded_model is second
+    gc.collect()
+    assert released() is None, "the superseded model's ONNX session is still resident"
+
+
+def test_link_predictor_keeps_only_the_active_model(tmp_path, monkeypatch):
+    from app.services import link_predictor as lp
+
+    (tmp_path / "enc.onnx").write_bytes(b"stub")
+    (tmp_path / "head.onnx").write_bytes(b"stub")
+    made: list = []
+    monkeypatch.setattr(lp, "model_dir", lambda: tmp_path)
+    monkeypatch.setattr(lp.ort, "InferenceSession", _counting_session(made))
+    monkeypatch.setattr(lp, "_loaded_key", None)
+    monkeypatch.setattr(lp, "_loaded_model", None)
+
+    def row(sha: str):
+        return types.SimpleNamespace(
+            name="link", sha256=sha, encoder_filename="enc.onnx", head_filename="head.onnx", input_size=64
+        )
+
+    v1, v2 = row("aaa"), row("bbb")
+
+    first = lp._load(v1)
+    assert first is not None
+    assert lp._load(v1) is first, "same sha should hit the slot, not rebuild"
+    assert len(made) == 2, "one encoder + one head"
+
+    # A link model is two sessions, so a leak here cost double.
+    released = [weakref.ref(first.encoder), weakref.ref(first.head)]
+    del first
+    second = lp._load(v2)
+    assert len(made) == 4
+    assert lp._loaded_key == ("link", "bbb")
+    assert lp._loaded_model is second
+    gc.collect()
+    assert [r() for r in released] == [None, None], "superseded encoder/head still resident"


### PR DESCRIPTION
Follow-up to #336, which capped `hive-backend`'s memory after it took hive down for six hours on 2026-08-20. That was containment. This is one of the two bugs that PR listed as outstanding.

## The bug

`color_predictor.py` and `link_predictor.py` both cached loaded ONNX sessions in a module-level dict keyed by `(name/filename, sha256)`, with no eviction and no size bound:

```python
_session_cache: dict[tuple[str, str], _Loaded] = {}
```

`reconcile()` deletes the DB row when a model is replaced or disappears from disk, but never touched this dict. So every model version ever activated kept its session resident for the life of the process — two sessions, for link models, since those are an encoder/head pair. The bound was never the cache, it was how often anyone published a model.

`clear_cache()` existed in both files to release exactly this, and nothing has ever called it — not a router, not a worker, not a test.

## The fix

One slot instead of a dict, and `clear_cache()` deleted rather than wired up.

`set_active()` enforces a single active model globally, and `_load()` is only ever called with the result of `get_active()`. So the cache was only ever *asked* for one key at a time — the dict could hold many entries but only one was ever reachable. A single slot is all there was anything to hold, which makes this a simplification rather than an eviction policy bolted on.

Replacing the slot drops the previous sessions. An in-flight `predict()` holds its own reference and finishes on the model it started with.

## Tests

Two new tests stub `ort.InferenceSession` (a real graph would need the `onnx` package — see the note atop `test_color_predict.py`) and assert through a `weakref` that a superseded session is genuinely released, not merely dropped from the slot. Full suite: 279 passed.

## The second bug: measured, and NOT worth fixing

#336 flagged `enable_cpu_mem_arena` being left at its default `True` as the likely identity of the two large anonymous mappings on prod (254 MB + 125 MB). I benchmarked it inside the running prod container against the real active model before changing anything, and the premise does not hold:

| | retained after session freed | batch of 5 | batch of 8 |
|---|---|---|---|
| arena ON (current) | 11.4 MB | 7.5 ms | 11.2 ms |
| arena OFF | 12.5 MB | **12.6 ms** | 13.1 ms |

Disabling the arena returns **no** memory — slightly more is retained, because what is not returned is glibc holding it, not ORT — and costs up to 68% more latency on the batch sizes this service actually uses. These models are ~700 KB and the batches are capped at 5–8 crops, so the arena was never big enough to matter.

Turning it off for the throwaway `_read_metadata()` sessions is likewise pointless: ORT allocates the arena lazily on first `Run()`, and those sessions only read `custom_metadata_map` and are discarded. Measured identically (4.6 MB either way).

So the 254 MB and 125 MB mappings are something else, and I have not identified them yet. What is now ruled out: imports account for ~70 MB total (numpy 13, scipy 20, onnxruntime 6, sqlalchemy+boto3 26), the ONNX arenas are single-digit MB, the `channel-crop` hot path accumulates nothing, and every background worker closes its DB sessions. The next step is `tracemalloc` snapshots on a timer inside the app, which is a bigger change than this one and wants its own PR.

This PR removes a real unbounded structure. It is not expected to flatten the daily growth curve on its own.