### PR TITLE
docs: how a regular layer joins the one below

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -143,6 +143,30 @@ Screw a **swivel stem caster (M6 × 15 mm)** into the connector's M6 thread. The
 
 Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 4: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into T-nuts.
 
+{% include step.html n="7" title="How the foot corner goes together" %}
+
+<figure class="figure-float-right">
+  <a href="https://img.basically.website/originals/assembly/bottom-two-layers/foot-corner-section.6ec3353ee6cf01ff.png" target="_blank" rel="noopener">
+    <img src="https://img.basically.website/web/assembly/bottom-two-layers/foot-corner-section.337680f09407c66f.jpg" alt="Vertical cross-section through one corner at the bottom of the machine, showing piece D running through the bottom layer's bracket and up into the second layer, the foot cover around it, and the exposed end below">
+  </a>
+  <figcaption>One corner at floor level, cut through the centre of the profile. The bottom layer is blue, the second layer's collar purple. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
+</figure>
+
+The corner itself is the same as any other, and it is only the vertical that changes: one piece D takes the place of the C that each of these two layers would otherwise have, and it stands proud at the bottom instead of being capped.
+
+The numbers on the drawing:
+
+<ol class="keyed-list">
+  <li><strong>External bracket — side</strong>, the same collar as on any layer, at the bottom layer's frame.</li>
+  <li><strong>External bracket - foot cover</strong> in place of the bottom vertical and cover. It closes the corner off but is far shorter, so the extrusion can leave the bottom of it.</li>
+  <li><strong>Piece D</strong>, 231 mm cut. It runs from below the bottom layer, through that layer's collar, and up to 3 mm below the flange face of the second layer's collar, replacing a piece C in each of the two layers.</li>
+  <li class="key-screw"><strong>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws per collar</strong> clamp the bracket onto piece D, at the bottom layer and again at the second layer. Same screws, same holes as on a regular layer.</li>
+  <li class="key-note"><strong>The exposed end of piece D</strong>, which takes the 2020 M6 foot connector and the caster. On the lengths as drawn it stands about 54 mm below the foot cover, but how far it should protrude is not recorded anywhere, so hold a foot connector against the end before you tighten the corner screws.</li>
+  <li><strong>The second layer's collar</strong>, with its External bracket — bottom vertical below it. From here up, every joint is the ordinary layer joint described in <a href="{{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-5">regular layers, step 5</a>.</li>
+</ol>
+
+Measured off the parts: the foot cover has no fastener holes of any kind, neither the vertical pair the bottom vertical's flange carries nor the self-tapping pair the brackets use, so it appears to go on as a cover rather than being screwed. <span class="fastener-todo">fastener not recorded</span>
+
 ## What comes next
 
 - Each of these two layers takes a [chute]({{ '/hardware/assembly/distribution/chute/' | relative_url }}), the same as any other layer.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -109,14 +109,38 @@ If you are using slide-in T-nuts, put them in as that guide says. The ends of th
   <figcaption>C between the layers above; D from the caster, past the bottom layer's corner, to the second layer. Photo courtesy of Christoph in the basically Discord.</figcaption>
 </figure>
 
+<figure class="figure-float-right">
+  <a href="https://img.basically.website/originals/assembly/bottom-two-layers/foot-corner-section.6ec3353ee6cf01ff.png" target="_blank" rel="noopener">
+    <img src="https://img.basically.website/web/assembly/bottom-two-layers/foot-corner-section.337680f09407c66f.jpg" alt="Vertical cross-section through one corner at the bottom of the machine, showing piece D running through the bottom layer's bracket and up into the second layer, the foot cover around it, and the exposed end below">
+  </a>
+  <figcaption>One corner at floor level, cut through the centre of the profile. The bottom layer is blue, the second layer's collar purple. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
+</figure>
+
+The corner itself is the same as on any layer. Only the vertical changes: one piece D takes the place of the C that each of these two layers would otherwise have, and it stands proud at the bottom instead of being capped.
+
 On each of the six corners, working on the second layer first:
 
-1. Slot an External bracket — cover onto the second layer's External bracket — side, before the extrusion goes in. It is awkward to fit afterwards.
-2. Slide a piece D down through the second layer's bracket and on down through the matching corner of the bottom layer, so one piece passes through both.
-3. Secure it at the second layer with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped through the holes near the bottom of the External bracket — side, bracing against the extrusion.
-4. Secure it again at the bottom layer's External bracket — side the same way, 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws.
+<ol class="numbered-steps">
+  <li>Slot an External bracket — cover onto the second layer's External bracket — side, before the extrusion goes in. It is awkward to fit afterwards.</li>
+  <li>Slide a piece D down through the second layer's bracket and on down through the matching corner of the bottom layer, so one piece passes through both.</li>
+  <li>Secure it at the second layer with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped through the holes near the bottom of the External bracket — side, bracing against the extrusion.</li>
+  <li>Secure it again at the bottom layer's External bracket — side the same way, 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws.</li>
+</ol>
 
