### PR TITLE
hive: one set-progress report per assignment at a time

### DIFF
--- a/software/hive/backend/app/routers/machines.py
+++ b/software/hive/backend/app/routers/machines.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel, Field
 from slowapi import Limiter
 from slowapi.util import get_remote_address
-from sqlalchemy import delete, func, select, tuple_
+from sqlalchemy import delete, func, select, text, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session, joinedload
@@ -711,6 +711,28 @@ def report_machine_set_progress(
     ).first()
     if not assignment:
         raise APIError(404, "No profile assignment found", "NO_ASSIGNMENT")
+
+    # One report per assignment at a time. Without this, a retry of a
+    # still-running report joins the row-lock queue behind it — waiting up to
+    # the 60s statement timeout while holding its own locks and pinning its
+    # whole parsed payload — and under a retry storm those waiters convoy
+    # (2026-08-20, the second half of the OOM loop: the convoy persisted even
+    # after the write path itself got fast). The advisory lock is
+    # transaction-scoped, so it releases on commit or rollback no matter how
+    # the request dies; a bounced retry just comes back once the in-flight
+    # report lands, and then usually no-ops. Postgres-only: sqlite (tests) is
+    # single-writer anyway.
+    if db.bind.dialect.name == "postgresql":
+        got_lock = db.execute(
+            text("SELECT pg_try_advisory_xact_lock(hashtext(:aid))"),
+            {"aid": str(assignment.id)},
+        ).scalar()
+        if not got_lock:
+            raise APIError(
+                429,
+                "A set-progress report for this machine is already being processed",
+                "SET_PROGRESS_BUSY",
+            )
 
     expected_version = assignment.active_version or assignment.desired_version
     expected_version_id = expected_version.id if expected_version is not None else None


### PR DESCRIPTION
Completes #343. The rewrite made the write path fast, but a retry of a still-running report could still join the row-lock queue behind it — waiting up to the 60s statement timeout while holding its own locks and pinning its whole parsed payload. Under a retry storm those waiters convoy; this was still visible on prod after v0.1.22 as `QueryCanceled ... while locking tuple` on `machine_set_progress` during the boot burst, with RSS creeping toward the cap.

A transaction-scoped `pg_try_advisory_xact_lock(hashtext(assignment_id))` at the top of the handler makes a concurrent writer bounce immediately with `429 SET_PROGRESS_BUSY` instead of queueing. Transaction-scoped means it releases on commit or rollback no matter how the request dies — abandoned threadpool workers included. The sorter's normal retry lands once the in-flight report commits, and then usually no-ops (the v0.1.22 `WHERE` skips unchanged rows).

Bench on local staging (real postgres): 3 concurrent full 8,520-item snapshots → one **200 in 1.7s**, two **429s in 0.23s**; identical follow-up **1.05s**, all-rows-changed follow-up **1.22s**. Postgres-only; sqlite (tests) is single-writer and skips the guard. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)