### PR TITLE
parts-calculator: an id names one thing

### DIFF
--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -940,6 +940,16 @@ def main():
     duplicate_uids = sorted({x for x in uids if uids.count(x) > 1})
     if duplicate_uids:
         sys.exit(f"duplicate uid(s): {duplicate_uids} -- mint a fresh one")
+    # An id names exactly one thing. A line says `part:` or `assembly:` so a
+    # collision still resolves there, but getPart(id)/getAssembly(id) do not
+    # take a kind, and a planned change targeting `parts` and `assemblies` by
+    # the same string is two different targets wearing one name. Keep the two
+    # namespaces disjoint (2026-08-22: `light-post` and `camera-extension`
+    # were each both, and became `-assembly` on the assembly side).
+    collisions = sorted(set(part_ids) & {a["id"] for a in manifest.get("assemblies", [])})
+    if collisions:
+        sys.exit(f"id(s) used by both a part and an assembly: {collisions} -- "
+                 f"rename the assembly (e.g. '<id>-assembly')")
     check_assemblies(manifest, set(part_ids))
     check_images(manifest)
     if args.metadata_only:

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -87,7 +87,7 @@
           "camera-extension-mount"
         ],
         "assemblies": [
-          "camera-extension"
+          "camera-extension-assembly"
         ]
       }
     },
@@ -432,7 +432,7 @@
       "quantities": {
         "feeder": 2
       },
-      "assembly": "light-post",
+      "assembly": "light-post-assembly",
       "stl_hash": "4298d9e5383cef563903685c5ba8eb3f177793b7aa3555710a864e2a000660c9",
       "color": {
         "role": "feeder"
@@ -453,7 +453,7 @@
       "quantities": {
         "feeder": 2
       },
-      "assembly": "light-post",
+      "assembly": "light-post-assembly",
       "stl_hash": "8759618be4ccf9f764520921386a0eb1209733f15a9e34b673cd104265b3057a",
       "color": {
         "fixed": "ivory-white"
@@ -473,7 +473,7 @@
       "quantities": {
         "feeder": 2
       },
-      "assembly": "light-post",
+      "assembly": "light-post-assembly",
       "stl_hash": "230825d03733af289fdc5fbf3b28b59f2d4f4cbb1d87b9db9e640f3d8d0e4a34",
       "color": {
         "role": "feeder"
@@ -2038,7 +2038,7 @@
       "quantities": {
         "classification-channel": 1
       },
-      "assembly": "camera-extension",
+      "assembly": "camera-extension-assembly",
       "stl_hash": "1253c651918595ba46bfc57401c0b2b6aeb2893649fa6c0d4b92c486943deee4",
       "color": {
         "fixed": "ash-gray"
@@ -2079,7 +2079,7 @@
       "quantities": {
         "classification-channel": 1
       },
-      "assembly": "camera-extension",
+      "assembly": "camera-extension-assembly",
       "stl_hash": "a69def7f420a0ac70bcc1be0827d5cb9e46b322ea5dfa09fa075f746b5b7f6c8",
       "color": {
         "fixed": "ash-gray"
@@ -5240,7 +5240,7 @@
   ],
   "assemblies": [
     {
-      "id": "light-post",
+      "id": "light-post-assembly",
       "uid": "v06x",
       "version": "1",
       "name": "Light post",
@@ -5692,7 +5692,7 @@
       ]
     },
     {
-      "id": "camera-extension",
+      "id": "camera-extension-assembly",
       "uid": "dc2i",
       "version": "1",
       "name": "Camera extension",
@@ -5795,11 +5795,11 @@
           "qty": 1
         },
         {
-          "assembly": "camera-extension",
+          "assembly": "camera-extension-assembly",
           "qty": 1
         },
         {
-          "assembly": "light-post",
+          "assembly": "light-post-assembly",
           "qty": 2
         },
         {

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -101,7 +101,7 @@
 					"camera-extension-mount"
 				],
 				"assemblies": [
-					"camera-extension"
+					"camera-extension-assembly"
 				]
 			}
 		},
@@ -368,7 +368,7 @@
 	],
 	"assemblies": [
 		{
-			"id": "light-post",
+			"id": "light-post-assembly",
 			"uid": "v06x",
 			"version": "1",
 			"name": "Light post",
@@ -820,7 +820,7 @@
 			]
 		},
 		{
-			"id": "camera-extension",
+			"id": "camera-extension-assembly",
 			"uid": "dc2i",
 			"version": "1",
 			"name": "Camera extension",
@@ -923,11 +923,11 @@
 					"qty": 1
 				},
 				{
-					"assembly": "camera-extension",
+					"assembly": "camera-extension-assembly",
 					"qty": 1
 				},
 				{
-					"assembly": "light-post",
+					"assembly": "light-post-assembly",
 					"qty": 2
 				},
 				{
@@ -2155,7 +2155,7 @@
 			"quantities": {
 				"feeder": 2
 			},
-			"assembly": "light-post",
+			"assembly": "light-post-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -2205,7 +2205,7 @@
 			"quantities": {
 				"feeder": 2
 			},
-			"assembly": "light-post",
+			"assembly": "light-post-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -2292,7 +2292,7 @@
 			"quantities": {
 				"feeder": 2
 			},
-			"assembly": "light-post",
+			"assembly": "light-post-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -8965,7 +8965,7 @@
 			"quantities": {
 				"classification-channel": 1
 			},
-			"assembly": "camera-extension",
+			"assembly": "camera-extension-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -9026,7 +9026,7 @@
 			"quantities": {
 				"classification-channel": 1
 			},
-			"assembly": "camera-extension",
+			"assembly": "camera-extension-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,


### PR DESCRIPTION
Stacked on #377 (which is itself on `engrave`), because it edits the same `parts.json` and would conflict otherwise. Happy to fold it into #377 instead if the stack is more trouble than the separation is worth.

`light-post` and `camera-extension` were each **simultaneously a printed part and an assembly**. A line survives it, because a line says `part:` or `assembly:` explicitly. Nothing else does:

- `getPart(id)` and `getAssembly(id)` take no kind, so any code resolving a bare id is a coin flip.
- The `improve-camera-extension` planned change listed the same string under `targets.parts` **and** `targets.assemblies` — two different targets wearing one name, indistinguishable in the data.

The assembly side takes the suffix, since the part is the thing people search for:

| was | now |
|---|---|
| assembly `light-post` | `light-post-assembly` |
| assembly `camera-extension` | `camera-extension-assembly` |

Ten references move: the two ids, two `feeder` lines, five per-part back-pointers, one change target. The **parts keep their ids**, and every `part:` line still points at the part. The docs paths are unaffected — they are site URLs, not catalog ids.

## Enforcement

`generate.py` now refuses a manifest whose part ids and assembly ids intersect, and the error names the fix:

```
id(s) used by both a part and an assembly: ['light-post'] -- rename the assembly (e.g. '<id>-assembly')
```

Verified by putting the collision back and running it.

## Verified

svelte-check 0 errors, production build clean, and the generated diff is 14 lines, every one of them an id rename and nothing else.
