### PR TITLE
docs: the draft pages all open with the AI-generated sentence

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -9,9 +9,9 @@ lede: How the four C-channels stand, at what heights, and what passes parts betw
 permalink: /hardware/assembly/feeder/arranging-c-channels/
 author: barthel
 warning: >-
-  **Skeleton page.** Assembled from the parts registry in the [parts
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and the
-  extrusion list on the bill of materials, not from a build. No height, angle or fastener here
+  extrusion list on the bill of materials, not from an actual build. No height, angle or fastener here
   has been checked against a machine, and the two starred steps are the ones that make the
   feeder work. Fill it in as you build.
 parts_needed:

--- a/docs/src/content/hardware/assembly/feeder/bulk-input.md
+++ b/docs/src/content/hardware/assembly/feeder/bulk-input.md
@@ -9,9 +9,9 @@ lede: The bucket and cap that hold unsorted parts over the first C-channel.
 permalink: /hardware/assembly/feeder/bulk-input/
 author: barthel
 warning: >-
-  **Skeleton page.** Written from the parts registry in the [parts
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=bulk-cap) and the
-  extrusion list on the bill of materials, not from a build. The bulk bucket itself is not
+  extrusion list on the bill of materials, not from an actual build. The bulk bucket itself is not
   published yet, so this page is mostly the shape of what is missing. Fill it in as you build.
 parts_needed:
   - part: bulk-cap

--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -9,9 +9,9 @@ lede: The rod arm that hangs a detection camera over a C-channel.
 permalink: /hardware/assembly/feeder/camera-mount/
 author: barthel
 warning: >-
-  **Skeleton page.** Written from the parts registry in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=camera-mount), not from a
-  build. The parts are recorded; the assembly order, every screw's position, the camera fixing
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=camera-mount), not from an
+  actual build. The parts are recorded; the assembly order, every screw's position, the camera fixing
   and all photographs are missing. Fill it in as you build.
 parts_needed:
   - part: camera-mount-part-6

--- a/docs/src/content/hardware/assembly/feeder/index.md
+++ b/docs/src/content/hardware/assembly/feeder/index.md
@@ -18,4 +18,4 @@ author: spencer
 6. **[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }})**, the handovers between channels.
 7. **[Arranging C-Channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }})**, the stand, the heights, and how the four sit together.
 
-Everything after the C-Channel page is a skeleton: the parts are recorded, the steps and the photographs are not. Each page says at the top what is missing from it.
+Everything after the C-Channel page is an AI-generated first draft: the parts are recorded, the steps and the photographs are not. Each page says at the top what is missing from it.

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -9,9 +9,9 @@ lede: The vertical COB light that lights a C-channel for the overhead camera.
 permalink: /hardware/assembly/feeder/light-post/
 author: barthel
 warning: >-
-  **Skeleton page.** Written from the parts registry in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=light-post), not from a
-  build. The parts and the two screws into the NEMA bracket are recorded; the rest of the
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=light-post), not from an
+  actual build. The parts and the two screws into the NEMA bracket are recorded; the rest of the
   order, the remaining screws and every photograph are still missing. Fill it in as you build.
 parts_needed:
   - part: light-post

--- a/docs/src/content/hardware/assembly/feeder/output-guides.md
+++ b/docs/src/content/hardware/assembly/feeder/output-guides.md
@@ -9,10 +9,11 @@ lede: The printed guides that carry parts from one C-channel to the next.
 permalink: /hardware/assembly/feeder/output-guides/
 author: barthel
 warning: >-
-  **Skeleton page.** The Output guide is in the parts catalog with a quantity and a colour and
-  nothing else: it is in no assembly in the [parts
-  calculator](https://parts-calculator.basically.website/assembly), and where it mounts is not
-  recorded anywhere. This page exists to be filled in, not to be followed.
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly), not from an actual build.
+  The Output guide is in the parts catalog with a quantity and a colour and nothing else: it is
+  in no assembly there, and where it mounts is not recorded anywhere. This page exists to be
+  filled in, not to be followed.
 parts_needed:
   - part: output-guide
     qty: 2

