### PR TITLE
hive-release: send a User-Agent when reporting a deploy

### DIFF
--- a/software/hive/scripts/hive_release_agent.py
+++ b/software/hive/scripts/hive_release_agent.py
@@ -509,7 +509,17 @@ def statusDeploy(phase: str, version: str = "") -> None:
         request = urllib.request.Request(
             f"{STATUS_URL}/deploy/{monitor}/{phase}",
             data=body,
-            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                # Required, and the reason this never once worked. Every other
+                # request in this file sets a User-Agent; this one passed a
+                # headers dict and left it out, so urllib supplied its own
+                # "Python-urllib/3.x" and Cloudflare 403'd it in front of the
+                # worker. The failure read like an auth problem and was not one:
+                # the status page answers a bad token with 401, never 403.
+                "User-Agent": "hive-release-agent",
+            },
             method="POST",
         )
         try:


### PR DESCRIPTION
## What was wrong

Hive's deploy reporting to the status page has **never worked once**. Every hive deploy since reporting was added has appeared on the page as a short unexplained outage rather than **Updating**, including tonight's `v0.1.25`:

```
could not tell the status page about the start of v0.1.25: HTTP Error 403: Forbidden
```

It reads like a credential problem and is not one. The status page answers a bad token with **401**, never 403 — `handleDeploy` has exactly one auth branch and it returns 401. The 403 came from **Cloudflare**, in front of the worker, rejecting the default `Python-urllib/3.x` user agent.

## Proof

From hive-prod, against the real endpoint, same deliberately-bogus token both times, only the agent differing:

```
no UA, bogus token   -> 403   (Cloudflare, never reached the worker)
with UA, bogus token -> 401   (worker auth, as designed)
```

And on a plain unauthenticated GET of `/healthz` from the same box, same second:

```
urllib UA  -> 403
curl UA    -> 200
browser UA -> 200
```

## The fix

Every other request in `hive_release_agent.py` already sets `User-Agent: hive-release-agent`. `statusDeploy` is the only one that passes a `headers=` dict, and it left the UA out — so urllib supplied its own. One header.

No new token is needed; the credential in `/etc/hive-status/beat.env` was always fine.