### PR TITLE
docs: skeleton pages for the undocumented feeder stages

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -5,9 +5,78 @@ type: how-to
 section: hardware
 slug: assembly-arranging-c-channels
 kicker: Feeder — Arranging C-Channels
-lede: How the C-channels are laid out together.
+lede: How the four C-channels stand, at what heights, and what passes parts between them.
 permalink: /hardware/assembly/feeder/arranging-c-channels/
-author: spencer
+author: barthel
+warning: >-
+  **Skeleton page.** Assembled from the parts registry in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and the
+  extrusion list on the bill of materials. No height, angle or fastener here has been checked
+  against a machine, and the two starred questions below are the ones that make the feeder work.
+  Fill it in as you build.
+parts_needed:
+  - part: leg
+    qty: 9
+  - part: foot
+    qty: 9
+  - part: leg-extension
+    qty: 9
 ---
 
-_Content pending._
+Four [C-channels]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}) are built the same way and then stood at different heights, so a part cascades from one to the next under gravity and arrives at the [interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) singulated.
+
+{% include fastener-legend.html %}
+
+## The order parts travel
+
+1. **C1**, the bulk channel, under the [bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}). Highest.
+2. **C2**, with a [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and an [overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}).
+3. **C3**, the same again, and the last metering stage.
+4. **The classification channel**, inside the [classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}), which images the part before it drops into the chute.
+
+[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) bridge the handovers between them.
+
+## The stand
+
+Each channel stands on its own printed legs: **3 legs, 3 feet and 3 leg extensions per channel**, 9 of each across the three feeder channels. The Leg is the 135 mm print; the extension raises it further, and the foot is what meets the bench.
+
+- How the leg, extension and foot stack, and what fastens them to each other, is not recorded: <span class="fastener-todo">fastener not recorded</span>.
+- How a leg attaches to the C-channel's stator or NEMA bracket is not recorded: <span class="fastener-todo">fastener not recorded</span>.
+- Whether the classification channel stands on legs of its own, or is carried by the chamber and the interface, is not recorded either. The catalog gives 9 of each for the feeder and none for the classification channel, which suggests the latter.
+
+## The framing
+
+The bill of materials gives the feeder's 2020 cut list. No step uses it yet, so what each piece bolts to is an open question.
+
+- **3 at 270 mm**, bulk bucket supports.
+- **3 at 190 mm**, mid C-channel supports.
+- **3 at 110 mm**, lower C-channel supports.
+- **Camera support**, either 1 at 300 mm fixed, or 1 at 350 mm plus 1 at 200 mm for the adjustable version. How that relates to the rod-and-arm [camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}), which hangs off the channels rather than off extrusion, is unclear and worth resolving on this page.
+
+{% include step.html n="1" title="Stand each channel" %}
+
+Fit legs, extensions and feet to each of the three feeder channels. Details unrecorded, see above.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Set the heights and the spacing" %}
+
+**★ The numbers this page most needs.** For each handover: the drop from one rotor to the next, the horizontal overlap between the channels, and how far around the circle the handover happens. Nothing about any of it is written down anywhere today.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="3" title="Fit the output guides" %}
+
+See [output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}).
+
+{% include step.html n="4" title="Add the bulk input, light posts and camera arms" %}
+
+[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}) on C1, [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and [camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}) on C2 and C3.
+
+{% include step.html n="5" title="Hand over to the classification channel" %}
+
+**★ The other open question.** How the classification channel sits relative to C3 and to the interface below it, and what carries it. Record it here.
+
+{% include step.html n="6" title="Turn it all by hand" %}
+
+Run parts through the whole cascade by hand, one channel at a time, before wiring the steppers. Anything that needs a nudge here will jam under power.

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -11,9 +11,9 @@ author: barthel
 warning: >-
   **Skeleton page.** Assembled from the parts registry in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and the
-  extrusion list on the bill of materials. No height, angle or fastener here has been checked
-  against a machine, and the two starred questions below are the ones that make the feeder work.
-  Fill it in as you build.
+  extrusion list on the bill of materials, not from a build. No height, angle or fastener here
+  has been checked against a machine, and the two starred steps are the ones that make the
+  feeder work. Fill it in as you build.
 parts_needed:
   - part: leg
     qty: 9
@@ -25,58 +25,79 @@ parts_needed:
 
 Four [C-channels]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}) are built the same way and then stood at different heights, so a part cascades from one to the next under gravity and arrives at the [interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) singulated.
 
+The fasteners and quantities in the parts list come from the parts registry and are called out inline at each step.
+
 {% include fastener-legend.html %}
 
-## The order parts travel
+Steps below refer to the channels by the names the software uses, in the order a part travels:
 
