### PR TITLE
docs: skeleton pages for installing the electronics

### DIFF
--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -19,6 +19,8 @@ Wire IDs match the schedule tables. Open items are in section 7.
   <p><b>These electronics pages are working notes right now, not finished documentation.</b> The harness is actively being specced, so parts of this change week to week and some of it contradicts what a machine already built looks like. Anything still undecided is written down as an open item in section 7 rather than smoothed over. Started from what Spencer had on July 12th 2026; treat it as the current thinking, not the final state.</p>
 </div>
 
+This page is the wiring. Where the PSU, the control board and the Orange Pi physically mount is [Installing the electronics]({{ '/hardware/electronics/installation/' | relative_url }}).
+
 ## 1 &nbsp; Power supply
 
 <dl class="spec-list">

--- a/docs/src/content/hardware/electronics/installation/control-board-mount.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-mount.md
@@ -1,0 +1,73 @@
+---
+layout: default
+title: Control board mount
+type: how-to
+section: hardware
+slug: electronics-control-board-mount
+kicker: Electronics — Control board mount
+lede: The basically Embedded Control Board v1.3 standing off its bracket, and how the bracket mounts to the frame.
+permalink: /hardware/electronics/installation/control-board-mount/
+author: barthel
+contributors: [spencer]
+warning: >-
+  **Skeleton page.** The printed bracket this board stands off is **not in the parts registry
+  yet**, so the central part of this page is missing and cannot be written from the
+  [parts calculator](https://parts-calculator.basically.website/assembly?focus=ctrl-board-mount).
+  What is recorded is listed below; everything else is marked in place.
+parts_needed:
+  - part: ctrl-board-basically
+    qty: 1
+  - part: standoff-m3-10mm
+    qty: 4
+  - part: hsi-m3
+    qty: 4
+  - part: scr-m3-tbd
+    qty: 4
+  - part: scr-m5-shcs-tbd
+    qty: 2
+---
+
+One per machine. The board is the machine's motion and IO controller: the Pico, the stepper drivers, the servo outputs and the LED outputs are all on it. What plugs into which connector is on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) and [stepper connectors]({{ '/hardware/electronics/steppers/' | relative_url }}) pages.
+
+{% include fastener-legend.html %}
+
+- **One per machine**, board revision **v1.3**.
+- The board does not touch the bracket: it stands on 4 M3 × 10 mm standoffs.
+- The 4 M3 heat inserts go in the bracket, not in the board.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>The bracket is missing from the parts registry.</b> The calculator records the board, the standoffs, the inserts and the screws, but not the printed part they all attach to. There is no STL and no render for it. Until somebody adds it, steps 2 and 3 below cannot be followed as written.</p>
+</div>
+
+{% include step.html n="1" title="Fit the Pico first" %}
+
+The board takes a Raspberry Pi Pico on 2.54 mm headers, and the headers have to be soldered on before the Pico can seat. Do it before the board goes on the mount, while both sides are still reachable. See [Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }}).
+
+{% include step.html n="2" title="Preparation: heat inserts in the bracket" %}
+
+The bracket takes 4 {% include fastener.html size="M3" variant="heat-insert" %}, one per standoff. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+Which part these go into is the open question above.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="3" title="Stand the board off the bracket" %}
+
+Screw the 4 standoffs into the inserts, sit the board on them, and fasten it down with 4 M3 screws.
+
+Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. The standoff length is the BOM sheet's 10 mm and has not been confirmed against the board mount either.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="4" title="Bolt the mount to the frame" %}
+
+2 <span class="fastener-todo">M5, length not recorded</span> screws into the 2020 frame, the same as the PSU box and the Orange Pi mount.
+
+Which extrusion and which orientation are not written down. See the layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}).
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="5" title="Cooling" %}
+
+The board ends up in an enclosure with no airflow other than a fan. Fans are wanted but they are not on the 24 V bus, so they run off the board or the Pi and the voltage follows the available pins. This is open item 1 on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page and there is nothing to install yet.

--- a/docs/src/content/hardware/electronics/installation/control-board-mount.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-mount.md
@@ -10,10 +10,10 @@ permalink: /hardware/electronics/installation/control-board-mount/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton page.** The printed bracket this board stands off is **not in the parts registry
-  yet**, so the central part of this page is missing and cannot be written from the
-  [parts calculator](https://parts-calculator.basically.website/assembly?focus=ctrl-board-mount).
-  What is recorded is listed below; everything else is marked in place.
+  **Skeleton page.** The parts and quantities are real, from the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=ctrl-board-mount), but
+  the printed bracket the board stands off is **not in the parts registry**, and no step here
+  has been checked against a machine. The steps below are placeholders with the gaps marked.
 parts_needed:
   - part: ctrl-board-basically
     qty: 1
@@ -27,47 +27,56 @@ parts_needed:
     qty: 2
 ---
 
-One per machine. The board is the machine's motion and IO controller: the Pico, the stepper drivers, the servo outputs and the LED outputs are all on it. What plugs into which connector is on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) and [stepper connectors]({{ '/hardware/electronics/steppers/' | relative_url }}) pages.
+The fasteners and quantities in the parts list come from the parts calculator and are called out inline at each step.
 
 {% include fastener-legend.html %}
 
