### PR TITLE
docs: output gear to rotor is M3 × 12, not M3 × 8

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -8,7 +8,7 @@ kicker: Feeder — C-Channel
 lede: The C-channel stage itself.
 permalink: /hardware/assembly/feeder/c-channel/
 author: spencer
-contributors: [barthel, brickcyclealice]
+contributors: [barthel, brickcyclealice, christoph]
 warning: >-
   **Steps 1 to 5 come from a build**, the order of operations and the photographs are
   BrickCycleAlice's. Step 6, the light post, is still an AI-generated first draft written
@@ -37,11 +37,9 @@ parts_needed:
   - part: brg-608-2rs
     qty: 1
   - part: scr-m3-12-cs
-    qty: 4
+    qty: 10
   - part: scr-m3-16-shcs
     qty: 3
-  - part: scr-m3-8-cs
-    qty: 6
   - part: scr-m3-8-shcs
     qty: 1
 ---
@@ -69,7 +67,9 @@ Both are press fits. No screws, no adhesive, no heat.
 
 {% include step.html n="2" title="Bolt the output gear to the rotor" %}
 
-Bolt the Output gear onto the underside of the rotor with 6 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, one at the outer end of each spoke, seated flush in the countersinks. The six holes are 60° apart on a 90 mm bolt circle, so the gear only goes on one way up.
+Bolt the Output gear onto the underside of the rotor with 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, one at the outer end of each spoke, seated flush in the countersinks. The six holes are 60° apart on a 90 mm bolt circle, so the gear only goes on one way up.
+
+**Use the 12 mm, not the 8 mm.** The gear is 8 mm thick at the bolt circle, and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush in the countersink finishes level with the top of the gear and never enters the rotor at all. The 12 mm leaves 4 mm of thread in the rotor's 5 mm flange and stops short of breaking through the far side.
 
 <figure>
   <img class="doc-figure" src="https://img.basically.website/web/assembly/c-channel/output-gear-bolted-to-rotor.71754b0d6ad3bd9a.jpg" alt="The grey 130-tooth output gear with a black-sealed 6806 bearing pressed into its centre, bolted onto a white rotor behind it, with a countersunk screw at the outer end of each of the six spokes">

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5842,7 +5842,7 @@
       "uid": "mttx",
       "version": "1",
       "name": "C-channel drive",
-      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Screw joints: 4 × [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 × [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 × [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 × [[hw:scr-m3-8-cs]] attach the output gear to the rotor, one per spoke (the light post's 2 × [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Screw joints: 4 × [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 × [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 × [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 × [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke — the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing (the light post's 2 × [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
       "status": "partial",
       "lines": [
@@ -5876,11 +5876,7 @@
         },
         {
           "part": "scr-m3-12-cs",
-          "qty": 4
-        },
-        {
-          "part": "scr-m3-8-cs",
-          "qty": 6
+          "qty": 10
         },
         {
           "part": "scr-m3-8-shcs",


### PR DESCRIPTION
Requested by aleph1111/christoph (@aleph1111_christoph) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1540821273972572240): "me again and scres. can you check https://docs.basically.website/hardware/assembly/feeder/c-channel/ Step 2 Bolt the output gear to the rotor mentions m3x8 csk screws. The gear itself is roughly 8mm high, so the crews dont even reach out. I used m3x12mm now to attach the gear to the rotor."

He is right, and the STLs agree exactly.

**Measured** off the pinned `output-gear` and `rotor-faceted` STLs, which are in shared assembly coordinates:

- Output gear spans z −11.00 to −3.00, so it is **8.00 mm thick at the bolt circle**.
- Its six holes are Ø3.40 clearance with a 90° countersink on the underside: Ø6.50 mouth at z −11, 1.55 mm deep.
- The rotor's bottom face is at z −3.00 and its six Ø2.80 thread-forming holes run z −3.00 to +2.00, i.e. **5.00 mm of flange**.
- The two hole sets are coaxial at R 89.98, 60° apart.

A countersunk screw's length is measured **over the head**, so an M3 × 8 seated flush at z −11 ends at z −3.00: dead level with the gear's top face, zero engagement in the rotor. An M3 × 12 ends at z +1.00, giving **4.0 mm of thread in the rotor** and stopping 1 mm short of breaking through the far side. M3 × 12 is the right screw.

**Changes**

- `docs/.../feeder/c-channel.md` — step 2 inline fastener 8 → 12 mm, plus a short note on why the 8 does not work; `parts_needed` drops `scr-m3-8-cs` ×6 and `scr-m3-12-cs` goes 4 → 10; christoph added to `contributors`.
- `parts-calculator/catalog/parts.json` — same swap on the `c-channel` assembly lines and in its description.

**Checks:** `npm run build` clean in `docs/`, `npm run check` clean in `parts-calculator/`, `validate_frontmatter.py` shows the same 5 pre-existing errors as main, `validate_images.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