-1. **C1**, the bulk channel, under the [bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}). Highest.
-2. **C2**, with a [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and an [overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}).
-3. **C3**, the same again, and the last metering stage.
-4. **The classification channel**, inside the [classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}), which images the part before it drops into the chute.
+- **C1**, the bulk channel, under the [bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}). Highest.
+- **C2**, with a [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and an [overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}).
+- **C3**, the same again, and the last metering stage.
+- **The classification channel**, inside the [classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}), which images the part before it drops into the chute.
 
-[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) bridge the handovers between them.
+{% include step.html n="1" title="Preparation" %}
 
-## The stand
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Legs, feet and leg extensions:</strong> 3 of each per channel, 9 of each across the three feeder channels. The Leg is the 135 mm print, the extension raises it further, and the foot is what meets the bench. No heat inserts recorded.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
 
-Each channel stands on its own printed legs: **3 legs, 3 feet and 3 leg extensions per channel**, 9 of each across the three feeder channels. The Leg is the 135 mm print; the extension raises it further, and the foot is what meets the bench.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Feeder extrusion, from the bill of materials:</strong> 3 pieces of 2020 at 270 mm (bulk bucket supports), 3 at 190 mm (mid C-channel supports), 3 at 110 mm (lower C-channel supports), and the camera support, either 1 at 300 mm fixed or 1 at 350 mm plus 1 at 200 mm adjustable. No step records what any of them bolts to.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
 
-- How the leg, extension and foot stack, and what fastens them to each other, is not recorded: <span class="fastener-todo">fastener not recorded</span>.
-- How a leg attaches to the C-channel's stator or NEMA bracket is not recorded: <span class="fastener-todo">fastener not recorded</span>.
-- Whether the classification channel stands on legs of its own, or is carried by the chamber and the interface, is not recorded either. The catalog gives 9 of each for the feeder and none for the classification channel, which suggests the latter.
+Build all four [C-channels]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}) before starting here, three with the faceted rotor and one with the finned one.
 
-## The framing
+{% include step.html n="2" title="Stand each channel" %}
 
-The bill of materials gives the feeder's 2020 cut list. No step uses it yet, so what each piece bolts to is an open question.
+Fit 3 legs, 3 extensions and 3 feet to each of the three feeder channels.
 
-- **3 at 270 mm**, bulk bucket supports.
-- **3 at 190 mm**, mid C-channel supports.
-- **3 at 110 mm**, lower C-channel supports.
-- **Camera support**, either 1 at 300 mm fixed, or 1 at 350 mm plus 1 at 200 mm for the adjustable version. How that relates to the rod-and-arm [camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}), which hangs off the channels rather than off extrusion, is unclear and worth resolving on this page.
+**Not recorded:** how the leg, extension and foot stack, what fastens them to each other, and how a leg attaches to the channel's stator or NEMA bracket. <span class="fastener-todo">fastener not recorded</span>
 
-{% include step.html n="1" title="Stand each channel" %}
-
-Fit legs, extensions and feet to each of the three feeder channels. Details unrecorded, see above.
+**Not recorded:** whether the classification channel stands on legs of its own or is carried by the chamber and the interface below it. The catalog gives 9 of each for the feeder and none for the classification channel, which suggests the latter.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="2" title="Set the heights and the spacing" %}
+{% include step.html n="3" title="★ Set the heights and the spacing" %}
 
-**★ The numbers this page most needs.** For each handover: the drop from one rotor to the next, the horizontal overlap between the channels, and how far around the circle the handover happens. Nothing about any of it is written down anywhere today.
+The numbers this page most needs, and none of them are written down anywhere today. For each handover, record:
+
+- the drop from one rotor to the next,
+- the horizontal overlap between the two channels,
+- how far around the circle the handover happens.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="3" title="Fit the output guides" %}
+{% include step.html n="4" title="Fit the output guides" %}
 
-See [output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}).
+One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) at each handover, C1 to C2 and C2 to C3.
 
-{% include step.html n="4" title="Add the bulk input, light posts and camera arms" %}
+<div class="img-placeholder">Image coming</div>
 
-[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}) on C1, [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and [camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}) on C2 and C3.
+{% include step.html n="5" title="Add the bulk input, the light posts and the camera arms" %}
 
-{% include step.html n="5" title="Hand over to the classification channel" %}
+[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}) on C1. A [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and an [overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}) on C2 and on C3.
 
-**★ The other open question.** How the classification channel sits relative to C3 and to the interface below it, and what carries it. Record it here.
+<div class="img-placeholder">Image coming</div>
 
-{% include step.html n="6" title="Turn it all by hand" %}
+{% include step.html n="6" title="★ Hand over to the classification channel" %}
 
-Run parts through the whole cascade by hand, one channel at a time, before wiring the steppers. Anything that needs a nudge here will jam under power.
+The other open question: how the classification channel sits relative to C3 and to the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) below it, and what carries its weight.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="7" title="Turn it all by hand" %}
+
+Run parts through the whole cascade by hand, one channel at a time, before wiring the steppers. Anything that needs a nudge here will jam under power. Wiring is on the [electronics]({{ '/hardware/electronics/' | relative_url }}) page.
+
+<div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/assembly/feeder/bulk-input.md
+++ b/docs/src/content/hardware/assembly/feeder/bulk-input.md
@@ -11,8 +11,8 @@ author: barthel
 warning: >-
   **Skeleton page.** Written from the parts registry in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=bulk-cap) and the
