### PR TITLE
hive: give the app logger somewhere to write

### DIFF
--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
@@ -47,6 +48,30 @@ from app.services.condition_worker import get_condition_worker
 from app.services.machine_stats import get_machine_stats_worker
 from app.services.server_health import get_memory_log_worker, get_storage_stats_worker
 from app.services.teacher_worker import get_teacher_worker
+
+def _configure_app_logging() -> None:
+    """Give the ``app`` logger somewhere to write.
+
+    uvicorn configures its own loggers and deliberately leaves the root logger
+    alone, so nothing in this package had a handler and all 50-odd logger calls
+    under app/ went nowhere — including the five background workers announcing
+    themselves at startup, and warnings like "color model has no usable classes"
+    that were meant to be the first sign something was wrong. None of it has
+    ever appeared in `docker logs`.
+
+    Configured on the ``app`` logger rather than the root on purpose: root would
+    also unmute botocore and friends, and this box does not need that volume.
+    uvicorn's own loggers do not propagate, so its access lines are unaffected.
+    """
+    app_logger = logging.getLogger("app")
+    app_logger.setLevel(logging.INFO)
+    if not app_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s"))
+        app_logger.addHandler(handler)
+
+
+_configure_app_logging()
 
 limiter = Limiter(key_func=get_remote_address)
 

--- a/software/hive/backend/tests/test_app_logging.py
+++ b/software/hive/backend/tests/test_app_logging.py
@@ -1,0 +1,51 @@
+"""The `app` logger must have somewhere to write.
+
+Until 2026-08-20 it did not. uvicorn configures its own loggers and leaves the
+root alone, so every logger call under app/ was dropped on the floor — five
+workers announcing themselves at startup, and warnings like "color model has no
+usable classes" that were supposed to be the first sign of trouble. Nothing had
+ever reached `docker logs`, and nobody noticed because absence of a log line
+looks exactly like absence of a problem.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import app.main  # noqa: F401  — configures app logging on import
+
+
+def test_app_logger_has_a_handler():
+    logger = logging.getLogger("app")
+    assert logger.handlers, "no handler means every app log line is silently dropped"
+    assert logger.level <= logging.INFO
+
+
+def test_app_log_lines_actually_come_out():
+    # Swap the handler's own stream rather than using capsys: the handler binds
+    # to stderr at import time, long before capsys replaces it, so capsys never
+    # sees these lines even when they are emitted correctly.
+    logger = logging.getLogger("app")
+    handler = next(h for h in logger.handlers if isinstance(h, logging.StreamHandler))
+    original, buffer = handler.stream, io.StringIO()
+    handler.setStream(buffer)
+    try:
+        logging.getLogger("app.services.server_health").info("canary-%s", 42)
+    finally:
+        handler.setStream(original)
+
+    written = buffer.getvalue()
+    assert "canary-42" in written, "a child of `app` must reach the handler"
+    assert "app.services.server_health" in written, "the formatter should name the logger"
+
+
+def test_only_the_app_logger_was_configured():
+    # Configuring root instead would unmute botocore and friends on a box that
+    # does not need the volume, so the handler must live on `app` and nowhere
+    # else. Asserted by identity rather than by counting handlers elsewhere:
+    # pytest owns root, and libraries legitimately install their own NullHandler.
+    logger = logging.getLogger("app")
+    handler = next(h for h in logger.handlers if isinstance(h, logging.StreamHandler))
+    assert handler not in logging.getLogger().handlers
+    assert handler not in logging.getLogger("botocore").handlers


### PR DESCRIPTION
Nothing under `app/` has ever appeared in the container log.

uvicorn configures its own loggers and deliberately leaves the root logger alone. The `app` logger therefore had no handler, and all **60 logging calls across 25 files** were dropped on the floor — every background worker announcing itself at startup, `"link model %s failed to load"`, `"color model %s has no usable classes"`. Signals written specifically to be the first sign of trouble, none of which could ever arrive.

## Why nobody noticed

hive logs two ways, and only one of them was working:

| path | count | visible before this? |
|---|---|---|
| `logging` | 60 calls, 25 files | **no** |
| bare `print()` | 21 calls, 4 files | yes |
| uvicorn access log | every request | yes |

`bootstrap_admin.py` and the three `profile_engine` modules use `print()`, so `docker logs hive-backend` was never empty — it just never contained anything from the logging module. An empty log reads exactly like a quiet system.

Found the hard way while shipping the memory sampler in #340: the sampler ran correctly and its output went nowhere.

## The change

Configure the `app` logger, not the root. Root would also unmute botocore and friends on a box that does not need the volume; uvicorn's own loggers do not propagate, so its access lines are untouched.

## Tests

Three, including one that swaps the handler's own stream and asserts a line from a child logger actually comes out formatted. That indirection is deliberate — `capsys` cannot see this handler, because it binds to stderr at import time long before capsys replaces it, so the obvious test would pass on broken code. Another asserts by identity that the handler did not land on root or botocore. Full suite: 290 passed.

## Not addressed

Those 21 `print()` calls should become logger calls. Wider change, own PR — noted so it doesn't get lost.