### PR TITLE
Door module: list the servo adapter, and warn that its insert count is unverified

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -8,6 +8,12 @@ kicker: Chute — Door module
 lede: The per-layer door mechanism that releases parts into a bin.
 permalink: /hardware/assembly/distribution/chute/door-module/
 author: spencer
+contributors: [barthel]
+parts_needed:
+  - part: servo-adapter-servo-side
+    qty: 1
+  - part: servo-adapter-flap-side
+    qty: 1
 ---
 
 The door module is made up of:
@@ -16,3 +22,12 @@ The door module is made up of:
 2. **[Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})** — the funnel that guides parts through the door.
 3. **[PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})** — the board that drives the servo.
 4. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** — the connectors that chain layers together.
+
+## Servo adapter
+
+The servo output couples to the door through a **two-piece servo adapter**, servo side and flap side, listed above. The two halves bolt together with 4 countersunk M3 screws on a bolt circle they share.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>Do not press heat inserts into the adapter without checking your own parts first.</strong> The BOM lists 4 short M3 inserts (ruthex RX-M3Sx4.0) per adapter, but the adapter models published here do not have a pocket for one: the flap side has four 4.0 mm bores through a 5.0 mm wall with a 90° countersink on the back face, and the servo side has four blind 2.8 mm holes, 4.0 mm deep, with solid material behind them. That is a self-tapping joint, screw straight into plastic. Until somebody confirms it against a built adapter, treat the insert count in the parts calculator as unverified.</p>
+</div>

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -39,7 +39,7 @@ Press the heat inserts in while both halves are still loose, before anything is 
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Servo adapter:</strong> 4 × {% include fastener.html size="M3" variant="heat-insert" text="M3 short heat-set insert (ruthex RX-M3Sx4.0)" %}, per the BOM. <strong>Check your own printed halves before you press any</strong>, and read the warning below.</p>
+    <p><strong>Servo adapter:</strong> 4 × {% include fastener.html size="M3" variant="heat-insert" text="M3 short heat-set insert (ruthex RX-M3Sx4.0)" %} per the BOM. <strong>Check your own printed halves before you press any</strong>, and read the warning below.</p>
   </div>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -14,6 +14,10 @@ parts_needed:
     qty: 1
   - part: servo-adapter-flap-side
     qty: 1
+  - part: hsi-m3s
+    qty: 4
+  - part: scr-m3-6-cs
+    qty: 4
 ---
 
 The door module is made up of:
@@ -25,9 +29,25 @@ The door module is made up of:
 
 ## Servo adapter
 
-The servo output couples to the door through a **two-piece servo adapter**, servo side and flap side, listed above. The two halves bolt together with 4 countersunk M3 screws on a bolt circle they share.
+The servo output couples to the door through a **two-piece servo adapter**, servo side and flap side. The two halves share a bolt circle of four holes and bolt together through it.
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Preparation" %}
+
+Press the heat inserts in while both halves are still loose, before anything is bolted together. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Servo adapter:</strong> 4 × {% include fastener.html size="M3" variant="heat-insert" text="M3 short heat-set insert (ruthex RX-M3Sx4.0)" %}, per the BOM. <strong>Check your own printed halves before you press any</strong>, and read the warning below.</p>
+  </div>
+</div>
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>Do not press heat inserts into the adapter without checking your own parts first.</strong> The BOM lists 4 short M3 inserts (ruthex RX-M3Sx4.0) per adapter, but the adapter models published here do not have a pocket for one: the flap side has four 4.0 mm bores through a 5.0 mm wall with a 90° countersink on the back face, and the servo side has four blind 2.8 mm holes, 4.0 mm deep, with solid material behind them. That is a self-tapping joint, screw straight into plastic. Until somebody confirms it against a built adapter, treat the insert count in the parts calculator as unverified.</p>
+  <p><strong>This joint is not confirmed against a built machine.</strong> The BOM lists 4 short M3 inserts (ruthex RX-M3Sx4.0) per adapter, but the adapter models published here have no pocket that clearly takes one: the flap side has four 4.0 mm bores through a 5.0 mm wall with a 90° countersink on the back face, and the servo side has four blind 2.8 mm holes, 4.0 mm deep, with solid material behind them. Read as printed, that is a countersunk screw self-tapping straight into plastic, with no insert anywhere, and on that reading an M3 × 6 mm screw only bites about 1 mm. Treat both the insert count and the screw length here as unverified until somebody checks a built adapter.</p>
 </div>
+
+{% include step.html n="2" title="Join the two halves" %}
+
+Bolt the flap side to the servo side with 4 {% include fastener.html size="M3" variant="countersunk" length="6" %} screws through the shared bolt circle, heads into the countersinks on the flap side.

