### PR TITLE
hive: report allocator counters so the leak stops being a guess

### DIFF
--- a/software/hive/backend/app/services/server_health.py
+++ b/software/hive/backend/app/services/server_health.py
@@ -10,7 +10,10 @@ size and memory are cheap and read live.
 
 from __future__ import annotations
 
+import ctypes
 import logging
+import re
+import sys
 import threading
 import time
 from datetime import datetime, timezone
@@ -155,7 +158,71 @@ def _process_rss_bytes() -> int | None:
     return None
 
 
+_MALLOC_INFO_TOTALS = re.compile(r'<(total|system) type="([a-z]+)"[^>]*size="(\d+)"')
+
+
+def _glibc_malloc_stats() -> dict[str, int] | None:
+    """glibc's own allocator accounting, read out of malloc_info(3).
+
+    RSS cannot tell "this process is holding live objects" apart from "glibc is
+    sitting on memory Python already freed", and those two have opposite fixes:
+    one is an object leak to hunt, the other is fragmentation to trim.
+
+    Deliberately NOT mallinfo2, which is the obvious choice and is wrong here:
+    it reports the main arena only. Tested against this image it insisted 1.2 MB
+    was in use while 200 MB of live bytearrays sat in the process. A confidently
+    wrong number is worse than no number. malloc_info walks every arena, and the
+    same test tracked the 200 MB alloc and its release exactly.
+
+    Only the trailing summary is parsed; the per-heap detail above it is far more
+    XML than this is worth.
+    """
+    try:
+        libc = ctypes.CDLL("libc.so.6")
+        libc.open_memstream.restype = ctypes.c_void_p
+        libc.open_memstream.argtypes = [ctypes.POINTER(ctypes.c_char_p), ctypes.POINTER(ctypes.c_size_t)]
+        libc.malloc_info.argtypes = [ctypes.c_int, ctypes.c_void_p]
+        libc.fclose.argtypes = [ctypes.c_void_p]
+        libc.free.argtypes = [ctypes.c_void_p]
+    except (OSError, AttributeError):
+        return None
+
+    buf = ctypes.c_char_p()
+    size = ctypes.c_size_t()
+    stream = libc.open_memstream(ctypes.byref(buf), ctypes.byref(size))
+    if not stream:
+        return None
+    try:
+        libc.malloc_info(0, stream)
+        libc.fclose(stream)
+        xml = ctypes.string_at(buf, size.value).decode("ascii", "replace")
+    finally:
+        libc.free(buf)
+
+    tail = xml[xml.rfind("</heap>"):] if "</heap>" in xml else xml
+    found = {f"{kind}:{name}": int(value) for kind, name, value in _MALLOC_INFO_TOTALS.findall(tail)}
+    return {
+        # Memory glibc currently holds from the kernel for its arenas.
+        "arena_bytes": found.get("system:current", 0),
+        # Free space inside those arenas — glibc has it, Python does not want it.
+        "free_in_arena_bytes": found.get("total:rest", 0),
+        # Large blocks mmapped individually, returned to the kernel when freed.
+        "mmapped_bytes": found.get("total:mmap", 0),
+        "heap_count": xml.count("<heap "),
+    }
+
+
 def get_memory_stats() -> dict[str, Any]:
+    # Cheap enough to read on every request: one libc call and one interpreter
+    # counter, no allocation, no walking the heap.
+    process = {
+        "process_rss_bytes": _process_rss_bytes(),
+        # Blocks live in CPython's own allocator. If this climbs with RSS the
+        # leak is Python objects; if RSS climbs while this stays flat it is
+        # C-level (psycopg2 result buffers, boto3, onnxruntime) or glibc.
+        "python_allocated_blocks": sys.getallocatedblocks(),
+        "glibc": _glibc_malloc_stats(),
+    }
     try:
         info = _read_meminfo()
         total = info.get("MemTotal")
@@ -165,7 +232,7 @@ def get_memory_stats() -> dict[str, Any]:
             "total_bytes": total,
             "available_bytes": available,
             "used_bytes": used,
-            "process_rss_bytes": _process_rss_bytes(),
+            **process,
         }
     except (FileNotFoundError, ValueError):
         # Not on Linux (e.g. local Mac dev) — /proc isn't available.
@@ -173,7 +240,7 @@ def get_memory_stats() -> dict[str, Any]:
             "total_bytes": None,
             "available_bytes": None,
             "used_bytes": None,
-            "process_rss_bytes": _process_rss_bytes(),
+            **process,
         }
 
 

