### PR TITLE
parts-calculator: the v1 board mounts, and the PSU housing as an assembly candidate

### DIFF
--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -158,6 +158,25 @@ def normalize_versions(part):
     return [entry]
 
 
+def normalize_assemblies(manifest):
+    """Assemblies pass through to the app as authored, with one fix-up: the
+    newest `versions` entry names the assembly's current uid, the way
+    normalize_versions() does it for a part. Only the SUPERSEDED entries carry
+    a uid in parts.json -- stamp_versions.py writes one there when a version is
+    replaced -- so without this the current revision reads back as uid null,
+    which is the one revision whose id is never in doubt."""
+    out = []
+    for asm in manifest.get("assemblies", []):
+        vs = asm.get("versions")
+        if vs and not vs[-1].get("uid"):
+            newest = vs[-1]
+            asm = dict(asm, versions=vs[:-1] + [{
+                "version": newest.get("version"), "uid": asm["uid"],
+                **{k: v for k, v in newest.items() if k != "version"}}])
+        out.append(asm)
+    return out
+
+
 def fetch_artifact(url, sha, dest):
     """Materialize a bucket object at dest, verifying its full sha256.
 
@@ -1015,7 +1034,7 @@ def main():
         data["sections"] = manifest["sections"]
         data["changes"] = manifest.get("changes", [])
         data["folders"] = manifest.get("folders", [])
-        data["assemblies"] = manifest.get("assemblies", [])
+        data["assemblies"] = normalize_assemblies(manifest)
         data["hardware"] = build_hardware(manifest)
         data["families"] = build_families(manifest)
         data["lasercut"] = build_lasercut(manifest)
@@ -1197,7 +1216,7 @@ def main():
         "folders": manifest.get("folders", []),
         "color_roles": manifest["color_roles"],
         "families": families,
-        "assemblies": manifest.get("assemblies", []),
+        "assemblies": normalize_assemblies(manifest),
         "parts": out_parts,
         "plates": plates,
         "hardware": hardware,

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -2497,6 +2497,164 @@
       "support": false
     },
     {
+      "id": "ctrl-board-extrusion-mount",
+      "uid": "1d5n",
+      "name": "Control board extrusion mount",
+      "description": "Plate the basically Embedded Control Board stands off, which bolts to the 2020 extrusion. The v1 mounting, in the machine today; the printed housing is the candidate that would replace it.",
+      "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Named 'basically board v1-3 open air fan - basically PCB to extrusion mount.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {
+        "electronics": 1
+      },
+      "assembly": "ctrl-board-mount",
+      "stl_hash": "f855b06c3b0f57fbd3756ebca08fa7e9a5aaf2f7c0b72d41c72ccb8cb5716873",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/6e1da7cee8967d584080406f"
+    },
+    {
+      "id": "orange-pi-extrusion-mount",
+      "uid": "nxh7",
+      "name": "Orange Pi extrusion mount",
+      "description": "Plate the Orange Pi 5 stands off, which bolts to the 2020 extrusion. Same design as the control board's mount with the opening and bolt pattern changed for the Pi.",
+      "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Named 'basically board v1-3 open air fan - Orange Pi 5 to extrusion mount.stl' (the zip's own prefix says 'basically board'; the part inside is the Pi's).",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {
+        "electronics": 1
+      },
+      "assembly": "orange-pi-mount",
+      "stl_hash": "4832b4065aef40589ccbe353e0e2214201f9ef5af1dd6c5df0af51fa079c4394",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/745c16803d318039967603f7"
+    },
+    {
+      "id": "fan-bracket-40mm",
+      "uid": "3ufy",
+      "name": "40 mm fan bracket",
+      "description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
+      "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Both zips carry a '40mm fan bracket.stl' -- Spencer: 'the fan bracket thing was identical on both'. The two files are NOT byte-identical (sha256 d4757b35... vs 7c3ea544...) but are the same solid: same 48x90x70 mm bounding box, same 7152 triangles, and the same volume to 7 significant figures (67894.9 mm3); no axis-aligned transform maps one onto the other, so it is one design re-exported at a different orientation. Exactly the case the uid model is for: one uid, and whichever bytes we pin are that design's stl_hash. Pinned from the control board's zip.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {
+        "electronics": 2
+      },
+      "assembly": null,
+      "stl_hash": "d4757b350b5690524838d0727a2e81c22135424104d47f4e102b73bbecdde995",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/6e1da7cee8967d584080406f"
+    },
+    {
+      "id": "meanwell-psu-housing-shell-rear",
+      "uid": "7qz3",
+      "name": "PSU housing — shell rear tray",
+      "description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell rear tray.stl'. Carries the self-tapping M3 holes for both lids.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "f4bc36015be125fe42a7027f667c3e3a8db46efe7e588000beb38ef1face83ec",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
+      "id": "meanwell-psu-housing-shell-front",
+      "uid": "1h8p",
+      "name": "PSU housing — shell front module",
+      "description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell front module.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "942fdcbb41979c057a8e2fb77fc7bbb69439284c76182f973eea802497ecfa9c",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
+      "id": "meanwell-psu-housing-lid-rear",
+      "uid": "m26o",
+      "name": "PSU housing — lid rear",
+      "description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid rear.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "83f226b5531d7eae5310e53213eaa63ba3bc49996d7b43dc71e661be3b614706",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
+      "id": "meanwell-psu-housing-lid-front",
+      "uid": "avux",
+      "name": "PSU housing — lid front",
+      "description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid front.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "126a70b01f4e677d0187902ad886ad4e310de50174889cb725b6edc8b46b0db0",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
+      "id": "meanwell-psu-housing-front-panel",
+      "uid": "n1oh",
+      "name": "PSU housing — front panel",
+      "description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - front panel.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "69dae822bcaf92f97b84be2b482a138e57b704db4104ab6440dbee550168964f",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
       "id": "scr-m3-tbd",
       "uid": "1kgy",
       "kind": "cots",
@@ -5476,6 +5634,61 @@
           "part": "scr-m4-6-cs",
           "qty": 4
         }
+      ],
+      "candidates": [
+        {
+          "uid": "1d0t",
+          "name": "Meanwell 24V PSU housing",
+          "created_at": "2026-08-22",
+          "message": "A five-piece printed housing around the supply in place of the three plates screwed to its own case. The Meanwell bolts into the shell rear tray on four [[hw:scr-m4-12-cs]]; the rear lid closes onto the tray with four [[hw:scr-m3-8-cs]] and the front lid spans the joint with four more, two into the rear tray and two into the shell front module; the front panel carries the mains inlet and simply slots into the front module, held by the front lid. Being test-printed; may become the next version, and renames this assembly if it does.",
+          "joining": [
+            {
+              "method": "self-tap",
+              "note": "Every [[hw:scr-m3-8-cs]] here cuts its own thread -- the tapping holes are in the printed shell parts, not the lids, and there are no inserts."
+            }
+          ],
+          "images": [
+            {
+              "url": "https://img.basically.website/parts/img/meanwell-psu-housing-v2-render-1fd60da3.png",
+              "alt": "Onshape render of the v2 PSU housing, closed and mounted on a 2020 extrusion",
+              "caption": "The v2 housing closed: vented rear lid, front panel with the mains inlet, on its extrusion."
+            }
+          ],
+          "lines": [
+            {
+              "part": "meanwell-psu-housing-shell-rear",
+              "qty": 1
+            },
+            {
+              "part": "psu-24v-350w",
+              "qty": 1
+            },
+            {
+              "part": "scr-m4-12-cs",
+              "qty": 4
+            },
+            {
+              "part": "meanwell-psu-housing-shell-front",
+              "qty": 1
+            },
+            {
+              "part": "meanwell-psu-housing-front-panel",
+              "qty": 1
+            },
+            {
+              "part": "meanwell-psu-housing-lid-rear",
+              "qty": 1
+            },
+            {
+              "part": "meanwell-psu-housing-lid-front",
+              "qty": 1
+            },
+            {
+              "part": "scr-m3-8-cs",
+              "qty": 8
+            }
+          ]
+        }
       ]
     },
     {
@@ -6024,11 +6237,15 @@
       "uid": "u12m",
       "version": "1",
       "name": "Control board mount",
-      "description": "The basically Embedded Control Board standing off its bracket. The printed bracket is not in the parts registry yet.",
+      "description": "The basically Embedded Control Board standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
       "section": "electronics",
       "docs": "/hardware/electronics/installation/control-board-mount/",
-      "status": "stub",
+      "status": "partial",
       "lines": [
+        {
+          "part": "ctrl-board-extrusion-mount",
+          "qty": 1
+        },
         {
           "part": "ctrl-board-basically",
           "qty": 1
@@ -6044,6 +6261,14 @@
         {
           "part": "standoff-m3-10mm",
           "qty": 4
+        },
+        {
+          "part": "fan-bracket-40mm",
+          "qty": 1
+        },
+        {
+          "part": "fan-40mm-24v",
+          "qty": 1
         }
       ],
       "candidates": [
@@ -6113,6 +6338,13 @@
             }
           ]
         }
+      ],
+      "images": [
+        {
+          "url": "https://img.basically.website/parts/img/ctrl-board-mount-v1-render-d7411f58.png",
+          "alt": "Onshape render of the control board's v1 extrusion mount and fan bracket",
+          "caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
+        }
       ]
     },
     {
@@ -6120,11 +6352,15 @@
       "uid": "5vat",
       "version": "1",
       "name": "Orange Pi mount",
-      "description": "The Orange Pi 5 standing off its bracket. The printed bracket is not in the parts registry yet.",
+      "description": "The Orange Pi 5 standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
       "section": "electronics",
       "docs": "/hardware/electronics/installation/orange-pi-mount/",
-      "status": "stub",
+      "status": "partial",
       "lines": [
+        {
+          "part": "orange-pi-extrusion-mount",
+          "qty": 1
+        },
         {
           "part": "sbc-orange-pi-5",
           "qty": 1
@@ -6140,6 +6376,21 @@
         {
           "part": "standoff-m3-10mm",
           "qty": 4
+        },
+        {
+          "part": "fan-bracket-40mm",
+          "qty": 1
+        },
+        {
+          "part": "fan-40mm-24v",
+          "qty": 1
+        }
+      ],
+      "images": [
+        {
+          "url": "https://img.basically.website/parts/img/orange-pi-mount-v1-render-f5159489.png",
+          "alt": "Onshape render of the Orange Pi's v1 extrusion mount and fan bracket",
+          "caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -2421,7 +2421,7 @@
     {
       "id": "ctrl-board-housing-base",
       "uid": "204b",
-      "name": "Control board housing — base",
+      "name": "Control Board Housing — Base",
       "description": "Base of the basically Embedded Control Board housing. The board screws straight to it on four heat inserts and the cover screws down onto four more; no standoffs.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted. Eight standard M3 inserts (hsi-m3, RX-M3x5.7 -- Spencer said 'the long variant', which is this one relative to the short M3S): four under the board, four for the cover.",
       "version": "1",
@@ -2445,7 +2445,7 @@
     {
       "id": "ctrl-board-housing-cover",
       "uid": "ksh2",
-      "name": "Control board housing — cover",
+      "name": "Control Board Housing — Cover",
       "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 × 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 × 16 mm screws, and the plunger passes through it.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
@@ -2463,7 +2463,7 @@
     {
       "id": "ctrl-board-housing-plunger",
       "uid": "cljt",
-      "name": "Control board housing — plunger",
+      "name": "Control Board Housing — Plunger",
       "description": "Plunger that passes through the housing cover, held in by the plunger retainer.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
@@ -2481,7 +2481,7 @@
     {
       "id": "ctrl-board-housing-plunger-retainer",
       "uid": "g9sx",
-      "name": "Control board housing — plunger retainer",
+      "name": "Control Board Housing — Plunger Retainer",
       "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 × 8 mm countersunk screws.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted. Two countersunk holes either side of the plunger slot (counted off the STL).",
       "version": "1",
@@ -2499,7 +2499,7 @@
     {
       "id": "ctrl-board-extrusion-mount",
       "uid": "1d5n",
-      "name": "Control board extrusion mount",
+      "name": "Control Board Extrusion Mount",
       "description": "Plate the basically Embedded Control Board stands off, which bolts to the 2020 extrusion. The v1 mounting, in the machine today; the printed housing is the candidate that would replace it.",
       "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Named 'basically board v1-3 open air fan - basically PCB to extrusion mount.stl'.",
       "version": "1",
@@ -2520,7 +2520,7 @@
     {
       "id": "orange-pi-extrusion-mount",
       "uid": "nxh7",
-      "name": "Orange Pi extrusion mount",
+      "name": "Orange Pi Extrusion Mount",
       "description": "Plate the Orange Pi 5 stands off, which bolts to the 2020 extrusion. Same design as the control board's mount with the opening and bolt pattern changed for the Pi.",
       "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Named 'basically board v1-3 open air fan - Orange Pi 5 to extrusion mount.stl' (the zip's own prefix says 'basically board'; the part inside is the Pi's).",
       "version": "1",
@@ -2541,7 +2541,7 @@
     {
       "id": "fan-bracket-40mm",
       "uid": "3ufy",
-      "name": "40 mm fan bracket",
+      "name": "40 mm Fan Bracket",
       "description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
       "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Both zips carry a '40mm fan bracket.stl' -- Spencer: 'the fan bracket thing was identical on both'. The two files are NOT byte-identical (sha256 d4757b35... vs 7c3ea544...) but are the same solid: same 48x90x70 mm bounding box, same 7152 triangles, and the same volume to 7 significant figures (67894.9 mm3); no axis-aligned transform maps one onto the other, so it is one design re-exported at a different orientation. Exactly the case the uid model is for: one uid, and whichever bytes we pin are that design's stl_hash. Pinned from the control board's zip.",
       "version": "1",
@@ -2562,7 +2562,7 @@
     {
       "id": "meanwell-psu-housing-shell-rear",
       "uid": "7qz3",
-      "name": "PSU housing — shell rear tray",
+      "name": "PSU Housing — Shell Rear Tray",
       "description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell rear tray.stl'. Carries the self-tapping M3 holes for both lids.",
       "version": "1",
@@ -2581,7 +2581,7 @@
     {
       "id": "meanwell-psu-housing-shell-front",
       "uid": "1h8p",
-      "name": "PSU housing — shell front module",
+      "name": "PSU Housing — Shell Front Module",
       "description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell front module.stl'.",
       "version": "1",
@@ -2600,7 +2600,7 @@
     {
       "id": "meanwell-psu-housing-lid-rear",
       "uid": "m26o",
-      "name": "PSU housing — lid rear",
+      "name": "PSU Housing — Lid Rear",
       "description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid rear.stl'.",
       "version": "1",
@@ -2619,7 +2619,7 @@
     {
       "id": "meanwell-psu-housing-lid-front",
       "uid": "avux",
-      "name": "PSU housing — lid front",
+      "name": "PSU Housing — Lid Front",
       "description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid front.stl'.",
       "version": "1",
@@ -2638,7 +2638,7 @@
     {
       "id": "meanwell-psu-housing-front-panel",
       "uid": "n1oh",
-      "name": "PSU housing — front panel",
+      "name": "PSU Housing — Front Panel",
       "description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - front panel.stl'.",
       "version": "1",
@@ -5638,7 +5638,7 @@
       "candidates": [
         {
           "uid": "1d0t",
-          "name": "Meanwell 24V PSU housing",
+          "name": "Meanwell 24V PSU Housing",
           "created_at": "2026-08-22",
           "message": "A five-piece printed housing around the supply in place of the three plates screwed to its own case. The Meanwell bolts into the shell rear tray on four [[hw:scr-m4-12-cs]]; the rear lid closes onto the tray with four [[hw:scr-m3-8-cs]] and the front lid spans the joint with four more, two into the rear tray and two into the shell front module; the front panel carries the mains inlet and simply slots into the front module, held by the front lid. Being test-printed; may become the next version, and renames this assembly if it does.",
           "joining": [
@@ -6274,7 +6274,7 @@
       "candidates": [
         {
           "uid": "rns2",
-          "name": "basically Embedded Control Board housing",
+          "name": "basically Embedded Control Board Housing",
           "created_at": "2026-08-22",
           "message": "A printed housing in place of the bracket and standoffs. The board screws straight to the base on four [[hw:hsi-m3]] with four [[hw:scr-m3-shcs-tbd]]; the cover closes onto four more inserts in the base with four [[hw:scr-m3-12-cs]] and carries a 40 mm 24 V fan; a plunger through the cover is held in by the plunger retainer on two [[hw:scr-m3-8-cs]]. Being test-printed; may become the next version, and renames this assembly if it does.",
           "joining": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -11,8 +11,8 @@
 		"density_g_cm3": 1.32,
 		"cost_per_kg": 24.99,
 		"commit_base_url": "https://github.com/basicallysource/sorter-v2/commit/",
-		"all_parts_zip": "https://img.basically.website/parts/bundle/all-parts-70099fd1.zip",
-		"all_parts_plain_zip": "https://img.basically.website/parts/bundle/all-parts-plain-eee4ad8e.zip"
+		"all_parts_zip": "https://img.basically.website/parts/bundle/all-parts-88a99646.zip",
+		"all_parts_plain_zip": "https://img.basically.website/parts/bundle/all-parts-plain-21d78499.zip"
 	},
 	"sections": [
 		{
@@ -762,6 +762,61 @@
 					"part": "scr-m4-6-cs",
 					"qty": 4
 				}
+			],
+			"candidates": [
+				{
+					"uid": "1d0t",
+					"name": "Meanwell 24V PSU housing",
+					"created_at": "2026-08-22",
+					"message": "A five-piece printed housing around the supply in place of the three plates screwed to its own case. The Meanwell bolts into the shell rear tray on four [[hw:scr-m4-12-cs]]; the rear lid closes onto the tray with four [[hw:scr-m3-8-cs]] and the front lid spans the joint with four more, two into the rear tray and two into the shell front module; the front panel carries the mains inlet and simply slots into the front module, held by the front lid. Being test-printed; may become the next version, and renames this assembly if it does.",
+					"joining": [
+						{
+							"method": "self-tap",
+							"note": "Every [[hw:scr-m3-8-cs]] here cuts its own thread -- the tapping holes are in the printed shell parts, not the lids, and there are no inserts."
+						}
+					],
+					"images": [
+						{
+							"url": "https://img.basically.website/parts/img/meanwell-psu-housing-v2-render-1fd60da3.png",
+							"alt": "Onshape render of the v2 PSU housing, closed and mounted on a 2020 extrusion",
+							"caption": "The v2 housing closed: vented rear lid, front panel with the mains inlet, on its extrusion."
+						}
+					],
+					"lines": [
+						{
+							"part": "meanwell-psu-housing-shell-rear",
+							"qty": 1
+						},
+						{
+							"part": "psu-24v-350w",
+							"qty": 1
+						},
+						{
+							"part": "scr-m4-12-cs",
+							"qty": 4
+						},
+						{
+							"part": "meanwell-psu-housing-shell-front",
+							"qty": 1
+						},
+						{
+							"part": "meanwell-psu-housing-front-panel",
+							"qty": 1
+						},
+						{
+							"part": "meanwell-psu-housing-lid-rear",
+							"qty": 1
+						},
+						{
+							"part": "meanwell-psu-housing-lid-front",
+							"qty": 1
+						},
+						{
+							"part": "scr-m3-8-cs",
+							"qty": 8
+						}
+					]
+				}
 			]
 		},
 		{
@@ -1310,11 +1365,15 @@
 			"uid": "u12m",
 			"version": "1",
 			"name": "Control board mount",
-			"description": "The basically Embedded Control Board standing off its bracket. The printed bracket is not in the parts registry yet.",
+			"description": "The basically Embedded Control Board standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
 			"section": "electronics",
 			"docs": "/hardware/electronics/installation/control-board-mount/",
-			"status": "stub",
+			"status": "partial",
 			"lines": [
+				{
+					"part": "ctrl-board-extrusion-mount",
+					"qty": 1
+				},
 				{
 					"part": "ctrl-board-basically",
 					"qty": 1
@@ -1330,6 +1389,14 @@
 				{
 					"part": "standoff-m3-10mm",
 					"qty": 4
+				},
+				{
+					"part": "fan-bracket-40mm",
+					"qty": 1
+				},
+				{
+					"part": "fan-40mm-24v",
+					"qty": 1
 				}
 			],
 			"candidates": [
@@ -1399,6 +1466,13 @@
 						}
 					]
 				}
+			],
+			"images": [
+				{
+					"url": "https://img.basically.website/parts/img/ctrl-board-mount-v1-render-d7411f58.png",
+					"alt": "Onshape render of the control board's v1 extrusion mount and fan bracket",
+					"caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
+				}
 			]
 		},
 		{
@@ -1406,11 +1480,15 @@
 			"uid": "5vat",
 			"version": "1",
 			"name": "Orange Pi mount",
-			"description": "The Orange Pi 5 standing off its bracket. The printed bracket is not in the parts registry yet.",
+			"description": "The Orange Pi 5 standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
 			"section": "electronics",
 			"docs": "/hardware/electronics/installation/orange-pi-mount/",
-			"status": "stub",
+			"status": "partial",
 			"lines": [
+				{
+					"part": "orange-pi-extrusion-mount",
+					"qty": 1
+				},
 				{
 					"part": "sbc-orange-pi-5",
 					"qty": 1
@@ -1426,6 +1504,21 @@
 				{
 					"part": "standoff-m3-10mm",
 					"qty": 4
+				},
+				{
+					"part": "fan-bracket-40mm",
+					"qty": 1
+				},
+				{
+					"part": "fan-40mm-24v",
+					"qty": 1
+				}
+			],
+			"images": [
+				{
+					"url": "https://img.basically.website/parts/img/orange-pi-mount-v1-render-f5159489.png",
+					"alt": "Onshape render of the Orange Pi's v1 extrusion mount and fan bracket",
+					"caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
 				}
 			]
 		},
@@ -11073,6 +11166,880 @@
 			"stl": "https://img.basically.website/parts/stl/ctrl-board-housing-plunger-retainer-g9sx-a3f84a1f.stl",
 			"render": "https://img.basically.website/parts/render/ctrl-board-housing-plunger-retainer-e543b945.png",
 			"stamped": []
+		},
+		{
+			"id": "ctrl-board-extrusion-mount",
+			"uid": "1d5n",
+			"name": "Control board extrusion mount",
+			"quantities": {
+				"electronics": 1
+			},
+			"assembly": "ctrl-board-mount",
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Plate the basically Embedded Control Board stands off, which bolts to the 2020 extrusion. The v1 mounting, in the machine today; the printed housing is the candidate that would replace it.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "1d5n",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/6e1da7cee8967d584080406f",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-f855b06c.stl",
+					"render": "https://img.basically.website/parts/render/ctrl-board-extrusion-mount-d9e570a6.png",
+					"grams": 32.58
+				}
+			],
+			"attributes": [],
+			"grams": 32.58,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3339,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-f855b06c.stl",
+			"render": "https://img.basically.website/parts/render/ctrl-board-extrusion-mount-d9e570a6.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-stamped-bottom-772743a4.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						124.22,
+						-4.84,
+						0.0
+					],
+					"size": [
+						12.1,
+						3.56
+					]
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-stamped-top-3e806cdb.stl",
+					"normal": [
+						0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						-17.07,
+						-4.84,
+						8.0
+					],
+					"size": [
+						12.1,
+						3.56
+					]
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-stamped-minus-y-side-921c15f1.stl",
+					"normal": [
+						-0.0,
+						-1.0,
+						0.0
+					],
+					"center": [
+						-16.37,
+						-8.0,
+						3.16
+					],
+					"size": [
+						12.1,
+						3.56
+					]
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-stamped-plus-y-side-0634aa9d.stl",
+					"normal": [
+						-0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						103.52,
+						128.0,
+						3.16
+					],
+					"size": [
+						12.1,
+						3.56
+					]
+				}
+			]
+		},
+		{
+			"id": "orange-pi-extrusion-mount",
+			"uid": "nxh7",
+			"name": "Orange Pi extrusion mount",
+			"quantities": {
+				"electronics": 1
+			},
+			"assembly": "orange-pi-mount",
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Plate the Orange Pi 5 stands off, which bolts to the 2020 extrusion. Same design as the control board's mount with the opening and bolt pattern changed for the Pi.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "nxh7",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/745c16803d318039967603f7",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-4832b406.stl",
+					"render": "https://img.basically.website/parts/render/orange-pi-extrusion-mount-fbabeb84.png",
+					"grams": 23.49
+				}
+			],
+			"attributes": [],
+			"grams": 23.49,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 2671,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-4832b406.stl",
+			"render": "https://img.basically.website/parts/render/orange-pi-extrusion-mount-fbabeb84.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-stamped-bottom-b22cd234.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						112.02,
+						-4.88,
+						0.0
+					],
+					"size": [
+						12.2,
+						3.5
+					]
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-stamped-top-21e7c631.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						-17.02,
+						-4.88,
+						8.0
+					],
+					"size": [
+						12.2,
+						3.5
+					]
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-stamped-minus-y-side-dd7500fc.stl",
+					"normal": [
+						0.0,
+						-1.0,
+						0.0
+					],
+					"center": [
+						-16.32,
+						-8.0,
+						3.12
+					],
+					"size": [
+						12.2,
+						3.5
+					]
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-stamped-plus-y-side-a48b059d.stl",
+					"normal": [
+						-0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						91.32,
+						64.0,
+						3.12
+					],
+					"size": [
+						12.2,
+						3.5
+					]
+				}
+			]
+		},
+		{
+			"id": "fan-bracket-40mm",
+			"uid": "3ufy",
+			"name": "40 mm fan bracket",
+			"quantities": {
+				"electronics": 2
+			},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "3ufy",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/6e1da7cee8967d584080406f",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-d4757b35.stl",
+					"render": "https://img.basically.website/parts/render/fan-bracket-40mm-acca133f.png",
+					"grams": 27.34
+				}
+			],
+			"attributes": [],
+			"grams": 27.34,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 4396,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-d4757b35.stl",
+			"render": "https://img.basically.website/parts/render/fan-bracket-40mm-acca133f.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-stamped-bottom-e46be2a1.stl",
+					"normal": [
+						-0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						68.91,
+						-15.84,
+						-0.0
+					],
+					"size": [
+						12.57,
+						3.56
+					]
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-stamped-minus-y-side-89a347bd.stl",
+					"normal": [
+						0.0,
+						-1.0,
+						0.0
+					],
+					"center": [
+						38.24,
+						-20.0,
+						65.84
+					],
+					"size": [
+						12.57,
+						3.56
+					]
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-stamped-top-7e2cb9e3.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						38.24,
+						-15.84,
+						70.0
+					],
+					"size": [
+						12.57,
+						3.56
+					]
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-stamped-plus-y-side-b430fa09.stl",
+					"normal": [
+						0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						68.91,
+						-8.0,
+						42.84
+					],
+					"size": [
+						12.57,
+						3.56
+					]
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-shell-rear",
+			"uid": "7qz3",
+			"name": "PSU housing \u2014 shell rear tray",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "7qz3",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-f4bc3601.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-shell-rear-dbcabe40.png",
+					"grams": 207.01
+				}
+			],
+			"attributes": [],
+			"grams": 207.01,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 26626,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-f4bc3601.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-shell-rear-dbcabe40.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-stamped-bottom-e138db4a.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						7.46,
+						121.57,
+						-9.0
+					],
+					"size": [
+						12.18,
+						4.52
+					]
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-stamped-top-8491c2b0.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						23.46,
+						-1.37,
+						0.0
+					],
+					"size": [
+						12.18,
+						4.52
+					]
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-stamped-plus-y-side-be233f81.stl",
+					"normal": [
+						-0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						212.54,
+						126.0,
+						-4.57
+					],
+					"size": [
+						12.18,
+						4.52
+					]
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-stamped-minus-y-side-c5985a36.stl",
+					"normal": [
+						-0.0,
+						-1.0,
+						0.0
+					],
+					"center": [
+						7.46,
+						-11.0,
+						-4.57
+					],
+					"size": [
+						12.18,
+						4.52
+					]
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-shell-front",
+			"uid": "1h8p",
+			"name": "PSU housing \u2014 shell front module",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "1h8p",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-942fdcbb.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-shell-front-3ee222fa.png",
+					"grams": 56.13
+				}
+			],
+			"attributes": [],
+			"grams": 56.13,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 6676,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-942fdcbb.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-shell-front-3ee222fa.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-stamped-bottom-c042d4e0.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						-21.35,
+						44.4,
+						-9.0
+					],
+					"size": [
+						12.25,
+						3.56
+					]
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-stamped-top-b8ca71e8.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						-42.5,
+						116.84,
+						0.0
+					],
+					"size": [
+						12.25,
+						3.56
+					]
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-stamped-plus-y-side-8dea25aa.stl",
+					"normal": [
+						-0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						-7.7,
+						126.0,
+						-5.04
+					],
+					"size": [
+						12.25,
+						3.56
+					]
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-stamped-minus-y-side-e7b60828.stl",
+					"normal": [
+						-0.0,
+						-1.0,
+						-0.0
+					],
+					"center": [
+						-44.8,
+						-11.0,
+						42.84
+					],
+					"size": [
+						12.25,
+						3.56
+					]
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-lid-rear",
+			"uid": "m26o",
+			"name": "PSU housing \u2014 lid rear",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "m26o",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-rear-m26o-83f226b5.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-lid-rear-94f18cfc.png",
+					"grams": 37.27
+				}
+			],
+			"attributes": [],
+			"grams": 37.27,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3979,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-rear-m26o-83f226b5.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-lid-rear-94f18cfc.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-rear-m26o-stamped-bottom-4a8feebd.stl",
+					"normal": [
+						0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						117.56,
+						-7.81,
+						46.2
+					],
+					"size": [
+						12.37,
+						3.63
+					]
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-rear-m26o-stamped-top-afc23a17.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						118.36,
+						-7.01,
+						50.2
+					],
+					"size": [
+						12.37,
+						3.63
+					]
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-lid-front",
+			"uid": "avux",
+			"name": "PSU housing \u2014 lid front",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "avux",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-front-avux-126a70b0.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-lid-front-5480c80f.png",
+					"grams": 59.08
+				}
+			],
+			"attributes": [],
+			"grams": 59.08,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3969,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-front-avux-126a70b0.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-lid-front-5480c80f.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-front-avux-stamped-bottom-eacd61c0.stl",
+					"normal": [
+						0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						102.06,
+						-7.84,
+						46.2
+					],
+					"size": [
+						12.74,
+						3.56
+					]
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-front-avux-stamped-top-613f5ec5.stl",
+					"normal": [
+						0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						101.26,
+						-7.04,
+						50.2
+					],
+					"size": [
+						12.74,
+						3.56
+					]
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-front-panel",
+			"uid": "n1oh",
+			"name": "PSU housing \u2014 front panel",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "n1oh",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-69dae822.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-front-panel-4aada3d4.png",
+					"grams": 15.7
+				}
+			],
+			"attributes": [],
+			"grams": 15.7,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3031,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-69dae822.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-front-panel-4aada3d4.png",
+			"stamped": [
+				{
+					"face": "+x side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-stamped-plus-x-side-d35582d2.stl",
+					"normal": [
+						1.0,
+						0.0,
+						0.0
+					],
+					"center": [
+						-50.2,
+						-0.53,
+						-0.81
+					],
+					"size": [
+						12.18,
+						3.63
+					]
+				},
+				{
+					"face": "-x side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-stamped-minus-x-side-321212f7.stl",
+					"normal": [
+						-1.0,
+						0.0,
+						0.0
+					],
+					"center": [
+						-55.1,
+						115.53,
+						-0.81
+					],
+					"size": [
+						12.18,
+						3.63
+					]
+				}
+			]
 		}
 	],
 	"plates": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -766,7 +766,7 @@
 			"candidates": [
 				{
 					"uid": "1d0t",
-					"name": "Meanwell 24V PSU housing",
+					"name": "Meanwell 24V PSU Housing",
 					"created_at": "2026-08-22",
 					"message": "A five-piece printed housing around the supply in place of the three plates screwed to its own case. The Meanwell bolts into the shell rear tray on four [[hw:scr-m4-12-cs]]; the rear lid closes onto the tray with four [[hw:scr-m3-8-cs]] and the front lid spans the joint with four more, two into the rear tray and two into the shell front module; the front panel carries the mains inlet and simply slots into the front module, held by the front lid. Being test-printed; may become the next version, and renames this assembly if it does.",
 					"joining": [
@@ -1402,7 +1402,7 @@
 			"candidates": [
 				{
 					"uid": "rns2",
-					"name": "basically Embedded Control Board housing",
+					"name": "basically Embedded Control Board Housing",
 					"created_at": "2026-08-22",
 					"message": "A printed housing in place of the bracket and standoffs. The board screws straight to the base on four [[hw:hsi-m3]] with four [[hw:scr-m3-shcs-tbd]]; the cover closes onto four more inserts in the base with four [[hw:scr-m3-12-cs]] and carries a 40 mm 24 V fan; a plunger through the cover is held in by the plunger retainer on two [[hw:scr-m3-8-cs]]. Being test-printed; may become the next version, and renames this assembly if it does.",
 					"joining": [
@@ -10827,7 +10827,7 @@
 		{
 			"id": "ctrl-board-housing-base",
 			"uid": "204b",
-			"name": "Control board housing \u2014 base",
+			"name": "Control Board Housing \u2014 Base",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -10953,7 +10953,7 @@
 		{
 			"id": "ctrl-board-housing-cover",
 			"uid": "ksh2",
-			"name": "Control board housing \u2014 cover",
+			"name": "Control Board Housing \u2014 Cover",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -11074,7 +11074,7 @@
 		{
 			"id": "ctrl-board-housing-plunger",
 			"uid": "cljt",
-			"name": "Control board housing \u2014 plunger",
+			"name": "Control Board Housing \u2014 Plunger",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -11122,7 +11122,7 @@
 		{
 			"id": "ctrl-board-housing-plunger-retainer",
 			"uid": "g9sx",
-			"name": "Control board housing \u2014 plunger retainer",
+			"name": "Control Board Housing \u2014 Plunger Retainer",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -11170,7 +11170,7 @@
 		{
 			"id": "ctrl-board-extrusion-mount",
 			"uid": "1d5n",
-			"name": "Control board extrusion mount",
+			"name": "Control Board Extrusion Mount",
 			"quantities": {
 				"electronics": 1
 			},
@@ -11294,7 +11294,7 @@
 		{
 			"id": "orange-pi-extrusion-mount",
 			"uid": "nxh7",
-			"name": "Orange Pi extrusion mount",
+			"name": "Orange Pi Extrusion Mount",
 			"quantities": {
 				"electronics": 1
 			},
@@ -11418,7 +11418,7 @@
 		{
 			"id": "fan-bracket-40mm",
 			"uid": "3ufy",
-			"name": "40 mm fan bracket",
+			"name": "40 mm Fan Bracket",
 			"quantities": {
 				"electronics": 2
 			},
@@ -11542,7 +11542,7 @@
 		{
 			"id": "meanwell-psu-housing-shell-rear",
 			"uid": "7qz3",
-			"name": "PSU housing \u2014 shell rear tray",
+			"name": "PSU Housing \u2014 Shell Rear Tray",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -11664,7 +11664,7 @@
 		{
 			"id": "meanwell-psu-housing-shell-front",
 			"uid": "1h8p",
-			"name": "PSU housing \u2014 shell front module",
+			"name": "PSU Housing \u2014 Shell Front Module",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -11786,7 +11786,7 @@
 		{
 			"id": "meanwell-psu-housing-lid-rear",
 			"uid": "m26o",
-			"name": "PSU housing \u2014 lid rear",
+			"name": "PSU Housing \u2014 Lid Rear",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -11872,7 +11872,7 @@
 		{
 			"id": "meanwell-psu-housing-lid-front",
 			"uid": "avux",
-			"name": "PSU housing \u2014 lid front",
+			"name": "PSU Housing \u2014 Lid Front",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -11958,7 +11958,7 @@
 		{
 			"id": "meanwell-psu-housing-front-panel",
 			"uid": "n1oh",
-			"name": "PSU housing \u2014 front panel",
+			"name": "PSU Housing \u2014 Front Panel",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,


### PR DESCRIPTION
Cut from `engrave` (#376), not `main`, so the diff reads clean on top of the uid stamp. **Base it back onto whatever `engrave` becomes before merging** — the only file that will conflict is `catalog.generated.json`, and the resolution is to re-run the generator, never a hand-merge.

## The v1 board mounts were never in the registry

`ctrl-board-mount` and `orange-pi-mount` were both `stub`, with descriptions that said so out loud. Now they carry their real parts:

| part | uid | g |
|---|---|---|
| Control board extrusion mount | `1d5n` | 33 |
| Orange Pi extrusion mount | `nxh7` | 24 |
| 40 mm fan bracket | `3ufy` | 27 |

The fan bracket is **one part used twice**, and it is a good exhibit for the uid model. Each zip ships a `40mm fan bracket.stl` and the two files are *not* byte-identical — but they have the same bounding box (48×90×70), the same 7152 triangles, and the same volume to seven significant figures (67894.9 mm³), with no axis-aligned transform mapping one onto the other. That is one design re-exported at a different orientation: **one uid, and whichever bytes we pin are that design's `stl_hash`.**

**Neither assembly's version moves.** Filling in a stub records what v1 has always physically been — a version marks a change to the thing, not to how completely we wrote it down. Both go `stub` → `partial`, because the screws are still `scr-m3-tbd` and the extrusion fixings aren't recorded.

## The PSU housing as an assembly candidate

`meanwell-psu-box` keeps v1 exactly as it is — the three plates screwed to the supply's own case, still the build — and gains candidate `1d0t`, "Meanwell 24V PSU housing", which renames the assembly if it is ever promoted.

Five printed parts, all with **empty `quantities`**: in no section, out of the all-parts bundle (89 members, up exactly 3 for the mounts), each still with its own `/part/<id>` page.

| part | uid | g |
|---|---|---|
| shell rear tray | `7qz3` | 207 |
| shell front module | `1h8p` | 56 |
| lid rear | `m26o` | 37 |
| lid front | `avux` | 59 |
| front panel | `n1oh` | 16 |

Fastening, as specified: supply into the shell rear tray on 4× `scr-m4-12-cs`; rear lid into the tray on 4× self-tapping `scr-m3-8-cs`; front lid 4× more of the same, two into the tray and two into the front module; front panel slots into the front module with no fasteners and the front lid traps it. Tapping holes are in the shell parts, recorded as a `self-tap` joining note.

## Assumptions

- The fan on the v1 mounts is the existing `fan-40mm-24v`. The bracket is a 40 mm fan bracket and that is the only 40 mm fan in the catalog; nobody said it is the 24 V one.
- The fan bracket's `assembly` back-pointer is `null`, because that legacy field holds one id and this part is in two assemblies. Another argument for the dashboard grouping from `lines` instead.

## Verified

575 bucket URLs serve real bytes; `check_generated_pins` agrees across 98 parts; svelte-check 0 errors; production build clean. Generated diff removes only the two stub descriptions and the bundle URL.

## Demo run of the promotion, and what it turned up

I promoted candidate `1d0t` to `meanwell-psu-box` v2 for real on a throwaway branch — moved the lines and uid up, bumped the version, gave the 5 parts quantities, deleted the candidate — committed it, and ran `stamp_versions.py`. It works:

```
  meanwell-psu-box v2 -> 832213ac

 v1 uid=skg6 commit=5a2d1c0
     meanwell-psu-back-mount x1 -> 15uh
     meanwell-psu-connections x1 -> 08id
     meanwell-psu-cap x1 -> 5nt1
     psu-24v-350w x1 -> s3ru
     scr-m4-6-cs x4 -> 5r29
```

v1 got its uid and a full line snapshot with each member pinned to the uid it had that day — the box as built then reads back part by part. **That branch is deleted; nothing here is promoted.**

The run turned up one defect, fixed in the second commit: the entry for the version being *introduced* read back `uid: null`. Only superseded entries get a uid written into `parts.json`, so the current revision was the only one without one. Parts already dodge this via `normalize_versions()`; `normalize_assemblies()` is the same fix on the same seam. No-op on today's data, so the generated file is byte-identical — verified at 0 lines of diff.

## Naming

Every part in this wave was named off the phrasing in chat, which is how `40 mm fan bracket` ended up as a page heading reading like a sentence fragment. All 12 are Title Case now — including the four control board housing parts from #375, so the two housings do not disagree with each other — as are both assembly candidate names. `basically` stays lowercase (company name, as in the existing basically Embedded Control Board) and unit symbols stay lowercase (`40 mm`). No id, uid or hash moves; the generated diff is 14 name lines and nothing else.

The older catalog is mostly sentence case (`Chute core`, `PSU back mount`) with a few Title Case outliers already (`Chute Stepper Idler Gear Bearing Retainer — Outer`). Worth one sweep to settle it, but not in this PR.

## Rebased onto engrave

On top of `c98b0541`. As predicted the only conflict was `catalog.generated.json`, resolved by re-running the generator against the new `generate.py`, not by hand.