-  extrusion list on the [bill of materials]({{ '/hardware/BOM' | relative_url }}), not from a
-  build. The bulk bucket itself is not published yet. Fill it in as you build.
+  extrusion list on the bill of materials, not from a build. The bulk bucket itself is not
+  published yet, so this page is mostly the shape of what is missing. Fill it in as you build.
 parts_needed:
   - part: bulk-cap
     qty: 1
@@ -20,21 +20,53 @@ parts_needed:
 
 The bulk input is where unsorted parts go in: a bucket held above the first C-channel, feeding parts down onto the rotor as the channel turns.
 
-- **One per machine**, on the first feeder channel (C1).
-- **The Bulk cap** slides onto the C1 [stator]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}) on a dovetail. It is the only part of this stage in the catalog today. The v2 revision (2026-08-18) opened up the dovetail clearance, because v1 needed too much force to slide on. If yours is a fight, check you have the current file.
-- **The bulk bucket is not published.** It is a separate print, roughly a full bed, and is not in the parts catalog yet, so there is no file to link and no quantity to give. Ask before printing something in its place.
-- **Its supports are on the BOM.** The extrusion list gives 3 pieces of 2020 at 270 mm as bulk bucket supports. How they attach at either end is not recorded.
+One per machine, on the first feeder channel (C1). The Bulk cap is the only part of this stage in the catalog today.
 
-{% include step.html n="1" title="Fit the bulk cap to the first channel" %}
+{% include fastener-legend.html %}
 
-Slide the Bulk cap onto the stator of the first C-channel, along its dovetail. No screws are recorded for this joint.
+{% include step.html n="1" title="Preparation" %}
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Bulk cap:</strong> no heat inserts, no screws recorded. It slides onto the C1 stator on a dovetail. Print it in the feeder colour.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Bulk bucket:</strong> not published. It is a separate print, roughly a full bed, and is not in the parts catalog, so there is no file to link and no quantity to give. Ask before printing something in its place.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Use the current Bulk cap. The v2 revision (2026-08-18) opened up the dovetail clearance because v1 needed too much force to slide on. If yours is a fight, check the file first rather than forcing it.</p>
+</div>
+
+{% include step.html n="2" title="Fit the bulk cap to the first channel" %}
+
+Slide the Bulk cap onto the stator of the first [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), along its dovetail. No screws are recorded for this joint.
+
+**Not recorded:** which way it faces relative to the handover to C2.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="2" title="Mount the bucket supports" %}
+{% include step.html n="3" title="Mount the bucket supports" %}
 
-Three 270 mm 2020 extrusions carry the bucket above the channel. Where they land on the [C-channel stand]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}), what fastens them, and how high the bucket sits above the rotor, are all unrecorded.
+Three pieces of 2020 extrusion cut to 270 mm carry the bucket above the channel. They are on the bill of materials as bulk bucket supports.
 
-{% include step.html n="3" title="Fit the bucket" %}
+**Not recorded:** where they land on the [C-channel stand]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}), what fastens them at either end, and how high the bucket sits above the rotor.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="4" title="Fit the bucket" %}
 
 Not documented, and the part is not published. Record the file, the fixings and the drop height here when it is.
+
+<div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/assembly/feeder/bulk-input.md
+++ b/docs/src/content/hardware/assembly/feeder/bulk-input.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: Bulk input
+type: how-to
+section: hardware
+slug: assembly-bulk-input
+kicker: Feeder — Bulk input
+lede: The bucket and cap that hold unsorted parts over the first C-channel.
+permalink: /hardware/assembly/feeder/bulk-input/
+author: barthel
+warning: >-
+  **Skeleton page.** Written from the parts registry in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=bulk-cap) and the
+  extrusion list on the [bill of materials]({{ '/hardware/BOM' | relative_url }}), not from a
+  build. The bulk bucket itself is not published yet. Fill it in as you build.
+parts_needed:
+  - part: bulk-cap
+    qty: 1
+---
+
+The bulk input is where unsorted parts go in: a bucket held above the first C-channel, feeding parts down onto the rotor as the channel turns.
+
+- **One per machine**, on the first feeder channel (C1).
+- **The Bulk cap** slides onto the C1 [stator]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}) on a dovetail. It is the only part of this stage in the catalog today. The v2 revision (2026-08-18) opened up the dovetail clearance, because v1 needed too much force to slide on. If yours is a fight, check you have the current file.
+- **The bulk bucket is not published.** It is a separate print, roughly a full bed, and is not in the parts catalog yet, so there is no file to link and no quantity to give. Ask before printing something in its place.
+- **Its supports are on the BOM.** The extrusion list gives 3 pieces of 2020 at 270 mm as bulk bucket supports. How they attach at either end is not recorded.
+
+{% include step.html n="1" title="Fit the bulk cap to the first channel" %}
+
+Slide the Bulk cap onto the stator of the first C-channel, along its dovetail. No screws are recorded for this joint.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Mount the bucket supports" %}
+
+Three 270 mm 2020 extrusions carry the bucket above the channel. Where they land on the [C-channel stand]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}), what fastens them, and how high the bucket sits above the rotor, are all unrecorded.
+
+{% include step.html n="3" title="Fit the bucket" %}
+
+Not documented, and the part is not published. Record the file, the fixings and the drop height here when it is.

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -115,6 +115,8 @@ Turn the stage by hand before wiring it. The train should run without a tight sp
 
 Two of the C-channels carry a light post, which bolts to this unit's NEMA bracket with 2 {% include fastener.html size="M3" variant="countersunk" length="20" %} screws that thread straight into the printed post.
 
