### PR TITLE
docs(top-interface): describe how the idler washer is installed

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -399,7 +399,9 @@ Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | rel
 
 Push a 608 2RS bearing into the Interface idler gear.
 
-Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards and secure it with an {% include fastener.html size="M3" variant="socket-button" length="35" %} screw and an M3 × 15 mm washer.
+Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards.
+
+Slide an M3 × 15 mm washer onto an {% include fastener.html size="M3" variant="socket-button" length="35" %} screw, then drive that screw through the bearing and into the bracket. The washer sits between the screw head and the outer face of the bearing, spanning its 8 mm bore: the screw head on its own is narrower than the bore and drops down inside it, so the washer is what actually holds the idler gear onto the bracket. Tighten until the washer is seated, then check that the idler gear still spins freely.
 
 Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four {% include fastener.html size="M5" variant="socket-button" length="12" %} screws.
 


### PR DESCRIPTION
Step 9, "Install the chute stepper motor", listed the M3 × 15 mm washer in the fastener call-out but never said where it goes, so it read as an optional extra. Today in #machine-setup-help someone got to that joint, asked "do I need a washer above this bearing?", and barthel confirmed he uses one.

**Change:** the idler-gear sentence is split in two. The second half now describes the installation: the washer goes onto the M3 × 35 mm button head screw first and sits between the screw head and the outer face of the 608 bearing, spanning its 8 mm bore (the screw head alone is narrower than the bore and drops inside it), plus a check that the idler still spins freely afterwards.

No fastener or quantity changes: `washer-m3-15` was already in the page's parts list at qty 1 from #311.

Built locally with Node 22 (`npm ci && npm run build`, clean); `validate_frontmatter.py` shows only the 5 errors already on `main`, `validate_images.py` clean.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1539909912241373254): "Add the washer installation to the description of "Install the chute stepper motor" in "Top Interface" Documentation".

<!--
request: https://discord.com/channels/1430279849171222682/1539909912241373254/1540049456190324816
-->
