### PR TITLE
sorter: restart-path fixes — LED recovery, flash identify timeout, machine restart in the UI

### DIFF
--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -254,6 +254,12 @@ static bool stepper_hw_enabled[STEPPER_COUNT] = {};
 // turn, endstop never fires). Starts true to match enableDriver(true) in setup().
 static bool stepper_drv_current_on[STEPPER_COUNT];
 
+// Tracks which digital outputs currently have their pad routed to the PWM block
+// rather than SIO. Declared up here because initialize_hardware() has to clear
+// it: it puts every output pad back on SIO, and a stale "already PWM" flag would
+// make later duty writes land on a pad the PWM block no longer drives.
+static bool digital_output_pwm_active[DIGITAL_OUTPUT_COUNT];
+
 static void ensure_stepper_hw_enabled(int i) {
     if (!stepper_hw_enabled[i]) {
         gpio_put(STEPPER_nEN_PINS[i], 0);
@@ -502,11 +508,16 @@ void initialize_hardware() {
         gpio_set_dir(digital_input_pins[i], GPIO_IN);
         gpio_pull_up(digital_input_pins[i]);
     }
-    // Initialize digital outputs
+    // Initialize digital outputs. gpio_init routes the pad back to SIO, so any
+    // channel that was driving PWM is no longer in PWM mode — clear the flag to
+    // match, or the next duty write skips re-arming the pad and silently does
+    // nothing. INIT arrives on every host start, so a host restart without a
+    // board reset used to leave the LEDs dark and unlightable.
     for (int i = 0; i < DIGITAL_OUTPUT_COUNT; i++) {
         gpio_init(digital_output_pins[i]);
         gpio_set_dir(digital_output_pins[i], GPIO_OUT);
         gpio_put(digital_output_pins[i], 0);
+        digital_output_pwm_active[i] = false;
     }
     // Turn on FAN0 permanently for cooling on boards that expose it.
     if (FAN0_OUTPUT_CHANNEL >= 0 && FAN0_OUTPUT_CHANNEL < DIGITAL_OUTPUT_COUNT) {
@@ -600,7 +611,6 @@ void CMDH_digital_read(const BusMessage *msg, BusMessage *resp) {
 // likewise always-low, so the full u16 range maps to real 0%..100%.
 static const uint16_t PWM_OUTPUT_WRAP = 65534;
 
-static bool digital_output_pwm_active[DIGITAL_OUTPUT_COUNT];
 static bool pwm_slice_configured[NUM_PWM_SLICES];
 
 static void digital_output_set_plain(int pin, uint8_t channel, bool value) {

--- a/software/sorter/backend/hardware/firmware_flash.py
+++ b/software/sorter/backend/hardware/firmware_flash.py
@@ -24,6 +24,13 @@ BOOTLOADER_MOUNT_TIMEOUT_S = 30.0
 BOOTLOADER_UNMOUNT_TIMEOUT_S = 20.0
 SERIAL_REAPPEAR_TIMEOUT_S = 15.0
 COPY_CHUNK_SIZE = 64 * 1024
+# The bus default (100ms) is tuned for the hot control loop, where a late reply
+# is better dropped than waited on. Flashing runs inside the same busy backend
+# process, and the flash thread can lose the GIL to vision work for longer than
+# that — long enough to read a frame back in pieces and report a perfectly
+# healthy board as "blank or wedged". Identification happens a handful of times
+# per flash, so buy the headroom.
+IDENTIFY_READ_TIMEOUT_S = 1.0
 
 ProgressFn = Callable[[float], None]
 
@@ -57,7 +64,7 @@ def validateUf2(data: bytes) -> str | None:
 def identifyBoard(gc: GlobalConfig, port: str) -> dict | None:
     bus: MCUBus | None = None
     try:
-        bus = MCUBus(port=port)
+        bus = MCUBus(port=port, timeout=IDENTIFY_READ_TIMEOUT_S)
         dev = MCUDevice(bus, 0)
         info = dev.detect()
         try:

--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -91,6 +91,7 @@ class DigitalOutputPin:
         self._value = False
         self._duty = 0
         self._enabled = True
+        self._pwm_armed = False
         self._gc = gc
 
     @property
@@ -104,6 +105,9 @@ class DigitalOutputPin:
         self._gc.logger.info(f"DigitalOutput ch{self._channel}: set value={self._value}")
         payload = struct.pack("<?", self._value) # 1 byte, boolean
         self._dev.send_command(InterfaceCommandCode.DIGITAL_WRITE, self._channel, payload)
+        # The firmware hands the pad back to SIO on a plain write, so the next
+        # duty write has to re-arm PWM mode.
+        self._pwm_armed = False
 
     @property
     def duty(self) -> int:
@@ -111,6 +115,20 @@ class DigitalOutputPin:
 
     def setDuty(self, duty: int) -> None:
         clamped = max(0, min(DIGITAL_OUTPUT_DUTY_MAX, int(duty)))
+        if not self._pwm_armed:
+            # The board only routes the pad to its PWM block on the first duty
+            # write after a plain one, and it tracks that with a flag that its
+            # INIT command does not clear. INIT is what board discovery sends on
+            # every host start, and it drives the pad low via SIO — so a board
+            # that was left in PWM mode by a previous host process comes back
+            # dark with its flag still saying "already PWM", and every later duty
+            # write lands on a pad the PWM block no longer drives. Older firmware
+            # is out in the field with that bug, so open each process's first duty
+            # write with a plain one: it clears the flag on both sides.
+            self._dev.send_command(
+                InterfaceCommandCode.DIGITAL_WRITE, self._channel, struct.pack("<?", False)
+            )
+            self._pwm_armed = True
         payload = struct.pack("<H", clamped)
         self._dev.send_command(
             InterfaceCommandCode.DIGITAL_WRITE_PWM, self._channel, payload

--- a/software/sorter/backend/server/routers/system.py
+++ b/software/sorter/backend/server/routers/system.py
@@ -252,6 +252,48 @@ def shutdown_machine() -> Dict[str, Any]:
     return {"ok": True, "message": "Machine is powering down..."}
 
 
+@router.post("/api/system/reboot")
+def reboot_machine() -> Dict[str, Any]:
+    """Reboot the whole Linux machine — equivalent to `reboot`.
+
+    Same deal as the shutdown endpoint: the shell command runs from a
+    background thread after a short delay so the HTTP response is delivered
+    before the OS starts tearing services down.
+    """
+
+    def _deferred_reboot() -> None:
+        import subprocess
+        import time
+
+        time.sleep(0.5)
+        # Backend runs as root on the Pi, so a plain `reboot` works; fall back to
+        # sudo / systemctl in case it's ever launched as an unprivileged user.
+        candidates = [
+            ["shutdown", "-r", "now"],
+            ["systemctl", "reboot"],
+            ["sudo", "-n", "shutdown", "-r", "now"],
+            ["sudo", "-n", "systemctl", "reboot"],
+        ]
+        logger = getattr(shared_state.gc_ref, "logger", None)
+        for cmd in candidates:
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10.0)
+                if result.returncode == 0:
+                    return
+                if logger is not None:
+                    logger.error(f"Reboot command {cmd!r} failed: {result.stderr.strip()}")
+            except FileNotFoundError:
+                continue
+            except Exception as exc:
+                if logger is not None:
+                    logger.error(f"Reboot command {cmd!r} raised: {exc}")
+        if logger is not None:
+            logger.error("All reboot commands failed; machine did not restart.")
+
+    threading.Thread(target=_deferred_reboot, daemon=True).start()
+    return {"ok": True, "message": "Machine is restarting..."}
+
+
 def _shared_variables():
     controller = shared_state.controller_ref
     coordinator = getattr(controller, "coordinator", None) if controller is not None else None

--- a/software/sorter/backend/tests/test_leds.py
+++ b/software/sorter/backend/tests/test_leds.py
@@ -2,7 +2,11 @@ import unittest
 from collections.abc import Sequence
 from typing import Any
 
-from hardware.sorter_interface import DIGITAL_OUTPUT_DUTY_MAX, DigitalOutputPin
+from hardware.sorter_interface import (
+    DIGITAL_OUTPUT_DUTY_MAX,
+    DigitalOutputPin,
+    InterfaceCommandCode,
+)
 from irl.leds import LedController, brightnessPercentToDuty, discoverLedOutputs
 from machine_platform.control_board import BoardIdentity
 
@@ -98,6 +102,57 @@ class LedOutputTests(unittest.TestCase):
         controller.allOff()
 
         self.assertEqual([o.pin.duty for o in self.outputs], [0, 0])
+
+
+class RecordingDevice:
+    def __init__(self) -> None:
+        self.commands: list[tuple[int, int, bytes]] = []
+
+    def send_command(self, command: int, channel: int, payload: bytes) -> object:
+        self.commands.append((command, channel, payload))
+        return None
+
+
+class PwmArmingTests(unittest.TestCase):
+    # The board only routes a pad to its PWM block on the first duty write after
+    # a plain one, and its INIT (sent on every host start) drives the pad low
+    # without clearing that flag. So a host process has to assume the board may
+    # still think it is in PWM mode and open with a plain write.
+    def setUp(self) -> None:
+        self.gc: Any = FakeGlobalConfig()
+        self.device = RecordingDevice()
+        self.pin = DigitalOutputPin(self.device, 0, self.gc)
+
+    def test_first_duty_write_is_preceded_by_a_plain_write(self) -> None:
+        self.pin.setDuty(DIGITAL_OUTPUT_DUTY_MAX)
+
+        self.assertEqual(
+            [command for command, _, _ in self.device.commands],
+            [InterfaceCommandCode.DIGITAL_WRITE, InterfaceCommandCode.DIGITAL_WRITE_PWM],
+        )
+
+    def test_later_duty_writes_do_not_repeat_it(self) -> None:
+        self.pin.setDuty(DIGITAL_OUTPUT_DUTY_MAX)
+        self.device.commands.clear()
+
+        self.pin.setDuty(0)
+
+        self.assertEqual(
+            [command for command, _, _ in self.device.commands],
+            [InterfaceCommandCode.DIGITAL_WRITE_PWM],
+        )
+
+    def test_a_plain_write_re_arms_the_next_duty_write(self) -> None:
+        self.pin.setDuty(DIGITAL_OUTPUT_DUTY_MAX)
+        self.pin.value = True
+        self.device.commands.clear()
+
+        self.pin.setDuty(DIGITAL_OUTPUT_DUTY_MAX)
+
+        self.assertEqual(
+            [command for command, _, _ in self.device.commands],
+            [InterfaceCommandCode.DIGITAL_WRITE, InterfaceCommandCode.DIGITAL_WRITE_PWM],
+        )
 
 
 if __name__ == "__main__":

--- a/software/sorter/frontend/src/lib/components/AppHeader.svelte
+++ b/software/sorter/frontend/src/lib/components/AppHeader.svelte
@@ -13,6 +13,7 @@
 	import NotificationsIndicator from '$lib/components/NotificationsIndicator.svelte';
 	import SortingProfileDropdown from '$lib/components/SortingProfileDropdown.svelte';
 	import { getMachinesContext } from '$lib/machines/context';
+	import { machineDowntime } from '$lib/stores/machineDowntime.svelte';
 	import { userConfig } from '$lib/stores/userConfig.svelte';
 	import {
 		AlertTriangle,
@@ -24,6 +25,7 @@
 		PowerOff,
 		RefreshCw,
 		RotateCcw,
+		RotateCw,
 		X
 	} from 'lucide-svelte';
 	import { onMount } from 'svelte';
@@ -39,6 +41,10 @@
 	let powerdownConfirmOpen = $state(false);
 	let poweringDown = $state(false);
 	let powerdownFailed = $state(false);
+	let rebootConfirmOpen = $state(false);
+	let rebooting = $state(false);
+	let rebootFailed = $state(false);
+	let rebootTimedOut = $state(false);
 
 	function currentBackendBaseUrl(): string {
 		return machineHttpBaseUrlFromWsUrl(manager.selectedMachine?.url) ?? getBackendHttpBase();
@@ -218,11 +224,13 @@
 		powerdownConfirmOpen = false;
 		powerdownFailed = false;
 		poweringDown = true;
+		machineDowntime.begin();
 		const baseUrl = currentBackendBaseUrl();
 		try {
 			const response = await fetch(`${baseUrl}/api/system/shutdown`, { method: 'POST' });
 			if (!response.ok) {
 				poweringDown = false;
+				machineDowntime.end();
 				powerdownFailed = true;
 			}
 			// On success, leave the progress modal up — the machine is going down and
@@ -232,6 +240,64 @@
 			// the response is delivered. Treat a dropped connection as success and keep
 			// the progress modal up.
 		}
+	}
+
+	function requestReboot() {
+		powerMenuOpen = false;
+		rebootConfirmOpen = true;
+	}
+
+	// The backend answers the reboot request before the OS starts tearing
+	// services down, so a probe right after it would still succeed. Wait for the
+	// machine to actually go away before we start watching for it to come back.
+	async function waitForBackendToGoDown(baseUrl: string): Promise<void> {
+		for (let attempt = 0; attempt < 30; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+			try {
+				await fetch(`${baseUrl}/api/system/status`, {
+					signal: AbortSignal.timeout(1500)
+				});
+			} catch {
+				return;
+			}
+		}
+	}
+
+	async function confirmReboot() {
+		rebootConfirmOpen = false;
+		rebootFailed = false;
+		rebootTimedOut = false;
+		rebooting = true;
+		machineDowntime.begin();
+		const baseUrl = currentBackendBaseUrl();
+		try {
+			const response = await fetch(`${baseUrl}/api/system/reboot`, { method: 'POST' });
+			if (!response.ok) {
+				rebooting = false;
+				machineDowntime.end();
+				rebootFailed = true;
+				return;
+			}
+		} catch {
+			// The request may not return if the OS starts tearing things down before
+			// the response is delivered. Treat a dropped connection as success and
+			// wait for the machine to come back.
+		}
+		await waitForBackendToGoDown(baseUrl);
+		// A full boot plus backend startup is a couple of minutes on the Pi.
+		const back = await waitForBackend(baseUrl, {
+			initialDelayMs: 5000,
+			maxAttempts: 180,
+			intervalMs: 2000
+		});
+		rebooting = false;
+		machineDowntime.end();
+		if (!back) {
+			rebootTimedOut = true;
+			return;
+		}
+		manager.connect(currentBackendWsUrl(), { force: true });
+		manager.refreshSelectedCameraFeeds();
 	}
 
 	function handlePowerMenuClickOutside(event: MouseEvent) {
@@ -549,6 +615,14 @@
 								Restart Backend
 							</button>
 							<button
+								onclick={requestReboot}
+								class="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-[#B11618] transition-colors hover:bg-danger/[0.08]"
+								title="Reboot the whole Linux computer the sorter runs on."
+							>
+								<RotateCw size={14} />
+								Full Machine Restart
+							</button>
+							<button
 								onclick={requestPowerDown}
 								class="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm text-[#B11618] transition-colors hover:bg-danger/[0.08]"
 							>
@@ -740,6 +814,110 @@
 		<div class="flex flex-col items-center gap-4 py-4">
 			<Spinner size={24} class="text-primary" />
 			<div class="text-sm text-text-muted">Waiting for the service to come back online.</div>
+		</div>
+	</Modal>
+
+	<Modal bind:open={rebootConfirmOpen} title="Restart the machine?">
+		<div class="flex flex-col gap-4">
+			<div class="flex items-start gap-3">
+				<div
+					class="flex h-9 w-9 shrink-0 items-center justify-center border border-danger/25 bg-danger/[0.08] text-[#B11618]"
+				>
+					<AlertTriangle size={18} />
+				</div>
+				<div>
+					<div class="text-sm text-text">
+						This reboots the entire machine — the same as running <span class="font-mono"
+							>reboot</span
+						> on the Linux computer. Everything powers back on by itself.
+					</div>
+					<div class="mt-2 text-sm text-text-muted">
+						Any running sort will be interrupted. The UI will be unavailable for a couple of minutes
+						while the machine boots back up.
+					</div>
+				</div>
+			</div>
+
+			<div class="flex items-center justify-end gap-2 border-t border-border pt-3">
+				<button
+					type="button"
+					onclick={() => (rebootConfirmOpen = false)}
+					class="inline-flex items-center gap-1.5 border border-border bg-bg px-3 py-1.5 text-sm text-text transition-colors hover:bg-surface"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={() => void confirmReboot()}
+					class="inline-flex items-center gap-1.5 border border-danger/25 bg-danger/[0.08] px-3 py-1.5 text-sm font-medium text-[#B11618] transition-colors hover:bg-danger/[0.14]"
+				>
+					<RotateCw size={14} />
+					Restart Machine
+				</button>
+			</div>
+		</div>
+	</Modal>
+
+	<Modal open={rebooting} title="Restarting machine..." dismissible={false}>
+		<div class="flex flex-col items-center gap-4 py-4 text-center">
+			<Spinner size={24} class="text-primary" />
+			<div class="text-sm text-text">The machine is rebooting.</div>
+			<div class="text-sm text-text-muted">
+				This page will stop responding for a bit. It reconnects on its own once the machine is back
+				up — usually a couple of minutes.
+			</div>
+		</div>
+	</Modal>
+
+	<Modal bind:open={rebootFailed} title="Restart failed">
+		<div class="flex flex-col gap-4">
+			<div class="flex items-start gap-3">
+				<div
+					class="flex h-9 w-9 shrink-0 items-center justify-center border border-danger/25 bg-danger/[0.08] text-[#B11618]"
+				>
+					<AlertTriangle size={18} />
+				</div>
+				<div class="text-sm text-text">
+					The reboot command could not be started. The machine is still running. Check the backend
+					logs for details.
+				</div>
+			</div>
+
+			<div class="flex items-center justify-end gap-2 border-t border-border pt-3">
+				<button
+					type="button"
+					onclick={() => (rebootFailed = false)}
+					class="inline-flex items-center gap-1.5 border border-border bg-bg px-3 py-1.5 text-sm text-text transition-colors hover:bg-surface"
+				>
+					Close
+				</button>
+			</div>
+		</div>
+	</Modal>
+
+	<Modal bind:open={rebootTimedOut} title="Machine is taking a while">
+		<div class="flex flex-col gap-4">
+			<div class="flex items-start gap-3">
+				<div
+					class="flex h-9 w-9 shrink-0 items-center justify-center border border-danger/25 bg-danger/[0.08] text-[#B11618]"
+				>
+					<AlertTriangle size={18} />
+				</div>
+				<div class="text-sm text-text">
+					The machine rebooted but hasn't come back online yet. It may still be booting — reload
+					this page in a minute to check again.
+				</div>
+			</div>
+
+			<div class="flex items-center justify-end gap-2 border-t border-border pt-3">
+				<button
+					type="button"
+					onclick={() => (rebootTimedOut = false)}
+					class="inline-flex items-center gap-1.5 border border-border bg-bg px-3 py-1.5 text-sm text-text transition-colors hover:bg-surface"
+				>
+					Close
+				</button>
+			</div>
 		</div>
 	</Modal>
 

--- a/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
+++ b/software/sorter/frontend/src/lib/components/BackendConnectionGuard.svelte
@@ -11,6 +11,7 @@
 		waitForBackend
 	} from '$lib/backend';
 	import { getMachinesContext } from '$lib/machines/context';
+	import { machineDowntime } from '$lib/stores/machineDowntime.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import { AlertTriangle, RefreshCw, Power, WifiOff } from 'lucide-svelte';
 	import { onMount } from 'svelte';
@@ -182,7 +183,7 @@
 	});
 </script>
 
-<Modal open={!healthy} title="Backend Unavailable">
+<Modal open={!healthy && !machineDowntime.deliberate} title="Backend Unavailable">
 	<div class="flex flex-col gap-4">
 		<div class="flex items-start gap-3">
 			<div

--- a/software/sorter/frontend/src/lib/stores/machineDowntime.svelte.ts
+++ b/software/sorter/frontend/src/lib/stores/machineDowntime.svelte.ts
@@ -1,0 +1,22 @@
+/**
+ * Flag for "the machine is down because we asked it to be".
+ *
+ * A full reboot or power down takes the backend away for minutes, which the
+ * connection guard would otherwise report as an outage and offer to fix by
+ * restarting the backend. The action that took the machine down owns the
+ * user-facing progress modal, so the guard stays quiet while this is set.
+ */
+
+let deliberate = $state(false);
+
+export const machineDowntime = {
+	get deliberate() {
+		return deliberate;
+	},
+	begin() {
+		deliberate = true;
+	},
+	end() {
+		deliberate = false;
+	}
+};


### PR DESCRIPTION
Three fixes from an Aug 13 session on the machine, all on the restart path. They were stranded on a stale branch (`spencer/feeder-per-channel-max-move`, whose own PR merged back in #302); this is them cherry-picked onto current main. Independent of each other — the camera/USB work from the same session is not here.

**LEDs came back dark and unlightable after any host restart.** The board routes a digital output's pad to its PWM block on the first duty write and remembers it in `digital_output_pwm_active`. INIT — sent by board discovery on every host start — re-runs `gpio_init` on those pads, handing them back to SIO and driving them low, but left that flag set. So any host restart that did not also reset the board (a backend restart, or the Pi rebooting over USB-powered Picos) came back with the LEDs off, the firmware convinced they were still in PWM mode, and every later duty write landing on a pad the PWM block no longer drove. The host still had 65535 on record, so the UI showed them lit. Fixed on both sides: firmware clears the flag alongside the `gpio_init` that invalidates it, so INIT means what its docstring says; the host opens each process's first duty write with a plain one, which clears the flag on old firmware too — boards in the field can't all be reflashed, and it costs one extra write per pin per boot.

**Firmware flash reported healthy boards as blank or wedged.** `identifyBoard` opened the bus at the default 100 ms read timeout, which is the control loop's budget — there a late reply is better dropped than waited on. But the flash runs inside the same backend process as vision and its thread can lose the GIL for longer than that, reading a response back in pieces. Flashing a v1-2 distribution board on kitbash failed three times in a row with "No responsive board … blank or wedged, hold BOOTSEL", against a board that answered the same command in 12 ms from an idle process. Identification happens a handful of times per flash, so it now gets a 1 s timeout of its own.

**Full machine restart from the UI.** The power menu could power the machine down but not reboot it, so recovering from anything needing a fresh boot meant SSHing in. Adds `POST /api/system/reboot` (same shell-command fallback chain as the existing shutdown endpoint) and a "Full Machine Restart" item beside the power down. Both confirm first; the restart then waits for the machine to go down, waits for it to come back, and reconnects on its own. While a reboot or power down is deliberately taking the machine away, the connection guard stays quiet — its "Backend Unavailable / Restart Backend" modal is wrong when we're the ones who took it down.

`test_leds.py` passes (9 tests). `svelte-check` reports the same 5 errors and 22 warnings as main, none in the files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
