### PR TITLE
docs(chute): record the M3 screw lengths for the layer connectors, funnel brackets and bearing covers

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -68,7 +68,12 @@ The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists ever
 
 Fit the Funnel bracket (left) and the Funnel bracket (right) to the chute core. Together with the door module and the layer connectors these use the chute's 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, all into the core's inserts.
 
-Which screw goes in which hole is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+The split across those 14, worked out from the STLs by comparing each mating part's wall thickness at its screw hole against the core's blind 5.70 mm insert pockets:
+
+- **Funnel brackets:** 4 × {% include fastener.html size="M3" variant="countersunk" length="12" %} (8.16 mm wall, so an 8 mm screw would not reach the insert at all)
+- **Bearing covers:** 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} (5.00 mm wall, 2 per cover)
+- **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}):** 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} (3.78 mm strap, 2 per connector)
+- **Servo bracket arms:** the remaining 2 × {% include fastener.html size="M3" variant="countersunk" length="12" %}. No published part sits on those two inserts, so this one is by elimination rather than measured.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -24,9 +24,7 @@ parts_needed:
   - part: funnel-bracket-right
     qty: 1
   - part: scr-m3-12-cs
-    qty: 6
-  - part: scr-m3-8-cs
-    qty: 8
+    qty: 4
 ---
 
 The funnel catches what the door releases and guides it into the bin below. It hangs off two printed brackets that are part of the chute.
@@ -52,7 +50,7 @@ Decide before printing, since it changes both the funnel and the bin set. The [p
 
 Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, using screws from the chute's set.
 
-Which of those go into the funnel brackets is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair, out of the chute's set of 6. Measured from the STLs: the bracket is 8.16 mm thick at the screw and the core's insert pocket is 5.70 mm deep, so a 12 mm screw goes 3.84 mm into the insert. An 8 mm screw would stop short of the insert entirely.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -19,10 +19,8 @@ parts_needed:
     qty: 1
   - part: layer-connector-2
     qty: 1
-  - part: scr-m3-12-cs
-    qty: 6
   - part: scr-m3-8-cs
-    qty: 8
+    qty: 4
 ---
 
 The layer connectors are a pair of printed parts, Layer connector A and Layer connector B, that join one layer's chute to the next one down so parts pass from chute to chute without a gap.
@@ -32,14 +30,16 @@ The fasteners and quantities are in the parts list above and are called out inli
 {% include fastener-legend.html %}
 
 - **How many:** 1 of each per distribution layer, plus 1 of each for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) and 1 of each for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
-- The screws in the list are the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s whole set of 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %}, shared with the funnel brackets and the door module. Only some of them land here.
+- **Screws:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per connector, 4 for the pair. They come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s set of 8, they are not extra.
 - Both connectors go into the chute core's M3 heat inserts.
 
 {% include step.html n="1" title="Fit the connectors to the chute core" %}
 
 Both connectors fasten to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), into its M3 heat inserts.
 
-The split between the two screw lengths is not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+Each connector takes 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flat strap between its two end blocks.
+
+**Why 8 mm and not 12.** Measured off the published STLs. The strap is **3.78 mm** thick at the screw: 1.91 mm of Ø3.40 mm clearance bore, then a 90° countersink opening out to Ø7.15 mm on the outer face. Every M3 pocket in the chute core is a **blind Ø4.20 × 5.70 mm** hole for a {% include fastener.html size="M3" variant="heat-insert" %} and has solid plastic behind it, no relief hole. So an 8 mm screw reaches 4.22 mm into the insert and stops 1.5 mm short of the bottom, while a 12 mm screw would need 8.22 mm of depth and would bottom out before the head ever seated.
 
 <div class="img-placeholder">Image coming</div>
 


### PR DESCRIPTION
Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1540438490712514561): "Decide which screw length to use for the layer connectors based on the STL files."

**Answer: M3 × 8 countersunk, 4 per pair.** M3 × 12 bottoms out.

Everything below is measured off the published STLs (`img.basically.website/parts/stl/...`), the same files the parts calculator links.

### The layer connectors

Each of Layer connector A and B is two 42 × 16 mm end blocks joined by a flat strap, with two Ø3.40 mm clearance holes in the strap, 31.86 mm apart.

- Strap thickness at the screw: **3.78 mm** (1.91 mm of plain Ø3.40 bore, then a 90° countersink opening out to Ø7.15 mm on the outer face, which is a DIN 7991 M3 flat head)
- Mating face is flat, no boss or standoff
- Every M3 pocket in the chute core is a **blind Ø4.20 × 5.70 mm** hole for a ruthex RX-M3x5.7, with 11.3 mm of solid plastic behind it at these positions and no relief hole

M3 × 8 reaches 4.22 mm into the insert and stops 1.5 mm short of the bottom. M3 × 12 would need 8.22 mm of depth into a 5.70 mm pocket, so it bottoms out 2.5 mm early and the head never seats.

### The rest of the chute core's set falls out of the same measurement

The `chute` assembly declares 6 × M3 × 12 and 8 × M3 × 8 into the core's 14 non-PCB inserts but has never said which goes where. Wall thickness at each mating part's screw hole, against the same 5.70 mm pocket:

| part | wall at the hole | screw | into the insert |
|---|---|---|---|
| Funnel bracket (× 2) | 8.16 mm | M3 × 12 | 3.84 mm |
| Bearing cover (× 2) | 5.00 mm | M3 × 8 | 3.00 mm |
| Layer connector (× 2) | 3.78 mm | M3 × 8 | 4.22 mm |
| Servo bracket arms | not published | M3 × 12 | by elimination |

That is 4 + 2 = 6 × M3 × 12 and 4 + 4 = 8 × M3 × 8, exactly the set already in `slicer/parts.json`, so the split is self-consistent and no manifest change is needed.

The bracket and cover positions are confirmed geometrically, not just by arithmetic: `funnel-bracket-left`'s two holes sit at (48, −70.98, 19.67) and (48, −70.98, 54.40), and the core's pockets at (48, ±64.99, 19.67) and (48, ±64.99, 54.40). Same for the covers at (−52.40, 92.83) and (−41.90, 132.31). The two arm inserts have no published part on them, so that row is the only inferred one and the page says so.

### Changes

- **`layer-connectors.md`** — `parts_needed` drops the whole-chute placeholder (6 × M3 × 12 + 8 × M3 × 8) for the 4 × M3 × 8 this page actually uses; the `fastener-todo` in step 1 is replaced with the length and the reason.
- **`chute-core.md`** — the "which screw goes in which hole is not recorded" placeholder in step 2 becomes the four-way split above.
- **`funnel.md`** — same placeholder resolved to 2 × M3 × 12 per bracket, and `parts_needed` narrowed from the whole chute set to the 4 × M3 × 12 the brackets take. Step 3 (funnel to bracket) is still unrecorded and still says so.

### Checks

- `npm ci && npm run build` clean on Node 20, all three pages render, no `fastener not recorded` left on any of them
- `validate_frontmatter.py` reports the 5 errors already on `main` and nothing new
- `validate_images.py` clean

<!--
request: https://discord.com/channels/1430279849171222682/1540438490712514561/1540443500871426108
-->
