### PR TITLE
hive: make the memory counters actually readable

### DIFF
--- a/software/hive/agent-docs/auth.md
+++ b/software/hive/agent-docs/auth.md
@@ -28,7 +28,10 @@ Design philosophy: **a key grants exactly what its scopes say, nothing more.**
 - Scope vocabulary lives in `deps.py` (`VALID_API_KEY_SCOPES`): currently
   `models:read`, `models:write`, `samples:read`, `samples:write`,
   `keys:manage`, `stats:read`, `fleet:read`, `fleet:anon`,
-  `contributors:read`, `parts:read`, `parts:prices`.
+  `contributors:read`, `parts:read`, `parts:prices`, `server_health:read`.
+  The picker in `frontend/src/routes/settings/+page.svelte` is a hand-kept copy
+  of this list — a scope missing there cannot be minted from the UI at all, so
+  add it in the same change.
 - The last six are the **service-to-service surface** —
   `routers/public_stats.py` and `routers/public_catalog.py`. Every tier of it
   additionally requires the key's owner to be an admin and the key to be
@@ -64,6 +67,15 @@ Design philosophy: **a key grants exactly what its scopes say, nothing more.**
   set (`_PRICE_FIELDS`), so a price field added upstream is excluded by default
   instead of leaking until somebody notices; add its name there in the same
   change.
+- **`server_health:read` is not part of that public surface** — it is the one
+  route under `/api/admin` a key can reach, and it uses the ordinary
+  `require_role_flex("admin")` + `require_api_key_scopes(...)` pairing rather
+  than `require_public_scope`. It exists so monitoring can watch storage, DB
+  size and the API's own memory counters across days without a human keeping a
+  browser session alive, which is what a slow memory leak actually requires.
+  The key's owner must still be an admin: the resolver only authenticates, and
+  dropping either dependency would widen the route rather than merely change
+  how it is called.
 - Keys may carry an optional `expires_at`; expired keys 401.
 - Revocation is a tombstone (`revoked_at`), not a delete, so the UI can show
   history.

--- a/software/hive/backend/app/deps.py
+++ b/software/hive/backend/app/deps.py
@@ -51,6 +51,14 @@ API_KEY_SCOPE_FLEET_ANON = "fleet:anon"
 # a part's weight has no need to quote its price.
 API_KEY_SCOPE_PARTS_READ = "parts:read"
 API_KEY_SCOPE_PARTS_PRICES = "parts:prices"