-- **One per machine**, board revision **v1.3**.
-- The board does not touch the bracket: it stands on 4 M3 × 10 mm standoffs.
-- The 4 M3 heat inserts go in the bracket, not in the board.
+One board per machine, revision v1.3. It is the machine's motion and IO controller: the Pico, the stepper drivers, the servo outputs and the LED outputs are all on it. What plugs into which connector is on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) and [stepper connectors]({{ '/hardware/electronics/steppers/' | relative_url }}) pages.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>The bracket is missing from the parts registry.</b> The calculator records the board, the standoffs, the inserts and the screws, but not the printed part they all attach to. There is no STL and no render for it. Until somebody adds it, steps 2 and 3 below cannot be followed as written.</p>
+  <p><b>The bracket is missing from the parts registry.</b> The calculator records the board, the standoffs, the inserts and the screws, but not the printed part they all attach to. There is no STL and no render for it, so steps 1 and 3 below cannot be followed as written until somebody adds it.</p>
 </div>
 
-{% include step.html n="1" title="Fit the Pico first" %}
+{% include step.html n="1" title="Preparation" %}
 
-The board takes a Raspberry Pi Pico on 2.54 mm headers, and the headers have to be soldered on before the Pico can seat. Do it before the board goes on the mount, while both sides are still reachable. See [Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }}).
+Before assembling anything, press the heat inserts into the parts that take them, while the parts are still loose. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
 
-{% include step.html n="2" title="Preparation: heat inserts in the bracket" %}
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Control board bracket:</strong> 4 × M3, one per standoff</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
 
-The bracket takes 4 {% include fastener.html size="M3" variant="heat-insert" %}, one per standoff. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+The board itself takes no inserts, and neither does anything else on this page.
 
-Which part these go into is the open question above.
+{% include step.html n="2" title="Fit the Pico" %}
 
-<div class="img-placeholder">Image coming</div>
+The board carries a Raspberry Pi Pico on 2.54 mm headers, and the headers have to be soldered on before the Pico can seat. Do it now, while both sides of the board are still reachable. See [Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }}).
 
 {% include step.html n="3" title="Stand the board off the bracket" %}
 
-Screw the 4 standoffs into the inserts, sit the board on them, and fasten it down with 4 M3 screws.
+**Heat inserts first:** the bracket takes 4 × M3 inserts, one per standoff. Press them in before assembling.
 
-Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. The standoff length is the BOM sheet's 10 mm and has not been confirmed against the board mount either.
+Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the board on them and fasten it down with 4 M3 screws.
+
+Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. The 10 mm standoff length is the BOM sheet's number and has not been confirmed against the bracket either.
 
 <div class="img-placeholder">Image coming</div>
 
 {% include step.html n="4" title="Bolt the mount to the frame" %}
 
-2 <span class="fastener-todo">M5, length not recorded</span> screws into the 2020 frame, the same as the PSU box and the Orange Pi mount.
+The mount hangs off the 2020 frame on 2 <span class="fastener-todo">M5, length not recorded</span> screws, the same as the [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }}).
 
-Which extrusion and which orientation are not written down. See the layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}).
+Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 
 <div class="img-placeholder">Image coming</div>
 
 {% include step.html n="5" title="Cooling" %}
 