--- a/parts-calculator/slicer/artifacts.json
+++ b/parts-calculator/slicer/artifacts.json
@@ -2,6 +2,461 @@
   "bucket": "sorter-v2-parts",
   "public_base": "https://img.basically.website/parts",
   "artifacts": {
+    "slicer/build/renders/bearing-cover-covered.png": {
+      "sha256": "1848eacc9e1388d81553a12ce75c8aa5b14e2113c7f8e43232139227a7e79f68",
+      "size": 35060,
+      "url": "https://img.basically.website/parts/render/bearing-cover-covered-1848eacc.png"
+    },
+    "slicer/build/renders/bearing-cover-servo.png": {
+      "sha256": "d22a3547da23a07e6b8977af564c74ccd04f7809c487a51657980a77c9d1263f",
+      "size": 39626,
+      "url": "https://img.basically.website/parts/render/bearing-cover-servo-d22a3547.png"
+    },
+    "slicer/build/renders/bearing-holder-left.png": {
+      "sha256": "587e06bc4d4b3f1bda9c88d0e6dcc6ac50251790478736519f79a5dff6c78cb7",
+      "size": 34126,
+      "url": "https://img.basically.website/parts/render/bearing-holder-left-587e06bc.png"
+    },
+    "slicer/build/renders/bearing-holder-right.png": {
+      "sha256": "ee69fcdc45be1cb311961439f750244a62d84fc53cb245740eb23e1b021e6ed7",
+      "size": 29231,
+      "url": "https://img.basically.website/parts/render/bearing-holder-right-ee69fcdc.png"
+    },
+    "slicer/build/renders/bearing-race.png": {
+      "sha256": "b62e32542b38a5bc088f1bc732daa9282e0db2e1db6f9000a2e94627d2e24591",
+      "size": 13511,
+      "url": "https://img.basically.website/parts/render/bearing-race-b62e3254.png"
+    },
+    "slicer/build/renders/bin-half-left.png": {
+      "sha256": "de4527ff1c2422db03239a36961a9e758aaf5c0a3f952ea26f3ed39c052f5dc9",
+      "size": 17660,
+      "url": "https://img.basically.website/parts/render/bin-half-left-de4527ff.png"
+    },
+    "slicer/build/renders/bin-half-right.png": {
+      "sha256": "0fb741a0d808c214f8852bd4269578ca8c31557c8ed7b21b825604114ed21c27",
+      "size": 17776,
+      "url": "https://img.basically.website/parts/render/bin-half-right-0fb741a0.png"
+    },
+    "slicer/build/renders/bin-retainer-left.png": {
+      "sha256": "1a29b1f6c061bea55b7672f1a12830a1b93ac0eb63e5dc2b1ffddddebb48bb65",
+      "size": 5080,
+      "url": "https://img.basically.website/parts/render/bin-retainer-left-1a29b1f6.png"
+    },
+    "slicer/build/renders/bin-retainer-right.png": {
+      "sha256": "18dacb249a0888a840a6f9451ee30d7804db3c1d3d8b35c7e8f032b7057ff30a",
+      "size": 4921,
+      "url": "https://img.basically.website/parts/render/bin-retainer-right-18dacb24.png"
+    },
+    "slicer/build/renders/bin-third-center.png": {
+      "sha256": "5c125ffb546cab4f115c00073f651fa87ceda9dba55164d2fcdd71e72745a88c",
+      "size": 15674,
+      "url": "https://img.basically.website/parts/render/bin-third-center-5c125ffb.png"
+    },
+    "slicer/build/renders/bin-third-left.png": {
+      "sha256": "025625d76732aa0d978610677270e8f984300a8019569a9e28024758eca015ee",
+      "size": 16159,
+      "url": "https://img.basically.website/parts/render/bin-third-left-025625d7.png"
+    },
+    "slicer/build/renders/bin-third-rightback.png": {
+      "sha256": "b6d0dbff71972a79590f1894f9de75f3cf04b98ab6bb3b7d3eb7330c87faad28",
+      "size": 14975,
+      "url": "https://img.basically.website/parts/render/bin-third-rightback-b6d0dbff.png"
+    },
+    "slicer/build/renders/bulk-cap.png": {
+      "sha256": "9800500a312dbffe740f334b5242ab4bda69dec41090fd1d76c6233477bd6cd9",
+      "size": 14652,
+      "url": "https://img.basically.website/parts/render/bulk-cap-9800500a.png"
+    },
+    "slicer/build/renders/cable-clamp-inner.png": {
+      "sha256": "4f2392702519aef441ba23a89535064d1ae2d1d0c2995658396c6201f4b7ae65",
+      "size": 14993,
+      "url": "https://img.basically.website/parts/render/cable-clamp-inner-4f239270.png"
+    },
+    "slicer/build/renders/cable-clamp-outer.png": {
+      "sha256": "f11a3bd4df63e55febd864ace0e3cf5f7feb901b3545a1bfdbb557005dec9b01",
+      "size": 13735,
+      "url": "https://img.basically.website/parts/render/cable-clamp-outer-f11a3bd4.png"
+    },
+    "slicer/build/renders/camera-extension-mount.png": {
+      "sha256": "5b2127b06526f25696748d657d410224b30097f6ea13dfec4f11263ebe69539b",
+      "size": 19807,
+      "url": "https://img.basically.website/parts/render/camera-extension-mount-5b2127b0.png"
+    },
+    "slicer/build/renders/camera-extension.png": {
+      "sha256": "33523f61f6e73600ba73f927b74dfc56a639b1377b80f4c51ec1d8379553a7c9",
+      "size": 31159,
+      "url": "https://img.basically.website/parts/render/camera-extension-33523f61.png"
+    },
+    "slicer/build/renders/camera-led-insert.png": {
+      "sha256": "9e276823fbf9cd472933ad352ca92d0a391a43d3dae6e3f988a497829d387811",
+      "size": 31633,
+      "url": "https://img.basically.website/parts/render/camera-led-insert-9e276823.png"
+    },
+    "slicer/build/renders/camera-mount-part-37.png": {
+      "sha256": "ea06c4bf3e27a9e030c2d8fcb584af52a19f2fad32c8dfbafee2706a60f4fd1f",
+      "size": 6907,
+      "url": "https://img.basically.website/parts/render/camera-mount-part-37-ea06c4bf.png"
+    },
+    "slicer/build/renders/camera-mount-part-37b.png": {
+      "sha256": "161b0d817fc964fc79b569bd04887edd99de88ea07412cb2d12a98f5e185e22f",
+      "size": 6571,
+      "url": "https://img.basically.website/parts/render/camera-mount-part-37b-161b0d81.png"
+    },
+    "slicer/build/renders/camera-mount-part-6.png": {
+      "sha256": "ca2136515b2fab33548e15ca5ec3b327c0206bd46ec203d96c068c4ad00c87e9",
+      "size": 11175,
+      "url": "https://img.basically.website/parts/render/camera-mount-part-6-ca213651.png"
+    },
+    "slicer/build/renders/camera-mount-rod-mount.png": {
+      "sha256": "7b2f527421664ca1a6f4ca9687c1e43d3e025e9c123df5dfa58b93a5d76e2ca6",
+      "size": 6445,
+      "url": "https://img.basically.website/parts/render/camera-mount-rod-mount-7b2f5274.png"
+    },
+    "slicer/build/renders/chute-core.png": {
+      "sha256": "312ae671ee01b039f12a0ec7642277560eb64101920c92125eef47aa3d85657c",
+      "size": 28399,
+      "url": "https://img.basically.website/parts/render/chute-core-312ae671.png"
+    },
+    "slicer/build/renders/chute-door.png": {
+      "sha256": "8538074d7dabc9c9461c9b7e346d19ace34aa02efebe5f98fde9a155e914b8c3",
+      "size": 12916,
+      "url": "https://img.basically.website/parts/render/chute-door-8538074d.png"
+    },
+    "slicer/build/renders/chute-stepper-idler-bearing-retainer-inner.png": {
+      "sha256": "fc9cf6107c45061d0ebb329669108adcbfcfa4f184e88363995e7f71541b6da9",
+      "size": 16416,
+      "url": "https://img.basically.website/parts/render/chute-stepper-idler-bearing-retainer-inner-fc9cf610.png"
+    },
+    "slicer/build/renders/chute-stepper-idler-bearing-retainer-outer.png": {
+      "sha256": "c6bd55cdba24e42714b10933f3ad56779a8b01eec28fc804c629741f8c4a7c91",
+      "size": 12796,
+      "url": "https://img.basically.website/parts/render/chute-stepper-idler-bearing-retainer-outer-c6bd55cd.png"
+    },
+    "slicer/build/renders/chute-stepper-support-block.png": {
+      "sha256": "226282190bcc254c7d1bdd061461e144d2b0c0e958beb2117b1b5142434ef40a",
+      "size": 7729,
+      "url": "https://img.basically.website/parts/render/chute-stepper-support-block-22628219.png"
+    },
+    "slicer/build/renders/classification-dome.png": {
+      "sha256": "df101611da2dc624e77f2e17ead862212c0e8d92d5e9db7a8390fdf4d912d8e6",
+      "size": 41520,
+      "url": "https://img.basically.website/parts/render/classification-dome-df101611.png"
+    },
+    "slicer/build/renders/ext-bracket-bottom-vertical.png": {
+      "sha256": "962b87dc29591fb5871676cf7d4f6908e6c3b5d57947f3ffb30c8127b1031121",
+      "size": 8198,
+      "url": "https://img.basically.website/parts/render/ext-bracket-bottom-vertical-962b87dc.png"
+    },
+    "slicer/build/renders/ext-bracket-cover.png": {
+      "sha256": "3bdc8f535bb7ad3bb17cd97cc4549dc164615a9e62e7dd3f5cbd284abe4735d6",
+      "size": 9812,
+      "url": "https://img.basically.website/parts/render/ext-bracket-cover-3bdc8f53.png"
+    },
+    "slicer/build/renders/ext-bracket-foot-cover.png": {
+      "sha256": "f2886e89867611b90170ff7d744fed5736b642a0f6ac5d31c05ab80139f04f59",
+      "size": 12231,
+      "url": "https://img.basically.website/parts/render/ext-bracket-foot-cover-f2886e89.png"
+    },
+    "slicer/build/renders/ext-bracket-left.png": {
+      "sha256": "5f374f1971a52540ad099c6bfebc2ac1b8fa08d8a0ca325a6c79dd06ed22ae09",
+      "size": 6794,
+      "url": "https://img.basically.website/parts/render/ext-bracket-left-5f374f19.png"
+    },
+    "slicer/build/renders/foot.png": {
+      "sha256": "9f275980ff0a9ab4fa3388829c2121f63af842064c4bfb28c90a6079f08b884e",
+      "size": 5008,
+      "url": "https://img.basically.website/parts/render/foot-9f275980.png"
+    },
+    "slicer/build/renders/frame-90deg-bracket.png": {
+      "sha256": "faadb50a48ac0583bb9cd14e1628df4799aad66d22a73e9f85f208b986bc1425",
+      "size": 5551,
+      "url": "https://img.basically.website/parts/render/frame-90deg-bracket-faadb50a.png"
+    },
+    "slicer/build/renders/frame-crossbeam.png": {
+      "sha256": "59615da4ee1d91f3d7c69938106822347c2d8f77a21a23e3fd8411cad1fc3e61",
+      "size": 6154,
+      "url": "https://img.basically.website/parts/render/frame-crossbeam-59615da4.png"
+    },
+    "slicer/build/renders/funnel-bracket-left.png": {
+      "sha256": "cdf94e6ffcea0970b5aa5ca05d1b338bf3ebc38e0c191e3a76723e4b4231306e",
+      "size": 21271,
+      "url": "https://img.basically.website/parts/render/funnel-bracket-left-cdf94e6f.png"
+    },
+    "slicer/build/renders/funnel-bracket-right.png": {
+      "sha256": "84b830ed45361bc4f603edf5168bd5812ebc533f95c255775e5f00518ff801f3",
+      "size": 20174,
+      "url": "https://img.basically.website/parts/render/funnel-bracket-right-84b830ed.png"
+    },
+    "slicer/build/renders/funnel-half.png": {
+      "sha256": "495cd9cc30554d6f86531670db08b5c494252871dc35c75f7e5e3e3b80bf61d0",
+      "size": 30720,
+      "url": "https://img.basically.website/parts/render/funnel-half-495cd9cc.png"
+    },
+    "slicer/build/renders/funnel-third.png": {
+      "sha256": "c8f8a464507421c3f137b256efd9da019df6779bced93b1fdf668b533d153669",
+      "size": 22991,
+      "url": "https://img.basically.website/parts/render/funnel-third-c8f8a464.png"
+    },
+    "slicer/build/renders/idler-gear.png": {
+      "sha256": "c0782c6fa418d43aab43e7786becf8987f3e6eb0bde43cd559b63f682379a025",
+      "size": 18031,
+      "url": "https://img.basically.website/parts/render/idler-gear-c0782c6f.png"
+    },
+    "slicer/build/renders/input-gear.png": {
+      "sha256": "66cc61e0c19d997964fb9c1d13b4d14ece48ea8cebc771f0be70a0ff29d7b1b4",
+      "size": 22451,
+      "url": "https://img.basically.website/parts/render/input-gear-66cc61e0.png"
+    },
+    "slicer/build/renders/interface-big-spacer.png": {
+      "sha256": "a6c1a73194a7d17099c52c4834fe1d347c16bc3ac6a0a2f99e2e2d16c73ba810",
+      "size": 7423,
+      "url": "https://img.basically.website/parts/render/interface-big-spacer-a6c1a731.png"
+    },
+    "slicer/build/renders/interface-bracket.png": {
+      "sha256": "5c15729ca1d2b5ec4dd658618f29ac12ee82f5321ccaaef858b37980d1c7dd30",
+      "size": 7185,
+      "url": "https://img.basically.website/parts/render/interface-bracket-5c15729c.png"
+    },
+    "slicer/build/renders/interface-cage-bracket-cable.png": {
+      "sha256": "c793cdb8b9c78ec8a2f07a806491750be9c01a3fd380a98abcd16d7fcd694a53",
+      "size": 5721,
+      "url": "https://img.basically.website/parts/render/interface-cage-bracket-cable-c793cdb8.png"
+    },
+    "slicer/build/renders/interface-cage-bracket.png": {
+      "sha256": "47013652c7c30cdfad0bcfacbab40d14a5fc94f2fa1eda4dd091cdc557d72421",
+      "size": 5496,
+      "url": "https://img.basically.website/parts/render/interface-cage-bracket-47013652.png"
+    },
+    "slicer/build/renders/interface-idler-gear.png": {
+      "sha256": "41504d0da0c322fdc3b3d43f957419ea5a2d0dbee970094d30ef5b4c989f603c",
+      "size": 17969,
+      "url": "https://img.basically.website/parts/render/interface-idler-gear-41504d0d.png"
+    },
+    "slicer/build/renders/interface-nema23-bracket.png": {
+      "sha256": "c0e2b1196f89aa8e640018bbc580503708032be470a667c1517a6e0b3288b9c2",
+      "size": 7376,
+      "url": "https://img.basically.website/parts/render/interface-nema23-bracket-c0e2b119.png"
+    },
+    "slicer/build/renders/interface-rib-switch.png": {
+      "sha256": "9a1e42399d4117fd1e24623708a32bc809d48c19ae570247bb61afbd96d3240d",
+      "size": 5755,
+      "url": "https://img.basically.website/parts/render/interface-rib-switch-9a1e4239.png"
+    },
+    "slicer/build/renders/interface-rib.png": {
+      "sha256": "8a8b8c082221b2bf161e41fb5537ee5ab16677012ed180a5e73be8b81bc9c8f2",
+      "size": 10203,
+      "url": "https://img.basically.website/parts/render/interface-rib-8a8b8c08.png"
+    },
+    "slicer/build/renders/interface-spacer.png": {
+      "sha256": "cd6bec995412db81cec1fb2dbc56068a42583c8e7518c9834625b4ac2ade428e",
+      "size": 5869,
+      "url": "https://img.basically.website/parts/render/interface-spacer-cd6bec99.png"
+    },
+    "slicer/build/renders/interface-spur-gear.png": {
+      "sha256": "e095a624ce39086f8249433c852cbdadf432fe68323d4b532095b8f5002b2e62",
+      "size": 18265,
+      "url": "https://img.basically.website/parts/render/interface-spur-gear-e095a624.png"
+    },
+    "slicer/build/renders/interface-upper-fixed-section.png": {
+      "sha256": "c38e48d4fd31b5826775ccee81c11d50bc89b75b549c930caf8203c5c7667850",
+      "size": 13928,
+      "url": "https://img.basically.website/parts/render/interface-upper-fixed-section-c38e48d4.png"
+    },
+    "slicer/build/renders/layer-connector-1.png": {
+      "sha256": "5524b1159723d422f8e5ef973f6e211a000740d9840ae5f245c14f87ce7105a3",
+      "size": 18374,
+      "url": "https://img.basically.website/parts/render/layer-connector-1-5524b115.png"
+    },
+    "slicer/build/renders/layer-connector-2.png": {
+      "sha256": "2da295eb4f7314a6d9a48559e58ada6595515e81aa434faa7df71b938c8b4a89",
+      "size": 13505,
+      "url": "https://img.basically.website/parts/render/layer-connector-2-2da295eb.png"
+    },
+    "slicer/build/renders/leg-extension.png": {
+      "sha256": "fae37f749fc76caef86667e75d259a369f89704e0811f6d34c36c6e07a77a5fc",
+      "size": 4571,
+      "url": "https://img.basically.website/parts/render/leg-extension-fae37f74.png"
+    },
+    "slicer/build/renders/leg.png": {
+      "sha256": "c0d7cb12e0e884d3969756ef14527b37a0a700effe2455e6856a48c703e33bd1",
+      "size": 3946,
+      "url": "https://img.basically.website/parts/render/leg-c0d7cb12.png"
+    },
+    "slicer/build/renders/light-post-cap-adapter.png": {
+      "sha256": "437c463ed6ec30cb86385e341055c17b40a1449632bbad2fd15f0afa72bb6500",
+      "size": 16285,
+      "url": "https://img.basically.website/parts/render/light-post-cap-adapter-437c463e.png"
+    },
+    "slicer/build/renders/light-post-cap.png": {
+      "sha256": "4b037cf17385e43cb39ac51728ada6484e002668a17c3e3d4ecb6cf8242470b2",
+      "size": 32421,
+      "url": "https://img.basically.website/parts/render/light-post-cap-4b037cf1.png"
+    },
+    "slicer/build/renders/light-post.png": {
+      "sha256": "d2c7494e1be40c21ff571156d567f390101663edb44074ddda5a6947a3a70182",
+      "size": 7443,
+      "url": "https://img.basically.website/parts/render/light-post-d2c7494e.png"
+    },
+    "slicer/build/renders/limit-switch-dowel-pin.png": {
+      "sha256": "b082ba5ab06390aeb775aae4a7efda885988ef79f10e4f70d97928bfebadecaa",
+      "size": 9047,
+      "url": "https://img.basically.website/parts/render/limit-switch-dowel-pin-b082ba5a.png"
+    },
+    "slicer/build/renders/limit-switch-hammer.png": {
+      "sha256": "a4bbdee338b228183b39a8c579b8de02d240a163269a71467509101c97faa6ce",
+      "size": 12787,
+      "url": "https://img.basically.website/parts/render/limit-switch-hammer-a4bbdee3.png"
+    },
+    "slicer/build/renders/limit-switch-housing.png": {
+      "sha256": "af3689402d18dda1355292770f477edff50c7d3f10eb783a5c80ae480d863e38",
+      "size": 7409,
+      "url": "https://img.basically.website/parts/render/limit-switch-housing-af368940.png"
+    },
+    "slicer/build/renders/ls-bottom-static.png": {
+      "sha256": "d0afdb95dd742328c37986b2aaaf674b8cf3936abb7b75c41cef06038902ce79",
+      "size": 14622,
+      "url": "https://img.basically.website/parts/render/ls-bottom-static-d0afdb95.png"
+    },
+    "slicer/build/renders/ls-hold-in-place.png": {
+      "sha256": "2758f86084f51fd4a76a22ef87e33ad275e4a88607f36c8fd2b6a22cd595d3a7",
+      "size": 11256,
+      "url": "https://img.basically.website/parts/render/ls-hold-in-place-2758f860.png"
+    },
+    "slicer/build/renders/ls-mount-to-chute.png": {
+      "sha256": "58b00fe73984f370c91172577aa816244d9233955beef5c84ed7a2076d7140a5",
+      "size": 45530,
+      "url": "https://img.basically.website/parts/render/ls-mount-to-chute-58b00fe7.png"
+    },
+    "slicer/build/renders/ls-mount-to-extrusion.png": {
+      "sha256": "223e181ed755559ceb94dccfa1f7c4cef12feca66ae97b4ca079315a522cdd45",
+      "size": 5765,
+      "url": "https://img.basically.website/parts/render/ls-mount-to-extrusion-223e181e.png"
+    },
+    "slicer/build/renders/ls-washer.png": {
+      "sha256": "dbb45813cd27a8e8b7e87935cacf54e90742f56784a9971e11716a4f3f1bec4f",
+      "size": 7467,
+      "url": "https://img.basically.website/parts/render/ls-washer-dbb45813.png"
+    },
+    "slicer/build/renders/meanwell-psu-back-mount.png": {
+      "sha256": "8274bb78334f6425f0a180aa09b03677dfcac2b41e1a2b019f3ceaf5701e167f",
+      "size": 5217,
+      "url": "https://img.basically.website/parts/render/meanwell-psu-back-mount-8274bb78.png"
+    },
+    "slicer/build/renders/meanwell-psu-cap.png": {
+      "sha256": "57608c505cf749a63fdae6fd57cdc76a9add856a966d1c6031ab12c1db224257",
+      "size": 5489,
+      "url": "https://img.basically.website/parts/render/meanwell-psu-cap-57608c50.png"
+    },
+    "slicer/build/renders/meanwell-psu-connections.png": {
+      "sha256": "e47505e6a3e5dd877cb305e1db061d8ee97f10c564e92f6b185727587f31a994",
+      "size": 7998,
+      "url": "https://img.basically.website/parts/render/meanwell-psu-connections-e47505e6.png"
+    },
+    "slicer/build/renders/nema-bracket.png": {
+      "sha256": "a22488004b6bc44a3c37d2806ae8765a5c722219df6fc48bdac060a3c540622a",
+      "size": 6751,
+      "url": "https://img.basically.website/parts/render/nema-bracket-a2248800.png"
+    },
+    "slicer/build/renders/output-gear.png": {
+      "sha256": "b72ef086744fe31998ed78620be4a1e1e4b1b7cc0053171386e80283b7a4a7fc",
+      "size": 14181,
+      "url": "https://img.basically.website/parts/render/output-gear-b72ef086.png"
+    },
+    "slicer/build/renders/output-guide.png": {
+      "sha256": "ffd57ba0a642c1d2490c5622eb2b04a31ca003a03544b5097dfc7793bff7361b",
+      "size": 7084,
+      "url": "https://img.basically.website/parts/render/output-guide-ffd57ba0.png"
+    },
+    "slicer/build/renders/ribbon-cable-clamp.png": {
+      "sha256": "52035213dd8a7881dca9c32c44f181a77c96fa2c4f0f8251bd61e20d65e81878",
+      "size": 6649,
+      "url": "https://img.basically.website/parts/render/ribbon-cable-clamp-52035213.png"
+    },
+    "slicer/build/renders/rotor-faceted.png": {
+      "sha256": "2199a0296335392c404140311946ecec67a88eb5a18aa7f417c95bc89b86c5dc",
+      "size": 22699,
+      "url": "https://img.basically.website/parts/render/rotor-faceted-2199a029.png"
+    },
+    "slicer/build/renders/rotor-finned.png": {
+      "sha256": "804fc90539e1b026387ed2f8d03629744d8586d80cd4007812d177adfaf38c69",
+      "size": 27159,
+      "url": "https://img.basically.website/parts/render/rotor-finned-804fc905.png"
+    },
+    "slicer/build/renders/servo-adapter-flap-side.png": {
+      "sha256": "3282d4e70d32bd97c45da89949a45e6aea171e4d5dab24e60fccf422f205fa66",
+      "size": 29362,
+      "url": "https://img.basically.website/parts/render/servo-adapter-flap-side-3282d4e7.png"
+    },
+    "slicer/build/renders/servo-adapter-servo-side.png": {
+      "sha256": "a2d02e031dcf3ad9f4c986198006213b3b591031e98aed6d9b563ec5842cd6e0",
+      "size": 35521,
+      "url": "https://img.basically.website/parts/render/servo-adapter-servo-side-a2d02e03.png"
+    },
+    "slicer/build/renders/servo-bracket-cover.png": {
+      "sha256": "38397211b0bb79721d8fd6aad56f63e4429a6e1284b62af3a6a9bf0516faeabc",
+      "size": 15219,
+      "url": "https://img.basically.website/parts/render/servo-bracket-cover-38397211.png"
+    },
+    "slicer/build/renders/servo-bracket-housing.png": {
+      "sha256": "722a1ebd233531d8a8d648461891742ee396a90aa58aa185e3e14cdf0391a84b",
+      "size": 17161,
+      "url": "https://img.basically.website/parts/render/servo-bracket-housing-722a1ebd.png"
+    },
+    "slicer/build/renders/servo-bracket-lower-arm.png": {
+      "sha256": "2d7bfc72cfe47c31cea86315eb5ff929f44be4b4a44d6a16c28f6d998aad4b38",
+      "size": 11872,
+      "url": "https://img.basically.website/parts/render/servo-bracket-lower-arm-2d7bfc72.png"
+    },
+    "slicer/build/renders/servo-bracket-side-arm.png": {
+      "sha256": "c8f9d3145d05ca888c3dd4c49f7935896fd7bfd674a33874c0f27c70f247eb52",
+      "size": 14239,
+      "url": "https://img.basically.website/parts/render/servo-bracket-side-arm-c8f9d314.png"
+    },
+    "slicer/build/renders/stator.png": {
+      "sha256": "02ab8b46abb514e96061673c1e078413ab62446e6ef76dde456eadd168d0db95",
+      "size": 13922,
+      "url": "https://img.basically.website/parts/render/stator-02ab8b46.png"
+    },
+    "slicer/build/renders/top-interface-split-spur-gear-1.png": {
+      "sha256": "852a476adfe902928c7922604f3e83098bcfbc803dfbf602cf39a59d7c1eeced",
+      "size": 20211,
+      "url": "https://img.basically.website/parts/render/top-interface-split-spur-gear-1-852a476a.png"
+    },
+    "slicer/build/renders/top-interface-split-spur-gear-2.png": {
+      "sha256": "5b6a50d73cd8f08c6a132ee5164b513f4994f715082210b1f6aea28c9488f7b3",
+      "size": 13884,
+      "url": "https://img.basically.website/parts/render/top-interface-split-spur-gear-2-5b6a50d7.png"
+    },
+    "slicer/build/renders/top-interface-split-spur-gear-3.png": {
+      "sha256": "39e19ab0bff3b91ad5037e81f6036fd88ae2d0122a7f623f5dbff15bdd99bc27",
+      "size": 30961,
+      "url": "https://img.basically.website/parts/render/top-interface-split-spur-gear-3-39e19ab0.png"
+    },
+    "slicer/build/renders/versions/bulk-cap-v1.png": {
+      "sha256": "9ec28d7a58973871083297f3a178020952961f3fc69ccd3cd328550ca2c158b6",
+      "size": 14649,
+      "url": "https://img.basically.website/parts/render/bulk-cap-v1-9ec28d7a.png"
+    },
+    "slicer/build/renders/versions/cable-clamp-outer-v1.png": {
+      "sha256": "ca79ce549550b61de0afa3125c96733aba074e0e06e1062daa672d3c1a6ea826",
+      "size": 13775,
+      "url": "https://img.basically.website/parts/render/cable-clamp-outer-v1-ca79ce54.png"
+    },
+    "slicer/build/renders/versions/interface-big-spacer-v1.png": {
+      "sha256": "8ef4cd81a0f6c510c2ba978a0da0a23b9633663ec0a0da877af23f549913e377",
+      "size": 8601,
+      "url": "https://img.basically.website/parts/render/interface-big-spacer-v1-8ef4cd81.png"
+    },
+    "slicer/build/renders/versions/interface-bracket-v1.png": {
+      "sha256": "299da0d4e2f9494f0f154cc2e66e4f5bd5a8d4d764eed345bef1d89b4bfc9fe5",
+      "size": 7191,
+      "url": "https://img.basically.website/parts/render/interface-bracket-v1-299da0d4.png"
+    },
+    "slicer/build/renders/versions/interface-upper-fixed-section-v1.png": {
+      "sha256": "84740ff9ba280bcc7f8104c793b77c27769435d26f5adbdee07b6cdf71909771",
+      "size": 13411,
+      "url": "https://img.basically.website/parts/render/interface-upper-fixed-section-v1-84740ff9.png"
+    },
     "slicer/build/plate-thumbs/3-bins-1.png": {
       "sha256": "4ef3faa71f64fe9015b195f85aa927a04e48eb85e35c248b0130c8b7b10e983e",
       "size": 5361,

--- a/parts-calculator/src/lib/data/parts.generated.json
+++ b/parts-calculator/src/lib/data/parts.generated.json
@@ -1409,15 +1409,15 @@
 					"commit": null,
 					"stl": "https://img.basically.website/parts/stl/stator-n6bm-323b2d1f.stl",
 					"render": "https://img.basically.website/parts/render/stator-02ab8b46.png",
-					"grams": 175.52
+					"grams": 175.75
 				}
 			],
 			"attributes": [],
