### PR TITLE
docs: reword the T-nut count sentence on regular layers

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -44,7 +44,7 @@ This guide covers creating a regular layer. It's also the basis for creating the
 
 Note that some of the ordering in this guide may seem unusual, but it's written this way to avoid both putting unnecessary strain on pieces, and allowing for the use of slide-in T-nuts.
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead. Where a step taps into a printed part and braces against the extrusion, fastening into a T-nut there instead needs a screw 4 mm shorter: an {% include fastener.html size="M5" variant="socket-button" length="12" %} in place of an {% include fastener.html size="M5" variant="socket-button" length="16" %}.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead. Where a step taps into a printed part and braces against the extrusion, fastening into a T-nut there instead needs a screw 4 mm shorter: an {% include fastener.html size="M5" variant="socket-button" length="12" %} rather than the {% include fastener.html size="M5" variant="socket-button" length="16" %} the step calls for.
 
 {% include fastener-legend.html %}
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -44,7 +44,7 @@ This guide covers creating a regular layer. It's also the basis for creating the
 
 Note that some of the ordering in this guide may seem unusual, but it's written this way to avoid both putting unnecessary strain on pieces, and allowing for the use of slide-in T-nuts.
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead. Where a step taps into a printed part and braces against the extrusion, fastening into a T-nut there instead needs a screw 4 mm shorter: an {% include fastener.html size="M5" variant="socket-button" length="12" %} rather than the {% include fastener.html size="M5" variant="socket-button" length="16" %} the step calls for.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
 
 {% include fastener-legend.html %}
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -44,7 +44,7 @@ This guide covers creating a regular layer. It's also the basis for creating the
 
 Note that some of the ordering in this guide may seem unusual, but it's written this way to avoid both putting unnecessary strain on pieces, and allowing for the use of slide-in T-nuts.
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The {% include fastener.html size="M5" variant="t-nut" %} count above is the minimum you need if you tap directly into the printed parts where you can, and goes up if you fasten with T-nuts throughout instead.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead. Where a step taps into a printed part and braces against the extrusion, fastening into a T-nut there instead needs a screw 4 mm shorter: an {% include fastener.html size="M5" variant="socket-button" length="12" %} in place of an {% include fastener.html size="M5" variant="socket-button" length="16" %}.
 
 {% include fastener-legend.html %}
 


### PR DESCRIPTION
Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1540085746788995082): "In the “Regular Layer” section of the assembly documentation, add the sentence “The number of M5 T-nuts listed above is the minimum you’ll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.” to indicate that the screw length must be 4 mm shorter if you want to use T-nuts instead of self-tapping screws."

The page already carried that point in the intro above Step 1, worded differently ("The M5 T-nut count above is the minimum you need if you tap directly into the printed parts where you can, and goes up if you fasten with T-nuts throughout instead"). This replaces it with the requested wording.

Wording only. An earlier revision of this PR also added a sentence spelling out the screw-length rule (M5 × 12 into a T-nut, M5 × 16 tapped and braced, 4 mm apart); barthel [rejected that](https://discord.com/channels/1430279849171222682/1540085746788995082/1540090256836268032), so it has been removed and the rule stays unwritten on every page.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1540085746788995082
request: https://discord.com/channels/1430279849171222682/1540085746788995082/1540090256836268032
preview: /hardware/assembly/distribution/bin-frame/regular-layers/
-->