+The post, its cap, the cap adapter and the COB plate have their own page: [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}).
+
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p><b>The C-channel COB light boards need a current-limiting resistor.</b> <b>220&#8486;, 1/4 W, in series, one per board.</b> Wired straight to 24V a 50 mm COB plate pulls about 0.5A and melts its printed mount. A board fed from a basically board v1.3 LED header already has one on the board. Full detail: <a href="{{ '/hardware/electronics/#43--leds-from-basically-board-v13' | relative_url }}">LEDs, on the wire harness page</a>.</p>

--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -11,8 +11,8 @@ author: barthel
 warning: >-
   **Skeleton page.** Written from the parts registry in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=camera-mount), not from a
-  build. The parts are recorded; the assembly order, every screw's position, the camera
-  fixing and all photographs are missing. Fill it in as you build.
+  build. The parts are recorded; the assembly order, every screw's position, the camera fixing
+  and all photographs are missing. Fill it in as you build.
 parts_needed:
   - part: camera-mount-part-6
     qty: 1
@@ -32,31 +32,64 @@ parts_needed:
 
 The overhead camera mount is a pair of 3/8 in steel rods clamped to a [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), carrying a printed arm that holds a detection camera above the channel.
 
-The fasteners and quantities are in the parts list above and are called out inline at each step.
+The fasteners and quantities in the parts list come from the parts registry and are called out inline at each step. **The list above is one arm's worth**, and the machine takes 2, so 4 rod mounts and 4 rod pieces in total.
+
+The camera these carry is the **OV9732 720p module**, which the parts registry lists as the C-channel and drop plate detection camera. The 4K IMX415 is a different camera and belongs to the [classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}).
 
 {% include fastener-legend.html %}
 
-- **Build 2 per machine.** The parts list above is one arm's worth, so it takes 4 rod mounts and 4 rod pieces in total.
-- **Rod is bought as stock and cut.** One 4 ft length of 3/8 in steel rod yields all four roughly 1 ft pieces. The exact cut length is not recorded yet.
-- The camera these carry is the **OV9732 720p module**, which the parts registry lists as the C-channel and drop-plate detection camera. The 4K IMX415 is a different camera and belongs to the [classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}).
-- Two arms for three feeder channels is not a mistake: the software's `split_feeder` camera layout puts a camera on C2, on C3 and on the carousel, which lines up with the two arms and the two [light posts]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}). That pairing is inferred from the parts counts and the software config, not from a build.
+Two arms for three feeder channels is not a mistake. The software's `split_feeder` camera layout puts a camera on C2, on C3 and on the carousel, which lines up with the two arms and the two [light posts]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}). That pairing is inferred from the part counts and the software config, not from a build.
 
-{% include step.html n="1" title="Cut the rods" %}
+{% include step.html n="1" title="Preparation" %}
 
-Cut two pieces of 3/8 in rod per arm. Length not recorded yet.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Steel rod:</strong> bought as 4 ft stock and cut down. One length yields all four pieces, roughly 1 ft each. <strong>The exact cut length is not recorded.</strong></p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Printed parts:</strong> no heat inserts recorded. The arm uses 3 M3 nuts rather than inserts, so nothing needs pressing in before assembly.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
+
+Colour does not matter on any of these parts.
 
 {% include step.html n="2" title="Clamp the rod mounts to the C-channel" %}
 
-Two Rod-to-C-channel mounts (Part 33) hold the rods on the channel. Which holes on the channel they use, and what fastens them, is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+Two Rod-to-C-channel mounts (Part 33) carry the rods on the channel.
+
+**Not recorded:** which holes on the channel they use, what fastens them, and how far apart they sit. <span class="fastener-todo">fastener not recorded</span>
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="3" title="Join the two arm halves" %}
+{% include step.html n="3" title="Fit the rods" %}
 
