### PR TITLE
hive: no request aggregates, and one periodic worker instead of four

### DIFF
--- a/software/hive/backend/alembic/versions/e1f2a3b4c5d6_stats_cache_distributions.py
+++ b/software/hive/backend/alembic/versions/e1f2a3b4c5d6_stats_cache_distributions.py
@@ -1,0 +1,52 @@
+"""machine_stats_cache: carry the whole distribution maps
+
+The public /stats endpoint recomputed every aggregate over machine_pieces on
+every request — about 18 sequential scans of a 240 MB table per call, at ten
+calls a minute, which pinned prod's two vCPUs. The per-machine cache that the
+admin fleet table already reads was most of the answer; it just did not carry
+the distributions. With them, every analytics scope is a fold over cache rows
+and nothing aggregates on the request path.
+
+Backfilled empty. The stats worker fills it on its first pass, and the fold
+treats a missing map as a machine with no pieces rather than as an error.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d4f6a8b0c2e1
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e1f2a3b4c5d6"
+down_revision = "d4f6a8b0c2e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "machine_stats_cache",
+        sa.Column("distributions", sa.JSON(), nullable=False, server_default="{}"),
+    )
+    # The index the live piece counter reads: rows this machine reported since
+    # the cache was built. CONCURRENTLY because the box this lands on is the one
+    # that was already saturated, and a plain CREATE INDEX takes a write lock on
+    # the table every machine syncs into.
+    if op.get_bind().dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            op.create_index(
+                "ix_machine_pieces_machine_created_at",
+                "machine_pieces",
+                ["machine_id", "created_at"],
+                postgresql_concurrently=True,
+                if_not_exists=True,
+            )
+    else:
+        op.create_index(
+            "ix_machine_pieces_machine_created_at", "machine_pieces", ["machine_id", "created_at"]
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_machine_pieces_machine_created_at", table_name="machine_pieces")
+    op.drop_column("machine_stats_cache", "distributions")

--- a/software/hive/backend/app/models/machine_piece.py
+++ b/software/hive/backend/app/models/machine_piece.py
@@ -68,4 +68,10 @@ class MachinePiece(Base):
         UniqueConstraint("machine_id", "piece_uuid", name="uq_machine_pieces_machine_piece"),
         Index("ix_machine_pieces_machine_local_id", "machine_id", "local_id"),
         Index("ix_machine_pieces_machine_seen_at", "machine_id", "seen_at"),
+        # Rows by when HIVE learned of them, which is what the analytics cache
+        # counts forward from between refreshes. Deliberately not seen_at: a
+        # machine that was offline uploads a backlog whose seen_at is days old,
+        # and those pieces have to show up in the live counter when they land,
+        # not whenever the next hourly pass happens to run.
+        Index("ix_machine_pieces_machine_created_at", "machine_id", "created_at"),
     )

--- a/software/hive/backend/app/models/machine_stats_cache.py
+++ b/software/hive/backend/app/models/machine_stats_cache.py
@@ -1,19 +1,31 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, Column, DateTime, Float, ForeignKey, Integer
+from sqlalchemy import JSON, BigInteger, Column, DateTime, Float, ForeignKey, Integer
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.models import Base
 
 
 class MachineStatsCache(Base):
-    """Pre-computed per-machine dashboard metrics.
+    """Pre-computed per-machine metrics — the ONE cache every stats surface reads.
 
     Recomputing piece/sample aggregates on every dashboard/overview request is
     expensive once a machine has synced hundreds of thousands of pieces. A
     background worker (app.services.machine_stats) refreshes one row per machine
     on an hourly cadence; the API serves these rows directly. One row per
     machine, upserted in place — no history.
+
+    Why per MACHINE and never per scope: every set a caller can ask about (one
+    machine, one owner's fleet, your machines, the whole fleet) is some subset
+    of these rows, so caching the machine lets any scope be folded in Python
+    from rows already in memory. Caching the scope instead means a new cache
+    entry for every question anyone thinks to ask, and two of them eventually
+    disagreeing about how many pieces exist.
+
+    That is why the distribution maps below are stored WHOLE rather than as a
+    top-15: a top-15 per machine cannot be folded into a correct top-15 for the
+    fleet, and the count of distinct parts across a set is the size of the union
+    of these keys, which a truncated map cannot give.
     """
 
     __tablename__ = "machine_stats_cache"
@@ -44,6 +56,15 @@ class MachineStatsCache(Base):
     total_sessions = Column(Integer, nullable=False, default=0)
     parts_found = Column(Integer, nullable=False, default=0)
     parts_needed = Column(Integer, nullable=False, default=0)