-The board ends up in an enclosure with no airflow other than a fan. Fans are wanted but they are not on the 24 V bus, so they run off the board or the Pi and the voltage follows the available pins. This is open item 1 on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page and there is nothing to install yet.
+The board ends up in an enclosure with no airflow other than a fan. Fans are wanted, but they are not on the 24 V bus, so they run off the board or the Pi and the voltage follows the available pins. This is open item 1 on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page and there is nothing to install yet.
+
+The control board mount is now complete. Everything that plugs into the board is on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page.

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: Installing the electronics
+type: landing
+section: hardware
+slug: electronics-installation
+kicker: Electronics — Installation
+lede: Where the PSU, the control board and the Orange Pi mount on the machine, and how each one goes together.
+permalink: /hardware/electronics/installation/
+author: barthel
+contributors: [spencer]
+warning: >-
+  **Skeleton pages.** These four pages exist so the gap is visible and fillable, not because
+  the steps are written. The parts come from the [parts
+  calculator](https://parts-calculator.basically.website/assembly), which records what each
+  mount is made of; nobody has written down the order, the orientation, or most of the screw
+  sizes. Everything unknown is marked in place rather than guessed at. Fill them in as you build.
+---
+
+The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover what connects to what. These pages cover the other half: where the hardware physically sits and what holds it there.
+
+## The three boxes
+
+The PSU, the control board and the Orange Pi each live in their own printed mount, and all three bolt to the machine's 2020 frame with 2 <span class="fastener-todo">M5, length not recorded</span> screws each, six in total.
+
+<figure class="harness-figure">
+  <img src="https://img.basically.website/web/electronics/component-layout-topdown.2d38b86c4b2e4d05.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
+  <figcaption>Where everything sits, top-down. This photo is currently the only record of the placement.</figcaption>
+</figure>
+
+1. **[PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }})**: the printed enclosure around the Mean Well LRS-350-24.
+2. **[Control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }})**: basically Embedded Control Board v1.3 on standoffs.
+3. **[Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }})**: Orange Pi 5 on standoffs.
+4. **[Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**: soldering the header pins so the Pico can seat in the control board. Do this before the board goes on its mount.
+
+## What is not recorded yet
+
+Listed here rather than buried on the individual pages, because these are the things that block finishing them:
+
+- **The printed brackets for the control board and the Orange Pi are not in the parts registry.** The calculator lists the board, the standoffs, the inserts and the screws, but not the part each one stands off. No STL, no render, no print settings.
+- **Screw lengths.** The six M5s that hold the boxes to the frame and the eight M3s in the two board mounts are placeholders. Measure one on a built machine.
+- **Where on the frame each box goes.** The photo above is the whole record. Which extrusion, which face, and which way round are not written down.
+- **Cooling.** The Pi and the board end up in enclosures with no airflow other than a fan, and how the fans are powered is still open (see open item 1 on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page).
+- **Whether the two housings and the two mounts are the same thing.** The calculator carries an Orange Pi 5 Housing and an Embedded Control Board Housing as separate, empty assemblies alongside the two mounts. Somebody who knows the CAD needs to say whether those are the missing brackets or a different design.

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -5,40 +5,40 @@ type: landing
 section: hardware
 slug: electronics-installation
 kicker: Electronics — Installation
-lede: Where the PSU, the control board and the Orange Pi mount on the machine, and how each one goes together.
+lede: Where the PSU, the control board and the Orange Pi mount on the machine. Build in this order.
 permalink: /hardware/electronics/installation/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton pages.** These four pages exist so the gap is visible and fillable, not because
-  the steps are written. The parts come from the [parts
-  calculator](https://parts-calculator.basically.website/assembly), which records what each
-  mount is made of; nobody has written down the order, the orientation, or most of the screw
-  sizes. Everything unknown is marked in place rather than guessed at. Fill them in as you build.
+  **Skeleton pages.** These four pages exist so the gap is visible and fillable, not because the
+  steps are written. The parts on each come from the [parts
+  calculator](https://parts-calculator.basically.website/assembly), which records what every
+  mount is made of; the assembly order, the orientation and most of the screw sizes are recorded
+  nowhere, so each gap is marked in place rather than guessed at. Correct them as you build.
 ---
 
-The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover what connects to what. These pages cover the other half: where the hardware physically sits and what holds it there.
+The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover what connects to what. These cover the other half: where the hardware physically sits and what holds it there.
 
-## The three boxes
+The PSU, the control board and the Orange Pi each live in their own mount, and all three bolt to the machine's 2020 frame with 2 <span class="fastener-todo">M5, length not recorded</span> screws each, six in total.
 
-The PSU, the control board and the Orange Pi each live in their own printed mount, and all three bolt to the machine's 2020 frame with 2 <span class="fastener-todo">M5, length not recorded</span> screws each, six in total.
-
-<figure class="harness-figure">
-  <img src="https://img.basically.website/web/electronics/component-layout-topdown.2d38b86c4b2e4d05.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/electronics/component-layout-topdown.2d38b86c4b2e4d05.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
   <figcaption>Where everything sits, top-down. This photo is currently the only record of the placement.</figcaption>
 </figure>
 
-1. **[PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }})**: the printed enclosure around the Mean Well LRS-350-24.
-2. **[Control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }})**: basically Embedded Control Board v1.3 on standoffs.
-3. **[Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }})**: Orange Pi 5 on standoffs.
-4. **[Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**: soldering the header pins so the Pico can seat in the control board. Do this before the board goes on its mount.
+1. **[Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**: soldering the header pins so the Pico can seat in the control board. First, while the board is still loose.
+2. **[PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }})**: the printed enclosure around the Mean Well LRS-350-24.
+3. **[Control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }})**: basically Embedded Control Board v1.3 on standoffs.
+4. **[Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }})**: Orange Pi 5 on standoffs.
+
+Wiring follows on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page, then [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).
 
 ## What is not recorded yet
 
-Listed here rather than buried on the individual pages, because these are the things that block finishing them:
+Collected here rather than left on the individual pages, because these are the things that block finishing them.
 
 - **The printed brackets for the control board and the Orange Pi are not in the parts registry.** The calculator lists the board, the standoffs, the inserts and the screws, but not the part each one stands off. No STL, no render, no print settings.