-Overhead camera mount A (part 37) and B (part 37b) join through the A/B connector (part 6), with the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws and 3 M3 nuts in the list above. Which joint takes which screw is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+Slide a cut rod into each mount.
+
+**Not recorded:** how the rods are clamped and how far they stand proud of the mounts.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="4" title="Fit the camera and set the height" %}
+{% include step.html n="4" title="Join the two arm halves" %}
 
-Nothing is recorded yet about how the camera fastens to the arm, how high above the channel it sits, or how it is squared to the channel. All three change what the detection zones see, so record what worked. Zone setup itself is software, see the [camera calibration]({{ '/sorter/camera-calibration/' | relative_url }}) page.
+Overhead camera mount A (part 37) and B (part 37b) join through the A/B connector (part 6), using the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws and 3 M3 nuts in the list above.
+
+**Not recorded:** which joint takes which screw, and whether the connector is what sets the arm's reach over the channel. <span class="fastener-todo">fastener not recorded</span>
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="5" title="Fit the camera and set the height" %}
+
+**Not recorded:** how the camera fastens to the arm, how high above the channel it sits, and how it is squared to the channel. All three change what the detection zones see, so write down what worked. <span class="fastener-todo">fastener not recorded</span>
+
+Build the second arm the same way. Setting the zones up afterwards is software, see [camera calibration]({{ '/sorter/camera-calibration/' | relative_url }}).
+
+<div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Overhead camera mount
+type: how-to
+section: hardware
+slug: assembly-overhead-camera-mount
+kicker: Feeder — Overhead camera mount
+lede: The rod arm that hangs a detection camera over a C-channel.
+permalink: /hardware/assembly/feeder/camera-mount/
+author: barthel
+warning: >-
+  **Skeleton page.** Written from the parts registry in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=camera-mount), not from a
+  build. The parts are recorded; the assembly order, every screw's position, the camera
+  fixing and all photographs are missing. Fill it in as you build.
+parts_needed:
+  - part: camera-mount-part-6
+    qty: 1
+  - part: camera-mount-part-37
+    qty: 1
+  - part: camera-mount-part-37b
+    qty: 1
+  - part: camera-mount-rod-mount
+    qty: 2
+  - part: rod-steel-3-8
+    qty: 2
+  - part: scr-m3-12-cs
+    qty: 3
+  - part: nut-m3
+    qty: 3
+---
+
+The overhead camera mount is a pair of 3/8 in steel rods clamped to a [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), carrying a printed arm that holds a detection camera above the channel.
+
+The fasteners and quantities are in the parts list above and are called out inline at each step.
+
+{% include fastener-legend.html %}
+
+- **Build 2 per machine.** The parts list above is one arm's worth, so it takes 4 rod mounts and 4 rod pieces in total.
+- **Rod is bought as stock and cut.** One 4 ft length of 3/8 in steel rod yields all four roughly 1 ft pieces. The exact cut length is not recorded yet.
+- The camera these carry is the **OV9732 720p module**, which the parts registry lists as the C-channel and drop-plate detection camera. The 4K IMX415 is a different camera and belongs to the [classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}).
+- Two arms for three feeder channels is not a mistake: the software's `split_feeder` camera layout puts a camera on C2, on C3 and on the carousel, which lines up with the two arms and the two [light posts]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}). That pairing is inferred from the parts counts and the software config, not from a build.
+
+{% include step.html n="1" title="Cut the rods" %}
+
+Cut two pieces of 3/8 in rod per arm. Length not recorded yet.
+
+{% include step.html n="2" title="Clamp the rod mounts to the C-channel" %}
+
+Two Rod-to-C-channel mounts (Part 33) hold the rods on the channel. Which holes on the channel they use, and what fastens them, is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="3" title="Join the two arm halves" %}
+
+Overhead camera mount A (part 37) and B (part 37b) join through the A/B connector (part 6), with the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws and 3 M3 nuts in the list above. Which joint takes which screw is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="4" title="Fit the camera and set the height" %}
+
+Nothing is recorded yet about how the camera fastens to the arm, how high above the channel it sits, or how it is squared to the channel. All three change what the detection zones see, so record what worked. Zone setup itself is software, see the [camera calibration]({{ '/sorter/camera-calibration/' | relative_url }}) page.

--- a/docs/src/content/hardware/assembly/feeder/index.md
+++ b/docs/src/content/hardware/assembly/feeder/index.md
@@ -10,6 +10,12 @@ permalink: /hardware/assembly/feeder/
 author: spencer
 ---
 