-			"grams": 175.52,
-			"support_grams": 23.42,
+			"grams": 175.75,
+			"support_grams": 23.07,
 			"support_used": true,
 			"support_intentional": true,
-			"print_seconds": 16014,
+			"print_seconds": 16023,
 			"color": {
 				"by_section": {
 					"feeder": {
@@ -2349,7 +2349,7 @@
 			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 7422,
+			"print_seconds": 7480,
 			"color": {
 				"role": "frame"
 			},


### PR DESCRIPTION
Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1540214002108465243/1540227275453243442): "Create a new PR and add the servo adapter as part on Door model parts list. Add a warning note about the question from earlier, the current adapter STLs show a self-tapping joint."

The two-piece servo adapter was documented nowhere: `servo-adapter-servo-side` and `servo-adapter-flap-side` appeared in no `parts_needed` block on any docs page, only in passing sentences on Chute core and Servo mount. The calculator points both the `flap-module` and `servo-adapter` assemblies at this page.

**What this adds to `door-module.md`:**

- A **Parts needed** card, via frontmatter: both adapter halves, 1 each.
- A short **Servo adapter** section saying what it is and how the halves join.
- A warning callout about the insert question.

**The warning, and why it is worded that way.** The BOM's Screws tab assigns 4 short M3 inserts (ruthex RX-M3Sx4.0) per adapter, "Servo adapter only", 4 per layer. The published adapter STLs do not agree, measured with trimesh (cylinder fits on connected components, then ray casts along each hole axis):

- `servo-adapter-flap-side` (v1, `lv7n`): four **4.0 mm** bores through a **5.0 mm** wall, 90° countersink on the back face opening to ~7.2 mm.
- `servo-adapter-servo-side` (v1, `fu2t`): four **blind 2.8 mm** holes, 4.0 mm deep, same bolt circle, 2.25 mm of solid material behind them.

A countersunk screw driven from the flap side self-taps into plastic on the servo side. 4.0 mm is ruthex's own recommended hole for an M3 insert, so the flap-side bore could be a pocket, but then nothing on the servo side would receive the screw. Both STLs are version 1 from 2026-06-27 and have never been revised.

**Second commit, also requested by barthel** ([from Discord](https://discord.com/channels/1430279849171222682/1540214002108465243/1540230126187454504): "Add all the necessary parts, such as screws and the heat inserts mentioned in the warning. Follow the Top Interface layout, especially the preparation step. The warning could also be included here."):

- `parts_needed` gains **4 × `hsi-m3s`** and **4 × `scr-m3-6-cs`**, so the card renders Printed parts / Heat inserts / Screws like every other assembly page.
- The body follows Top interface: a `fastener-legend`, **Step 1 Preparation** with a `prep-item` for the inserts and a link to the heat-inserts helper, then **Step 2 Join the two halves** with the `fastener.html` include for the screw.
- The warning now lives inside the Preparation step, where somebody about to press an insert will actually read it, and covers **both** unverified numbers: the insert count and the 6 mm screw length (~1 mm bite if the joint really is self-tapping).

**Based on #355, not `main`**, because `hsi-m3s` is the part #355 adds — on `main` the card would render a bare grey id. The diff here is one docs file. Retarget to `main` after #355 merges (`gh api -X PATCH .../pulls/357 -f base=main`).

Neither number is asserted as fact anywhere on the page; both are attributed to the BOM and flagged.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540214002108465243/1540227275453243442
preview: /hardware/assembly/distribution/chute/door-module/
-->