-Let the bottom end of piece D stand proud of the bottom layer's corner rather than sitting flush with it: the foot connector bolts into that exposed end, and the External bracket - foot cover in step 4 is deliberately shorter than an ordinary cover so the extrusion pops out far enough to take it. How far it should protrude is not written down anywhere; hold a foot connector against the end before you tighten the corner screws.
+Let the bottom end of piece D stand proud of the bottom layer's corner rather than sitting flush with it: the foot connector bolts into that exposed end, and the External bracket - foot cover in step 4 is deliberately shorter than an ordinary cover so the extrusion pops out far enough to take it.
+
+The numbers on the drawing:
+
+<ol class="keyed-list">
+  <li><strong>External bracket — side</strong>, the same collar as on any layer, at the bottom layer's frame.</li>
+  <li><strong>External bracket - foot cover</strong> in place of the bottom vertical and cover. It closes the corner off but is far shorter, so the extrusion can leave the bottom of it.</li>
+  <li><strong>Piece D</strong>, 231 mm cut. It runs from below the bottom layer, through that layer's collar, and up to 3 mm below the flange face of the second layer's collar, replacing a piece C in each of the two layers.</li>
+  <li class="key-screw"><strong>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws per collar</strong> clamp the bracket onto piece D, at the bottom layer and again at the second layer. Same screws, same holes as on a regular layer.</li>
+  <li class="key-note"><strong>The exposed end of piece D</strong>, which takes the 2020 M6 foot connector and the caster. On the lengths as drawn it stands about 54 mm below the foot cover, but how far it should protrude is not recorded anywhere, so hold a foot connector against the end before you tighten the corner screws.</li>
+  <li><strong>The second layer's collar</strong>, with its External bracket — bottom vertical below it. From here up, every joint is the ordinary layer joint described in <a href="{{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-5">regular layers, step 5</a>.</li>
+</ol>
+
+Measured off the parts: the foot cover has no fastener holes of any kind, neither the vertical pair the bottom vertical's flange carries nor the self-tapping pair the brackets use, so it appears to go on as a cover rather than being screwed. <span class="fastener-todo">fastener not recorded</span>
 
 The two layers are now one rigid unit and their spacing is set by the bracket positions, not by anything you have to measure.
 
@@ -142,30 +166,6 @@ Screw a **swivel stem caster (M6 × 15 mm)** into the connector's M6 thread. The
 {% include step.html n="6" title="Add the bin retainers" %}
 
 Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 4: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into T-nuts.
-
-{% include step.html n="7" title="How the foot corner goes together" %}
-
-<figure class="figure-float-right">
-  <a href="https://img.basically.website/originals/assembly/bottom-two-layers/foot-corner-section.6ec3353ee6cf01ff.png" target="_blank" rel="noopener">
-    <img src="https://img.basically.website/web/assembly/bottom-two-layers/foot-corner-section.337680f09407c66f.jpg" alt="Vertical cross-section through one corner at the bottom of the machine, showing piece D running through the bottom layer's bracket and up into the second layer, the foot cover around it, and the exposed end below">
-  </a>
-  <figcaption>One corner at floor level, cut through the centre of the profile. The bottom layer is blue, the second layer's collar purple. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
-</figure>
-
-The corner itself is the same as any other, and it is only the vertical that changes: one piece D takes the place of the C that each of these two layers would otherwise have, and it stands proud at the bottom instead of being capped.
-
-The numbers on the drawing:
-
-<ol class="keyed-list">
-  <li><strong>External bracket — side</strong>, the same collar as on any layer, at the bottom layer's frame.</li>
-  <li><strong>External bracket - foot cover</strong> in place of the bottom vertical and cover. It closes the corner off but is far shorter, so the extrusion can leave the bottom of it.</li>
-  <li><strong>Piece D</strong>, 231 mm cut. It runs from below the bottom layer, through that layer's collar, and up to 3 mm below the flange face of the second layer's collar, replacing a piece C in each of the two layers.</li>
-  <li class="key-screw"><strong>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws per collar</strong> clamp the bracket onto piece D, at the bottom layer and again at the second layer. Same screws, same holes as on a regular layer.</li>
-  <li class="key-note"><strong>The exposed end of piece D</strong>, which takes the 2020 M6 foot connector and the caster. On the lengths as drawn it stands about 54 mm below the foot cover, but how far it should protrude is not recorded anywhere, so hold a foot connector against the end before you tighten the corner screws.</li>
-  <li><strong>The second layer's collar</strong>, with its External bracket — bottom vertical below it. From here up, every joint is the ordinary layer joint described in <a href="{{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-5">regular layers, step 5</a>.</li>
-</ol>
-
-Measured off the parts: the foot cover has no fastener holes of any kind, neither the vertical pair the bottom vertical's flange carries nor the self-tapping pair the brackets use, so it appears to go on as a cover rather than being screwed. <span class="fastener-todo">fastener not recorded</span>
 
 ## What comes next
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -203,11 +203,13 @@ Set the next layer down so that each External bracket — bottom vertical's flan
 
 What the numbers mark:
 