-- **Screw lengths.** The six M5s that hold the boxes to the frame and the eight M3s in the two board mounts are placeholders. Measure one on a built machine.
-- **Where on the frame each box goes.** The photo above is the whole record. Which extrusion, which face, and which way round are not written down.
-- **Cooling.** The Pi and the board end up in enclosures with no airflow other than a fan, and how the fans are powered is still open (see open item 1 on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page).
+- **Screw lengths.** The six M5s that hold the mounts to the frame and the eight M3s in the two board mounts are placeholders. Measure one on a built machine.
+- **Where on the frame each mount goes.** The photo above is the whole record. Which extrusion, which face, and which way round are not written down.
+- **Cooling.** The Pi and the board end up in enclosures with no airflow other than a fan, and how the fans are powered is still open (open item 1 on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page).
 - **Whether the two housings and the two mounts are the same thing.** The calculator carries an Orange Pi 5 Housing and an Embedded Control Board Housing as separate, empty assemblies alongside the two mounts. Somebody who knows the CAD needs to say whether those are the missing brackets or a different design.

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -1,0 +1,69 @@
+---
+layout: default
+title: Orange Pi mount
+type: how-to
+section: hardware
+slug: electronics-orange-pi-mount
+kicker: Electronics — Orange Pi mount
+lede: The Orange Pi 5 standing off its bracket, and how the bracket mounts to the frame.
+permalink: /hardware/electronics/installation/orange-pi-mount/
+author: barthel
+contributors: [spencer]
+warning: >-
+  **Skeleton page.** The printed bracket the Pi stands off is **not in the parts registry
+  yet**, so the central part of this page is missing and cannot be written from the
+  [parts calculator](https://parts-calculator.basically.website/assembly?focus=orange-pi-mount).
+  What is recorded is listed below; everything else is marked in place.
+parts_needed:
+  - part: sbc-orange-pi-5
+    qty: 1
+  - part: standoff-m3-10mm
+    qty: 4
+  - part: hsi-m3
+    qty: 4
+  - part: scr-m3-tbd
+    qty: 4
+  - part: scr-m5-shcs-tbd
+    qty: 2
+---
+
+One per machine. Which Orange Pi 5 to buy, how much RAM and storage it needs, the WiFi module, the USB hub and cooling are all on the [Orange Pi 5]({{ '/hardware/orange-pi-5/' | relative_url }}) page. This page is only about bolting it to the machine.
+
+{% include fastener-legend.html %}
+
+- **One per machine.**
+- The mount is the same shape as the [control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}): 4 standoffs, 4 inserts, 4 M3 screws, 2 M5 into the frame.
+- The Pi is powered by its own 24 V to USB-C adapter off the PSU, not from the control board.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>The bracket is missing from the parts registry.</b> The calculator records the Pi, the standoffs, the inserts and the screws, but not the printed part they all attach to. There is no STL and no render for it. Until somebody adds it, steps 1 and 2 below cannot be followed as written.</p>
+</div>
+
+{% include step.html n="1" title="Preparation: heat inserts in the bracket" %}
+
+The bracket takes 4 {% include fastener.html size="M3" variant="heat-insert" %}, one per standoff. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Stand the Pi off the bracket" %}
+
+Screw the 4 standoffs into the inserts, sit the Pi on them, and fasten it down with 4 M3 screws.
+
+Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. The standoff length is the BOM sheet's 10 mm and has not been confirmed against the board mount either.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="3" title="Bolt the mount to the frame" %}
+
+2 <span class="fastener-todo">M5, length not recorded</span> screws into the 2020 frame, the same as the PSU box and the control board mount.
+
+Which extrusion and which orientation are not written down. See the layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}).
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="4" title="Plug it in" %}
+
+Power, the USB hub and the cameras are all on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page. Flashing and configuring the Pi is [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).
+
+Whether the Pi's heatsink or fan fits with the mount in place, and where the fan is fed from, is not recorded. Fan power is open item 1 on the wire harness page.

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -10,10 +10,10 @@ permalink: /hardware/electronics/installation/orange-pi-mount/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton page.** The printed bracket the Pi stands off is **not in the parts registry
-  yet**, so the central part of this page is missing and cannot be written from the
-  [parts calculator](https://parts-calculator.basically.website/assembly?focus=orange-pi-mount).
-  What is recorded is listed below; everything else is marked in place.
+  **Skeleton page.** The parts and quantities are real, from the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=orange-pi-mount), but
+  the printed bracket the Pi stands off is **not in the parts registry**, and no step here has
+  been checked against a machine. The steps below are placeholders with the gaps marked.
 parts_needed:
   - part: sbc-orange-pi-5
     qty: 1
@@ -27,43 +27,56 @@ parts_needed:
     qty: 2
 ---
 
-One per machine. Which Orange Pi 5 to buy, how much RAM and storage it needs, the WiFi module, the USB hub and cooling are all on the [Orange Pi 5]({{ '/hardware/orange-pi-5/' | relative_url }}) page. This page is only about bolting it to the machine.
+The fasteners and quantities in the parts list come from the parts calculator and are called out inline at each step.
 
 {% include fastener-legend.html %}
 
-- **One per machine.**
-- The mount is the same shape as the [control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}): 4 standoffs, 4 inserts, 4 M3 screws, 2 M5 into the frame.
-- The Pi is powered by its own 24 V to USB-C adapter off the PSU, not from the control board.
+One per machine. Which Orange Pi 5 to buy, how much RAM and storage it needs, the WiFi module, the USB hub and cooling are all on the [Orange Pi 5]({{ '/hardware/orange-pi-5/' | relative_url }}) page. This page is only about bolting it to the machine, and it is the same shape as the [control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}): 4 inserts, 4 standoffs, 4 M3 screws, 2 M5 into the frame.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>The bracket is missing from the parts registry.</b> The calculator records the Pi, the standoffs, the inserts and the screws, but not the printed part they all attach to. There is no STL and no render for it. Until somebody adds it, steps 1 and 2 below cannot be followed as written.</p>
+  <p><b>The bracket is missing from the parts registry.</b> The calculator records the Pi, the standoffs, the inserts and the screws, but not the printed part they all attach to. There is no STL and no render for it, so steps 1 and 2 below cannot be followed as written until somebody adds it.</p>
 </div>
 
-{% include step.html n="1" title="Preparation: heat inserts in the bracket" %}
+{% include step.html n="1" title="Preparation" %}
 
-The bracket takes 4 {% include fastener.html size="M3" variant="heat-insert" %}, one per standoff. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+Before assembling anything, press the heat inserts into the parts that take them, while the parts are still loose. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
 
-<div class="img-placeholder">Image coming</div>
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Orange Pi bracket:</strong> 4 × M3, one per standoff</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
+
+The Pi itself takes no inserts, and neither does anything else on this page.
 
 {% include step.html n="2" title="Stand the Pi off the bracket" %}
 
-Screw the 4 standoffs into the inserts, sit the Pi on them, and fasten it down with 4 M3 screws.
+**Heat inserts first:** the bracket takes 4 × M3 inserts, one per standoff. Press them in before assembling.
 
-Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. The standoff length is the BOM sheet's 10 mm and has not been confirmed against the board mount either.
+Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the Pi on them and fasten it down with 4 M3 screws.
+
+Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. The 10 mm standoff length is the BOM sheet's number and has not been confirmed against the bracket either.
+
+Whether the Pi's heatsink or fan clears the standoffs is not recorded either.
 
 <div class="img-placeholder">Image coming</div>
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}
 
