### PR TITLE
docs: make the back-to-top button findable

### DIFF
--- a/docs/src/lib/components/BackToTop.svelte
+++ b/docs/src/lib/components/BackToTop.svelte
@@ -2,25 +2,37 @@
 	/* A floating "back to top" control, bottom right, on every page.
 
 	   It is not permanently on screen: the assembly tree gets deep, and the
-	   moment you want the menu again is the moment you start scrolling back
-	   up. So it appears on an upward scroll once you are a screenful or so
-	   down, and gets out of the way again as soon as you scroll on down. */
+	   moment you want the menu again is the moment you stop, or start
+	   scrolling back up. So it hides itself only while you are actively
+	   scrolling down the page, and is there the rest of the time. Revealing it
+	   on an upward scroll alone was too well hidden: two people looked for it
+	   on the day it shipped and neither found it. */
 
-	// How far down the page you have to be before the button can appear.
-	const SHOW_AFTER = 600;
+	// How far down the page you have to be before the button appears at all.
+	// Low enough that a page which barely scrolls still gets one.
+	const SHOW_AFTER = 240;
 	// Ignore scroll jitter and touch momentum wobble; only a deliberate
 	// movement flips the direction. Small deltas accumulate instead of
 	// resetting the anchor, so a slow drag upward still counts.
 	const DELTA = 24;
+	// Scrolling stops, the button comes back. This is what makes it findable:
+	// you never have to know the reveal gesture, you just have to stop.
+	const IDLE_MS = 350;
 
 	let visible = $state(false);
 	let anchorY = 0;
+	let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
 	$effect(() => {
 		anchorY = window.scrollY;
+		// Firefox restores the scroll position on reload, and a link can land
+		// part-way down a page. Neither fires a scroll event, so seed from
+		// where we actually are rather than waiting to be told.
+		visible = anchorY >= SHOW_AFTER;
 
 		const onScroll = () => {
 			const y = window.scrollY;
+			clearTimeout(idleTimer);
 			if (y < SHOW_AFTER) {
 				visible = false;
 				anchorY = y;
@@ -34,10 +46,14 @@
 				visible = false;
 				anchorY = y;
 			}
+			idleTimer = setTimeout(() => (visible = true), IDLE_MS);
 		};
 
 		window.addEventListener('scroll', onScroll, { passive: true });
-		return () => window.removeEventListener('scroll', onScroll);
+		return () => {
+			window.removeEventListener('scroll', onScroll);
+			clearTimeout(idleTimer);
+		};
 	});
 
 	function toTop() {


### PR DESCRIPTION
Follow-up to #361. The button worked, but you had to already know how to summon it, so two people looked for it on the day it shipped and neither found one.

**What was wrong**

- It only revealed itself on an **upward** scroll. Stopping, which is when you actually go looking for the menu, left it hidden.
- The threshold was **600px**. The docs front page is about 1200px tall, so it maxes out near 200px of scroll and the button could never appear there at all. Same for most landing pages.

**What it does now**

- Hides only while you are **actively scrolling down**. Scroll up, or just stop for 350ms, and it is there.
- Threshold down to **240px**, so a page that barely scrolls still gets one.
- Seeded from `window.scrollY` on mount, so a restored scroll position (Firefox does this on reload) or a link into the middle of a page shows it without waiting for a scroll event.

**Verified** by mounting the component under vitest + jsdom locally and driving `window.scrollY`: hidden at the top, hidden while scrolling down, visible after the idle delay, visible immediately on an upward scroll, hidden again near the top, and unmoved by sub-threshold jitter. The same harness confirms the shipped version never becomes visible on a page that only scrolls 200px, which is the reported symptom. The harness is not committed (the docs site has no test setup and this adds no dependencies to it).

`npm run check` 0 errors (4 pre-existing `Requirements.svelte` warnings), `npm run build` clean.

Reported by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1540309253942681630/1540337627323174972): "I don't see any floating "back to top" button on mozilla firefox on mac?"

Originally requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1540309253942681630): "could we get a floating button 'back to top' down the bottom right hand corner, maybe that appears on scroll up. On all pages. When you get deep down in the docs or assembly tree it takes a long time to return to the menu."

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540309253942681630/1540337627323174972
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1540309253942681630
preview: /hardware/assembly/distribution/top-interface/
-->