+# Infrastructure telemetry: storage totals, database size, and the API process's
+# own memory counters. Every scope above describes the DATA hive holds; this one
+# describes the SERVER holding it, which is a different thing to be trusted with.
+# A monitoring key that watches memory over days has no business reading
+# machines, parts or contributors, and none of those consumers need to know how
+# much disk is left. Admin-only on top of the scope, because the storage and DB
+# figures say as much about the business as they do about the box.
+API_KEY_SCOPE_SERVER_HEALTH_READ = "server_health:read"
 VALID_API_KEY_SCOPES = frozenset(
     {
         API_KEY_SCOPE_MODELS_READ,
@@ -64,6 +72,7 @@ VALID_API_KEY_SCOPES = frozenset(
         API_KEY_SCOPE_CONTRIBUTORS_READ,
         API_KEY_SCOPE_PARTS_READ,
         API_KEY_SCOPE_PARTS_PRICES,
+        API_KEY_SCOPE_SERVER_HEALTH_READ,
     }
 )
 

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -45,7 +45,7 @@ from app.services.profile_catalog import get_existing_profile_catalog_service, g
 from app.services.candidate_matview import get_candidate_matview_worker
 from app.services.condition_worker import get_condition_worker
 from app.services.machine_stats import get_machine_stats_worker
-from app.services.server_health import get_storage_stats_worker
+from app.services.server_health import get_memory_log_worker, get_storage_stats_worker
 from app.services.teacher_worker import get_teacher_worker
 
 limiter = Limiter(key_func=get_remote_address)
@@ -59,6 +59,7 @@ async def lifespan(_app: FastAPI):
     get_condition_worker().start()
     get_machine_stats_worker().start()
     get_storage_stats_worker().start()
+    get_memory_log_worker().start()  # diagnostic, delete with the 2026-08 leak
     get_candidate_matview_worker().start()
     try:
         yield
@@ -68,6 +69,7 @@ async def lifespan(_app: FastAPI):
         get_condition_worker().stop()
         get_machine_stats_worker().stop()
         get_storage_stats_worker().stop()
+        get_memory_log_worker().stop()
         service = get_existing_profile_catalog_service()
         if service is not None:
             service.stop_auto_sync_loop()

--- a/software/hive/backend/app/routers/admin.py
+++ b/software/hive/backend/app/routers/admin.py
@@ -4,7 +4,14 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from app.deps import get_db, require_role, verify_csrf
+from app.deps import (
+    API_KEY_SCOPE_SERVER_HEALTH_READ,
+    get_db,
+    require_api_key_scopes,
+    require_role,
+    require_role_flex,
+    verify_csrf,
+)
 from app.errors import APIError
 from app.models.user import User
 from app.schemas.auth import AdminUpdateUserRequest, UserResponse
@@ -19,14 +26,21 @@ router = APIRouter(prefix="/api/admin", tags=["admin"])
 def server_health(
     refresh_storage: bool = Query(False),
     db: Session = Depends(get_db),
-    _admin: User = Depends(require_role("admin")),
+    _admin: User = Depends(require_role_flex("admin")),
+    _scope_guard: User = Depends(require_api_key_scopes(API_KEY_SCOPE_SERVER_HEALTH_READ)),
 ):
     """Storage usage (sample vs piece images vs models), DB size, and memory.
 
     Storage figures come from a cache a background worker walks on a slow
     cadence — reading them is instant. refresh_storage=true just nudges that
     worker to walk again soon and returns the current cache immediately (the
-    walk itself is far too slow to run inside the request)."""
+    walk itself is far too slow to run inside the request).
+
+    The only admin route reachable by API key, so that monitoring can watch the
+    box over days without a human holding a browser session open. Still
+    admin-only: `require_role_flex` authenticates a key, `require_api_key_scopes`
+    is what actually authorizes it, and a key needs both the role and
+    `server_health:read`."""
     if refresh_storage:
         get_storage_stats_worker().wake()
     return get_server_health(db)

--- a/software/hive/backend/app/services/server_health.py
+++ b/software/hive/backend/app/services/server_health.py
@@ -372,3 +372,78 @@ def get_storage_stats_worker() -> StorageStatsWorker:
             if _INSTANCE is None:
                 _INSTANCE = StorageStatsWorker()
     return _INSTANCE
+
+
+MEMORY_LOG_INTERVAL_S = 300.0
+
+
+class MemoryLogWorker:
+    """Writes one memory line to the log every five minutes.
+
+    DIAGNOSTIC. This exists for the leak that took hive down on 2026-08-20 and
+    should be deleted the day that closes — see hive-prod-server.md.
+
+    The same numbers are on /api/admin/server-health, which is the right place
+    for them, but reading that needs a login and a leak is measured in days.
+    A log line is what is still there tomorrow, survives a restart in the
+    journal, and costs nothing to collect. Deliberately not folded into
+    StorageStatsWorker: that ticks every three hours and only after walking the
+    whole object store, which is far too coarse and too expensive to sample on.
+    """
+
+    def __init__(self) -> None:
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._start_lock = threading.Lock()
+
+    def start(self) -> None:
+        with self._start_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._thread = threading.Thread(target=self._loop, daemon=True, name="memory-log-worker")
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def _loop(self) -> None:
+        logger.info("MemoryLogWorker: started")
+        while not self._stop_event.is_set():
+            self._log_once()
+            if self._stop_event.wait(timeout=MEMORY_LOG_INTERVAL_S):
+                break
+        logger.info("MemoryLogWorker: stopped")
+
+    def _log_once(self) -> None:
+        try:
+            stats = get_memory_stats()
+            glibc = stats.get("glibc") or {}
+            logger.info(
+                "memory rss=%.0fMB blocks=%d arena=%.0fMB free_in_arena=%.0fMB mmap=%.0fMB heaps=%s",
+                _as_mb(stats.get("process_rss_bytes")),
+                stats.get("python_allocated_blocks") or 0,
+                _as_mb(glibc.get("arena_bytes")),
+                _as_mb(glibc.get("free_in_arena_bytes")),
+                _as_mb(glibc.get("mmapped_bytes")),
+                glibc.get("heap_count"),
+            )
+        except Exception:
+            # A diagnostic must never be the reason the process dies.
+            logger.exception("MemoryLogWorker: sample failed")
+
+
+def _as_mb(value: int | None) -> float:
+    return (value or 0) / (1024 * 1024)
+
+
+_MEMORY_LOG_INSTANCE: MemoryLogWorker | None = None
+
+
+def get_memory_log_worker() -> MemoryLogWorker:
+    global _MEMORY_LOG_INSTANCE
+    if _MEMORY_LOG_INSTANCE is None:
+        with _INSTANCE_LOCK:
+            if _MEMORY_LOG_INSTANCE is None:
+                _MEMORY_LOG_INSTANCE = MemoryLogWorker()
+    return _MEMORY_LOG_INSTANCE

--- a/software/hive/backend/tests/test_api_key_scopes.py
+++ b/software/hive/backend/tests/test_api_key_scopes.py
@@ -340,3 +340,59 @@ class TestApiKeyScopes:
             headers=key_headers,
         )
         assert response.status_code == 403
+
+
+class TestServerHealthScope:
+    """`server_health:read` is the one /api/admin route a key can reach.
+
+    Both guards have to hold: the key's owner must be an admin AND the key must
+    carry the scope. Dropping either would widen the route, so both are pinned
+    here rather than only the happy path.
+    """
+
+    def test_scoped_admin_key_reads_server_health(self, client: TestClient, db: Session) -> None:
+        admin_headers = _login_admin(client, db)
+        token = _create_api_key(
+            client, admin_headers, name="monitoring", scopes=["server_health:read"]
+        )
+        response = client.get(
+            "/api/admin/server-health", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 200, response.text
+        memory = response.json()["memory"]
+        # The counters this scope exists to expose.
+        assert "python_allocated_blocks" in memory
+        assert "glibc" in memory
+
+    def test_key_without_the_scope_is_refused(self, client: TestClient, db: Session) -> None:
+        admin_headers = _login_admin(client, db)
+        token = _create_api_key(
+            client, admin_headers, name="models-only", scopes=["models:read"]
+        )
+        response = client.get(
+            "/api/admin/server-health", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 403, response.text
+
+    def test_non_admin_key_is_refused_even_with_the_scope(
+        self, client: TestClient, db: Session
+    ) -> None:
+        # Minting needs admin, so mint as admin and then demote the owner. What
+        # is under test is the role check at read time, not who may mint: a key
+        # keeps its scopes when its owner loses the role, and the scope alone
+        # must not be enough.
+        admin_headers = _login_admin(client, db)
+        token = _create_api_key(
+            client, admin_headers, name="soon-demoted", scopes=["server_health:read"]
+        )
+        _promote(db, "admin-scopes@test.com", "member")
+        response = client.get(
+            "/api/admin/server-health", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 403, response.text
+
+    def test_cookie_admin_still_works(self, client: TestClient, db: Session) -> None:
+        # require_role_flex replaced require_role; the browser path must be intact.
+        admin_headers = _login_admin(client, db)
+        response = client.get("/api/admin/server-health", headers=admin_headers)
+        assert response.status_code == 200, response.text

--- a/software/hive/frontend/src/routes/settings/+page.svelte
+++ b/software/hive/frontend/src/routes/settings/+page.svelte
@@ -110,7 +110,11 @@
 		{ scope: 'keys:manage', label: 'Manage API keys' },
 		{ scope: 'stats:read', label: 'Read aggregate stats' },
 		{ scope: 'fleet:read', label: 'Read the fleet roster (machines + linked owners)' },
-		{ scope: 'contributors:read', label: 'Read the contributor leaderboard' }
+		{ scope: 'fleet:anon', label: 'Read the de-identified fleet roster (no owners, no names)' },
+		{ scope: 'contributors:read', label: 'Read the contributor leaderboard' },
+		{ scope: 'parts:read', label: 'Read the parts catalog' },
+		{ scope: 'parts:prices', label: 'Read parts market prices' },
+		{ scope: 'server_health:read', label: 'Read server health (storage, DB size, memory)' }
 	];
 	let apiKeySelectedScopes = $state<string[]>([]);
 	let apiKeyExpiresInDays = $state('');


### PR DESCRIPTION
Fourth in the 2026-08-20 memory work (#336 ceiling, #337 session cache, #338 counters). #338 put the allocator counters on `/api/admin/server-health` and then they were unreadable, because that route needs a browser session and a leak this shape is measured in days. Two ways in, neither of which involves anyone's password.

## 1. The app logs it itself

One line every five minutes into the container log:

```
memory rss=712MB blocks=248113 arena=181MB free_in_arena=44MB mmap=379MB heaps=3
```

No credential exists at all, it survives restarts in the journal, and it keeps sampling overnight with nobody watching. Marked DIAGNOSTIC in both the class docstring and at the call site, to be deleted when the leak closes.

Its own thread rather than folded into `StorageStatsWorker` — that ticks every three hours and only after walking the whole object store, which is far too coarse to sample a leak on and far too expensive to make finer. The sampler sleeps between lines. The body is wrapped so a failed read can never be the reason the process dies.

## 2. An API key can read the endpoint

Done the way `agent-docs/auth.md` prescribes, which is **not** the one-line flip I first assumed:

- a **new** scope, `server_health:read`, rather than reusing a vaguely-related one — the doc is explicit that a new key-accessible surface gets its own scope
- `require_role_flex("admin")` **paired with** `require_api_key_scopes(...)`, matching `create_api_key`. The resolver only authenticates; the scope guard authorizes. A key needs both the admin role and the scope, and dropping either dependency widens the route rather than changing how it is called.

It is deliberately not part of the `public_stats` / `public_catalog` service surface. Every scope there describes the *data* hive holds; this one describes the *server* holding it, and the consumers don't overlap.

## Drive-by: the scope picker was missing three scopes

`frontend/src/routes/settings/+page.svelte` keeps a hand-copied list of `VALID_API_KEY_SCOPES`, and it had drifted — `fleet:anon`, `parts:read` and `parts:prices` were backend-only by accident, so no key carrying them could be minted through the UI. Added, along with the new one, and `auth.md` now records that the two lists have to move together.

## Tests

Both guards are pinned, not just the happy path: a key without the scope 403s; a key whose owner is demoted *after* minting 403s even though it still carries the scope; and cookie admin access is pinned too, since `require_role_flex` replaced `require_role` on a route the browser uses. Backend 287 passed. Frontend `pnpm check`: 0 errors.

## Still not the leak

This is tooling, not a fix. Once it has run a few hours the fork resolves: `blocks` climbing with RSS means Python objects and a `tracemalloc` hunt; `blocks` flat while RSS climbs means C-level or glibc retention, and `free_in_arena` says which.