-1. **[C-Channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }})** — the C-channel stage itself.
-2. **[Classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }})** — where parts are imaged for classification.
-3. **[Arranging C-Channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }})** — how the C-channels are laid out together.
+1. **[C-Channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }})**, the C-channel stage itself. Build four.
+2. **[Classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }})**, where parts are imaged for classification.
+3. **[Light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }})**, the side light on C2 and C3.
+4. **[Overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }})**, the rod arm that hangs a detection camera over a channel.
+5. **[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }})**, the bucket and cap that feed C1.
+6. **[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }})**, the handovers between channels.
+7. **[Arranging C-Channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }})**, the stand, the heights, and how the four sit together.
+
+Everything after the C-Channel page is a skeleton: the parts are recorded, the steps and the photographs are not. Each page says at the top what is missing from it.

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -1,0 +1,68 @@
+---
+layout: default
+title: Light post
+type: how-to
+section: hardware
+slug: assembly-light-post
+kicker: Feeder — Light post
+lede: The vertical COB light that lights a C-channel for the overhead camera.
+permalink: /hardware/assembly/feeder/light-post/
+author: barthel
+warning: >-
+  **Skeleton page.** Written from the parts registry in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=light-post), not from a
+  build. The parts and the two screws into the NEMA bracket are recorded; the rest of the
+  order, the remaining screws and every photograph are still missing. Fill it in as you build.
+parts_needed:
+  - part: light-post
+    qty: 1
+  - part: light-post-cap
+    qty: 1
+  - part: light-post-cap-adapter
+    qty: 1
+  - part: led-cob-50mm-24v
+    qty: 1
+  - part: scr-m3-12-cs
+    qty: 3
+  - part: scr-m3-20-cs
+    qty: 2
+---
+
+The light post is a vertical printed post carrying a 50 mm COB LED plate, which lights the channel from the side so the overhead camera sees parts against an even background. It bolts to a [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }})'s NEMA bracket.
+
+The fasteners and quantities are in the parts list above and are called out inline at each step.
+
+{% include fastener-legend.html %}
+
+- **Build 2 per machine**, one each on the second and third feeder channels. The parts list above is one post's worth.
+- The cap prints **white**; the post follows the feeder colour.
+- Side lighting is deliberate. Overhead COB lighting was tried first and washed out the ArUco tags, see [feeder experiments]({{ '/lab/feeder-experiments/' | relative_url }}).
+
+{% include step.html n="1" title="Assemble the post, adapter and cap" %}
+
+The post, the Light post cap adapter and the Light post cap join with the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws in the list above.
+
+How the three screws split between the two joints is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Fit the COB plate" %}
+
+The 50 mm COB plate mounts in the cap. How it is retained is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>The C-channel COB light boards need a current-limiting resistor.</b> <b>220&#8486;, 1/4 W, in series, one per board.</b> Wired straight to 24V a 50 mm COB plate pulls about 0.5A and melts its printed mount. A board fed from a basically board v1.3 LED header already has one on the board. Full detail: <a href="{{ '/hardware/electronics/#43--leds-from-basically-board-v13' | relative_url }}">LEDs, on the wire harness page</a>.</p>
+</div>
+
+{% include step.html n="3" title="Bolt the post to the NEMA bracket" %}
+
+The post bolts to the C-channel's NEMA bracket with 2 {% include fastener.html size="M3" variant="countersunk" length="20" %} screws that thread straight into the printed post. No heat insert, no nut.
+
+Which of the bracket's holes they use, and which way the post faces relative to the channel, are not recorded yet.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="4" title="Aim it" %}
+
+Nothing is recorded yet about how the post is aimed or how high the plate sits above the channel. Both matter to the camera exposure, so record what worked when you build one.

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -30,39 +30,67 @@ parts_needed:
 
 The light post is a vertical printed post carrying a 50 mm COB LED plate, which lights the channel from the side so the overhead camera sees parts against an even background. It bolts to a [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }})'s NEMA bracket.
 
-The fasteners and quantities are in the parts list above and are called out inline at each step.
+The fasteners and quantities in the parts list come from the parts registry and are called out inline at each step. **The list above is one post's worth**, and the machine takes 2, one each on the second and third feeder channels.
 
 {% include fastener-legend.html %}
 
-- **Build 2 per machine**, one each on the second and third feeder channels. The parts list above is one post's worth.
-- The cap prints **white**; the post follows the feeder colour.
-- Side lighting is deliberate. Overhead COB lighting was tried first and washed out the ArUco tags, see [feeder experiments]({{ '/lab/feeder-experiments/' | relative_url }}).
+{% include step.html n="1" title="Preparation" %}
 
-{% include step.html n="1" title="Assemble the post, adapter and cap" %}
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Light post:</strong> no heat inserts recorded. The 2 M3 × 20 mm screws that hold it to the NEMA bracket thread straight into the print.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
 
-The post, the Light post cap adapter and the Light post cap join with the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws in the list above.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Light post cap:</strong> prints white, so it does not soak up the light it is carrying. Whether it takes an insert for the COB plate is not recorded.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
 
-How the three screws split between the two joints is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+The post and the cap adapter follow the feeder colour.
+
+{% include step.html n="2" title="Assemble the post, adapter and cap" %}
+
+Join the Light post, the Light post cap adapter and the Light post cap with the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws in the list above.
+
+**Not recorded:** how the three screws split between the two joints, and which way round the adapter goes. <span class="fastener-todo">fastener not recorded</span>
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="2" title="Fit the COB plate" %}
+{% include step.html n="3" title="Fit the COB plate" %}
 