+
+    # Whole distribution maps for this machine, the input the analytics fold
+    # sums over. Shape:
+    #   {"status": {"<status>": count},
+    #    "parts":  {"<part_id>":  [count, "<part_name>"]},
+    #    "colors": {"<color_id>": [count, "<color_name>"]}}
+    # Names ride along because a caller ranking parts wants to print one, and
+    # re-joining a catalog per request is the cost this cache exists to avoid.
+    distributions = Column(JSON, nullable=False, default=dict)
 
     computed_at = Column(
         DateTime(timezone=True),

--- a/software/hive/backend/app/routers/analytics.py
+++ b/software/hive/backend/app/routers/analytics.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.deps import get_current_user, get_db
-from app.models.machine_daily_stats import MachineDailyStats
 from app.models.user import User
 from app.services import analytics
 
@@ -21,17 +20,10 @@ def get_analytics(
 ):
     """Analytics over a set of machines, chosen by (in precedence order)
     machine_id, owner_id, or scope=mine|all. Authorization is enforced by
-    resolve_machine_set; served from machine_daily_stats + live group-bys."""
+    resolve_machine_set; served entirely from the pre-computed caches."""
     resolved = analytics.resolve_machine_set(
         db, current_user, machine_id=machine_id, owner_id=owner_id, scope=scope
     )
-    # Cold-start: populate the daily table on the first request if the worker
-    # hasn't run yet, so analytics isn't blank on a fresh deploy.
-    if db.query(MachineDailyStats.machine_id).first() is None:
-        try:
-            analytics.refresh_daily_stats(db)
-        except Exception:
-            db.rollback()
     data = analytics.get_analytics(db, resolved["ids"])
     return {
         "scope": {

--- a/software/hive/backend/app/routers/machines.py
+++ b/software/hive/backend/app/routers/machines.py
@@ -175,7 +175,7 @@ def admin_machine_stats(
     """Per-machine lifetime metrics (pieces, PPM, on-time %) across ALL machines.
 
     Served from the machine_stats_cache table, refreshed hourly by the
-    MachineStatsWorker (see app.services.machine_stats). Cold-start fallback:
+    machine-stats worker (see app.services.machine_stats). Cold-start fallback:
     if the cache has never been populated, compute it once here so the first
     admin load isn't blank.
     """
@@ -199,7 +199,7 @@ def admin_refresh_machine_stats(
     _csrf: None = Depends(verify_csrf),
 ):
     """Force an immediate recompute of every machine's cached stats."""
-    count = machine_stats.refresh_cache(db)
+    count = machine_stats.refresh_all(db)
     return {"ok": True, "refreshed": count, "worker": get_machine_stats_worker().status()}
 
 

--- a/software/hive/backend/app/routers/piece_color_labels.py
+++ b/software/hive/backend/app/routers/piece_color_labels.py
@@ -386,7 +386,7 @@ def color_coverage(
 # "Has same-piece candidates" — a channel crop exists within the piece's
 # arrival window (DEFAULT_PARAMS lookback/slop). Precomputed into the
 # piece_has_candidates materialized view (a8c1d2e3f4a5, refreshed by
-# CandidateMatviewWorker) and hash-joined here; both the with_candidates filter
+# candidate_matview worker) and hash-joined here; both the with_candidates filter
 # and the priority sort key read it, so it is needed for every row of the grid
 # before pagination, not just for a piece someone opens.
 #

--- a/software/hive/backend/app/routers/public_stats.py
+++ b/software/hive/backend/app/routers/public_stats.py
@@ -69,7 +69,6 @@ from app.deps import (
     resolve_public_scopes,
 )
 from app.models.machine import Machine
-from app.models.machine_daily_stats import MachineDailyStats
 from app.models.machine_piece import MachinePiece
 from app.models.user import User
 from app.models.user_identity import UserIdentity
@@ -136,15 +135,16 @@ require_fleet_anon_key = require_public_scope(API_KEY_SCOPE_FLEET_ANON)
 @router.get("/stats", dependencies=[Depends(require_stats_key)])
 def get_public_stats(db: Session = Depends(get_db)):
     """Aggregate analytics across every non-archived machine — the same block the
-    admin all-machines dashboard renders, minus any per-owner PII."""
+    admin all-machines dashboard renders, minus any per-owner PII.
+
+    This is the most-called endpoint hive has: the website's live counter polls
+    it through an edge cache that misses once per Cloudflare PoP, which lands as
+    a steady ten requests a minute whether or not anyone is looking. It must
+    therefore cost approximately nothing. It is a fold over cached rows plus
+    three indexed range counts, none of which touch more than the last day of
+    machine_pieces. See `services/analytics` for what happens when it doesn't.
+    """
     ids = [mid for (mid,) in db.query(Machine.id).filter(Machine.archived_at.is_(None)).all()]
-    # Cold-start: populate the daily table on the first request if the worker
-    # hasn't run yet, so stats aren't blank on a fresh deploy.
-    if db.query(MachineDailyStats.machine_id).first() is None:
-        try:
-            analytics.refresh_daily_stats(db)
-        except Exception:
-            db.rollback()
     data = analytics.get_analytics(db, ids)
     return {
         "scope": {"kind": "all", "label": "All machines", "machine_count": len(ids)},
@@ -396,16 +396,27 @@ def _local_day_in_progress(db: Session, ids: list) -> dict:
 
     Postgres only (prod); the local-zone date math relies on ``timezone()``.
     Elsewhere (SQLite tests) return nothing and the client keeps its UTC fallback.
+
+    The zone conversion happens ONCE, to produce a UTC instant for local
+    midnight, and the filter is then a plain range on seen_at. Comparing
+    ``date(timezone(tz, seen_at))`` to today instead — which is what this used
+    to do — wraps the indexed column in a function, so no index applies and
+    every call sequentially scanned the whole table to count one day.
     """
     if db.bind.dialect.name != "postgresql":
         return {}
-    today_local = db.query(func.date(func.timezone(PUBLIC_STATS_LOCAL_TZ, func.now()))).scalar()
-    piece_local_date = func.date(func.timezone(PUBLIC_STATS_LOCAL_TZ, MachinePiece.seen_at))
+    today_local, day_start_utc = db.query(
+        func.date(func.timezone(PUBLIC_STATS_LOCAL_TZ, func.now())),
+        func.timezone(
+            PUBLIC_STATS_LOCAL_TZ,
+            func.date_trunc("day", func.timezone(PUBLIC_STATS_LOCAL_TZ, func.now())),
+        ),
+    ).one()
     pieces = (
         db.query(func.count())
         .select_from(MachinePiece)
         .filter(MachinePiece.machine_id.in_(ids))
-        .filter(piece_local_date == today_local)
+        .filter(MachinePiece.seen_at >= day_start_utc)
         .scalar()
     ) or 0
     return {"last_day_local": today_local.isoformat(), "last_day_local_pieces": int(pieces)}

--- a/software/hive/backend/app/services/analytics.py
+++ b/software/hive/backend/app/services/analytics.py
@@ -463,7 +463,7 @@ def get_analytics(db: Session, machine_ids: list[Any]) -> dict[str, Any]:
             "unique_parts": len(folded["parts"]),
             "unique_colors": len(folded["colors"]),
             "active_seconds": round(active_seconds, 1),
-            "overall_ppm": (counts["distributed"] * 60.0 / active_seconds) if active_seconds > 0 else 0.0,
+            "overall_ppm": round(counts["distributed"] * 60.0 / active_seconds, 3) if active_seconds > 0 else 0.0,
             "capacity_recent": series[-1]["capacity_per_day"] if series else 0.0,
             "first_day": day_bounds[0].isoformat() if day_bounds[0] else None,
             "last_day": day_bounds[1].isoformat() if day_bounds[1] else None,

--- a/software/hive/backend/app/services/analytics.py
+++ b/software/hive/backend/app/services/analytics.py
@@ -1,14 +1,32 @@
 """Analytics over an arbitrary set of machines.
 
-The same primitives serve every context — one machine, a user's whole fleet, one
-user's fleet (admin), or the entire fleet (admin) — by resolving the request to a
-list of machine ids and aggregating over it:
+**No request aggregates.** Every number served here is a fold over two
+pre-computed tables — machine_stats_cache (one row per machine, hourly) and
+machine_daily_stats (one row per machine-day) — and the fold is plain Python
+over rows fetched by primary key. The set a caller asks about (one machine, one
+owner's fleet, yours, the whole fleet) only chooses which rows to add up.
+
+That rule is the point of this module and it was learned the expensive way. The
+version this replaced ran the group-bys live, "cheap at current scale". By
+August 2026 machine_pieces held 354k rows in 240 MB, one /stats call was about
+18 sequential scans of it and took 5-7 seconds, the public site called it every
+6 seconds, and both of prod's vCPUs were pinned around the clock. Nothing about
+that was a sudden failure: the cost per call had been growing linearly with the
+table since June and nobody was watching it.
+
+So: if a number here starts needing a scan of machine_pieces, it belongs in the
+worker that builds the cache (`services/machine_stats.py`), not here.
+
+The one exception, deliberately: `_live_pieces_since` counts rows newer than
+the cache watermark through the (machine_id, seen_at) index, so the headline
+piece counter ticks up between hourly passes. It reads minutes of data, never
+the table.
 
   * time-series  — machines / pieces / distributed / avg-PPM / sorting-capacity
-    per day, from the pre-computed machine_daily_stats table.
-  * distributions — pieces by machine / classification status / top parts / top
-    colors (live group-bys, cheap at current scale).
-  * totals        — headline numbers for the set.
+    per day, from machine_daily_stats.
+  * distributions — pieces by machine / classification status / top parts /
+    colors / categories, folded from the cached per-machine maps.
+  * totals        — headline numbers for the set, plus the live top-up.
 
 "Sorting capacity" on day D = for each machine active that day, its PPM that day
 projected over a full day (× 1440 min), summed across machines — i.e. how many
@@ -18,6 +36,7 @@ pieces the fleet could theoretically sort in a day at that day's throughput.
 from __future__ import annotations
 
 import uuid as uuid_mod
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import func
@@ -27,6 +46,7 @@ from app.errors import APIError
 from app.models.machine import Machine
 from app.models.machine_daily_stats import MachineDailyStats
 from app.models.machine_piece import MachinePiece
+from app.models.machine_stats_cache import MachineStatsCache
 from app.models.user import User
 
 # Idle-gap threshold — must match app.services.machine_stats so the derived
@@ -272,112 +292,144 @@ def _bricklink_rgb() -> dict[int, str | None]:
         return {}
 
 
-def get_distributions(db: Session, machine_ids: list[Any]) -> dict[str, Any]:
-    if not machine_ids:
-        return {"by_machine": [], "by_status": [], "top_parts": [], "top_colors": []}
+def _fold_cached(db: Session, machine_ids: list[Any]) -> dict[str, Any]:
+    """Merge the cached per-machine rows for a set into one aggregate.
 
-    base = db.query(MachinePiece).filter(MachinePiece.machine_id.in_(machine_ids))
-
-    by_status = [
-        {"label": status or "unknown", "value": count}
-        for status, count in (
-            base.with_entities(MachinePiece.classification_status, func.count())
-            .group_by(MachinePiece.classification_status)
-            .all()
-        )
-    ]
-
-    top_parts = [
-        {"part_id": pid, "part_name": pname, "value": count}
-        for pid, pname, count in (
-            base.with_entities(MachinePiece.part_id, func.max(MachinePiece.part_name), func.count())
-            .filter(MachinePiece.part_id.isnot(None))
-            .group_by(MachinePiece.part_id)
-            .order_by(func.count().desc())
-            .limit(15)
-            .all()
-        )
-    ]
-
-    top_colors = [
-        {"color_id": cid, "color_name": cname, "value": count}
-        for cid, cname, count in (
-            base.with_entities(MachinePiece.color_id, func.max(MachinePiece.color_name), func.count())
-            .filter(MachinePiece.color_id.isnot(None))
-            .group_by(MachinePiece.color_id)
-            .order_by(func.count().desc())
-            .limit(15)
-            .all()
-        )
-    ]
-    # Attach each BrickLink color's swatch hex, so a client can DRAW the colour
-    # instead of only reprinting its name. Same catalog the labeling UI picks
-    # from. A non-numeric bucket like "any_color", or an id the catalog has no
-    # swatch for, gets rgb=None and the client decides how to render "no colour".
-    rgb_by_bl_id = _bricklink_rgb()
-    for entry in top_colors:
-        try:
-            entry["rgb"] = rgb_by_bl_id.get(int(entry["color_id"]))
-        except (TypeError, ValueError):
-            entry["rgb"] = None
-
-    # Categories are parts folded up by their BrickLink category. Every part is
-    # counted (not just the top fifteen) so the shares are honest, then the
-    # catalog maps part -> category and the biggest categories are kept.
-    part_counts = (
-        base.with_entities(MachinePiece.part_id, func.count())
-        .filter(MachinePiece.part_id.isnot(None))
-        .group_by(MachinePiece.part_id)
-        .all()
+    Pure Python over rows already fetched by primary key. Sums are sums; the
+    part and colour maps are merged key-by-key, which is what makes
+    `unique_parts` for a set exactly the size of the union rather than an
+    estimate, and what makes a fleet-wide top-15 correct rather than a top-15
+    of top-15s.
+    """
+    rows = (
+        db.query(MachineStatsCache).filter(MachineStatsCache.machine_id.in_(machine_ids)).all()
+        if machine_ids
+        else []
     )
-    top_categories = _category_distribution(part_counts, limit=15)
 
-    by_machine: list[dict[str, Any]] = []
-    if len(machine_ids) > 1:
-        name_by_id = {
-            str(mid): name
-            for mid, name in db.query(Machine.id, Machine.name).filter(Machine.id.in_(machine_ids)).all()
-        }
-        rows = (
-            base.with_entities(MachinePiece.machine_id, func.count())
-            .group_by(MachinePiece.machine_id)
-            .order_by(func.count().desc())
-            .all()
-        )
-        by_machine = [
-            {"machine_id": str(mid), "label": name_by_id.get(str(mid), "?"), "value": count}
-            for mid, count in rows
-        ]
+    totals = {"pieces_seen": 0, "distributed": 0, "classified": 0, "machines": 0}
+    status: dict[str, int] = {}
+    parts: dict[str, list[Any]] = {}
+    colors: dict[str, list[Any]] = {}
+    by_machine: list[tuple[str, int]] = []
+    # Machines grouped by how fresh their row is, which is what the live top-up
+    # counts forward from. Per machine and not per set: a machine with no row
+    # yet (registered since the last pass) contributes nothing to the sums, so
+    # its bucket is None and ALL of its pieces are counted live. That is the
+    # cold-start case handled by arithmetic instead of by a special case.
+    cached = {str(row.machine_id): row for row in rows}
+    since_buckets: dict[datetime | None, list[Any]] = {}
+    for mid in machine_ids:
+        row = cached.get(str(mid))
+        since_buckets.setdefault(row.computed_at if row is not None else None, []).append(mid)
+
+    for row in rows:
+        totals["pieces_seen"] += row.pieces_seen or 0
+        totals["distributed"] += row.distributed or 0
+        totals["classified"] += row.classified or 0
+        if row.pieces_seen:
+            totals["machines"] += 1
+            by_machine.append((str(row.machine_id), int(row.pieces_seen)))
+
+        dist = row.distributions or {}
+        for label, count in (dist.get("status") or {}).items():
+            status[label] = status.get(label, 0) + int(count)
+        for src, dest in ((dist.get("parts") or {}, parts), (dist.get("colors") or {}, colors)):
+            for key, entry in src.items():
+                count, name = (entry + [None])[:2] if isinstance(entry, list) else (entry, None)
+                current = dest.get(key)
+                if current is None:
+                    dest[key] = [int(count), name]
+                else:
+                    current[0] += int(count)
+                    current[1] = current[1] or name
 
     return {
+        "totals": totals,
+        "status": status,
+        "parts": parts,
+        "colors": colors,
         "by_machine": by_machine,
-        "by_status": by_status,
-        "top_parts": top_parts,
-        "top_colors": top_colors,
-        "top_categories": top_categories,
+        "since_buckets": since_buckets,
+        # When the folded half was built — the stalest row in the set, so "as
+        # of" is never a claim the freshest member can't back up.
+        "watermark": min((r.computed_at for r in rows if r.computed_at), default=None),
     }
 
 
-def get_totals(db: Session, machine_ids: list[Any], series: list[dict[str, Any]] | None = None) -> dict[str, Any]:
-    empty = {
-        "machines": 0, "pieces_seen": 0, "distributed": 0, "classified": 0,
-        "unique_parts": 0, "unique_colors": 0, "active_seconds": 0.0,
-        "overall_ppm": 0.0, "capacity_recent": 0.0, "first_day": None, "last_day": None,
-    }
-    if not machine_ids:
-        return empty
+def _live_pieces_since(db: Session, since_buckets: dict[datetime | None, list[Any]]) -> int:
+    """Pieces this fleet reported since each machine's cache row was built.
 
-    agg = (
-        db.query(
-            func.count().label("pieces_seen"),
-            func.count().filter(MachinePiece.bin_x.isnot(None)).label("distributed"),
-            func.count().filter(MachinePiece.classification_status == "classified").label("classified"),
-            func.count(func.distinct(MachinePiece.part_id)).label("unique_parts"),
-            func.count(func.distinct(MachinePiece.color_id)).label("unique_colors"),
+    The only query analytics runs against machine_pieces, and normally it is a
+    single index range on (machine_id, created_at) covering rows newer than the
+    last refresh — minutes of data, not the table. One query per distinct
+    watermark, and a fleet refreshed in one pass shares one.
+
+    ``created_at`` (when hive stored the row) and not ``seen_at`` (when the
+    machine saw the piece): a machine that has been offline uploads a backlog
+    stamped days ago, and those pieces have to count when they arrive rather
+    than an hour later.
+
+    A machine with no cached row yet counts from the beginning, which is the
+    right answer — its cached contribution is zero — and is bounded by what
+    that one machine has ever sorted. It self-corrects on the next worker pass.
+
+    The count can lag by the few seconds a refresh takes (rows landing mid-pass
+    are in neither half until the following one). That direction is chosen: the
+    counter creeps up to the truth instead of overshooting and visibly falling
+    back, which is what stamping the watermark before the pass would do.
+    """
+    total = 0
+    for since, ids in since_buckets.items():
+        if not ids:
+            continue
+        query = (
+            db.query(func.count())
+            .select_from(MachinePiece)
+            .filter(MachinePiece.machine_id.in_(ids))
         )
-        .filter(MachinePiece.machine_id.in_(machine_ids))
-        .one()
-    )
+        if since is not None:
+            query = query.filter(MachinePiece.created_at >= since)
+        total += int(query.scalar() or 0)
+    return total
+
+
+def _ranked(counts: dict[str, list[Any]], id_key: str, name_key: str, limit: int) -> list[dict[str, Any]]:
+    ranked = sorted(counts.items(), key=lambda kv: kv[1][0], reverse=True)[:limit]
+    return [{id_key: key, name_key: entry[1], "value": entry[0]} for key, entry in ranked]
+
+
+def get_analytics(db: Session, machine_ids: list[Any]) -> dict[str, Any]:
+    """Totals, time-series and distributions for a set of machines.
+
+    Reads machine_stats_cache and machine_daily_stats and folds them. The only
+    thing it asks of machine_pieces is an indexed count of rows newer than the
+    cache, so the cost is flat in the size of that table — which is the whole
+    point, because it grew from 51k rows in June to 354k in August and the old
+    version's cost grew with it.
+    """
+    if not machine_ids:
+        return {
+            "totals": {
+                "machines": 0, "pieces_seen": 0, "distributed": 0, "classified": 0,
+                "unique_parts": 0, "unique_colors": 0, "active_seconds": 0.0,
+                "overall_ppm": 0.0, "capacity_recent": 0.0,
+                "first_day": None, "last_day": None,
+            },
+            "timeseries": [],
+            "distributions": {"by_machine": [], "by_status": [], "top_parts": [], "top_colors": [], "top_categories": []},
+            "fresh_as_of": None,
+        }
+
+    folded = _fold_cached(db, machine_ids)
+    series = get_timeseries(db, machine_ids)
+    counts = folded["totals"]
+
+    # Live top-up. Only pieces_seen gets it: it is the number people watch
+    # climb, and the rest (which part, which colour, whether it was
+    # distributed) is not knowable without reading the rows themselves.
+    pieces_seen = counts["pieces_seen"] + _live_pieces_since(db, folded["since_buckets"])
+
     active_seconds = (
         db.query(func.coalesce(func.sum(MachineDailyStats.active_seconds), 0.0))
         .filter(MachineDailyStats.machine_id.in_(machine_ids))
@@ -388,39 +440,51 @@ def get_totals(db: Session, machine_ids: list[Any], series: list[dict[str, Any]]
         .filter(MachineDailyStats.machine_id.in_(machine_ids))
         .one()
     )
-    machines_with_pieces = (
-        db.query(func.count(func.distinct(MachinePiece.machine_id)))
-        .filter(MachinePiece.machine_id.in_(machine_ids))
-        .scalar()
-    ) or 0
 
-    distributed = agg.distributed or 0
-    overall_ppm = (distributed * 60.0 / active_seconds) if active_seconds > 0 else 0.0
+    top_colors = _ranked(folded["colors"], "color_id", "color_name", 15)
+    rgb_by_bl_id = _bricklink_rgb()
+    for entry in top_colors:
+        try:
+            entry["rgb"] = rgb_by_bl_id.get(int(entry["color_id"]))
+        except (TypeError, ValueError):
+            entry["rgb"] = None
 
-    # Recent capacity = the most recent day's theoretical daily throughput.
-    if series is None:
-        series = get_timeseries(db, machine_ids)
-    capacity_recent = series[-1]["capacity_per_day"] if series else 0.0
-
-    return {
-        "machines": machines_with_pieces,
-        "pieces_seen": agg.pieces_seen or 0,
-        "distributed": distributed,
-        "classified": agg.classified or 0,
-        "unique_parts": agg.unique_parts or 0,
-        "unique_colors": agg.unique_colors or 0,
-        "active_seconds": round(active_seconds, 1),
-        "overall_ppm": round(overall_ppm, 3),
-        "capacity_recent": capacity_recent,
-        "first_day": day_bounds[0].isoformat() if day_bounds[0] else None,
-        "last_day": day_bounds[1].isoformat() if day_bounds[1] else None,
+    name_by_id = {
+        str(mid): name
+        for mid, name in db.query(Machine.id, Machine.name).filter(Machine.id.in_(machine_ids)).all()
     }
 
-
-def get_analytics(db: Session, machine_ids: list[Any]) -> dict[str, Any]:
-    series = get_timeseries(db, machine_ids)
     return {
-        "totals": get_totals(db, machine_ids, series=series),
+        "totals": {
+            "machines": counts["machines"],
+            "pieces_seen": pieces_seen,
+            "distributed": counts["distributed"],
+            "classified": counts["classified"],
+            "unique_parts": len(folded["parts"]),
+            "unique_colors": len(folded["colors"]),
+            "active_seconds": round(active_seconds, 1),
+            "overall_ppm": (counts["distributed"] * 60.0 / active_seconds) if active_seconds > 0 else 0.0,
+            "capacity_recent": series[-1]["capacity_per_day"] if series else 0.0,
+            "first_day": day_bounds[0].isoformat() if day_bounds[0] else None,
+            "last_day": day_bounds[1].isoformat() if day_bounds[1] else None,
+        },
         "timeseries": series,
-        "distributions": get_distributions(db, machine_ids),
+        "distributions": {
+            # Only meaningful for a set; one machine's breakdown by machine is itself.
+            "by_machine": [
+                {"machine_id": mid, "label": name_by_id.get(mid, "?"), "value": value}
+                for mid, value in sorted(folded["by_machine"], key=lambda kv: kv[1], reverse=True)
+            ] if len(machine_ids) > 1 else [],
+            "by_status": [{"label": label, "value": value} for label, value in folded["status"].items()],
+            "top_parts": _ranked(folded["parts"], "part_id", "part_name", 15),
+            "top_colors": top_colors,
+            # Every part is counted, not just the top fifteen, so the shares are
+            # honest; the catalog then maps part -> category.
+            "top_categories": _category_distribution(
+                [(key, entry[0]) for key, entry in folded["parts"].items()], limit=15
+            ),
+        },
+        # When the folded half was built. The caller can say "as of" rather than
+        # implying every number in the payload is to-the-second.
+        "fresh_as_of": folded["watermark"].isoformat() if folded["watermark"] else None,
     }

--- a/software/hive/backend/app/services/candidate_matview.py
+++ b/software/hive/backend/app/services/candidate_matview.py
@@ -9,71 +9,33 @@ comfortably inside that window the view is indistinguishable from live data.
 
 from __future__ import annotations
 
-import logging
 import threading
-import time
 
 from sqlalchemy import text
 
 from app.database import engine
-
-logger = logging.getLogger(__name__)
+from app.services.periodic import PeriodicWorker
 
 REFRESH_INTERVAL_S = 300.0
 
 
-class CandidateMatviewWorker:
-    """Daemon thread that refreshes piece_has_candidates on a fixed cadence."""
-
-    def __init__(self) -> None:
-        self._thread: threading.Thread | None = None
-        self._stop_event = threading.Event()
-        self._start_lock = threading.Lock()
-
-    def start(self) -> None:
-        with self._start_lock:
-            if self._thread is not None and self._thread.is_alive():
-                return
-            self._stop_event.clear()
-            self._thread = threading.Thread(
-                target=self._loop, daemon=True, name="candidate-matview-worker"
-            )
-            self._thread.start()
-
-    def stop(self) -> None:
-        self._stop_event.set()
-
-    def _loop(self) -> None:
-        logger.info("CandidateMatviewWorker: started")
-        while not self._stop_event.is_set():
-            self._stop_event.wait(timeout=REFRESH_INTERVAL_S)
-            if self._stop_event.is_set():
-                break
-            self._refresh_once()
-        logger.info("CandidateMatviewWorker: stopped")
-
-    def _refresh_once(self) -> None:
-        started = time.monotonic()
-        try:
-            # CONCURRENTLY can't run inside a transaction, and the refresh is
-            # allowed to outlive the app-wide statement timeout.
-            with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
-                conn.execute(text("SET statement_timeout = 0"))
-                conn.execute(text("REFRESH MATERIALIZED VIEW CONCURRENTLY piece_has_candidates"))
-            logger.info(
-                "CandidateMatviewWorker: refreshed in %.1fs", time.monotonic() - started
-            )
-        except Exception:
-            logger.exception("CandidateMatviewWorker: refresh failed")
+def refresh_once() -> None:
+    # CONCURRENTLY can't run inside a transaction, and the refresh is allowed
+    # to outlive the app-wide statement timeout.
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        conn.execute(text("SET statement_timeout = 0"))
+        conn.execute(text("REFRESH MATERIALIZED VIEW CONCURRENTLY piece_has_candidates"))
 
 
-_worker: CandidateMatviewWorker | None = None
+_worker: PeriodicWorker | None = None
 _worker_lock = threading.Lock()
 
 
-def get_candidate_matview_worker() -> CandidateMatviewWorker:
+def get_candidate_matview_worker() -> PeriodicWorker:
     global _worker
     with _worker_lock:
         if _worker is None:
-            _worker = CandidateMatviewWorker()
+            _worker = PeriodicWorker(
+                "candidate-matview-worker", refresh_once, lambda: REFRESH_INTERVAL_S
+            )
         return _worker

--- a/software/hive/backend/app/services/machine_stats.py
+++ b/software/hive/backend/app/services/machine_stats.py
@@ -1,23 +1,28 @@
-"""Per-machine dashboard stats: computation, persistent cache, refresh worker.
+"""Per-machine stats: computation, persistent cache, refresh worker.
 
-Two families of metrics per machine:
+**This module owns the only fleet-scale aggregation in the app.** Nothing on a
+request path may scan machine_pieces; `services/analytics.py` folds the rows
+this writes, and every stats surface reads that fold. See `analytics` for why.
+
+Three families of metrics per machine:
   * piece-derived  — pieces_seen, distributed, PPM, on-time %, unique parts/colors
     (from machine_pieces; active sorting time inferred from piece-timestamp density)
   * sample-derived — total/accepted samples, sessions, set-progress parts
     (from samples / upload_sessions / machine_set_progress)
+  * distributions  — the whole per-machine part / color / status maps, which are
+    what let an arbitrary set of machines be answered without touching pieces.
 
 Recomputing these over the whole fleet on every request was the load source on
-the admin machines page. Instead a daemon thread refreshes one row per machine
-into machine_stats_cache hourly; the API reads those rows. Single-machine
-overviews lazily compute + cache on a miss so a brand-new machine isn't blank
-until the next scheduled pass.
+the admin machines page, and later on the public one. Instead a daemon thread
+refreshes one row per machine into machine_stats_cache hourly; the API reads
+those rows. Single-machine overviews lazily compute + cache on a miss so a
+brand-new machine isn't blank until the next scheduled pass.
 """
 
 from __future__ import annotations
 
 import logging
 import threading
-import time
 import uuid as uuid_mod
 from datetime import datetime, timezone
 from typing import Any
@@ -30,6 +35,7 @@ from app.database import SessionLocal
 from app.models.machine import Machine
 from app.models.machine_piece import MachinePiece
 from app.models.machine_stats_cache import MachineStatsCache
+from app.services.periodic import PeriodicWorker
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +64,10 @@ _NUMERIC_FIELDS = (
 _DATE_FIELDS = ("first_seen", "last_seen", "first_capture", "last_capture")
 
 
+def _empty_distributions() -> dict[str, Any]:
+    return {"status": {}, "parts": {}, "colors": {}}
+
+
 def _empty_stats() -> dict[str, Any]:
     stats: dict[str, Any] = {f: 0 for f in _NUMERIC_FIELDS}
     stats["active_seconds"] = 0.0
@@ -65,6 +75,7 @@ def _empty_stats() -> dict[str, Any]:
     stats["ontime_pct"] = 0.0
     for f in _DATE_FIELDS:
         stats[f] = None
+    stats["distributions"] = _empty_distributions()
     return stats
 
 
@@ -161,6 +172,45 @@ def _compute_piece_stats(db: Session, machine_ids: list[Any] | None = None) -> d
     return result
 
 
+def _compute_distributions(db: Session, machine_ids: list[Any] | None = None) -> dict[str, dict[str, Any]]:
+    """Whole per-machine distribution maps: status, parts, colors.
+
+    Three grouped passes per refresh, in place of the same three group-bys run
+    on every analytics request. Kept WHOLE (no top-N) because the fold that
+    builds a fleet-wide answer needs every key: a top-15 per machine cannot be
+    folded into a correct top-15 for the fleet, and `unique_parts` for a set is
+    the size of the union of these keys.
+    """
+
+    def _scoped(query):
+        return query.filter(MachinePiece.machine_id.in_(machine_ids)) if machine_ids is not None else query
+
+    out: dict[str, dict[str, Any]] = {}
+
+    def _bucket(mid: Any, key: str) -> dict[str, Any]:
+        return out.setdefault(str(mid), {"status": {}, "parts": {}, "colors": {}})[key]
+
+    for mid, status, count in _scoped(
+        db.query(MachinePiece.machine_id, MachinePiece.classification_status, func.count())
+    ).group_by(MachinePiece.machine_id, MachinePiece.classification_status).all():
+        _bucket(mid, "status")[status or "unknown"] = int(count)
+
+    for column, name_column, key in (
+        (MachinePiece.part_id, MachinePiece.part_name, "parts"),
+        (MachinePiece.color_id, MachinePiece.color_name, "colors"),
+    ):
+        rows = (
+            _scoped(db.query(MachinePiece.machine_id, column, func.max(name_column), func.count()))
+            .filter(column.isnot(None))
+            .group_by(MachinePiece.machine_id, column)
+            .all()
+        )
+        for mid, value, name, count in rows:
+            _bucket(mid, key)[str(value)] = [int(count), name]
+
+    return out
+
+
 def _compute_sample_stats(db: Session, machine_ids: list[Any] | None = None) -> dict[str, dict[str, Any]]:
     from app.models.sample import Sample
     from app.models.upload_session import UploadSession
@@ -227,6 +277,7 @@ def compute_stats(db: Session, machine_ids: list[Any] | None = None) -> dict[str
 
     piece_stats = _compute_piece_stats(db, ids)
     sample_stats = _compute_sample_stats(db, ids)
+    distributions = _compute_distributions(db, ids)
 
     merged: dict[str, dict[str, Any]] = {}
     for mid in ids:
@@ -234,6 +285,7 @@ def compute_stats(db: Session, machine_ids: list[Any] | None = None) -> dict[str
         stats = _empty_stats()
         stats.update(piece_stats.get(mid_str, {}))
         stats.update(sample_stats.get(mid_str, {}))
+        stats["distributions"] = distributions.get(mid_str, _empty_distributions())
         merged[mid_str] = stats
     return merged
 
@@ -257,6 +309,7 @@ def refresh_cache(db: Session, machine_ids: list[Any] | None = None) -> int:
             db.add(row)
         for field in _NUMERIC_FIELDS + _DATE_FIELDS:
             setattr(row, field, values[field])
+        row.distributions = values.get("distributions") or _empty_distributions()
         row.computed_at = now
     db.commit()
     return len(stats)
@@ -316,116 +369,59 @@ def get_machine_stats(db: Session, machine_id: Any) -> dict[str, Any]:
     return _serialize(_empty_stats(), None)
 
 
-class MachineStatsWorker:
-    """Daemon thread that refreshes machine_stats_cache on a fixed cadence."""
+def refresh_all(db: Session) -> int:
+    """One full pass over a session: per-machine cache, then the daily table.
 
-    def __init__(self) -> None:
-        self._thread: threading.Thread | None = None
-        self._stop_event = threading.Event()
-        self._wake_event = threading.Event()
-        self._start_lock = threading.Lock()
-        self._state_lock = threading.Lock()
-        self._state: dict[str, Any] = {
-            "running": False,
-            "last_run_at": None,
-            "last_run_machines": 0,
-            "last_run_duration_s": None,
-            "last_error": None,
-            "total_runs": 0,
-        }
+    This is the ONLY place in the app that aggregates over machine_pieces at
+    fleet scale. Everything served to a request is a fold over what this
+    writes, so anything that wants fresh numbers — the worker, a test, an admin
+    forcing a rebuild — calls this rather than growing its own copy.
+    """
+    count = refresh_cache(db)
+    # Same pass also maintains the per-day analytics substrate.
+    from app.services import analytics
 
-    def start(self) -> None:
-        with self._start_lock:
-            if self._thread is not None and self._thread.is_alive():
-                return
-            self._stop_event.clear()
-            self._thread = threading.Thread(target=self._loop, daemon=True, name="machine-stats-worker")
-            self._thread.start()
-        self._update_state(running=True)
-
-    def stop(self) -> None:
-        self._stop_event.set()
-        self._wake_event.set()
-        self._update_state(running=False)
-
-    def wake(self) -> None:
-        """Ask the loop to run a refresh pass as soon as possible."""
-        self._wake_event.set()
-
-    def status(self) -> dict[str, Any]:
-        with self._state_lock:
-            snapshot = dict(self._state)
-        snapshot["interval_s"] = self._interval_s()
-        return snapshot
-
-    def _interval_s(self) -> float:
-        return max(60.0, float(settings.MACHINE_STATS_REFRESH_INTERVAL_MINUTES) * 60.0)
-
-    def _loop(self) -> None:
-        logger.info("MachineStatsWorker: started")
-        # Prime the cache on boot so the first dashboard load is already warm.
-        self._run_one_pass()
-        while not self._stop_event.is_set():
-            self._wake_event.wait(timeout=self._interval_s())
-            self._wake_event.clear()
-            if self._stop_event.is_set():
-                break
-            self._run_one_pass()
-        self._update_state(running=False)
-        logger.info("MachineStatsWorker: stopped")
-
-    def _run_one_pass(self) -> None:
-        started = time.monotonic()
-        db = SessionLocal()
-        try:
-            count = refresh_cache(db)
-            # Same pass also maintains the per-day analytics substrate.
-            from app.services import analytics
-
-            analytics.refresh_daily_stats(db)
-            self._update_state(
-                last_run_at=datetime.now(timezone.utc).isoformat(),
-                last_run_machines=count,
-                last_run_duration_s=round(time.monotonic() - started, 3),
-                last_error=None,
-                increment_runs=1,
-            )
-            logger.info("MachineStatsWorker: refreshed %d machines in %.2fs", count, time.monotonic() - started)
-        except Exception as exc:
-            logger.exception("MachineStatsWorker pass crashed: %s", exc)
-            db.rollback()
-            self._update_state(last_error=str(exc))
-        finally:
-            db.close()
-
-    def _update_state(self, **kwargs: Any) -> None:
-        with self._state_lock:
-            if "running" in kwargs:
-                self._state["running"] = bool(kwargs.pop("running"))
-            if "increment_runs" in kwargs:
-                self._state["total_runs"] += int(kwargs.pop("increment_runs"))
-            for key, value in kwargs.items():
-                self._state[key] = value
+    analytics.refresh_daily_stats(db)
+    return count
 
 
-_INSTANCE: MachineStatsWorker | None = None
+def _refresh_pass() -> dict[str, Any]:
+    db = SessionLocal()
+    try:
+        return {"last_run_machines": refresh_all(db)}
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+_INSTANCE: PeriodicWorker | None = None
 _INSTANCE_LOCK = threading.Lock()
 
 
-def get_machine_stats_worker() -> MachineStatsWorker:
+def get_machine_stats_worker() -> PeriodicWorker:
     global _INSTANCE
     if _INSTANCE is None:
         with _INSTANCE_LOCK:
             if _INSTANCE is None:
-                _INSTANCE = MachineStatsWorker()
+                _INSTANCE = PeriodicWorker(
+                    "machine-stats-worker",
+                    _refresh_pass,
+                    # Read per pass, not once at startup, so changing the
+                    # setting takes effect without a restart.
+                    lambda: max(60.0, float(settings.MACHINE_STATS_REFRESH_INTERVAL_MINUTES) * 60.0),
+                    # Prime the cache on boot so the first dashboard load is warm.
+                    run_at_start=True,
+                )
     return _INSTANCE
 
 
 __all__ = [
     "compute_stats",
     "refresh_cache",
+    "refresh_all",
     "get_fleet_stats",
     "get_machine_stats",
-    "MachineStatsWorker",
     "get_machine_stats_worker",
 ]

--- a/software/hive/backend/app/services/periodic.py
+++ b/software/hive/backend/app/services/periodic.py
@@ -1,0 +1,139 @@
+"""One periodic background worker, used by everything that runs on a cadence.
+
+Four services had each grown their own copy of the same daemon thread — a
+``_thread``, a ``_stop_event``, a ``_start_lock``, a ``start``/``stop`` pair, a
+``_loop`` that waits then calls one function, and a module-level singleton
+behind ``get_x_worker()``. The copies had drifted (some logged the duration,
+some swallowed exceptions differently, one read its interval once at startup
+instead of per pass), which is the usual cost of four things doing one thing.
+
+A periodic worker is the whole abstraction: a name, a callable, and how long to
+wait between calls. Everything specific to a job belongs in the callable.
+
+The interval is a callable rather than a number so a job whose cadence comes
+from settings picks up a change without a restart, and so a job can back off.
+
+Note this is for jobs that run on a CLOCK. A worker that waits on a queue
+(``teacher_worker``) or drains a table as fast as rows appear
+(``condition_worker``) is a different animal and does not belong here.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class PeriodicWorker:
+    """Daemon thread that calls ``job`` every ``interval()`` seconds.
+
+    ``job`` may return a dict, which is merged into ``status()``. That is how a
+    job reports something only it understands ("machines refreshed") without
+    this class having to know what the job does.
+
+    An exception in ``job`` is logged with its traceback, recorded as
+    ``last_error``, and the loop continues. A cache that fails to rebuild
+    serves stale data, which is worth much more than a worker that dies
+    silently on one bad pass.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        job: Callable[[], Any],
+        interval: Callable[[], float],
+        *,
+        run_at_start: bool | Callable[[], bool] = False,
+    ) -> None:
+        self.name = name
+        self._job = job
+        self._interval = interval
+        # Callable form is for a job whose first pass is expensive and may
+        # already be warm from the previous process (walking an object store),
+        # so it is decided on the thread rather than at construction.
+        self._run_at_start = run_at_start
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._wake_event = threading.Event()
+        self._start_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._state: dict[str, Any] = {
+            "running": False,
+            "last_run_at": None,
+            "last_run_duration_s": None,
+            "last_error": None,
+            "total_runs": 0,
+        }
+
+    def start(self) -> None:
+        with self._start_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._thread = threading.Thread(target=self._loop, daemon=True, name=self.name)
+            self._thread.start()
+        self._merge_state(running=True)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._wake_event.set()
+        self._merge_state(running=False)
+
+    def wake(self) -> None:
+        """Ask the loop to run a pass as soon as it can, without waiting out the interval."""
+        self._wake_event.set()
+
+    def run_once(self) -> Any:
+        """Run one pass inline. For tests and for cold-start warmup."""
+        return self._run()
+
+    def status(self) -> dict[str, Any]:
+        with self._state_lock:
+            snapshot = dict(self._state)
+        snapshot["interval_s"] = self._interval()
+        return snapshot
+
+    def _loop(self) -> None:
+        logger.info("%s: started", self.name)
+        first = self._run_at_start() if callable(self._run_at_start) else self._run_at_start
+        if first:
+            self._run()
+        while not self._stop_event.is_set():
+            self._wake_event.wait(timeout=self._interval())
+            self._wake_event.clear()
+            if self._stop_event.is_set():
+                break
+            self._run()
+        self._merge_state(running=False)
+        logger.info("%s: stopped", self.name)
+
+    def _run(self) -> Any:
+        started = time.monotonic()
+        try:
+            detail = self._job()
+        except Exception as exc:
+            logger.exception("%s: pass failed", self.name)
+            self._merge_state(last_error=str(exc))
+            return None
+        elapsed = round(time.monotonic() - started, 3)
+        state: dict[str, Any] = {
+            "last_run_at": datetime.now(timezone.utc).isoformat(),
+            "last_run_duration_s": elapsed,
+            "last_error": None,
+        }
+        if isinstance(detail, dict):
+            state.update(detail)
+        self._merge_state(_increment_runs=True, **state)
+        logger.info("%s: pass finished in %.1fs", self.name, elapsed)
+        return detail
+
+    def _merge_state(self, *, _increment_runs: bool = False, **values: Any) -> None:
+        with self._state_lock:
+            if _increment_runs:
+                self._state["total_runs"] += 1
+            self._state.update(values)

--- a/software/hive/backend/app/services/server_health.py
+++ b/software/hive/backend/app/services/server_health.py
@@ -2,10 +2,9 @@
 
 Storage accounting walks the whole object store (local disk or S3). On S3/Spaces
 that lists every key, which takes long enough that doing it inside the request
-blew past Cloudflare's proxy timeout (524). So a background daemon thread
-(StorageStatsWorker, mirroring MachineStatsWorker) walks the store on a slow
-cadence and upserts a single cache row; the API reads that row instantly. DB
-size and memory are cheap and read live.
+blew past Cloudflare's proxy timeout (524). So a PeriodicWorker walks the store
+on a slow cadence and upserts a single cache row; the API reads that row
+instantly. DB size and memory are cheap and read live.
 """
 
 from __future__ import annotations
@@ -15,7 +14,6 @@ import logging
 import re
 import sys
 import threading
-import time
 from datetime import datetime, timezone
 from typing import Any
 
@@ -25,6 +23,7 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.database import SessionLocal
 from app.models.server_storage_cache import ServerStorageCache
+from app.services.periodic import PeriodicWorker
 from app.services.storage_backend import get_backend
 
 logger = logging.getLogger(__name__)
@@ -252,198 +251,100 @@ def get_server_health(db: Session) -> dict[str, Any]:
     }
 
 
-class StorageStatsWorker:
-    """Daemon thread that walks the object store into server_storage_cache on a
-    slow cadence. Mirrors MachineStatsWorker."""
+def _storage_interval_s() -> float:
+    return max(300.0, float(settings.SERVER_STORAGE_REFRESH_INTERVAL_MINUTES) * 60.0)
 
-    def __init__(self) -> None:
-        self._thread: threading.Thread | None = None
-        self._stop_event = threading.Event()
-        self._wake_event = threading.Event()
-        self._start_lock = threading.Lock()
-        self._state_lock = threading.Lock()
-        self._state: dict[str, Any] = {
-            "running": False,
-            "last_run_at": None,
-            "last_run_files": 0,
-            "last_run_duration_s": None,
-            "last_error": None,
-            "total_runs": 0,
-        }
 
-    def start(self) -> None:
-        with self._start_lock:
-            if self._thread is not None and self._thread.is_alive():
-                return
-            self._stop_event.clear()
-            self._thread = threading.Thread(target=self._loop, daemon=True, name="storage-stats-worker")
-            self._thread.start()
-        self._update_state(running=True)
-
-    def stop(self) -> None:
-        self._stop_event.set()
-        self._wake_event.set()
-        self._update_state(running=False)
-
-    def wake(self) -> None:
-        """Ask the loop to run a fresh storage walk as soon as possible."""
-        self._wake_event.set()
-
-    def status(self) -> dict[str, Any]:
-        with self._state_lock:
-            snapshot = dict(self._state)
-        snapshot["interval_s"] = self._interval_s()
-        return snapshot
-
-    def _interval_s(self) -> float:
-        return max(300.0, float(settings.SERVER_STORAGE_REFRESH_INTERVAL_MINUTES) * 60.0)
-
-    def _loop(self) -> None:
-        logger.info("StorageStatsWorker: started")
-        # Prime the cache on boot so the first server-health load is warm. Only
-        # walk if the row is stale/missing, so a restart doesn't re-walk a store
-        # that was just measured.
-        if self._needs_initial_walk():
-            self._run_one_pass()
-        while not self._stop_event.is_set():
-            self._wake_event.wait(timeout=self._interval_s())
-            self._wake_event.clear()
-            if self._stop_event.is_set():
-                break
-            self._run_one_pass()
-        self._update_state(running=False)
-        logger.info("StorageStatsWorker: stopped")
-
-    def _needs_initial_walk(self) -> bool:
-        db = SessionLocal()
-        try:
-            row = db.query(ServerStorageCache).filter(ServerStorageCache.id == 1).first()
-            if row is None or row.computed_at is None:
-                return True
-            age = datetime.now(timezone.utc) - row.computed_at
-            return age.total_seconds() >= self._interval_s()
-        except Exception:
+def _needs_initial_walk() -> bool:
+    """Only walk on boot if the cached row is missing or already stale, so a
+    restart does not re-walk a store that was measured minutes ago."""
+    db = SessionLocal()
+    try:
+        row = db.query(ServerStorageCache).filter(ServerStorageCache.id == 1).first()
+        if row is None or row.computed_at is None:
             return True
-        finally:
-            db.close()
-
-    def _run_one_pass(self) -> None:
-        started = time.monotonic()
-        db = SessionLocal()
-        try:
-            stats = refresh_storage_cache(db)
-            self._update_state(
-                last_run_at=datetime.now(timezone.utc).isoformat(),
-                last_run_files=int(stats.get("total_files", 0)),
-                last_run_duration_s=round(time.monotonic() - started, 3),
-                last_error=None,
-                increment_runs=1,
-            )
-            logger.info(
-                "StorageStatsWorker: walked %d files in %.2fs",
-                stats.get("total_files", 0),
-                time.monotonic() - started,
-            )
-        except Exception as exc:
-            logger.exception("StorageStatsWorker pass crashed: %s", exc)
-            db.rollback()
-            self._update_state(last_error=str(exc))
-        finally:
-            db.close()
-
-    def _update_state(self, **kwargs: Any) -> None:
-        with self._state_lock:
-            if "running" in kwargs:
-                self._state["running"] = bool(kwargs.pop("running"))
-            if "increment_runs" in kwargs:
-                self._state["total_runs"] += int(kwargs.pop("increment_runs"))
-            for key, value in kwargs.items():
-                self._state[key] = value
+        return (datetime.now(timezone.utc) - row.computed_at).total_seconds() >= _storage_interval_s()
+    except Exception:
+        return True
+    finally:
+        db.close()
 
 
-_INSTANCE: StorageStatsWorker | None = None
+def _storage_pass() -> dict[str, Any]:
+    db = SessionLocal()
+    try:
+        stats = refresh_storage_cache(db)
+        return {"last_run_files": int(stats.get("total_files", 0))}
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+_INSTANCE: PeriodicWorker | None = None
 _INSTANCE_LOCK = threading.Lock()
 
 
-def get_storage_stats_worker() -> StorageStatsWorker:
+def get_storage_stats_worker() -> PeriodicWorker:
     global _INSTANCE
     if _INSTANCE is None:
         with _INSTANCE_LOCK:
             if _INSTANCE is None:
-                _INSTANCE = StorageStatsWorker()
+                _INSTANCE = PeriodicWorker(
+                    "storage-stats-worker",
+                    _storage_pass,
+                    _storage_interval_s,
+                    run_at_start=_needs_initial_walk,
+                )
     return _INSTANCE
 
 
 MEMORY_LOG_INTERVAL_S = 300.0
 
 
-class MemoryLogWorker:
-    """Writes one memory line to the log every five minutes.
+def _log_memory_once() -> None:
+    """Write one memory line to the log.
 
     DIAGNOSTIC. This exists for the leak that took hive down on 2026-08-20 and
     should be deleted the day that closes — see hive-prod-server.md.
 
     The same numbers are on /api/admin/server-health, which is the right place
-    for them, but reading that needs a login and a leak is measured in days.
-    A log line is what is still there tomorrow, survives a restart in the
-    journal, and costs nothing to collect. Deliberately not folded into
-    StorageStatsWorker: that ticks every three hours and only after walking the
-    whole object store, which is far too coarse and too expensive to sample on.
+    for them, but reading that needs a login and a leak is measured in days. A
+    log line is what is still there tomorrow, survives a restart in the
+    journal, and costs nothing to collect. Deliberately its own worker rather
+    than folded into the storage walk: that ticks every three hours and only
+    after walking the whole object store, far too coarse to sample on.
     """
-
-    def __init__(self) -> None:
-        self._thread: threading.Thread | None = None
-        self._stop_event = threading.Event()
-        self._start_lock = threading.Lock()
-
-    def start(self) -> None:
-        with self._start_lock:
-            if self._thread is not None and self._thread.is_alive():
-                return
-            self._stop_event.clear()
-            self._thread = threading.Thread(target=self._loop, daemon=True, name="memory-log-worker")
-            self._thread.start()
-
-    def stop(self) -> None:
-        self._stop_event.set()
-
-    def _loop(self) -> None:
-        logger.info("MemoryLogWorker: started")
-        while not self._stop_event.is_set():
-            self._log_once()
-            if self._stop_event.wait(timeout=MEMORY_LOG_INTERVAL_S):
-                break
-        logger.info("MemoryLogWorker: stopped")
-
-    def _log_once(self) -> None:
-        try:
-            stats = get_memory_stats()
-            glibc = stats.get("glibc") or {}
-            logger.info(
-                "memory rss=%.0fMB blocks=%d arena=%.0fMB free_in_arena=%.0fMB mmap=%.0fMB heaps=%s",
-                _as_mb(stats.get("process_rss_bytes")),
-                stats.get("python_allocated_blocks") or 0,
-                _as_mb(glibc.get("arena_bytes")),
-                _as_mb(glibc.get("free_in_arena_bytes")),
-                _as_mb(glibc.get("mmapped_bytes")),
-                glibc.get("heap_count"),
-            )
-        except Exception:
-            # A diagnostic must never be the reason the process dies.
-            logger.exception("MemoryLogWorker: sample failed")
+    stats = get_memory_stats()
+    glibc = stats.get("glibc") or {}
+    logger.info(
+        "memory rss=%.0fMB blocks=%d arena=%.0fMB free_in_arena=%.0fMB mmap=%.0fMB heaps=%s",
+        _as_mb(stats.get("process_rss_bytes")),
+        stats.get("python_allocated_blocks") or 0,
+        _as_mb(glibc.get("arena_bytes")),
+        _as_mb(glibc.get("free_in_arena_bytes")),
+        _as_mb(glibc.get("mmapped_bytes")),
+        glibc.get("heap_count"),
+    )
 
 
 def _as_mb(value: int | None) -> float:
     return (value or 0) / (1024 * 1024)
 
 
-_MEMORY_LOG_INSTANCE: MemoryLogWorker | None = None
+_MEMORY_LOG_INSTANCE: PeriodicWorker | None = None
 
 
-def get_memory_log_worker() -> MemoryLogWorker:
+def get_memory_log_worker() -> PeriodicWorker:
     global _MEMORY_LOG_INSTANCE
     if _MEMORY_LOG_INSTANCE is None:
         with _INSTANCE_LOCK:
             if _MEMORY_LOG_INSTANCE is None:
-                _MEMORY_LOG_INSTANCE = MemoryLogWorker()
+                _MEMORY_LOG_INSTANCE = PeriodicWorker(
+                    "memory-log-worker",
+                    _log_memory_once,
+                    lambda: MEMORY_LOG_INTERVAL_S,
+                    run_at_start=True,
+                )
     return _MEMORY_LOG_INSTANCE

--- a/software/hive/backend/tests/conftest.py
+++ b/software/hive/backend/tests/conftest.py
@@ -39,6 +39,25 @@ engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
 TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 
+def refresh_stats() -> None:
+    """Run the stats worker's pass against the test database.
+
+    Every number the analytics endpoints serve is a fold over
+    machine_stats_cache and machine_daily_stats, so a test that syncs pieces
+    and then reads a distribution or a daily series has to let the worker run
+    in between — which is exactly what production does on its hourly pass.
+    Reading immediately after a sync legitimately returns the pre-sync numbers,
+    except for the piece counter, which is topped up live.
+    """
+    from app.services import machine_stats
+
+    session = TestingSessionLocal()
+    try:
+        machine_stats.refresh_all(session)
+    finally:
+        session.close()
+
+
 @pytest.fixture(autouse=True)
 def _setup_db() -> Generator[None, None, None]:
     """Create all tables before each test and drop them after."""

--- a/software/hive/backend/tests/test_analytics.py
+++ b/software/hive/backend/tests/test_analytics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from app.models.user import User
-from tests.conftest import _login_user, _register_user
+from tests.conftest import _login_user, _register_user, refresh_stats
 
 
 def _bearer(token: str) -> dict[str, str]:
@@ -27,6 +27,7 @@ def _sync_two_days(client, machine_token) -> None:
     ]
     r = client.post("/api/machine/sync/piece-records", headers=_bearer(machine_token), json={"records": records})
     assert r.status_code == 200, r.text
+    refresh_stats()
 
 
 def test_single_machine_analytics(client, machine_token, test_machine):
@@ -102,3 +103,61 @@ def test_other_users_machine_is_404(client, db, machine_token, test_machine):
     r = client.get("/api/analytics")
     assert r.status_code == 200
     assert r.json()["timeseries"] == []
+
+
+def test_piece_counter_is_live_between_refreshes(client, machine_token, test_machine):
+    """The headline counter tops up from the cache watermark; the rest doesn't.
+
+    This is the whole tiering, in one test. Pieces that arrive after a refresh
+    are counted immediately, because that number is what people watch climb.
+    The distributions and the daily series they belong to stay as of the last
+    pass, because recomputing those on demand is what pinned the box.
+    """
+    _sync_two_days(client, machine_token)  # syncs, then refreshes
+
+    later = 1_760_000_000.0 + 2 * 86400.0
+    r = client.post(
+        "/api/machine/sync/piece-records",
+        headers=_bearer(machine_token),
+        json={"records": [
+            {"piece_uuid": "e", "local_id": 5, "seen_at": later,
+             "classification_status": "classified", "part_id": "3003", "color_id": "9"},
+        ]},
+    )
+    assert r.status_code == 200, r.text
+
+    body = client.get(f"/api/analytics?machine_id={test_machine['id']}").json()
+    assert body["totals"]["pieces_seen"] == 5          # live
+    assert len(body["timeseries"]) == 2                # still as of the last pass
+    part_ids = {p["part_id"] for p in body["distributions"]["top_parts"]}
+    assert "3003" not in part_ids
+    assert body["fresh_as_of"] is not None
+
+    refresh_stats()
+    body = client.get(f"/api/analytics?machine_id={test_machine['id']}").json()
+    assert body["totals"]["pieces_seen"] == 5          # not double-counted
+    assert len(body["timeseries"]) == 3
+    assert "3003" in {p["part_id"] for p in body["distributions"]["top_parts"]}
+
+
+def test_distributions_fold_across_machines(client, db, machine_token, test_machine):
+    """Two machines' cached maps merge into one correct answer.
+
+    A per-machine top-N could not do this: unique_parts for the pair is the
+    size of the union of their part maps, and the fleet ranking has to see
+    every key, not each machine's leaders.
+    """
+    _sync_two_days(client, machine_token)
+    user = db.query(User).filter(User.email == "member@test.com").first()
+    user.role = "admin"
+    db.commit()
+
+    body = client.get("/api/analytics?scope=all").json()
+    # 3001 appears on both days, 3002 on one; "d" has no part id at all.
+    assert body["totals"]["unique_parts"] == 2
+    assert body["totals"]["unique_colors"] == 2
+    ranked = [(p["part_id"], p["value"]) for p in body["distributions"]["top_parts"]]
+    assert ranked[0] == ("3001", 2)
+    assert dict(body["distributions"]["by_status"] and
+                {s["label"]: s["value"] for s in body["distributions"]["by_status"]}) == {
+        "classified": 3, "unknown": 1}


### PR DESCRIPTION
## Why

`/api/public/stats` recomputed every number from scratch on every call — about **18 sequential scans of `machine_pieces`** (354k rows, 240 MB) per request, **5–7 seconds each**. The website's live counter polls it through an edge cache that misses once per Cloudflare PoP, which lands as a steady **10 requests a minute** whether or not anyone is looking. One was always in flight, so both of prod's vCPUs stayed pinned (`psi_cpu_some` ~40%, load 3.1, steal ~0.3 — our own work).

An index cannot fix it: the `IN` list is all 24 non-archived machines, so every row matches and the seq scan is correct. And it had been getting worse on its own — the table went 51k rows (June) → 154k (July) → 149k (August so far).

## What

Two things already did the same job and only one had been fixed. `machine_stats.py` cached per-machine aggregates hourly for the admin fleet table; `analytics.py` ran the identical group-bys live for everything else. So the cache grows the distribution maps, and analytics becomes a fold over it.

- **`machine_stats_cache` carries whole part/colour/status maps per machine.** Whole and not top-N: a top-15 per machine cannot be folded into a correct top-15 for the fleet, and `unique_parts` for a set is the size of the union of the keys.
- **`analytics.get_analytics` sums cached rows in Python.** `get_totals` and `get_distributions` are deleted. Every scope — one machine, an owner, a user's fleet, all of them — is the same fold over a different subset of rows.
- **The one number people watch climb stays live**: pieces recorded since each machine's cache watermark, over a new `(machine_id, created_at)` index. `created_at` and not `seen_at`, so a machine uploading a backlog counts when it lands rather than an hour later.
- **`_local_day_in_progress`** compared `date(timezone(tz, seen_at))` to today, which wraps the indexed column in a function and scanned the whole table to count one day. Now a range on `seen_at`.
- **Four hand-rolled daemon-thread classes** (machine stats, storage stats, memory log, candidate matview) collapse into `services/periodic.PeriodicWorker`. They had drifted: different logging, different error handling, one reading its interval once at startup instead of per pass.
- **`refresh_all(db)`** is the single entry point for a rebuild — used by the worker, the admin force-refresh endpoint, and the tests.

The rule this encodes, written into `services/analytics.py`: **no HTTP request aggregates.** If a number starts needing a scan of `machine_pieces`, it belongs in the worker.

## Freshness tiers

| | fresh as of |
|---|---|
| total pieces | live, every request |
| trailing 24h, local day in progress | live, indexed range |
| distributions, daily series, unique counts | last hourly pass (`fresh_as_of` in the payload) |

## Measured, at prod scale (354k rows on a real postgres)

| | before | after |
|---|---|---|
| live piece count | 191 ms (seq scan + disk-spilled `COUNT(DISTINCT)`) | **13 ms** (bitmap index scan) |
| local day in progress | 72 ms (parallel seq scan) | **1.8 ms** (bitmap index scan) |
| scans of `machine_pieces` per request | ~18 | **1** |

The 191 ms figure is *one* of the eight aggregates the endpoint ran; on prod, with 128 MB `shared_buffers` against a 240 MB table, that same query measures **5,163 ms** and spills 11.4 MB to disk on every call.

Also verified: the fold matches SQL ground truth for counts, distinct parts and distinct colours; the counter tops up between passes and does not double-count after one; migration upgrades and downgrades cleanly on postgres.

## Deploy note

The migration creates the index `CONCURRENTLY` — it lands on the box that is already saturated, and a plain `CREATE INDEX` takes a write lock on the table every machine syncs into.

Full suite green (293 passed).