--- a/docs/src/content/hardware/electronics/installation/control-board-mount.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-mount.md
@@ -10,10 +10,11 @@ permalink: /hardware/electronics/installation/control-board-mount/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton page.** The parts and quantities are real, from the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=ctrl-board-mount), but
-  the printed bracket the board stands off is **not in the parts registry**, and no step here
-  has been checked against a machine. The steps below are placeholders with the gaps marked.
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=ctrl-board-mount), not
+  from an actual build. The parts and quantities are real, but the printed bracket the board
+  stands off is **not in the parts registry**, and no step here has been checked against a
+  machine. The steps below are placeholders with the gaps marked.
 parts_needed:
   - part: ctrl-board-basically
     qty: 1

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -10,11 +10,12 @@ permalink: /hardware/electronics/installation/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton pages.** These four pages exist so the gap is visible and fillable, not because the
-  steps are written. The parts on each come from the [parts
-  calculator](https://parts-calculator.basically.website/assembly), which records what every
-  mount is made of; the assembly order, the orientation and most of the screw sizes are recorded
-  nowhere, so each gap is marked in place rather than guessed at. Correct them as you build.
+  **AI-generated first drafts.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly), not from an actual build.
+  These four pages exist so the gap is visible and fillable, not because the steps are written.
+  The parts on each come from the calculator, which records what every mount is made of; the
+  assembly order, the orientation and most of the screw sizes are recorded nowhere, so each gap
+  is marked in place rather than guessed at. Correct them as you build.
 ---
 
 The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover what connects to what. These cover the other half: where the hardware physically sits and what holds it there.

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -10,10 +10,11 @@ permalink: /hardware/electronics/installation/orange-pi-mount/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton page.** The parts and quantities are real, from the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=orange-pi-mount), but
-  the printed bracket the Pi stands off is **not in the parts registry**, and no step here has
-  been checked against a machine. The steps below are placeholders with the gaps marked.
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=orange-pi-mount), not
+  from an actual build. The parts and quantities are real, but the printed bracket the Pi stands
+  off is **not in the parts registry**, and no step here has been checked against a machine. The
+  steps below are placeholders with the gaps marked.
 parts_needed:
   - part: sbc-orange-pi-5
     qty: 1

--- a/docs/src/content/hardware/electronics/installation/pico-headers.md
+++ b/docs/src/content/hardware/electronics/installation/pico-headers.md
@@ -10,10 +10,11 @@ permalink: /hardware/electronics/installation/pico-headers/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton page.** The parts and quantities are real, from the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=pico-headers). The
-  procedure is not recorded anywhere and no step here has been checked against a build, so the
-  steps below are placeholders with the gaps marked.
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=pico-headers), not from
+  an actual build. The parts and quantities are real. The procedure is not recorded anywhere and
+  no step here has been checked against a build, so the steps below are placeholders with the
+  gaps marked.
 parts_needed:
   - part: mcu-rpi-pico
     qty: 1

--- a/docs/src/content/hardware/electronics/installation/psu-box.md
+++ b/docs/src/content/hardware/electronics/installation/psu-box.md
@@ -10,10 +10,11 @@ permalink: /hardware/electronics/installation/psu-box/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Skeleton page.** The parts and quantities are real, from the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=meanwell-psu-box). The
-  assembly order is not recorded anywhere and no step here has been checked against a machine,
-  so the steps below are placeholders with the gaps marked. Correct them as you build.
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=meanwell-psu-box), not
+  from an actual build. The parts and quantities are real. The assembly order is not recorded
+  anywhere and no step here has been checked against a machine, so the steps below are
+  placeholders with the gaps marked. Correct them as you build.
 parts_needed:
   - part: psu-24v-350w
     qty: 1


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540434549673033768/1540623336046989362
preview: /hardware/assembly/feeder/light-post/
preview: /hardware/electronics/installation/
-->
Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1540434549673033768/1540623336046989362): "For the skeleton pages, simply replace the sentence “Skeleton page. Written from the parts registry in the parts calculator, not from a build” with the sentence from the AI-generated pages: “AI-generated first draft. Written from the machine assembly tree in the parts calculator, not from an actual build,” and leave the following sentences as they are."

Two labels were in use on unverified pages, **Skeleton page** and **AI-generated first draft**, saying the same thing. Now there is one, and it is the AI wording.

**Only the opening sentence changes.** Every page keeps the sentences after it that say what is missing from that page in particular: the bracket that is not in the parts registry on the two board mounts, the unpublished bulk bucket, the starred steps on Arranging C-Channels, and so on.

**Pages changed (10):** the 5 feeder drafts (light post, overhead camera mount, bulk input, output guides, arranging C-channels) and the 5 electronics installation pages (PSU box, control board mount, Orange Pi mount, Pico headers, and their landing page). The feeder landing page's one-line summary drops the word skeleton too.

**Untouched:** the pages that already carried the AI-generated note (chute core, chute PCB, funnel, layer connectors, MG995 servo mount, bottom two layers, classification chamber), and the C-channel page, whose note correctly says steps 1 to 5 come from BrickCycleAlice's build and only step 6 is a draft.

`npm run build` passes locally (Node 22) and `validate_frontmatter.py` reports only the 5 errors already on main.