-The 50 mm COB plate mounts in the cap. How it is retained is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+The 50 mm COB plate mounts in the cap, facing across the channel.
+
+**Not recorded:** what retains the plate. <span class="fastener-todo">fastener not recorded</span>
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p><b>The C-channel COB light boards need a current-limiting resistor.</b> <b>220&#8486;, 1/4 W, in series, one per board.</b> Wired straight to 24V a 50 mm COB plate pulls about 0.5A and melts its printed mount. A board fed from a basically board v1.3 LED header already has one on the board. Full detail: <a href="{{ '/hardware/electronics/#43--leds-from-basically-board-v13' | relative_url }}">LEDs, on the wire harness page</a>.</p>
 </div>
 
-{% include step.html n="3" title="Bolt the post to the NEMA bracket" %}
+<div class="img-placeholder">Image coming</div>
 
-The post bolts to the C-channel's NEMA bracket with 2 {% include fastener.html size="M3" variant="countersunk" length="20" %} screws that thread straight into the printed post. No heat insert, no nut.
+{% include step.html n="4" title="Bolt the post to the NEMA bracket" %}
 
-Which of the bracket's holes they use, and which way the post faces relative to the channel, are not recorded yet.
+Bolt the post to the C-channel's NEMA bracket with 2 {% include fastener.html size="M3" variant="countersunk" length="20" %} screws, which thread straight into the printed post. No heat insert, no nut.
+
+**Not recorded:** which holes in the bracket they use, and which way the post faces relative to the channel.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="4" title="Aim it" %}
+{% include step.html n="5" title="Aim the light" %}
 
-Nothing is recorded yet about how the post is aimed or how high the plate sits above the channel. Both matter to the camera exposure, so record what worked when you build one.
+Side lighting is deliberate: overhead COB lighting was tried first and washed out the ArUco tags, see [feeder experiments]({{ '/lab/feeder-experiments/' | relative_url }}).
+
+**Not recorded:** how high the plate sits above the channel and how it is aimed. Both change the camera exposure, so write down what worked.
+
+Build the second post the same way. Wiring is on the [electronics]({{ '/hardware/electronics/' | relative_url }}) page.
+
+<div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/assembly/feeder/output-guides.md
+++ b/docs/src/content/hardware/assembly/feeder/output-guides.md
@@ -20,15 +20,33 @@ parts_needed:
 
 An output guide bridges the gap where one C-channel hands parts to the next, so a part leaving a rotor lands on the following channel instead of on the floor.
 
-- **2 per machine.** Which channels they sit between is not recorded. Three feeder channels give two handovers (C1 to C2, C2 to C3), so two guides is consistent with one per handover, but that is inference from the count, not a documented fact.
-- Prints in the feeder colour (black or charcoal).
+Two per machine. Which channels they sit between is not recorded: three feeder channels give two handovers, C1 to C2 and C2 to C3, so two guides is consistent with one per handover, but that is inference from the count rather than a documented fact.
 
-{% include step.html n="1" title="Fit the guides between channels" %}
+{% include fastener-legend.html %}
 
-How the guide fastens, to which part, and at what angle are all unrecorded: <span class="fastener-todo">fastener not recorded</span>.
+{% include step.html n="1" title="Preparation" %}
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Output guide:</strong> no heat inserts recorded and no fasteners of its own. Prints in the feeder colour.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
+
+{% include step.html n="2" title="Fit a guide at each handover" %}
+
+Build the channels and stand them first, see [arranging C-Channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}). The guide goes in once the two channels either side of it are at their final heights.
+
+**Not recorded:** what the guide fastens to, with what, and at what angle. <span class="fastener-todo">fastener not recorded</span>
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="2" title="Check the handover" %}
+{% include step.html n="3" title="Check the handover" %}
 