--- a/software/hive/backend/tests/test_memory_stats.py
+++ b/software/hive/backend/tests/test_memory_stats.py
@@ -1,0 +1,68 @@
+"""Allocator counters on the admin server-health payload.
+
+These exist to answer one question during a memory investigation: is the process
+holding live objects, or is glibc sitting on memory Python already freed? The
+counters are only useful if they move with reality, so that is what is asserted
+here rather than mere presence.
+
+glibc-specific numbers are absent off Linux (dev Macs), so those assertions are
+conditional. `python_allocated_blocks` works everywhere.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from app.services.server_health import _glibc_malloc_stats, get_memory_stats
+
+_ON_GLIBC = sys.platform.startswith("linux")
+
+
+def test_memory_stats_exposes_allocator_counters():
+    stats = get_memory_stats()
+    assert isinstance(stats["python_allocated_blocks"], int)
+    assert stats["python_allocated_blocks"] > 0
+    assert "glibc" in stats
+    assert "process_rss_bytes" in stats
+
+
+def test_python_allocated_blocks_tracks_live_objects():
+    before = get_memory_stats()["python_allocated_blocks"]
+    held = [object() for _ in range(50_000)]
+    during = get_memory_stats()["python_allocated_blocks"]
+    assert during > before, "allocating objects must raise the block count"
+    del held
+    after = get_memory_stats()["python_allocated_blocks"]
+    assert after < during, "releasing them must lower it again"
+
+
+def test_glibc_stats_track_large_allocations():
+    if not _ON_GLIBC:
+        return  # no libc.so.6 to read; the None path is covered below
+
+    stats = _glibc_malloc_stats()
+    assert stats is not None, "malloc_info should be readable on glibc"
+    baseline = stats["mmapped_bytes"]
+
+    # Big blocks bypass the arenas and are mmapped individually, which is the
+    # path mallinfo2 misses entirely — the reason this uses malloc_info.
+    held = [bytearray(1024 * 1024) for _ in range(64)]
+    during = _glibc_malloc_stats()
+    assert during is not None
+    assert during["mmapped_bytes"] > baseline + 32 * 1024 * 1024, (
+        "64 MB of live buffers should be visible in the allocator's own accounting"
+    )
+
+    del held
+    after = _glibc_malloc_stats()
+    assert after is not None
+    assert after["mmapped_bytes"] < during["mmapped_bytes"], "freed blocks should drop out"
+
+
+def test_glibc_stats_shape_is_stable():
+    stats = _glibc_malloc_stats()
+    if stats is None:
+        return  # not glibc
+    for key in ("arena_bytes", "free_in_arena_bytes", "mmapped_bytes", "heap_count"):
+        assert isinstance(stats[key], int), f"{key} must be an int"
+        assert stats[key] >= 0


### PR DESCRIPTION
Third PR in the 2026-08-20 memory work, after #336 (memory ceiling) and #337 (ONNX session cache). This one does not fix anything — it makes the next step possible.

## Why

Three theories about where `hive-backend`'s memory goes have now been wrong:

- the unbounded ONNX `_session_cache` — real bug, fixed in #337, not the growth
- `enable_cpu_mem_arena` — benchmarked, returns no memory and costs up to 68% latency
- OpenBLAS thread buffers — 4 MB, and `OPENBLAS_NUM_THREADS` changes nothing on 2 cores

All three were plausible from reading code. All three died on contact with a measurement. The reason they kept coming is that RSS was the only number anyone had, and **RSS cannot distinguish a live object from memory glibc is holding after Python freed it** — which matters because those have opposite fixes. One is an object leak to hunt with `tracemalloc`; the other is fragmentation, and the answer is `malloc_trim`.

## What

Two counters on the existing `GET /api/admin/server-health` payload, next to the `process_rss_bytes` it already returns:

- **`python_allocated_blocks`** — `sys.getallocatedblocks()`. Climbs with RSS → Python objects. Flat while RSS climbs → C-level (psycopg2 buffers, boto3, onnxruntime) or glibc retention.
- **`glibc`** — `arena_bytes`, `free_in_arena_bytes`, `mmapped_bytes`, `heap_count`. A large and growing `free_in_arena_bytes` is fragmentation, not a leak.

Both are O(1)-ish — one libc call and one interpreter counter, no heap walk — so they are read live rather than cached behind the storage worker.

## `malloc_info`, not `mallinfo2`

`mallinfo2` is the obvious call and it is wrong here. It reports the **main arena only**. Tested against this exact image it insisted 1.2 MB was in use while 200 MB of live `bytearray`s sat in the process:

```
mallinfo2   baseline: in_use=1.2MB  →  after allocating 200MB: in_use=1.2MB
malloc_info baseline: mmap=0.4MB    →  after allocating 200MB: mmap=201.2MB  →  after free: 0.4MB
```

A confidently wrong number is worse than no number, so the `mallinfo2` version was thrown away. `malloc_info(3)` walks every arena and tracked the allocation and its release exactly. Verified twice: in a scratch process, and with this implementation extracted verbatim from the source and run inside the **running prod container**, so the test cannot drift from what ships.

## Tests

Four new tests, asserting the counters actually move with reality rather than merely existing — allocating 50k objects raises the block count and dropping them lowers it; 64 MB of live buffers show up in the allocator's own accounting and disappear when freed. glibc assertions no-op off Linux for dev Macs. Full suite: 283 passed.

## Next

Poll this over a few hours of real traffic and the fork resolves itself. Note this needs elapsed time, not another read of the code — the growth is a slow multi-day climb that nothing reproduces on demand.