-1. **External bracket — side and cover**, the 60.5 mm collar at each frame.
-2. **Piece C**, 154 mm cut. It starts 3 mm above its own collar's underside and ends 3 mm below the flange face of the collar above, so it spans the whole 160 mm between one frame and the next.
-3. **External bracket — bottom vertical**, 119.6 mm of tube. It sleeves the upper part of piece C, so the extrusion is not visible on an assembled machine, and its foot seats on the rim of its own layer's collar. That seat is what sets the 160 mm spacing between frames.
-4. **The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that join the layers**, up through the flange into the bracket above. The flange has a 5.6 mm clearance hole through 8 mm of plastic and the bracket above a 4.4 mm self-tapping hole 10 mm deep, so the screw is 8 mm of clearance and 8 mm of thread, and a longer one bottoms out before it clamps.
-5. **The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that clamp the bracket onto the extrusion**, self-tapping through the bracket wall. Piece C is held only here, in its own layer's bracket, and nothing screws into it from the layer above.
-6. **Where two pieces of C meet**: they stop about 3 mm short of each other at the flange face and never touch.
+<ol class="keyed-list">
+  <li><strong>External bracket — side and cover</strong>, the 60.5 mm collar at each frame.</li>
+  <li><strong>Piece C</strong>, 154 mm cut. It starts 3 mm above its own collar's underside and ends 3 mm below the flange face of the collar above, so it spans the whole 160 mm between one frame and the next.</li>
+  <li><strong>External bracket — bottom vertical</strong>, 119.6 mm of tube. It sleeves the upper part of piece C, so the extrusion is not visible on an assembled machine, and its foot seats on the rim of its own layer's collar. That seat is what sets the 160 mm spacing between frames.</li>
+  <li><strong>The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that join the layers</strong>, up through the flange into the bracket above. The flange has a 5.6 mm clearance hole through 8 mm of plastic and the bracket above a 4.4 mm self-tapping hole 10 mm deep, so the screw is 8 mm of clearance and 8 mm of thread, and a longer one bottoms out before it clamps.</li>
+  <li><strong>The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that clamp the bracket onto the extrusion</strong>, self-tapping through the bracket wall. Piece C is held only here, in its own layer's bracket, and nothing screws into it from the layer above.</li>
+  <li><strong>Where two pieces of C meet</strong>: they stop about 3 mm short of each other at the flange face and never touch.</li>
+</ol>
 
 Both screw pairs are drawn dashed because neither lies in the plane of the cut: the joining pair sits 20.6 mm either side of it, and the clamping pair comes in at 45° to it.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -192,11 +192,22 @@ A regular layer is now complete. You will also need to construct a [Chute core](
 
 A finished layer already carries everything that spans up to the next one: piece C standing out of its External bracket — side, and the External bracket — bottom vertical capping that extrusion. Joining two layers is therefore only the flange joint at each of the six corners.
 
-Set the next layer down so that each External bracket — bottom vertical's flange face meets the underside of that layer's External bracket — side, and drive 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws up through each flange into the bracket above. **That pair is the whole layer-to-layer fastening, 12 screws per joint.** The flange carries a 5.6 mm clearance hole through 8 mm of plastic and the bracket above a 4.4 mm self-tapping hole 10 mm deep, so an {% include fastener.html size="M5" variant="socket-button" length="16" %} is 8 mm of clearance and 8 mm of thread, and a longer screw has nowhere to go.
-
-The extrusion is not screwed to the layer above. Piece C is clamped only in its own layer's bracket, and two layers' pieces of C stop about 3 mm short of each other at the flange face, so they never touch. The foot of the External bracket — bottom vertical seats on the rim of its own layer's collar, and that is what sets the 160 mm spacing between one frame and the next.
+Set the next layer down so that each External bracket — bottom vertical's flange face meets the underside of that layer's External bracket — side, and drive 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws up through each flange into the bracket above. **That pair is the whole layer-to-layer fastening, 12 screws per joint.**
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/layer-joint-section.abfaad01e86d6134.jpg" alt="Vertical cross-section through one corner of two stacked layers, showing the lower layer's vertical extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, and the two screw pairs in red">
-  <figcaption>Section through one corner, cut through the centre of the profile on the bracket's symmetry plane. Blue is the lower layer, purple the layer above: the whole span between two frames belongs to the lower layer, and the only fasteners between the two are the two {% include fastener.html size="M5" variant="socket-button" length="16" %} through the flange. Drawn from the part geometry rather than from a build.</figcaption>
+  <a href="https://img.basically.website/originals/assembly/regular-layers/layer-joint-section.11acc0911bc91277.png" target="_blank" rel="noopener">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/layer-joint-section.21c4ee094a2c72b8.jpg" alt="Vertical cross-section through one corner of two stacked layers, with the lower layer's extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, the two screw pairs dashed in red, and six numbered callouts">
+  </a>
+  <figcaption>Section through one corner, cut through the centre of the profile. Blue is the lower layer, purple the layer above. Click the drawing to enlarge it. Drawn from the part geometry rather than from a build.</figcaption>
 </figure>
+
+What the numbers mark:
+
+1. **External bracket — side and cover**, the 60.5 mm collar at each frame.
+2. **Piece C**, 154 mm cut. It starts 3 mm above its own collar's underside and ends 3 mm below the flange face of the collar above, so it spans the whole 160 mm between one frame and the next.
+3. **External bracket — bottom vertical**, 119.6 mm of tube. It sleeves the upper part of piece C, so the extrusion is not visible on an assembled machine, and its foot seats on the rim of its own layer's collar. That seat is what sets the 160 mm spacing between frames.
+4. **The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that join the layers**, up through the flange into the bracket above. The flange has a 5.6 mm clearance hole through 8 mm of plastic and the bracket above a 4.4 mm self-tapping hole 10 mm deep, so the screw is 8 mm of clearance and 8 mm of thread, and a longer one bottoms out before it clamps.
+5. **The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that clamp the bracket onto the extrusion**, self-tapping through the bracket wall. Piece C is held only here, in its own layer's bracket, and nothing screws into it from the layer above.
+6. **Where two pieces of C meet**: they stop about 3 mm short of each other at the flange face and never touch.
+
+Both screw pairs are drawn dashed because neither lies in the plane of the cut: the joining pair sits 20.6 mm either side of it, and the clamping pair comes in at 45° to it.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -194,22 +194,22 @@ A regular layer is now complete. You will also need to construct a [Chute core](
   <a href="https://img.basically.website/originals/assembly/regular-layers/layer-joint-section.11acc0911bc91277.png" target="_blank" rel="noopener">
     <img src="https://img.basically.website/web/assembly/regular-layers/layer-joint-section.21c4ee094a2c72b8.jpg" alt="Vertical cross-section through one corner of two stacked layers, with the lower layer's extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, the two screw pairs dashed in red, and six numbered callouts">
   </a>
-  <figcaption>Section through one corner, cut through the centre of the profile. Blue is the lower layer, purple the layer above. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
+  <figcaption>One corner where any two layers meet, cut through the centre of the profile. Blue is the lower layer, purple the layer above. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
 </figure>
 
 A finished layer already carries everything that spans up to the next one: piece C standing out of its External bracket — side, and the External bracket — bottom vertical capping that extrusion. Joining two layers is therefore only the flange joint at each of the six corners.
 
 Set the next layer down so that each External bracket — bottom vertical's flange face meets the underside of that layer's External bracket — side, and drive 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws up through each flange into the bracket above. **That pair is the whole layer-to-layer fastening, 12 screws per joint.**
 
-What the numbers mark:
+The numbers on the drawing:
 
 <ol class="keyed-list">
   <li><strong>External bracket — side and cover</strong>, the 60.5 mm collar at each frame.</li>
   <li><strong>Piece C</strong>, 154 mm cut. It starts 3 mm above its own collar's underside and ends 3 mm below the flange face of the collar above, so it spans the whole 160 mm between one frame and the next.</li>
   <li><strong>External bracket — bottom vertical</strong>, 119.6 mm of tube. It sleeves the upper part of piece C, so the extrusion is not visible on an assembled machine, and its foot seats on the rim of its own layer's collar. That seat is what sets the 160 mm spacing between frames.</li>
-  <li><strong>The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that join the layers</strong>, up through the flange into the bracket above. The flange has a 5.6 mm clearance hole through 8 mm of plastic and the bracket above a 4.4 mm self-tapping hole 10 mm deep, so the screw is 8 mm of clearance and 8 mm of thread, and a longer one bottoms out before it clamps.</li>
-  <li><strong>The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that clamp the bracket onto the extrusion</strong>, self-tapping through the bracket wall. Piece C is held only here, in its own layer's bracket, and nothing screws into it from the layer above.</li>
-  <li><strong>Where two pieces of C meet</strong>: they stop about 3 mm short of each other at the flange face and never touch.</li>
+  <li class="key-screw"><strong>The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that join the layers</strong>, up through the flange into the bracket above. The flange has a 5.6 mm clearance hole through 8 mm of plastic and the bracket above a 4.4 mm self-tapping hole 10 mm deep, so the screw is 8 mm of clearance and 8 mm of thread, and a longer one bottoms out before it clamps.</li>
+  <li class="key-screw"><strong>The two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that clamp the bracket onto the extrusion</strong>, self-tapping through the bracket wall. Piece C is held only here, in its own layer's bracket, and nothing screws into it from the layer above.</li>
+  <li class="key-note"><strong>Where two pieces of C meet</strong>: they stop about 3 mm short of each other at the flange face and never touch.</li>
 </ol>
 
 Both screw pairs are drawn dashed because neither lies in the plane of the cut: the joining pair sits 20.6 mm either side of it, and the clamping pair comes in at 45° to it.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -190,16 +190,16 @@ A regular layer is now complete. You will also need to construct a [Chute core](
 
 {% include step.html n="5" title="Join the layer to the one below" %}
 
+<figure class="figure-float-right">
+  <a href="https://img.basically.website/originals/assembly/regular-layers/layer-joint-section.11acc0911bc91277.png" target="_blank" rel="noopener">
+    <img src="https://img.basically.website/web/assembly/regular-layers/layer-joint-section.21c4ee094a2c72b8.jpg" alt="Vertical cross-section through one corner of two stacked layers, with the lower layer's extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, the two screw pairs dashed in red, and six numbered callouts">
+  </a>
+  <figcaption>Section through one corner, cut through the centre of the profile. Blue is the lower layer, purple the layer above. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
+</figure>
+
 A finished layer already carries everything that spans up to the next one: piece C standing out of its External bracket — side, and the External bracket — bottom vertical capping that extrusion. Joining two layers is therefore only the flange joint at each of the six corners.
 
 Set the next layer down so that each External bracket — bottom vertical's flange face meets the underside of that layer's External bracket — side, and drive 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws up through each flange into the bracket above. **That pair is the whole layer-to-layer fastening, 12 screws per joint.**
-
-<figure>
-  <a href="https://img.basically.website/originals/assembly/regular-layers/layer-joint-section.11acc0911bc91277.png" target="_blank" rel="noopener">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/layer-joint-section.21c4ee094a2c72b8.jpg" alt="Vertical cross-section through one corner of two stacked layers, with the lower layer's extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, the two screw pairs dashed in red, and six numbered callouts">
-  </a>
-  <figcaption>Section through one corner, cut through the centre of the profile. Blue is the lower layer, purple the layer above. Click the drawing to enlarge it. Drawn from the part geometry rather than from a build.</figcaption>
-</figure>
 
 What the numbers mark:
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -187,3 +187,16 @@ On each corner, slide an External bracket — bottom vertical onto piece C (Laye
 On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
 
 A regular layer is now complete. You will also need to construct a [Chute core]({{ '/hardware/assembly/distribution/chute/' | relative_url }}) for each layer you build.
+
+{% include step.html n="5" title="Join the layer to the one below" %}
+
+A finished layer already carries everything that spans up to the next one: piece C standing out of its External bracket — side, and the External bracket — bottom vertical capping that extrusion. Joining two layers is therefore only the flange joint at each of the six corners.
+
+Set the next layer down so that each External bracket — bottom vertical's flange face meets the underside of that layer's External bracket — side, and drive 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws up through each flange into the bracket above. **That pair is the whole layer-to-layer fastening, 12 screws per joint.** The flange carries a 5.6 mm clearance hole through 8 mm of plastic and the bracket above a 4.4 mm self-tapping hole 10 mm deep, so an {% include fastener.html size="M5" variant="socket-button" length="16" %} is 8 mm of clearance and 8 mm of thread, and a longer screw has nowhere to go.
+
+The extrusion is not screwed to the layer above. Piece C is clamped only in its own layer's bracket, and two layers' pieces of C stop about 3 mm short of each other at the flange face, so they never touch. The foot of the External bracket — bottom vertical seats on the rim of its own layer's collar, and that is what sets the 160 mm spacing between one frame and the next.
+
+<figure>
+  <img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/layer-joint-section.abfaad01e86d6134.jpg" alt="Vertical cross-section through one corner of two stacked layers, showing the lower layer's vertical extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, and the two screw pairs in red">
+  <figcaption>Section through one corner, cut through the centre of the profile on the bracket's symmetry plane. Blue is the lower layer, purple the layer above: the whole span between two frames belongs to the lower layer, and the only fasteners between the two are the two {% include fastener.html size="M5" variant="socket-button" length="16" %} through the flange. Drawn from the part geometry rather than from a build.</figcaption>
+</figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -531,8 +531,11 @@ The numbers on the photo and the drawing:
   <li class="key-screw"><strong>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws</strong> at the base of that bracket brace it against the extrusion, the same screws and holes a layer's own vertical gets. Nothing else fastens the interface to the layer.</li>
 </ol>
 
+<div class="clear-float"></div>
+
 The top interface is now complete.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-4.28f9d54d3c156c6b.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
+  <figcaption>The finished interface, seen from above with the top plate on.</figcaption>
 </figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -505,11 +505,11 @@ Attach an External bracket cover to each of the External bracket sides, then fas
 
 {% include step.html n="14" title="How the interface joins the top layer" %}
 
-<figure class="figure-float-right">
+<figure>
   <a href="https://img.basically.website/originals/assembly/top-interface/framing-joint.ed0a06d244ffe45d.png" target="_blank" rel="noopener">
-    <img src="https://img.basically.website/web/assembly/top-interface/framing-joint.be2cac2fd31d13c3.jpg" alt="The interface assembly upside down on its top plate with six vertical extrusions standing out of it, each held in an interface bracket and sleeved by an interface spacer">
+    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-joint.be2cac2fd31d13c3.jpg" alt="The interface assembly upside down on its top plate with six vertical extrusions standing out of it, each held in an interface bracket and sleeved by an interface spacer">
   </a>
-  <figcaption>The interface framing before the top layer goes on, with one arm marked. The numbers match the list below. Click to enlarge.</figcaption>
+  <figcaption>The interface framing before the top layer goes on, with one arm marked. The numbers match the list below. Click the photo to open it full size.</figcaption>
 </figure>
 
 This joint is not the same as the one between two layers, so it is worth naming what is different. There is **no External bracket — bottom vertical and no flange here**, and therefore none of the vertical screws that hold one layer to the next.

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -503,6 +503,27 @@ Follow the first two stages of [a regular layer]({{ '/hardware/assembly/distribu
 
 Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the holes at the base of the External bracket sides, bracing against the extrusion. These holes run parallel to the extrusion profile, and the screws are self-tapping. See the [external bracket]({{ '/hardware/assembly/distribution/external-bracket/' | relative_url }}) instructions for building the bracket itself.
 
+{% include step.html n="14" title="How the interface joins the top layer" %}
+
+<figure class="figure-float-right">
+  <a href="https://img.basically.website/originals/assembly/top-interface/framing-joint.ed0a06d244ffe45d.png" target="_blank" rel="noopener">
+    <img src="https://img.basically.website/web/assembly/top-interface/framing-joint.be2cac2fd31d13c3.jpg" alt="The interface assembly upside down on its top plate with six vertical extrusions standing out of it, each held in an interface bracket and sleeved by an interface spacer">
+  </a>
+  <figcaption>The interface framing before the top layer goes on, with one arm marked. The numbers match the list below. Click to enlarge.</figcaption>
+</figure>
+
+This joint is not the same as the one between two layers, so it is worth naming what is different. There is **no External bracket — bottom vertical and no flange here**, and therefore none of the vertical screws that hold one layer to the next.
+
+The numbers on the photo:
+
+<ol class="keyed-list">
+  <li><strong>Interface bracket</strong>, one per corner. Piece F is held in it by 4 {% include fastener.html size="M5" variant="socket-button" length="20" %} screws into {% include fastener.html size="M5" variant="t-nut" text="T-nuts" %}, the only place in the framing where the vertical is fixed with T-nuts rather than a self-tapping screw.</li>
+  <li><strong>Interface spacer</strong>, slid onto the extrusion with its lip at the top facing the centre. It takes no screws.</li>
+  <li><strong>Piece F</strong>, 274 mm cut (280 mm in CAD) against a layer's 154 mm, so the interface sits 120 mm further above the top layer than one layer's spacing.</li>
+</ol>
+
+At the other end the joint is ordinary: piece F drops into the top layer's **External bracket — side**, the cover clips on, and 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws at the base of the bracket brace it against the extrusion, exactly as a layer's own vertical is held. Nothing else fastens the interface to the layer.
+
 The top interface is now complete.
 
 <figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -531,6 +531,8 @@ The numbers on the photo and the drawing:
   <li class="key-screw"><strong>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws</strong> at the base of that bracket brace it against the extrusion, the same screws and holes a layer's own vertical gets. Nothing else fastens the interface to the layer.</li>
 </ol>
 
+**Piece F does not reach the top of the Interface bracket, and nowhere near the top plate.** How deep it goes is not stated anywhere in the build, but it is fixed at both ends by what has to be screwed: the lower end has to reach past the two screws at the base of the layer's bracket, and the upper end has to cover the bracket's second pair of T-nut screws, whose bosses sit about 90 mm above the bracket's underside. A 274 mm piece cannot do both and also reach the top of a 120 mm bracket, so it stands about 6 mm past the upper screws and stops roughly 23 mm short of the top of the bracket. That is what the drawing shows.
+
 <div class="clear-float"></div>
 
 The top interface is now complete.

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -509,20 +509,27 @@ Attach an External bracket cover to each of the External bracket sides, then fas
   <a href="https://img.basically.website/originals/assembly/top-interface/framing-joint.ed0a06d244ffe45d.png" target="_blank" rel="noopener">
     <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-joint.be2cac2fd31d13c3.jpg" alt="The interface assembly upside down on its top plate with six vertical extrusions standing out of it, each held in an interface bracket and sleeved by an interface spacer">
   </a>
-  <figcaption>The interface framing before the top layer goes on, with one arm marked. The numbers match the list below. Click the photo to open it full size.</figcaption>
+  <figcaption>The interface framing before the top layer goes on, with one arm marked 1 to 3. Click the photo to open it full size.</figcaption>
 </figure>
 
-This joint is not the same as the one between two layers, so it is worth naming what is different. There is **no External bracket — bottom vertical and no flange here**, and therefore none of the vertical screws that hold one layer to the next.
+<figure class="figure-float-right">
+  <a href="https://img.basically.website/originals/assembly/top-interface/joint-section.e96f8eb4493c6488.png" target="_blank" rel="noopener">
+    <img src="https://img.basically.website/web/assembly/top-interface/joint-section.78eb670eb255aa81.jpg" alt="Vertical cross-section through one interface corner, showing the interface bracket and spacer in purple, piece F in grey running down into the top layer's bracket in blue">
+  </a>
+  <figcaption>The same corner in section, cut through the centre of the profile. Purple is the interface, blue the top layer's bracket, grey the extrusion. Click to enlarge. The interface parts are not exported in a shared frame with the layer parts, so the part lengths are measured but their heights come from seating each one on the part below it.</figcaption>
+</figure>
 
-The numbers on the photo:
+This joint is not the same as the one between two layers, so it is worth naming what is different. There is **no External bracket — bottom vertical and no flange here**, and therefore none of the vertical screws that hold one layer to the next. Piece F is instead gripped at the interface end and clamped at the layer end, and it is sleeved the whole way between them, so no extrusion shows on a finished machine.
+
+The numbers on the photo and the drawing:
 
 <ol class="keyed-list">
-  <li><strong>Interface bracket</strong>, one per corner. Piece F is held in it by 4 {% include fastener.html size="M5" variant="socket-button" length="20" %} screws into {% include fastener.html size="M5" variant="t-nut" text="T-nuts" %}, the only place in the framing where the vertical is fixed with T-nuts rather than a self-tapping screw.</li>
-  <li><strong>Interface spacer</strong>, slid onto the extrusion with its lip at the top facing the centre. It takes no screws.</li>
+  <li><strong>Interface bracket</strong>, one per corner, a 120 mm channel around the extrusion. Piece F is held in it by 4 {% include fastener.html size="M5" variant="socket-button" length="20" %} screws into {% include fastener.html size="M5" variant="t-nut" text="T-nuts" %}, the only place in the framing where a vertical is fixed with T-nuts rather than a self-tapping screw.</li>
+  <li><strong>Interface spacer</strong>, a 129.7 mm sleeve, slid onto the extrusion with its lip at the top facing the centre. It takes no screws and simply sits between the bracket and the layer's collar.</li>
   <li><strong>Piece F</strong>, 274 mm cut (280 mm in CAD) against a layer's 154 mm, so the interface sits 120 mm further above the top layer than one layer's spacing.</li>
+  <li><strong>The top layer's External bracket — side</strong>, with its cover, exactly the collar any layer has.</li>
+  <li class="key-screw"><strong>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws</strong> at the base of that bracket brace it against the extrusion, the same screws and holes a layer's own vertical gets. Nothing else fastens the interface to the layer.</li>
 </ol>
-
-At the other end the joint is ordinary: piece F drops into the top layer's **External bracket — side**, the cover clips on, and 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws at the base of the bracket brace it against the extrusion, exactly as a layer's own vertical is held. Nothing else fastens the interface to the layer.
 
 The top interface is now complete.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -485,6 +485,8 @@ After this step the chute should still rotate to each of its limits.
 
 Insert an extrusion piece F (Interface vertical support) into each of the Interface brackets. Hold each one in place with four {% include fastener.html size="M5" variant="socket-button" length="20" %} screws into four T-nuts.
 
+**Do not push piece F all the way through the bracket.** Leave its end roughly 20 mm short of the far end of the channel: that is far enough in to cover both pairs of T-nut screws, and it leaves enough of the extrusion standing out to reach past the screws at the base of the layer's External bracket — side later in this step. [Step 14]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}#step-14) shows the whole corner in section.
+
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-1.ae2ef835181f63bd.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">
 </figure>

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1072,6 +1072,18 @@ body {
 	color: var(--muted);
 }
 
+/* Numbered key for a keyed drawing: the site's lists render without markers,
+   so a list whose items are referred to by number opts back in. */
+.keyed-list {
+	list-style: decimal;
+	padding-left: 1.5rem;
+	margin: 0 0 1.4rem;
+}
+
+.keyed-list li {
+	margin-bottom: 0.5rem;
+}
+
 @media (max-width: 740px) {
 	.figure-float-right {
 		float: none;

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1072,6 +1072,11 @@ body {
 	color: var(--muted);
 }
 
+/* Ends a floated figure, so what follows starts below it rather than beside. */
+.clear-float {
+	clear: both;
+}
+
 /* An ordered procedure inside a step: the site's lists carry no markers, so a
    list whose order matters draws plain numbers. */
 .numbered-steps {

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -861,6 +861,7 @@ body {
 /* ── Step headings ─────────────────────────────────────────────────────── */
 
 .step-heading {
+	clear: both;
 	display: flex;
 	flex-direction: column;
 	gap: 3px;
@@ -1046,6 +1047,38 @@ body {
 	height: auto;
 	margin: 0 auto 1.4rem;
 	border: 1px solid var(--line);
+}
+
+/* A figure floated into the right margin, with the step text running beside it.
+   Falls back to a normal centred figure on narrow screens. */
+.figure-float-right {
+	float: right;
+	width: 240px;
+	max-width: 45%;
+	margin: 0 0 1rem 1.6rem;
+}
+
+.figure-float-right img {
+	display: block;
+	width: 100%;
+	height: auto;
+	border: 1px solid var(--line);
+}
+
+.figure-float-right figcaption {
+	margin-top: 6px;
+	font-size: 0.8125rem;
+	line-height: 1.4;
+	color: var(--muted);
+}
+
+@media (max-width: 740px) {
+	.figure-float-right {
+		float: none;
+		width: 100%;
+		max-width: 440px;
+		margin: 1.4rem auto;
+	}
 }
 
 .video-embed-portrait {

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1072,16 +1072,47 @@ body {
 	color: var(--muted);
 }
 
-/* Numbered key for a keyed drawing: the site's lists render without markers,
-   so a list whose items are referred to by number opts back in. */
+/* Numbered key for a keyed drawing: the site's lists render without markers, so
+   a list whose items are referred to by number draws its own. The badges match
+   the numbered markers on the drawing, including their colour. */
 .keyed-list {
-	list-style: decimal;
-	padding-left: 1.5rem;
+	list-style: none;
+	counter-reset: keyed;
+	padding-left: 0;
 	margin: 0 0 1.4rem;
 }
 
 .keyed-list li {
-	margin-bottom: 0.5rem;
+	counter-increment: keyed;
+	position: relative;
+	padding-left: 2.1rem;
+	margin-bottom: 0.6rem;
+}
+
+.keyed-list li::before {
+	content: counter(keyed);
+	position: absolute;
+	left: 0;
+	top: 0.1em;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.4rem;
+	height: 1.4rem;
+	border-radius: 50%;
+	background: #1a6eb0;
+	color: #fff;
+	font-size: 0.78rem;
+	font-weight: 700;
+	line-height: 1;
+}
+
+.keyed-list li.key-screw::before {
+	background: #c4322c;
+}
+
+.keyed-list li.key-note::before {
+	background: #262c36;
 }
 
 @media (max-width: 740px) {

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1072,6 +1072,18 @@ body {
 	color: var(--muted);
 }
 
+/* An ordered procedure inside a step: the site's lists carry no markers, so a
+   list whose order matters draws plain numbers. */
+.numbered-steps {
+	list-style: decimal;
+	padding-left: 1.6rem;
+	margin: 0 0 1.4rem;
+}
+
+.numbered-steps li {
+	margin-bottom: 0.5rem;
+}
+
 /* Numbered key for a keyed drawing: the site's lists render without markers, so
    a list whose items are referred to by number draws its own. The badges match
    the numbered markers on the drawing, including their colour. */


### PR DESCRIPTION
Adds a fifth step to the regular layers page covering how two layers actually join, which was not documented anywhere: the only fastening between two layers is the pair of M5 x 16 through each External bracket - bottom vertical flange into the bracket above, 12 per joint.

The step embeds a section drawing of one corner, cut through the centre of the profile on the bracket's symmetry plane, coloured by which layer each part belongs to. The outlines are the real part geometry, sectioned out of the published STLs for `ext-bracket-left`, `ext-bracket-cover` and `ext-bracket-bottom-vertical`; the drawing is stated in the caption as derived from geometry rather than from a build.

Numbers in the step, all measured off those STLs:

- flange: 5.6 mm clearance hole through 8 mm of plastic
- bracket above: 4.4 mm self-tapping hole, 10 mm deep, at 20.6 mm either side of the corner bisector
- so an M5 x 16 is 8 mm clearance plus 8 mm thread, and a longer screw bottoms out
- closest the printed parts can stack without interfering is 159.75 mm, i.e. the 160 mm pitch, which is also piece C's CAD length

**Not changed, worth a look separately:** the page's `parts_needed` lists 36 M5 x 16 per layer, which is the four screws per corner that step 3 uses plus the spokes. The 12 that join a layer to the one below do not appear to be in that total, and the page's other fastener sums are already known to be off (`scr-m5-12-shcs` is listed as 12 where the steps use 36). Left alone here rather than guessed at.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1540622172027101324/1540634889412677694): "Extract the actual image, the caption, and the text, and create a separate step in the regular layer documentation on how to merge two layers. Copy the text into the step description and embed the image in the step."

**Update, 2026-08-22:** two more entries in the same format, both asked for in the same thread.

- **Bottom two layers, step 7:** a section of one corner at floor level. Piece D through the bottom layer's collar and up to 3 mm below the second layer's flange face, the foot cover in place of bottom vertical plus cover, and the exposed end that takes the connector and caster (about 54 mm on the lengths as drawn, flagged as not recorded). Also measured: the foot cover has no fastener holes of any kind, which is evidence on the page's open question about whether it is screwed or clipped, so the flag stays.
- **Top interface, step 14:** now carries both a marked-up photo and a section drawing. what is different about that joint. No bottom vertical and no flange, so none of the vertical screws; piece F is 274 mm against a layer's 154 mm; it is held in the Interface bracket by 4 M5 x 20 into T-nuts, sleeved by the Interface spacer, and clamped at the layer end by the ordinary 2 M5 x 16. The image is the existing framing photo with one arm marked, because the interface parts are exported in separate local frames and cannot be stacked into a true section the way the layer parts can.

Also in this PR: the drawing key is a numbered list whose badges match the markers on the drawing, `.figure-float-right` floats a figure into the right margin with the text running beside it, and `.numbered-steps` gives an ordered procedure its numbers back.

**Three additions to `layout.css`, all opt-in classes**, because the site had no float class, no click-to-zoom, and no list markers at all (its reset removes them, so every ordered list in the docs currently renders as unnumbered lines). Nothing existing changes appearance; `.step-heading` also gained `clear: both` so a float cannot overlap the next step.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540634889412677694
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540637421249626172
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540640495577866271
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540641136375234602
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540646704213131336
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540650630165569586
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540654165578088469
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540656204890771576
request: https://discord.com/channels/1430279849171222682/1540622172027101324/1540658254433095690
preview: /hardware/assembly/distribution/bin-frame/regular-layers/
-->