-Turn both channels by hand with a few parts on the upstream rotor and watch the transfer before wiring anything. Note here what gap or angle worked.
+Turn both channels by hand with a few parts on the upstream rotor and watch the transfer before wiring anything. A part should leave one rotor and land on the next without being carried back around.
+
+Write down here what gap and angle worked.
+
+<div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/assembly/feeder/output-guides.md
+++ b/docs/src/content/hardware/assembly/feeder/output-guides.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Output guides
+type: how-to
+section: hardware
+slug: assembly-output-guides
+kicker: Feeder — Output guides
+lede: The printed guides that carry parts from one C-channel to the next.
+permalink: /hardware/assembly/feeder/output-guides/
+author: barthel
+warning: >-
+  **Skeleton page.** The Output guide is in the parts catalog with a quantity and a colour and
+  nothing else: it is in no assembly in the [parts
+  calculator](https://parts-calculator.basically.website/assembly), and where it mounts is not
+  recorded anywhere. This page exists to be filled in, not to be followed.
+parts_needed:
+  - part: output-guide
+    qty: 2
+---
+
+An output guide bridges the gap where one C-channel hands parts to the next, so a part leaving a rotor lands on the following channel instead of on the floor.
+
+- **2 per machine.** Which channels they sit between is not recorded. Three feeder channels give two handovers (C1 to C2, C2 to C3), so two guides is consistent with one per handover, but that is inference from the count, not a documented fact.
+- Prints in the feeder colour (black or charcoal).
+
+{% include step.html n="1" title="Fit the guides between channels" %}
+
+How the guide fastens, to which part, and at what angle are all unrecorded: <span class="fastener-todo">fastener not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Check the handover" %}
+
+Turn both channels by hand with a few parts on the upstream rotor and watch the transfer before wiring anything. Note here what gap or angle worked.

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -65,6 +65,14 @@ sections:
                 url: /hardware/assembly/feeder/c-channel/
               - title: Classification chamber
                 url: /hardware/assembly/feeder/classification-chamber/
+              - title: Light post
+                url: /hardware/assembly/feeder/light-post/
+              - title: Overhead camera mount
+                url: /hardware/assembly/feeder/camera-mount/
+              - title: Bulk input
+                url: /hardware/assembly/feeder/bulk-input/
+              - title: Output guides
+                url: /hardware/assembly/feeder/output-guides/
               - title: Arranging C-Channels
                 url: /hardware/assembly/feeder/arranging-c-channels/
           - title: Software setup

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -4875,6 +4875,7 @@
       "name": "Light post",
       "description": "The feeder light post: post, cap, and cap adapter. 2 per machine. Bolts to a C-channel NEMA bracket.",
       "status": "partial",
+      "docs": "/hardware/assembly/feeder/light-post/",
       "joining": [
         {
           "method": "self-tap",
@@ -5100,6 +5101,7 @@
       "name": "Overhead camera mount",
       "description": "Camera mount for the C-channels. 2 per machine, each hanging off two ~1 ft steel rods.",
       "status": "partial",
+      "docs": "/hardware/assembly/feeder/camera-mount/",
       "lines": [
         {
           "part": "camera-mount-part-6",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -371,6 +371,7 @@
 			"name": "Light post",
 			"description": "The feeder light post: post, cap, and cap adapter. 2 per machine. Bolts to a C-channel NEMA bracket.",
 			"status": "partial",
+			"docs": "/hardware/assembly/feeder/light-post/",
 			"joining": [
 				{
 					"method": "self-tap",
@@ -596,6 +597,7 @@
 			"name": "Overhead camera mount",
 			"description": "Camera mount for the C-channels. 2 per machine, each hanging off two ~1 ft steel rods.",
 			"status": "partial",
+			"docs": "/hardware/assembly/feeder/camera-mount/",
 			"lines": [
 				{
 					"part": "camera-mount-part-6",


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540434549673033768/1540435942928809984
preview: /hardware/assembly/feeder/
preview: /hardware/assembly/feeder/arranging-c-channels/
-->
Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1540434549673033768/1540435942928809984): "Please create needed skeleton sides.", after asking which components and assembly steps are still missing from the feeder documentation.

Four feeder stages had no page anywhere on the site, and a fifth was a `_Content pending._` stub. Every part below is in `parts-calculator/slicer/parts.json` with a per-machine quantity, and most of them are in no assembly in the tree either, so nothing pointed a builder at them.

**New pages**

- `/hardware/assembly/feeder/light-post/` — post, cap, cap adapter, COB plate, 2 per machine. Previously only step 6 of the C-channel page, which covers 2 of its 5 screws.
- `/hardware/assembly/feeder/camera-mount/` — the 3/8 in rod arm, 2 per machine, parts 6 / 37 / 37b + 2 rod mounts.
- `/hardware/assembly/feeder/bulk-input/` — the bulk cap, and the fact that the bulk bucket is not published yet.
- `/hardware/assembly/feeder/output-guides/` — 2 per machine, in no assembly and mentioned nowhere.

**Filled in**

- `arranging-c-channels.md` — the cascade order, the stand (leg / foot / leg extension, 9 each), and the feeder 2020 cut list off the BOM page. The two things it most needs, the handover heights and how the classification channel is carried, are marked with ★.
- Feeder landing page and `nav.yml` list all seven pages; the C-channel page links to the new light post page.
- `parts.json`: `docs` pointers on the `light-post` and `camera-mount` assemblies, which had none. No slicer input changed, so the regen should be a no-op.

**These are skeletons, not instructions.** Every page opens with a warning saying it was written from the parts registry rather than a build, and unknown fasteners are `<span class="fastener-todo">` and missing photos are `img-placeholder`, so they show up as gaps to fill rather than reading as verified steps.

`npm run build` passes locally (Node 22) and `validate_frontmatter.py` reports only the 5 errors already on main.
