### PR TITLE
docs: stamp cut length on the "Parts needed" extrusion cards

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -201,7 +201,8 @@ Adding a drawing: new YAML source, an entry in the data file, an entry in the
 
 `src/liquid/_data/parts.yml` is the catalog, keyed by id. Fields: `name`,
 `image`, `page` (detail page, optional), `category` (groups the "Parts
-needed" block), `length_mm` (screw length, stamped on the card image),
+needed" block), `length_mm` (screw length or extrusion cut length, stamped on the card
+image),
 `notes` (short, collected into a list under the whole block),
 `caption` (small text under a single card, e.g. a cut length),
 `heat_inserts: [{insert, qty}]`. ids and render filenames mirror the
@@ -210,10 +211,12 @@ needed" block), `length_mm` (screw length, stamped on the card image),
 - A page lists what it needs via `parts_needed` (see front matter). Cards render
   image + name, linked to the detail page when one exists, grouped by category,
   with a quantity badge and any notes.
-- **Every screw needs `length_mm`.** One photo stands in for a whole family of
-  screws (every M5 socket head cap screw shares one picture), so without the
-  length stamped on the card an M5 x 12 and an M5 x 35 are the same card. The
-  parts calculator's hardware list does the same thing for the same reason.
+- **Every screw and every 2020 extrusion needs `length_mm`.** One photo stands
+  in for a whole family of screws (every M5 socket head cap screw shares one
+  picture), so without the length stamped on the card an M5 x 12 and an M5 x 35
+  are the same card. The same is true of the extrusions, which differ only in
+  cut length. The parts calculator's hardware list does the same thing for the
+  same reason.
 - Part detail pages live under `src/content/hardware/parts/`. Only put a part
   in the nav if it has a detail page worth linking; the catalog can hold parts
   with no page.

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -30,8 +30,9 @@
 											<img class="part-card-img" src={part.image} alt={part.name} loading="lazy" />
 										{/if}
 										{#if part.qty}<span class="part-card-qty">{part.qty}×</span>{/if}
-										<!-- One screw photo stands in for every length in its family, so the
-										     length gets stamped on the corner, as on the parts calculator. -->
+										<!-- One photo stands in for every length in a screw family, and for
+										     every cut length of 2020 extrusion, so the length gets stamped on
+										     the corner, as on the parts calculator. -->
 										{#if part.length_mm}<span class="part-card-len">{part.length_mm}mm</span>{/if}
 										{#if part.not_in_calc}<span class="part-card-warn" title="Not currently in the parts calculator">!</span>{/if}
 										{#if part.alternative}<span

--- a/docs/src/liquid/_data/parts.yml
+++ b/docs/src/liquid/_data/parts.yml
@@ -101,18 +101,21 @@ bin-retainer-right:
 ext-2020-ag:
   name: Outer horizontal / Horizontal interface frame (A/G)
   category: Aluminum extrusion (2020)
+  length_mm: 320
   image: https://img.basically.website/web/parts/extrusion/extrusion-2020.0691a894c8154731.png
   caption: 2020 aluminum extrusion, cut to 320 mm (pieces A and G).
 
 ext-2020-bh:
   name: Spoke / Interface spoke, short (B/H)
   category: Aluminum extrusion (2020)
+  length_mm: 158
   image: https://img.basically.website/web/parts/extrusion/extrusion-2020.0691a894c8154731.png
   caption: 2020 aluminum extrusion, cut to 158 mm (pieces B and H).
 
 ext-2020-c:
   name: Layer vertical support (C)
   category: Aluminum extrusion (2020)
+  length_mm: 154
   image: https://img.basically.website/web/parts/extrusion/extrusion-2020.0691a894c8154731.png
   caption: 2020 aluminum extrusion, cut to 154 mm (piece C).
 
@@ -269,12 +272,14 @@ ribbon-cable-clamp:
 extrusion-e:
   name: Interface spoke, long (E)
   category: Aluminum extrusion (2020)
+  length_mm: 238
   image: https://img.basically.website/web/parts/top-interface/extrusion-e.bce3a0752b0f99f5.png
   caption: 2020 aluminum extrusion, cut to 238 mm (piece E).
 
 extrusion-f:
   name: Interface vertical support (F)
   category: Aluminum extrusion (2020)
+  length_mm: 274
   image: https://img.basically.website/web/parts/top-interface/extrusion-f.7e1f6b2dc9e069f7.png
   caption: 2020 aluminum extrusion, cut to 274 mm (piece F).
 


### PR DESCRIPTION
The screw cards got a length stamp in #333. The 2020 extrusions have the same problem: one photo (`extrusion-2020.0691a894c8154731.png`) stands in for A/G, B/H and C, so a 320 mm bar and a 154 mm bar render as identical cards. The interface pieces E and F have their own photos but are equally hard to tell apart at thumbnail size.

`length_mm` is already generic in `Requirements.svelte` and `content.ts`, so this is a data change plus documentation:

- `docs/src/liquid/_data/parts.yml` — `length_mm` on all 5 `Aluminum extrusion (2020)` entries: `ext-2020-ag` 320, `ext-2020-bh` 158, `ext-2020-c` 154, `extrusion-e` 238, `extrusion-f` 274. These are the cut lengths (CAD minus the 6 mm clearance trim on C/E/F), matching the parts calculator's `framing.ts` and each card's existing caption.
- `docs/AGENTS.md` — the rule now covers extrusions as well as screws.
- `Requirements.svelte` — comment only.

Affects the 3 pages that list extrusions: regular-layers, external-bracket, top-interface.

`npm run build` passes; the built HTML shows the new badges (320/158/154 on regular-layers, 154 on external-bracket, 238/274 on top-interface). `validate_frontmatter.py` reports the same 5 pre-existing errors as `main`; `validate_images.py` clean.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1540077229319528448): "Please add a length tag to the “needed parts” cards for the aluminum profiles/extrusions, just as you did for the screws."

<!--
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1540077229319528448
-->