-2 <span class="fastener-todo">M5, length not recorded</span> screws into the 2020 frame, the same as the PSU box and the control board mount.
+The mount hangs off the 2020 frame on 2 <span class="fastener-todo">M5, length not recorded</span> screws, the same as the [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}).
 
-Which extrusion and which orientation are not written down. See the layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}).
+Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 
 <div class="img-placeholder">Image coming</div>
 
 {% include step.html n="4" title="Plug it in" %}
 
-Power, the USB hub and the cameras are all on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page. Flashing and configuring the Pi is [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).
+The Pi is powered by its own 24 V to USB-C adapter off the PSU, not from the control board. That, the USB hub and the cameras are all on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page.
 
-Whether the Pi's heatsink or fan fits with the mount in place, and where the fan is fed from, is not recorded. Fan power is open item 1 on the wire harness page.
+Fan power is open item 1 on that page and is still unresolved, so there is nothing to wire for cooling yet.
+
+The Orange Pi mount is now complete. Flashing and configuring the Pi is [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).

--- a/docs/src/content/hardware/electronics/installation/pico-headers.md
+++ b/docs/src/content/hardware/electronics/installation/pico-headers.md
@@ -10,9 +10,10 @@ permalink: /hardware/electronics/installation/pico-headers/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton page.** The parts are recorded in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=pico-headers); the
-  procedure is not recorded anywhere. Nothing here has been checked against a build.
+  **Skeleton page.** The parts and quantities are real, from the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=pico-headers). The
+  procedure is not recorded anywhere and no step here has been checked against a build, so the
+  steps below are placeholders with the gaps marked.
 parts_needed:
   - part: mcu-rpi-pico
     qty: 1
@@ -20,23 +21,24 @@ parts_needed:
     qty: 20
 ---
 
-The Pico ships bare. The control board expects it on 2.54 mm headers, so the pins are a separate purchase and a soldering job before the board goes on its [mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}).
+The Pico ships bare. The [basically Embedded Control Board]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}) expects it on 2.54 mm headers, so the pins are a separate purchase and a soldering job before the board goes on its mount.
 
-- **One per machine**, the same Pico the control board carries.
-- 20 header pins, two 20-pin rows broken to length.
+One Pico per machine, 20 header pins, two rows of 20 broken off a breakaway strip. It is the only assembly in the parts tree recorded as soldered: every pin goes into the Pico's through-holes, nothing here presses or clips together.
 
-{% include step.html n="1" title="Break the headers to length" %}
+{% include step.html n="1" title="Preparation" %}
 
-Two rows of 20. Snap them off a breakaway strip.
+Break the header strip into two rows of 20. Nothing here takes a heat insert.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="2" title="Solder them on" %}
+{% include step.html n="2" title="Solder the headers to the Pico" %}
 
-Which side the pins go on, and therefore which way up the Pico sits in the board, is not recorded here. Check the board before soldering, because it cannot be undone easily.
+Which face of the Pico the pins go on, and therefore which way up it sits in the board, is not recorded: <span class="fastener-todo">orientation not recorded</span>. Check the board's socket before soldering, because it is difficult to undo.
 
 <div class="img-placeholder">Image coming</div>
 
 {% include step.html n="3" title="Seat it in the board" %}
 
-The Pico goes into its socket on the basically Embedded Control Board. Flashing the firmware is covered in [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).
+Push the Pico into its socket on the basically Embedded Control Board, then carry on with the [control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}).
+
+The Pico is now ready. Flashing its firmware is covered in [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).

--- a/docs/src/content/hardware/electronics/installation/pico-headers.md
+++ b/docs/src/content/hardware/electronics/installation/pico-headers.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Pico headers
+type: how-to
+section: hardware
+slug: electronics-pico-headers
+kicker: Electronics — Pico headers
+lede: Soldering 2.54 mm header pins to the Raspberry Pi Pico so it can seat in the control board.
+permalink: /hardware/electronics/installation/pico-headers/
+author: barthel
+contributors: [spencer]
+warning: >-
+  **Skeleton page.** The parts are recorded in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=pico-headers); the
+  procedure is not recorded anywhere. Nothing here has been checked against a build.
+parts_needed:
+  - part: mcu-rpi-pico
+    qty: 1
+  - part: header-pins-254
+    qty: 20
+---
+
+The Pico ships bare. The control board expects it on 2.54 mm headers, so the pins are a separate purchase and a soldering job before the board goes on its [mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}).
+
+- **One per machine**, the same Pico the control board carries.
+- 20 header pins, two 20-pin rows broken to length.
+
+{% include step.html n="1" title="Break the headers to length" %}
+
+Two rows of 20. Snap them off a breakaway strip.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Solder them on" %}
+
+Which side the pins go on, and therefore which way up the Pico sits in the board, is not recorded here. Check the board before soldering, because it cannot be undone easily.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="3" title="Seat it in the board" %}
+
+The Pico goes into its socket on the basically Embedded Control Board. Flashing the firmware is covered in [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).

--- a/docs/src/content/hardware/electronics/installation/psu-box.md
+++ b/docs/src/content/hardware/electronics/installation/psu-box.md
@@ -10,10 +10,10 @@ permalink: /hardware/electronics/installation/psu-box/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton page.** The parts are recorded in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=meanwell-psu-box); the
-  assembly order is not recorded anywhere, so this page lists what the box is made of and
-  marks what is missing. No step here has been checked against a machine.
+  **Skeleton page.** The parts and quantities are real, from the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=meanwell-psu-box). The
+  assembly order is not recorded anywhere and no step here has been checked against a machine,
+  so the steps below are placeholders with the gaps marked. Correct them as you build.
 parts_needed:
   - part: psu-24v-350w
     qty: 1
