### PR TITLE
hive: fast deploys — conditional predeploy dump, deep health, tests gate releases

### DIFF
--- a/.github/workflows/hive-release.yml
+++ b/.github/workflows/hive-release.yml
@@ -1,10 +1,11 @@
 name: Hive Release
 
-# Pushing a `hive/vX.Y.Z` tag is the ONLY thing that ships Hive. This workflow
-# builds both images, pushes them to GHCR, and then publishes the GitHub
-# Release. The ordering matters: prod polls for releases, so a release that
-# exists is a release whose images are already in the registry. There is no
-# window where prod can see a version it cannot install.
+# Pushing a `hive/vX.Y.Z` tag is the ONLY thing that ships Hive. Tests and
+# image builds run in parallel; the GitHub Release is published only after
+# both succeed. The ordering matters twice over: prod polls for releases, so a
+# release that exists is a release whose images are already in the registry
+# AND whose tests passed. Images for a failed run may exist in GHCR, but prod
+# never sees them — it only installs published releases.
 
 on:
   push:
@@ -15,17 +16,23 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build-and-release:
+  test:
+    uses: ./.github/workflows/hive-tests.yml
+
+  build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       packages: write
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+      backend_image: ${{ steps.ver.outputs.backend_image }}
+      frontend_image: ${{ steps.ver.outputs.frontend_image }}
+      backend_digest: ${{ steps.backend.outputs.digest }}
+      frontend_digest: ${{ steps.frontend.outputs.digest }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Derive version
         id: ver
@@ -77,22 +84,45 @@ jobs:
           cache-from: type=gha,scope=hive-frontend
           cache-to: type=gha,mode=max,scope=hive-frontend
 
+  release:
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # The release agent compares this against the fingerprint of the release
+      # it is running to decide whether the deploy needs a pre-deploy DB dump.
+      # Only alembic/versions counts: that directory is the schema.
+      - name: Migrations fingerprint
+        id: mig
+        run: |
+          FP=$(find software/hive/backend/alembic/versions -type f -name '*.py' -not -path '*__pycache__*' \
+            | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+          echo "fingerprint=$FP" >> "$GITHUB_OUTPUT"
+
       # The manifest pins DIGESTS, not tags. Prod pulls by digest, so what runs
-      # is bit-identical to what this job built even if someone later moves the
-      # `:vX.Y.Z` tag. The `latest` tags above exist only for humans poking at
-      # the registry — nothing in the deploy path reads them.
+      # is bit-identical to what the build job built even if someone later
+      # moves the `:vX.Y.Z` tag. The `latest` tags above exist only for humans
+      # poking at the registry — nothing in the deploy path reads them.
       - name: Build release manifest
         run: |
           cat > hive-release.json <<EOF
           {
-            "version": "${{ steps.ver.outputs.version }}",
+            "version": "${{ needs.build.outputs.version }}",
             "tag": "${GITHUB_REF_NAME}",
             "commit": "${GITHUB_SHA}",
             "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "run_url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
+            "migrations": "${{ steps.mig.outputs.fingerprint }}",
             "images": {
-              "backend": "${{ steps.ver.outputs.backend_image }}@${{ steps.backend.outputs.digest }}",
-              "frontend": "${{ steps.ver.outputs.frontend_image }}@${{ steps.frontend.outputs.digest }}"
+              "backend": "${{ needs.build.outputs.backend_image }}@${{ needs.build.outputs.backend_digest }}",
+              "frontend": "${{ needs.build.outputs.frontend_image }}@${{ needs.build.outputs.frontend_digest }}"
             }
           }
           EOF
@@ -142,7 +172,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: "Hive ${{ steps.ver.outputs.version }}"
+          name: "Hive ${{ needs.build.outputs.version }}"
           generate_release_notes: false
           body_path: RELEASE_NOTES.md
           files: |

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -1,0 +1,34 @@
+name: Hive tests
+
+# The backend suite, run in the two places a regression can slip through: on
+# every PR that touches the backend, and (via workflow_call) as the gate the
+# release workflow requires before it publishes anything prod can install.
+
+on:
+  pull_request:
+    paths:
+      - 'software/hive/backend/**'
+      - '.github/workflows/hive-tests.yml'
+  workflow_call:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: software/hive/backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: software/hive/backend/uv.lock
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run tests
+        run: uv run pytest -q

--- a/software/hive/backend/app/main.py
+++ b/software/hive/backend/app/main.py
@@ -1,13 +1,17 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
 from app.config import settings
+from app.deps import get_db
 from app.errors import APIError, api_error_handler, http_exception_handler, unhandled_exception_handler
 from app.routers import (
     admin,
@@ -151,5 +155,9 @@ app.include_router(ai_usage.router)
 
 
 @app.get("/api/health")
-def health():
-    return {"ok": True, "service": "hive-backend"}
+def health(db: Session = Depends(get_db)):
+    # The round-trip is the point: a health check that touches nothing reports
+    # a sick service as healthy. A dead DB raises (non-2xx); an exhausted pool
+    # or starved worker hangs, which the caller's timeout turns into a failure.
+    db.execute(text("SELECT 1"))
+    return {"ok": True, "service": "hive-backend", "database": "ok"}

--- a/software/hive/backend/tests/test_health.py
+++ b/software/hive/backend/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+
+
+def test_health_round_trips_the_database(client: TestClient) -> None:
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["database"] == "ok"

--- a/software/hive/scripts/CUTOVER.md
+++ b/software/hive/scripts/CUTOVER.md
@@ -419,9 +419,13 @@ python3 /usr/local/lib/hive/hive_release_agent.py rollback
 systemctl start hive-release.timer
 ```
 
-Every deploy writes a `*-predeploy.dump` **before** it migrates, so the dump
-matching the schema you want back is always the one taken by the deploy that
-broke it.
+A deploy whose release changes `alembic/versions` writes a `*-predeploy.dump`
+**before** it migrates, so the dump matching the schema you want back is always
+the one taken by the deploy that broke it. Deploys with no migration changes
+skip the dump on purpose — an app-only deploy is undone by `rollback`, not a
+restore, and the nightly + off-box copies cover data loss. The agent decides by
+comparing the `migrations` fingerprint in `hive-release.json` against the
+running release's; a release without the field always dumps.
 
 ### Updating the agent itself
 

--- a/software/hive/scripts/hive_release_agent.py
+++ b/software/hive/scripts/hive_release_agent.py
@@ -198,6 +198,24 @@ def writeState(cfg: AgentConfig, name: str, payload: dict[str, Any]) -> None:
 
 # ------------------------------------------------------------------ backup
 
+def migrationsChanged(current: Optional[dict[str, Any]], manifest: dict[str, Any]) -> bool:
+    """Only a release that can change the schema earns a pre-deploy dump.
+
+    An app-only deploy is undone by rolling back to the previous image, which a
+    dump cannot help with (restoring one would discard data written since). The
+    dump exists for destructive migrations, so it is taken exactly when the
+    incoming release's migrations differ from the running one's. The fingerprint
+    is computed by CI over alembic/versions and shipped in hive-release.json; a
+    missing fingerprint on either side (older manifest, first run under this
+    agent) dumps, because guessing "unchanged" is the expensive mistake.
+    """
+    before = (current or {}).get("migrations")
+    after = manifest.get("migrations")
+    if not before or not after:
+        return True
+    return before != after
+
+
 def takeBackup(cfg: AgentConfig, reason: str) -> Path:
     requirePostgres()
     cfg.backup_dir.mkdir(parents=True, exist_ok=True)
@@ -456,7 +474,10 @@ def installRelease(cfg: AgentConfig, release: dict[str, Any], force: bool) -> bo
         return False
 
     log(f"installing {manifest['version']} (commit {manifest['commit'][:9]})")
-    takeBackup(cfg, "predeploy")
+    if migrationsChanged(current, manifest):
+        takeBackup(cfg, "predeploy")
+    else:
+        log("migrations unchanged — skipping pre-deploy dump (nightly + off-box copies stand)")
 
     try:
         applyRelease(cfg, manifest, compose_path)


### PR DESCRIPTION
Deploys were ~15 minutes tag-to-live and the pre-deploy pg_dump was most of it, on a box where postgres shares the cores with the app. Three changes:

**Conditional pre-deploy dump.** CI stamps a fingerprint of `alembic/versions` into `hive-release.json`; the release agent dumps only when the incoming release's fingerprint differs from the running one's (or either is missing). An app-only deploy is undone by rolling back to the previous image — a dump can't help with that, restoring one would discard data written since. The dump exists for destructive migrations, so it runs exactly then. Nightly + off-box backups untouched.

**`/api/health` does a real DB round-trip.** The static version could not fail. Now a dead DB is a non-2xx and an exhausted pool or starved worker hangs into the caller's timeout — which is what the deploy health gate, auto-rollback, and container healthchecks all key on.

**Tests gate releases.** New reusable `hive-tests.yml` runs the backend suite (291 tests, ~3 min) on every PR touching the backend, and the release workflow requires it — in parallel with the image build, so it adds no wall clock. Images for a failed run may exist in GHCR, but prod only installs published releases.

Full suite passes locally. After merge the agent script must be re-applied on prod by hand (it is not self-updating, per CUTOVER.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)