### PR TITLE
docs: floating back-to-top button on every page

### DIFF
--- a/docs/src/lib/components/BackToTop.svelte
+++ b/docs/src/lib/components/BackToTop.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	/* A floating "back to top" control, bottom right, on every page.
+
+	   It is not permanently on screen: the assembly tree gets deep, and the
+	   moment you want the menu again is the moment you start scrolling back
+	   up. So it appears on an upward scroll once you are a screenful or so
+	   down, and gets out of the way again as soon as you scroll on down. */
+
+	// How far down the page you have to be before the button can appear.
+	const SHOW_AFTER = 600;
+	// Ignore scroll jitter and touch momentum wobble; only a deliberate
+	// movement flips the direction. Small deltas accumulate instead of
+	// resetting the anchor, so a slow drag upward still counts.
+	const DELTA = 24;
+
+	let visible = $state(false);
+	let anchorY = 0;
+
+	$effect(() => {
+		anchorY = window.scrollY;
+
+		const onScroll = () => {
+			const y = window.scrollY;
+			if (y < SHOW_AFTER) {
+				visible = false;
+				anchorY = y;
+				return;
+			}
+			const delta = y - anchorY;
+			if (delta <= -DELTA) {
+				visible = true;
+				anchorY = y;
+			} else if (delta >= DELTA) {
+				visible = false;
+				anchorY = y;
+			}
+		};
+
+		window.addEventListener('scroll', onScroll, { passive: true });
+		return () => window.removeEventListener('scroll', onScroll);
+	});
+
+	function toTop() {
+		const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
+		visible = false;
+		// The button is about to hide itself, so hand focus to the first thing
+		// at the top of the page rather than dropping it on the body.
+		document.querySelector<HTMLElement>('.site-header .brand')?.focus({ preventScroll: true });
+	}
+</script>
+
+<button
+	type="button"
+	class="back-to-top"
+	class:is-visible={visible}
+	aria-label="Back to top"
+	title="Back to top"
+	onclick={toTop}
+>
+	<svg viewBox="0 0 16 16" fill="none" aria-hidden="true" width="14" height="14">
+		<path d="M8 13.5V3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+		<path
+			d="M3.5 7.5 8 3l4.5 4.5"
+			stroke="currentColor"
+			stroke-width="1.6"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		/>
+	</svg>
+	<span>Back to top</span>
+</button>

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import NavTree from '$lib/components/NavTree.svelte';
 	import SearchModal from '$lib/components/SearchModal.svelte';
+	import BackToTop from '$lib/components/BackToTop.svelte';
 
 	let { data, children } = $props();
 
@@ -145,3 +146,5 @@
 		</p>
 	</footer>
 </div>
+
+<BackToTop />

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1828,3 +1828,68 @@ blockquote {
 	border-radius: 3px;
 	margin-right: 2px;
 }
+
+/* ── Back to top ───────────────────────────────────────────────────────── */
+
+/* Fixed bottom right on every page. Hidden until BackToTop.svelte decides
+   otherwise (an upward scroll, once you are a screenful down), and hidden in
+   the prerendered HTML because `visible` starts false. */
+.back-to-top {
+	position: fixed;
+	right: max(20px, env(safe-area-inset-right));
+	bottom: max(20px, env(safe-area-inset-bottom));
+	z-index: 40;
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	padding: 9px 12px;
+	font: inherit;
+	font-size: 0.82rem;
+	font-weight: 500;
+	color: var(--muted);
+	background: var(--surface);
+	border: 1px solid var(--line);
+	box-shadow: 0 2px 10px -2px rgba(0, 0, 0, 0.14);
+	cursor: pointer;
+	opacity: 0;
+	visibility: hidden;
+	transform: translateY(6px);
+	transition:
+		opacity 0.16s ease,
+		transform 0.16s ease,
+		visibility 0.16s ease,
+		color 0.12s ease,
+		border-color 0.12s ease;
+}
+
+.back-to-top.is-visible {
+	opacity: 1;
+	visibility: visible;
+	transform: translateY(0);
+}
+
+.back-to-top:hover {
+	color: var(--ink);
+	border-color: var(--muted);
+}
+
+@media (max-width: 740px) {
+	.back-to-top {
+		right: max(12px, env(safe-area-inset-right));
+		bottom: max(12px, env(safe-area-inset-bottom));
+		padding: 9px 10px;
+	}
+
+	/* Icon only where the page is narrow enough for the label to crowd the
+	   copy underneath it. */
+	.back-to-top span {
+		display: none;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.back-to-top {
+		transition: none;
+		transform: none;
+	}
+}


### PR DESCRIPTION
Adds a floating **Back to top** control fixed to the bottom right of every docs page.

**Behaviour**, following what was asked for: it stays hidden while you read down the page, and slides in as soon as you scroll back up, once you are more than ~600px down. Scrolling on down hides it again, and it never appears near the top of a page. A 24px delta threshold keeps touch momentum and scroll jitter from flickering it.

- New component `docs/src/lib/components/BackToTop.svelte`, mounted once in `src/routes/+layout.svelte`, so it is on every page with no per-page work.
- Scroll listener is `passive`, registered in an `$effect` and torn down with it. Starts hidden, so the prerendered HTML has it hidden too.
- Click scrolls to the top and hands focus to the header brand link, so keyboard users are not left with focus on a button that just hid itself.
- Styling follows the site rules: sharp edges, flat 1px border, tokens only, no raw hex. Icon only below 740px. `prefers-reduced-motion` drops both the transition and the smooth scroll.

**Checks:** `npm run check` 0 errors (4 pre-existing `Requirements.svelte` a11y warnings), `npm run build` clean, `validate_frontmatter.py` at the 5 errors already on `main`, `validate_images.py` green.

Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1540309253942681630): "could we get a floating button 'back to top' down the bottom right hand corner, maybe that appears on scroll up. On all pages. When you get deep down in the docs or assembly tree it takes a long time to return to the menu."

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1540309253942681630
preview: /hardware/assembly/
-->