@@ -29,43 +29,61 @@ parts_needed:
     qty: 2
 ---
 
-The supply is a **Mean Well LRS-350-24**: 24 V, 14.6 A, 350 W, single output. Three printed parts wrap it, and the whole box bolts to the frame. Everything downstream of it, including the three DC output pigtails, is on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page.
+The fasteners and quantities in the parts list come from the parts calculator and are called out inline at each step.
 
 {% include fastener-legend.html %}
 
-- **One per machine.**
-- The three printed parts fasten to the supply's **own case threads**, which are M4. That is what the 4 {% include fastener.html size="M4" variant="countersunk" length="6" %} screws are for.
-- The box takes no heat inserts.
+Several steps below refer to the supply's terminal block by screw number. Mean Well numbers them itself, and this is the assignment:
+
+<dl class="spec-list">
+  <dt>1, 2, 3</dt><dd>AC/L, AC/N, FG (earth)</dd>
+  <dt>4, 5, 6</dt><dd>DC output -V</dd>
+  <dt>7, 8, 9</dt><dd>DC output +V</dd>
+</dl>
+
+One DC output pigtail per +V/-V pair: 7 with 4, 8 with 5, 9 with 6. The full spec, the terminal sizes and the pigtail build are on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) and [make your own PSU pigtail]({{ '/hardware/electronics/psu-pigtail/' | relative_url }}) pages.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>Mains wiring.</b> Screws 1, 2 and 3 on the supply's terminal block are live AC. They are fed by the fused IEC inlet switch's own pre-terminated leads, so there is no AC cable to make, but the box has to be closed before the machine is plugged in.</p>
+  <p><b>Screws 1, 2 and 3 are live mains.</b> They are fed by the fused IEC inlet switch's own pre-terminated leads, so there is no AC cable to make, but the cap goes on before the machine is plugged in.</p>
 </div>
 
-{% include step.html n="1" title="Print the three parts" %}
+{% include step.html n="1" title="Preparation" %}
 
-Back mount, connections plate, and cap. All three print in the frame colour. Print settings and the STL for each are on the [parts calculator](https://parts-calculator.basically.website/assembly?focus=meanwell-psu-box).
+Print the three enclosure parts: the PSU back mount, the PSU connections plate and the PSU box cap. All three are one per machine and print in the frame colour. The STL and the print settings for each are on the [parts calculator](https://parts-calculator.basically.website/assembly?focus=meanwell-psu-box).
 
-<div class="img-placeholder">Image coming</div>
-
-{% include step.html n="2" title="Wire the terminal block before closing the box" %}
-
-The terminal block is 9 screws and Mean Well numbers them: **1** AC/L, **2** AC/N, **3** FG, **4-6** DC output -V, **7-9** DC output +V. One DC output pigtail per +V/-V pair, 7 with 4, 8 with 5, 9 with 6. Full spec, terminal sizes and the pigtail build are on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) and [PSU pigtail]({{ '/hardware/electronics/psu-pigtail/' | relative_url }}) pages.
-
-The order the plates go on relative to the wiring is not recorded. It matters, because the connections plate is what the cables pass through.
-
-{% include step.html n="3" title="Assemble the box" %}
-
-Fit the back mount, the connections plate and the cap to the supply's case with 4 {% include fastener.html size="M4" variant="countersunk" length="6" %} screws.
-
-Which part takes which screws, and in what order, is not recorded: <span class="fastener-todo">assembly order not recorded</span>.
+**No heat inserts:** nothing in this box takes one. The printed parts fasten into the supply's own case threads, which are M4, so there is nothing to press in before assembling.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="4" title="Bolt the box to the frame" %}
+{% include step.html n="2" title="Fit the printed parts to the supply" %}
 
-The box hangs off the 2020 frame on 2 <span class="fastener-todo">M5, length not recorded</span> screws, the same as the other two electronics mounts.
+Fasten the PSU back mount, the PSU connections plate and the PSU box cap to the supply's case with 4 {% include fastener.html size="M4" variant="countersunk" length="6" %} screws.
+
+Which part takes which of the four screws, and the order they go on in, is not recorded: <span class="fastener-todo">assembly order not recorded</span>. It matters, because the connections plate is the end the cables pass through and the terminal block has to still be reachable.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="3" title="Wire the terminal block" %}
+
+Land the fused IEC inlet switch's leads on screws 1, 2 and 3, and the three DC output pigtails on the +V/-V pairs above. Route them out through the connections plate.
+
+Whether this happens before or after the plates go on is the open question in step 2.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="4" title="Close the box" %}
+
+Fit the cap. The box is closed before the machine sees mains.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="5" title="Bolt the box to the frame" %}
+
+The box hangs off the 2020 frame on 2 <span class="fastener-todo">M5, length not recorded</span> screws, the same as the [control board mount]({{ '/hardware/electronics/installation/control-board-mount/' | relative_url }}) and the [Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }}).
 
 Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 
 <div class="img-placeholder">Image coming</div>
+
+The PSU box is now complete. Everything that plugs into it is on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page.

