### PR TITLE
docs: stator's four bracket holes are Ø2.4 and need opening to 2.8

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -56,7 +56,7 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 {% include step.html n="1" title="Preparation" %}
 
-**No heat inserts on this assembly.** Every screw here threads straight into a printed part, except the three that go into the stepper's own tapped holes. That is how one was built, and the part STLs agree: the rotor's six holes are Ø2.8 mm and the stator's are Ø2.4 and Ø2.8 mm, all thread-forming, while the NEMA bracket and the output gear are Ø3.4 mm clearance throughout with nothing threaded in them.
+**No heat inserts on this assembly.** Every screw here threads straight into a printed part, except the three that go into the stepper's own tapped holes. That is how one was built, and the part STLs agree: the rotor's six holes are Ø2.8 mm and the stator's are Ø2.4 and Ø2.8 mm, all thread-forming (the four Ø2.4 need opening out before they will take a screw, see step 5), while the NEMA bracket and the output gear are Ø3.4 mm clearance throughout with nothing threaded in them.
 
 **Press both bearings into their gears first**, while the parts are loose and you can support them on the bench.
 
@@ -101,6 +101,11 @@ Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3"
 {% include step.html n="5" title="Mount the stator, then drop in the rotor" %}
 
 Fasten the NEMA bracket to the underside of the stator with 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>Drill these four holes in the stator out to 2.8 mm first.</b> They are modelled at Ø2.4 mm, which is under an M3's 2.46 mm thread root, and a printed hole comes out smaller again, so the screw has to cut a full-depth thread through 10 mm of plastic. It will cam out or split the boss before it goes in. Every other M3 thread-forming hole on this assembly, including the other four in the same stator, is Ø2.8 mm, so open these to match (a 2.8 mm bit, or 7/64"). With 10 mm of engagement there is no loss of holding power.</p>
+</div>
 
 Then lower the rotor, output gear and all, onto the raised hub in the middle of the bracket, so the 130T comes down into mesh with the idler.
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -313,6 +313,7 @@
       "name": "Stator",
       "description": "Feeder stator. 4 required: 1 gray + 3 black.",
       "internal_notes": "One per C-channel area. 1 gray, 3 black. Required. ~240mm disc (bed-max).",
+      "info": "The four holes the NEMA bracket screws into are modelled at \u00d82.4 mm, under an M3's 2.46 mm thread root, so an M3 will not thread into 10 mm of them as printed. Drill those four out to 2.8 mm, matching the other four thread-forming holes in the same part, before assembly.",
       "version": "1",
       "created_at": "2026-06-27",
       "updated_at": "2026-06-27",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1127,7 +1127,7 @@
 			"uid": "mttx",
 			"version": "1",
 			"name": "C-channel drive",
-			"description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-8-cs]] attach the output gear to the rotor, one per spoke (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+			"description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke \u2014 the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
 			"docs": "/hardware/assembly/feeder/c-channel/",
 			"status": "partial",
 			"lines": [
@@ -1161,11 +1161,7 @@
 				},
 				{
 					"part": "scr-m3-12-cs",
-					"qty": 4
-				},
-				{
-					"part": "scr-m3-8-cs",
-					"qty": 6
+					"qty": 10
 				},
 				{
 					"part": "scr-m3-8-shcs",
@@ -1577,7 +1573,7 @@
 			},
 			"optional": false,
 			"onshape": null,
-			"info": null,
+			"info": "The four holes the NEMA bracket screws into are modelled at \u00d82.4 mm, under an M3's 2.46 mm thread root, so an M3 will not thread into 10 mm of them as printed. Drill those four out to 2.8 mm, matching the other four thread-forming holes in the same part, before assembly.",
 			"low_tolerance": false,
 			"low_tolerance_note": null,
 			"layer_scope": "all",


### PR DESCRIPTION
christoph reported that the M3s will not screw into the stator where the NEMA bracket bolts on, and that the holes look small. They are.

Measured off the published stator STL (`stator-n6bm-323b2d1f`), cylinder fitting over the mesh:

- The four holes the bracket lands in: **Ø2.40 mm, 10 mm deep**, thread-forming.
- The other four holes in the same stator: **Ø2.80 mm**.
- The NEMA bracket's four Ø3.40 clearance holes sit on exactly those four Ø2.40 centres (`111.4, 5.7` / `-67.0, 89.2` / `-13.7, -110.9` / `-76.4, -81.5`), so these are definitely the bracket screws' holes.

M3's minor diameter is 2.459 mm, so Ø2.40 is below the thread root before printing tolerance takes anything off it. The screw has to cut a full-depth thread through 10 mm of plastic, which is why it cams out or splits the boss instead of going in. Ø2.8 is what every other M3 thread-forming hole on this assembly uses (rotor, light post, and the other four in this same part), so opening these four to 2.8 mm makes the part internally consistent and still leaves 10 mm of engagement.

This is a note for builders, not a fix. The Ø2.4 looks like a slip in the CAD, since it is the odd one out inside its own part, and that lives in OnShape rather than in this repo.

Changes:

- **`docs/.../feeder/c-channel.md`** — warning callout at step 5 (where the bracket goes onto the stator) saying to drill the four holes to 2.8 mm first, and a pointer to it from the Preparation step, which already quoted the Ø2.4 figure without saying it was a problem.
- **`parts-calculator/catalog/parts.json`** — `info` note on the `stator` part with the same instruction.
- **`catalog.generated.json`** — regenerated with `catalog/generate.py --metadata-only`. It also picks up the `scr-m3-12-cs` / `scr-m3-8-cs` change from #378, which landed in `parts.json` on main but had not been regenerated there.

Requested by aleph1111/christoph (@aleph1111_christoph) [from Discord](https://discord.com/channels/1430279849171222682/1487518366020276397/1540834146656592002): "can you check the diameter on the stator holes that the nema bracket should screw into? on the nema they look like m3, but i cant screw them into the stator as printed, and they look very small."

request: https://discord.com/channels/1430279849171222682/1487518366020276397/1540834146656592002