--- a/docs/src/content/hardware/electronics/installation/psu-box.md
+++ b/docs/src/content/hardware/electronics/installation/psu-box.md
@@ -1,0 +1,71 @@
+---
+layout: default
+title: PSU box
+type: how-to
+section: hardware
+slug: electronics-psu-box
+kicker: Electronics — PSU box
+lede: The printed enclosure around the Mean Well LRS-350-24, and how it mounts to the frame.
+permalink: /hardware/electronics/installation/psu-box/
+author: barthel
+contributors: [spencer]
+warning: >-
+  **Skeleton page.** The parts are recorded in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=meanwell-psu-box); the
+  assembly order is not recorded anywhere, so this page lists what the box is made of and
+  marks what is missing. No step here has been checked against a machine.
+parts_needed:
+  - part: psu-24v-350w
+    qty: 1
+  - part: meanwell-psu-back-mount
+    qty: 1
+  - part: meanwell-psu-connections
+    qty: 1
+  - part: meanwell-psu-cap
+    qty: 1
+  - part: scr-m4-6-cs
+    qty: 4
+  - part: scr-m5-shcs-tbd
+    qty: 2
+---
+
+The supply is a **Mean Well LRS-350-24**: 24 V, 14.6 A, 350 W, single output. Three printed parts wrap it, and the whole box bolts to the frame. Everything downstream of it, including the three DC output pigtails, is on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page.
+
+{% include fastener-legend.html %}
+
+- **One per machine.**
+- The three printed parts fasten to the supply's **own case threads**, which are M4. That is what the 4 {% include fastener.html size="M4" variant="countersunk" length="6" %} screws are for.
+- The box takes no heat inserts.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>Mains wiring.</b> Screws 1, 2 and 3 on the supply's terminal block are live AC. They are fed by the fused IEC inlet switch's own pre-terminated leads, so there is no AC cable to make, but the box has to be closed before the machine is plugged in.</p>
+</div>
+
+{% include step.html n="1" title="Print the three parts" %}
+
+Back mount, connections plate, and cap. All three print in the frame colour. Print settings and the STL for each are on the [parts calculator](https://parts-calculator.basically.website/assembly?focus=meanwell-psu-box).
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="2" title="Wire the terminal block before closing the box" %}
+
+The terminal block is 9 screws and Mean Well numbers them: **1** AC/L, **2** AC/N, **3** FG, **4-6** DC output -V, **7-9** DC output +V. One DC output pigtail per +V/-V pair, 7 with 4, 8 with 5, 9 with 6. Full spec, terminal sizes and the pigtail build are on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) and [PSU pigtail]({{ '/hardware/electronics/psu-pigtail/' | relative_url }}) pages.
+
+The order the plates go on relative to the wiring is not recorded. It matters, because the connections plate is what the cables pass through.
+
+{% include step.html n="3" title="Assemble the box" %}
+
+Fit the back mount, the connections plate and the cap to the supply's case with 4 {% include fastener.html size="M4" variant="countersunk" length="6" %} screws.
+
+Which part takes which screws, and in what order, is not recorded: <span class="fastener-todo">assembly order not recorded</span>.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="4" title="Bolt the box to the frame" %}
+
+The box hangs off the 2020 frame on 2 <span class="fastener-todo">M5, length not recorded</span> screws, the same as the other two electronics mounts.
+
+Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
+
+<div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/index.md
+++ b/docs/src/content/hardware/index.md
@@ -11,5 +11,5 @@ author: spencer
 ---
 
 - **[Assembly]({{ '/hardware/assembly/' | relative_url }})**: the build order, structured like a set of instructions.
-- **[Electronics]({{ '/hardware/electronics/' | relative_url }})**: the wire harness, stepper connectors and polarity, the cable order spec, and the rendered WireViz drawings.
+- **[Electronics]({{ '/hardware/electronics/' | relative_url }})**: the wire harness, stepper connectors and polarity, the cable order spec, the rendered WireViz drawings, and [installing the electronics]({{ '/hardware/electronics/installation/' | relative_url }}).
 - **[Bill of materials](https://parts-calculator.basically.website/hardware)**: every part, with sources and part numbers.

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -72,6 +72,17 @@ sections:
       - title: Electronics
         url: /hardware/electronics/
         children:
+          - title: Installing the electronics
+            url: /hardware/electronics/installation/
+            children:
+              - title: PSU box
+                url: /hardware/electronics/installation/psu-box/
+              - title: Control board mount
+                url: /hardware/electronics/installation/control-board-mount/
+              - title: Orange Pi mount
+                url: /hardware/electronics/installation/orange-pi-mount/
+              - title: Pico headers
+                url: /hardware/electronics/installation/pico-headers/
           - title: Stepper connectors
             url: /hardware/electronics/steppers/
           - title: Order spec

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5230,6 +5230,7 @@
       "id": "meanwell-psu-box",
       "name": "Meanwell 24V PSU box",
       "description": "Enclosure for the Meanwell 24V power supply: back mount, connections plate, and cap, screwed to the supply's own case.",
+      "docs": "/hardware/electronics/installation/psu-box/",
       "status": "partial",
       "lines": [
         {
@@ -5282,6 +5283,7 @@
       "id": "pico-headers",
       "name": "Pico with headers",
       "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare — the pins are a separate purchase.",
+      "docs": "/hardware/electronics/installation/pico-headers/",
       "status": "partial",
       "joining": [
         {
@@ -5766,6 +5768,7 @@
       "id": "ctrl-board-mount",
       "name": "Control board mount",
       "description": "The basically Embedded Control Board standing off its bracket. The printed bracket is not in the parts registry yet.",
+      "docs": "/hardware/electronics/installation/control-board-mount/",
       "status": "stub",
       "lines": [
         {
@@ -5790,6 +5793,7 @@
       "id": "orange-pi-mount",
       "name": "Orange Pi mount",
       "description": "The Orange Pi 5 standing off its bracket. The printed bracket is not in the parts registry yet.",
+      "docs": "/hardware/electronics/installation/orange-pi-mount/",
       "status": "stub",
       "lines": [
         {
@@ -5814,7 +5818,7 @@
       "id": "electronics",
       "name": "Electronics",
       "description": "The three boxes that bolt to the frame: the PSU, the control board, and the Orange Pi. Each takes 2 × [[hw:scr-m5-shcs-tbd]] — nobody has measured the length yet.",
-      "docs": "/hardware/electronics/",
+      "docs": "/hardware/electronics/installation/",
       "status": "partial",
       "lines": [
         {

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -726,6 +726,7 @@
 			"id": "meanwell-psu-box",
 			"name": "Meanwell 24V PSU box",
 			"description": "Enclosure for the Meanwell 24V power supply: back mount, connections plate, and cap, screwed to the supply's own case.",
+			"docs": "/hardware/electronics/installation/psu-box/",
 			"status": "partial",
 			"lines": [
 				{
@@ -778,6 +779,7 @@
 			"id": "pico-headers",
 			"name": "Pico with headers",
 			"description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare \u2014 the pins are a separate purchase.",
+			"docs": "/hardware/electronics/installation/pico-headers/",
 			"status": "partial",
 			"joining": [
 				{
@@ -1262,6 +1264,7 @@
 			"id": "ctrl-board-mount",
 			"name": "Control board mount",
 			"description": "The basically Embedded Control Board standing off its bracket. The printed bracket is not in the parts registry yet.",
+			"docs": "/hardware/electronics/installation/control-board-mount/",
 			"status": "stub",
 			"lines": [
 				{
@@ -1286,6 +1289,7 @@
 			"id": "orange-pi-mount",
 			"name": "Orange Pi mount",
 			"description": "The Orange Pi 5 standing off its bracket. The printed bracket is not in the parts registry yet.",
+			"docs": "/hardware/electronics/installation/orange-pi-mount/",
 			"status": "stub",
 			"lines": [
 				{
@@ -1310,7 +1314,7 @@
 			"id": "electronics",
 			"name": "Electronics",
 			"description": "The three boxes that bolt to the frame: the PSU, the control board, and the Orange Pi. Each takes 2 \u00d7 [[hw:scr-m5-shcs-tbd]] \u2014 nobody has measured the length yet.",
-			"docs": "/hardware/electronics/",
+			"docs": "/hardware/electronics/installation/",
 			"status": "partial",
 			"lines": [
 				{


### PR DESCRIPTION
Adds `/hardware/electronics/installation/`, five skeleton pages covering where the electronics physically go:

- **Installing the electronics** (overview): the three boxes that bolt to the 2020 frame, and a list of what is not recorded yet
- **PSU box**: the printed enclosure around the Mean Well LRS-350-24
- **Control board mount**: basically Embedded Control Board v1.3 on standoffs
- **Orange Pi mount**: Orange Pi 5 on standoffs
- **Pico headers**: soldering the header pins before the board goes on its mount

### Why

Nothing about mounting the electronics is documented anywhere on the site. `/hardware/electronics/` and its children are wiring only; the single record of physical placement is the top-down photo in section 2 of the harness page. The only page on the whole site that says "screw this board down" is the per-layer adapter board under the chute.

### These are skeletons on purpose

The parts on each page come from `parts-calculator/slicer/parts.json`, which records what each mount is made of. The assembly order, the orientation, and most of the screw sizes are recorded nowhere, so every gap is marked in place (`fastener-todo` span or a callout) rather than guessed at. Specifically:

- The **printed brackets for the control board and the Orange Pi are not in the parts registry**. No STL, no render. Called out in a warning callout on both pages, because those pages cannot be finished without them.
- The six **M5s** that hold the boxes to the frame (`scr-m5-shcs-tbd`) and the eight **M3s** in the two board mounts (`scr-m3-tbd`) are placeholders. Somebody needs to measure one on a built machine.
- **Which extrusion each box goes on, and which way round**, is not written down.
- The calculator also carries an `orange-pi-5-housing` and an `embedded-control-board-housing` as separate empty assemblies alongside the two mounts. Whether those are the missing brackets or a different design is a question for whoever knows the CAD, and it is flagged on the overview page rather than answered.

### Also in this PR

- `parts-calculator/slicer/parts.json`: `docs` links added for `meanwell-psu-box`, `ctrl-board-mount`, `orange-pi-mount` and `pico-headers`, and the parent `electronics` assembly retargeted from `/hardware/electronics/` to the new installation landing. Regenerated `parts.generated.json` with `filament.py --metadata-only` (6-line diff, no reslice).
- Nav entries under Hardware → Electronics, and a pointer from the harness page and the hardware landing.

`npm run build` passes on Node 22 and `validate_frontmatter.py` is at the 5 errors already on main. The two prerender 404s the build reports (`/hardware/preparation/`, `/sorter/architecture/`) are pre-existing and untouched here.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1540435587767734412/1540436470228328449): "Please create needed skeleton sides."

Layout follow-up by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1540435587767734412/1540436882838519819): "Use the Top Interface page as a template for style and layout." The four content pages now follow `/hardware/assembly/distribution/top-interface/`: fastener legend, a numbered **Preparation** step first with `prep-item` blocks, inline `fastener.html` includes in the prose, callouts inline, and a closing line per page. The PSU box opens with the terminal-block screw map as a spec list, the same way top interface opens with its top-plate hole map.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540435587767734412/1540436470228328449
request: https://discord.com/channels/1430279849171222682/1540435587767734412/1540436882838519819
preview: /hardware/electronics/installation/
-->

