### PR TITLE
parts-calculator: what to print, as a count, and a manifest that says so

### DIFF
--- a/parts-calculator/src/lib/config.ts
+++ b/parts-calculator/src/lib/config.ts
@@ -13,7 +13,12 @@ export const CONFIG_KEY = 'sorter-filament-config-v1';
 export type StoredConfig = {
 	printBins: boolean;
 	surplus: number;
-	selected: Record<string, boolean>;
+	/** Parts whose printed count has been edited away from what the machine
+	 *  needs, id -> count (0 = not printing it). Absent means "follow the
+	 *  machine", so a new part in the catalog needs no migration. */
+	qty: Record<string, number>;
+	/** v1's per-part checkbox. Read once and folded into `qty`, never written. */
+	selected?: Record<string, boolean>;
 	inclSupport: Record<string, boolean>;
 };
 

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -808,10 +808,35 @@ export function effectiveGrams(part: Part, inclSupport: boolean): number {
 /** Group the SELECTED parts' filament by resolved color, with bulk-tier pricing.
  *  `inclSupport(id)` decides whether a part's support material counts.
  *  `surplusPct` adds a buffer (incidental parts / failed prints) before spool counts. */
+/** Split `total` across `weights` as whole units, keeping the proportions and
+ *  summing to exactly `total` (largest remainder). Used when a part's printed
+ *  quantity has been edited away from what the machine needs and its colours
+ *  have to follow: 3 of 4 charcoal and 1 of 4 white, asked for 2, is 2 and 0
+ *  rather than a fractional spool. */
+export function apportion(weights: number[], total: number): number[] {
+	const sum = weights.reduce((a, b) => a + b, 0);
+	if (total <= 0 || weights.length === 0) return weights.map(() => 0);
+	if (sum <= 0) return weights.map((_, i) => (i === 0 ? total : 0));
+	const exact = weights.map((w) => (w / sum) * total);
+	const out = exact.map(Math.floor);
+	let left = total - out.reduce((a, b) => a + b, 0);
+	// hand the remainder to the largest fractional parts first
+	const order = exact
+		.map((v, i) => ({ i, frac: v - Math.floor(v) }))
+		.sort((a, b) => b.frac - a.frac);
+	for (const { i } of order) {
+		if (left <= 0) break;
+		out[i] += 1;
+		left -= 1;
+	}
+	return out;
+}
+
 export function buyList(
 	layers: number,
 	roleColors: Record<string, string>,
-	isSelected: (id: string) => boolean,
+	/** How many of this part are actually being printed (0 = not printing it). */
+	qtyOf: (id: string) => number,
 	inclSupport: (id: string) => boolean,
 	variantCount: (id: string) => number | null,
 	surplusPct = 0
@@ -824,24 +849,22 @@ export function buyList(
 } {
 	const byColor = new Map<string, number>();
 	for (const part of PARTS) {
-		if (!isSelected(part.id)) continue;
+		const want = qtyOf(part.id);
+		if (want <= 0) continue;
 		const each = effectiveGrams(part, inclSupport(part.id));
 		const vc = variantCount(part.id);
-		if (vc !== null) {
-			// variant part (e.g. funnel): total machine count chosen per layer
-			for (const u of colorUnits(part, vc, roleColors)) {
-				const key = u.colorId ?? '__any__';
-				byColor.set(key, (byColor.get(key) ?? 0) + each * u.count);
-			}
-			continue;
-		}
-		for (const [cat, qty] of Object.entries(part.quantities)) {
-			const mult = effectiveMult(part, cat, layers);
-			for (const u of colorUnits(part, qty, roleColors, cat)) {
-				const key = u.colorId ?? '__any__';
-				byColor.set(key, (byColor.get(key) ?? 0) + each * u.count * mult);
-			}
-		}
+		// The colour split is authored per machine, so scale it to whatever is
+		// actually being printed. Unedited, this is the identity.
+		const units =
+			vc !== null ? colorUnits(part, vc, roleColors) : machineColorUnits(part, layers, roleColors);
+		const counts = apportion(
+			units.map((u) => u.count),
+			want
+		);
+		units.forEach((u, i) => {
+			const key = u.colorId ?? '__any__';
+			byColor.set(key, (byColor.get(key) ?? 0) + each * counts[i]);
+		});
 	}
 	const buffer = 1 + surplusPct / 100;
 	const rows = [...byColor.entries()].map(([key, raw]) => {

--- a/parts-calculator/src/lib/manifest.ts
+++ b/parts-calculator/src/lib/manifest.ts
@@ -1,0 +1,95 @@
+/**
+ * The print manifest: what to print, how many of each, and which file is which.
+ *
+ * It is written as plain aligned text rather than CSV on purpose, because its
+ * main home is inside the STL zip, where the reader is a person who has just
+ * unzipped forty files named `<part>-<uid>-<hash8>.stl` and wants to know what
+ * they are and how many to run. It doubles as the record of a build: the uid
+ * on each line is the exact design revision, so a manifest kept next to a
+ * finished machine still says what went into it.
+ */
+import { SETTINGS, type Part } from './filament';
+import type { ExportSpec } from './csv';
+
+export type ManifestRow = {
+	part: Part;
+	qty: number;
+	/** Machine-required count, when it differs from `qty` (an edited quantity). */
+	defaultQty: number;
+	gramsEach: number;
+	colorName: string;
+	/** Basename of the STL as it appears in the zip. */
+	file: string;
+	/** Assemblies this part goes into, for the "used in" note. */
+	usedIn: string[];
+};
+
+const pad = (s: string, n: number) => (s.length >= n ? s : s + ' '.repeat(n - s.length));
+const padL = (s: string, n: number) => (s.length >= n ? s : ' '.repeat(n - s.length) + s);
+
+/** Aligned, human-first. Returns the whole file body. */
+export function printManifest(rows: ManifestRow[], spec: ExportSpec, layerSizes: string[]): string {
+	const live = rows.filter((r) => r.qty > 0).sort((a, b) => a.part.name.localeCompare(b.part.name));
+
+	const nameW = Math.max(4, ...live.map((r) => r.part.name.length));
+	const colorW = Math.max(5, ...live.map((r) => r.colorName.length));
+
+	const head = [
+		'Sorter V2 — print manifest',
+		`Generated ${spec.date} · release ${spec.release} · ${spec.layers} layer${spec.layers === 1 ? '' : 's'} (${layerSizes.join(', ')})`,
+		`${SETTINGS.printer} · ${SETTINGS.process} · ${SETTINGS.infill_density} ${SETTINGS.infill_pattern.replace('adaptivecubic', 'adaptive cubic')} · ${SETTINGS.filament}`,
+		''
+	];
+
+	const columns =
+		`${padL('QTY', 4)}  ${pad('PART', nameW)}  ${pad('UID', 4)}  ${padL('EACH', 7)}  ${padL('TOTAL', 8)}  ${pad('COLOR', colorW)}  FILE`;
+
+	const body = live.map((r) => {
+		const total = r.gramsEach * r.qty;
+		return (
+			`${padL(String(r.qty), 4)}  ${pad(r.part.name, nameW)}  ${pad(r.part.uid, 4)}  ` +
+			`${padL(`${r.gramsEach.toFixed(0)} g`, 7)}  ${padL(`${total.toFixed(0)} g`, 8)}  ` +
+			`${pad(r.colorName, colorW)}  ${r.file}`
+		);
+	});
+
+	const pieces = live.reduce((n, r) => n + r.qty, 0);
+	const grams = live.reduce((n, r) => n + r.gramsEach * r.qty, 0);
+	const foot = [
+		'',
+		`${live.length} part${live.length === 1 ? '' : 's'} · ${pieces} piece${pieces === 1 ? '' : 's'} · ${(grams / 1000).toFixed(2)} kg of filament`
+	];
+
+	// Only worth saying when it happened: a quantity that is not the machine's.
+	const edited = live.filter((r) => r.qty !== r.defaultQty);
+	if (edited.length) {
+		foot.push(
+			'',
+			'Edited quantities (the machine calls for a different number):',
+			...edited.map((r) => `  ${r.part.name}: printing ${r.qty}, machine needs ${r.defaultQty}`)
+		);
+	}
+
+	// A shared part is the one thing a flat list cannot show, so say it here.
+	const shared = live.filter((r) => r.usedIn.length > 1);
+	if (shared.length) {
+		foot.push(
+			'',
+			'Used in more than one place:',
+			...shared.map((r) => `  ${r.part.name}: ${r.usedIn.join(', ')}`)
+		);
+	}
+
+	const missing = rows.filter((r) => r.qty <= 0);
+	if (missing.length) {
+		foot.push('', `Not printing (${missing.length}): ${missing.map((r) => r.part.name).join(', ')}`);
+	}
+
+	return [...head, columns, '─'.repeat(columns.length), ...body, ...foot, ''].join('\n');
+}
+
+/** Filename for the standalone download; the copy inside the zip is always
+ *  `print-manifest.txt` so it sorts to the top and is obvious. */
+export function manifestFilename(spec: ExportSpec): string {
+	return `sorter-${spec.release}-print-manifest-${spec.layers}-layer-${spec.date}.txt`;
+}

--- a/parts-calculator/src/lib/uses.ts
+++ b/parts-calculator/src/lib/uses.ts
@@ -1,0 +1,161 @@
+/**
+ * Where each printed part is actually used, and how many go there.
+ *
+ * A part is not a thing you print once. It is a thing you print N times because
+ * it is needed in N places, and those places are what you tick on and off when
+ * you decide what to put on a plate. This module turns the catalog into that
+ * list: one `PartUse` per (part, assembly) pair, carrying the count for the
+ * current layer configuration.
+ *
+ * Two sources have to be reconciled, because neither is complete on its own:
+ *
+ *   - `part.quantities` (section -> count) covers every part in the build and
+ *     is what the totals have always been computed from. It is authoritative
+ *     for HOW MANY.
+ *   - the assembly tree's `lines` say WHERE, and are the only thing that knows
+ *     a part is used in two different places. But the tree is still filling in:
+ *     as of 2026-08-22 it reaches 73 of the 89 build parts, and for five more
+ *     it reaches only some of the copies (frame-90deg-bracket is in both the
+ *     `layer` and `interface` sections; the tree has only the layer ones).
+ *
+ * So the tree supplies the grouping, the sections supply the number, and
+ * whatever the tree cannot account for becomes one explicit "not in the
+ * assembly tree yet" use rather than quietly going missing. The invariant that
+ * makes the UI safe to build on: **a part's uses always sum to exactly the
+ * quantity the machine needs.** Nothing can hide in the gap.
+ */
+import {
+	ASSEMBLIES,
+	PARTS,
+	getAssembly,
+	lineQty,
+	machineQty,
+	type Part
+} from './filament';
+
+/** The id used for the bucket holding copies the assembly tree doesn't explain. */
+export const UNTRACKED = '~untracked';
+
+export type PartUse = {
+	/** Stable across re-renders and safe as a persisted key. */
+	key: string;
+	partId: string;
+	/** The assembly that lists this part, or null for the untracked bucket. */
+	assemblyId: string | null;
+	assemblyName: string;
+	qty: number;
+};
+
+const useKey = (partId: string, assemblyId: string | null) =>
+	`${partId}@${assemblyId ?? UNTRACKED}`;
+
+/** Walk the machine tree, attributing each part to the assembly that directly lists
+ *  it, multiplied by how many of that assembly the machine has. */
+function treeCounts(layers: number): Map<string, Map<string, number>> {
+	const out = new Map<string, Map<string, number>>();
+	const seen = new Set<string>();
+	function walk(assemblyId: string, mult: number) {
+		// Guard against a cycle in authored data; a machine tree has none, but a
+		// typo could make one and an infinite walk is a blank page.
+		const guard = `${assemblyId}:${mult}`;
+		if (seen.has(guard)) return;
+		seen.add(guard);
+		const asm = getAssembly(assemblyId);
+		if (!asm) return;
+		for (const line of asm.lines ?? []) {
+			const n = lineQty(line, layers) * mult;
+			if (line.assembly) {
+				walk(line.assembly, n);
+			} else if (line.part) {
+				const per = out.get(line.part) ?? new Map<string, number>();
+				per.set(assemblyId, (per.get(assemblyId) ?? 0) + n);
+				out.set(line.part, per);
+			}
+		}
+	}
+	walk('machine', 1);
+	return out;
+}
+
+/**
+ * Every part's uses for this layer configuration, keyed by part id.
+ *
+ * `variantCount` is the page's per-layer override for parts whose count comes
+ * from the funnel/bin size choices rather than from a fixed per-section count.
+ * Parts with no sections at all (a candidate's parts, which are not in the
+ * build) get no uses, which is what keeps them off the dashboard.
+ */
+export function buildUses(
+	layers: number,
+	variantCount: (id: string) => number | null
+): Map<string, PartUse[]> {
+	const tree = treeCounts(layers);
+	const byPart = new Map<string, PartUse[]>();
+
+	for (const part of PARTS) {
+		if (!Object.keys(part.quantities).length) continue; // not in the build
+		const needed = variantCount(part.id) ?? machineQty(part, layers);
+		if (needed <= 0) continue;
+
+		const uses: PartUse[] = [];
+		let placed = 0;
+		for (const [assemblyId, qty] of tree.get(part.id) ?? []) {
+			// Never let the tree claim more copies than the machine needs; the
+			// sections are the authority on the number.
+			const take = Math.min(qty, needed - placed);
+			if (take <= 0) break;
+			uses.push({
+				key: useKey(part.id, assemblyId),
+				partId: part.id,
+				assemblyId,
+				assemblyName: getAssembly(assemblyId)?.name ?? assemblyId,
+				qty: take
+			});
+			placed += take;
+		}
+		if (placed < needed) {
+			uses.push({
+				key: useKey(part.id, null),
+				partId: part.id,
+				assemblyId: null,
+				assemblyName: 'Not in the assembly tree yet',
+				qty: needed - placed
+			});
+		}
+		byPart.set(part.id, uses);
+	}
+	return byPart;
+}
+
+/** Assemblies that appear as a use somewhere, in machine-tree order, so the
+ *  by-assembly view lists them the way the tree walks them. */
+export function assemblyOrder(): string[] {
+	const order: string[] = [];
+	const seen = new Set<string>();
+	function walk(id: string) {
+		if (seen.has(id)) return;
+		seen.add(id);
+		order.push(id);
+		for (const line of getAssembly(id)?.lines ?? []) {
+			if (line.assembly) walk(line.assembly);
+		}
+	}
+	walk('machine');
+	// anything authored but not reachable from `machine` still deserves a place
+	for (const a of ASSEMBLIES) if (!seen.has(a.id)) order.push(a.id);
+	return order;
+}
+
+/** Total copies of a part the machine needs — always the sum of its uses. */
+export function defaultQty(uses: PartUse[] | undefined): number {
+	return (uses ?? []).reduce((n, u) => n + u.qty, 0);
+}
+
+/** Which parts are used in more than one assembly — the marker in both views. */
+export function sharedParts(byPart: Map<string, PartUse[]>): Set<string> {
+	const shared = new Set<string>();
+	for (const [id, uses] of byPart) if (uses.length > 1) shared.add(id);
+	return shared;
+}
+
+export type { Part };

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -41,6 +41,8 @@
 	import BuildPlates from '$lib/components/BuildPlates.svelte';
 	import Seo from '$lib/components/Seo.svelte';
 	import { zipSync } from 'fflate';
+	import { buildUses, defaultQty as sumUses, sharedParts } from '$lib/uses';
+	import { printManifest, manifestFilename, type ManifestRow } from '$lib/manifest';
 	import { onMount } from 'svelte';
 	import { loadConfig, saveConfig, clearConfig } from '$lib/config';
 	import { layerStore, addLayer as addLayerStore, removeLayerAt, setSize, setSizes } from '$lib/layers.svelte';
@@ -56,8 +58,6 @@
 
 	// ---- defaults (also used by "reset to default") -----------------------------
 	const defaultFunnelSizes = (): ('third' | 'half')[] => ['third', 'third', 'half'];
-	const defaultSelected = () =>
-		Object.fromEntries(PARTS.map((p) => [p.id, !('bins' in p.quantities)]));
 	// only parts that *opt into* support (support_intentional) expose the toggle; they
 	// default to counting their support. Parts the slicer auto-forced support on are
 	// left out entirely — no toggle, no support in the totals.
@@ -75,15 +75,46 @@
 	}
 	// colours live in the shared store so the assembly tab sees the same choices
 	const roleColors = $derived(colorStore.roles);
-	let selected = $state<Record<string, boolean>>(defaultSelected());
+	// What to print, as a count. Only parts whose quantity has been EDITED away
+	// from what the machine needs live here; everything else follows the machine,
+	// so adding a part to the catalog doesn't need a migration. 0 means "not
+	// printing it", which is what the row checkbox writes.
+	let qtyOverride = $state<Record<string, number>>({});
+	let listView = $state<'assembly' | 'unique'>('assembly');
 	let surplus = $state(15);
 	let printBins = $state(false); // top-level: print bins or not (auto-selects the right bins)
 	const partsById = new Map(PARTS.map((p) => [p.id, p]));
-	// bins are governed by the printBins toggle (+ per-layer size); everything else by its checkbox
-	function isIncluded(id: string): boolean {
+	// How many the machine needs, before any editing. Bins are governed by the
+	// printBins toggle rather than a count, so they are 0 until it is on.
+	function machineNeeds(id: string): number {
 		const p = partsById.get(id);
-		if (p && 'bins' in p.quantities) return printBins;
-		return selected[id];
+		if (!p) return 0;
+		if ('bins' in p.quantities && !printBins) return 0;
+		return sumUses(uses.get(id));
+	}
+	/** How many are actually being printed. */
+	function qtyOf(id: string): number {
+		const over = qtyOverride[id];
+		return over === undefined ? machineNeeds(id) : Math.max(0, over);
+	}
+	function isEdited(id: string): boolean {
+		return qtyOverride[id] !== undefined && qtyOverride[id] !== machineNeeds(id);
+	}
+	function setQty(id: string, n: number) {
+		const clean = Math.max(0, Math.round(Number(n) || 0));
+		if (clean === machineNeeds(id)) delete qtyOverride[id];
+		else qtyOverride[id] = clean;
+	}
+	function resetQty(id: string) {
+		delete qtyOverride[id];
+	}
+	function isIncluded(id: string): boolean {
+		return qtyOf(id) > 0;
+	}
+	/** Scale a machine-wide figure to the quantity actually being printed. */
+	function qtyScale(id: string): number {
+		const need = machineNeeds(id);
+		return need > 0 ? qtyOf(id) / need : 0;
 	}
 	// include each part's support material in totals — default on for the stator only
 	let inclSupport = $state<Record<string, boolean>>(defaultInclSupport());
@@ -98,7 +129,10 @@
 			// roleColors is not read here — colors.svelte owns it (and migrates the old blob)
 			if (typeof c.printBins === 'boolean') printBins = c.printBins;
 			if (typeof c.surplus === 'number') surplus = c.surplus;
-			if (c.selected) selected = { ...selected, ...c.selected };
+			if (c.qty) qtyOverride = { ...c.qty };
+			// v1 stored a checkbox per part; a false becomes "print none of it".
+			else if (c.selected)
+				for (const [id, on] of Object.entries(c.selected)) if (!on) qtyOverride[id] = 0;
 			if (c.inclSupport) inclSupport = { ...inclSupport, ...c.inclSupport };
 		}
 		configLoaded = true;
@@ -145,13 +179,13 @@
 		if (target !== location.pathname + location.search) replaceState(target, {});
 	});
 	$effect(() => {
-		const snapshot = { printBins, surplus, selected, inclSupport };
+		const snapshot = { printBins, surplus, qty: qtyOverride, inclSupport };
 		if (configLoaded) saveConfig($state.snapshot(snapshot));
 	});
 	function resetToDefaults() {
 		setSizes(defaultFunnelSizes());
 		resetRoleColors();
-		selected = defaultSelected();
+		qtyOverride = {};
 		inclSupport = defaultInclSupport();
 		surplus = 15;
 		printBins = false;
@@ -197,6 +231,21 @@
 		}
 	}
 
+	// Every part's places-it-is-used, reconciled against the section quantities
+	// (see $lib/uses). The assembly tree supplies the grouping; anything it can't
+	// account for lands in an explicit bucket so the counts always add up.
+	const uses = $derived(buildUses(layers, variantCount));
+	const shared = $derived(sharedParts(uses));
+	function usedIn(id: string): string[] {
+		return (uses.get(id) ?? []).map((u) => u.assemblyName);
+	}
+	/** The assembly a part is filed under in the by-assembly view: the first one
+	 *  the machine tree walks into. A part used in several places is listed once,
+	 *  under the first, and carries a marker naming the others. */
+	function primaryAssembly(id: string): string | null {
+		return (uses.get(id) ?? []).find((u) => u.assemblyId)?.assemblyId ?? null;
+	}
+
 	// per-layer size 'half' = 12 bins, 'third' = 18 bins
 	const sizePreview = {
 		half: { count: 12, bins: ['bin-half-left', 'bin-half-right'], funnel: 'funnel-half' },
@@ -207,35 +256,44 @@
 	}
 
 	const buy = $derived(
-		buyList(layers, roleColors, isIncluded, supportOn, variantCount, surplus)
+		buyList(layers, roleColors, qtyOf, supportOn, variantCount, surplus)
 	);
 
 	// theoretical total print time: every included part printed alone, sequentially,
 	// on one printer (one part per plate — no batching)
 	const totalPrintSeconds = $derived(
-		PARTS.reduce((sum, p) => {
-			if (!isIncluded(p.id)) return sum;
-			const vc = variantCount(p.id);
-			const count = vc !== null ? vc : machineQty(p, layers);
-			return sum + p.print_seconds * count;
-		}, 0)
+		PARTS.reduce((sum, p) => sum + p.print_seconds * qtyOf(p.id), 0)
 	);
 
 	const sectionRows = $derived(
 		SECTIONS.map((s) => {
 			const parts = PARTS.filter((p) => sectionQty(p, s.id) > 0);
 			const mult = categoryMultiplier(s.id, layers);
-			const selectedGrams = parts
-				.filter((p) => isIncluded(p.id))
-				.reduce(
-					(sum, p) => sum + effectiveGrams(p, supportOn(p.id)) * displayCount(p, s.id, layers, variantCount),
-					0
-				);
+			const selectedGrams = parts.reduce(
+				(sum, p) =>
+					sum +
+					effectiveGrams(p, supportOn(p.id)) *
+						displayCount(p, s.id, layers, variantCount) *
+						qtyScale(p.id),
+				0
+			);
 			return { section: s, parts, mult, selectedGrams };
 		}).filter((r) => r.parts.length > 0)
 	);
 
 	const selectedParts = $derived(PARTS.filter((p) => isIncluded(p.id)));
+
+	// The flat view: every part in the build exactly once, alphabetical, with the
+	// count it is being printed at. Parts with no section (a candidate's parts)
+	// are not in the build and are not listed.
+	const uniqueRows = $derived(
+		PARTS.filter((p) => Object.keys(p.quantities).length > 0)
+			.map((p) => ({ p, qty: qtyOf(p.id), need: machineNeeds(p.id) }))
+			.sort((a, b) => a.p.name.localeCompare(b.p.name))
+	);
+	const uniqueGrams = $derived(
+		uniqueRows.reduce((sum, r) => sum + effectiveGrams(r.p, supportOn(r.p.id)) * r.qty, 0)
+	);
 
 	// CSV of what's selected: quantities, real sliced weights, resolved colours,
 	// and the permanent STL link, so the file is enough to print from.
@@ -256,7 +314,7 @@
 			})
 		);
 	}
-	const allSelected = $derived(PARTS.every((p) => selected[p.id]));
+	const allSelected = $derived(PARTS.every((p) => machineNeeds(p.id) === 0 || qtyOf(p.id) > 0));
 
 	const prettyPattern = SETTINGS.infill_pattern.replace('adaptivecubic', 'adaptive cubic');
 	const settingsRows: [string, string][] = [
@@ -269,7 +327,11 @@
 	];
 
 	function setAll(v: boolean) {
-		selected = Object.fromEntries(PARTS.map((p) => [p.id, v]));
+		for (const p of PARTS) {
+			if ('bins' in p.quantities) continue; // the printBins toggle owns these
+			if (v) resetQty(p.id);
+			else setQty(p.id, 0);
+		}
 	}
 
 	type Block =
@@ -278,21 +340,29 @@
 	function groupBlocks(parts: Part[], sectionId: string): Block[] {
 		const blocks: Block[] = [];
 		const represented = new Set<string>();
-		let cur: Extract<Block, { kind: 'group' }> | null = null;
+		// The assembly comes from the machine tree (which assembly LISTS this part),
+		// never from a field on the part: one part is used in several assemblies and
+		// a single field cannot say so. Members of a group need not be adjacent in
+		// the catalog, so a group is placed where its first member appears and the
+		// rest join it there.
+		const byGroup = new Map<string, Extract<Block, { kind: 'group' }>>();
 		for (const p of parts) {
-			const groupKind = p.folder ? 'folder' : p.assembly ? 'assembly' : null;
-			const groupId = p.folder ?? p.assembly;
-			if (groupKind && groupId) {
-				if (groupKind === 'assembly') represented.add(groupId);
-				if (!cur || cur.id !== groupId || cur.groupKind !== groupKind) {
-					cur = { kind: 'group', groupKind, id: groupId, parts: [] };
-					blocks.push(cur);
-				}
-				cur.parts.push(p);
-			} else {
-				cur = null;
+			const asmId = primaryAssembly(p.id);
+			const groupKind = p.folder ? 'folder' : asmId ? 'assembly' : null;
+			const groupId = p.folder ?? asmId;
+			if (!groupKind || !groupId) {
 				blocks.push({ kind: 'part', part: p });
+				continue;
 			}
+			if (groupKind === 'assembly') represented.add(groupId);
+			const key = `${groupKind}:${groupId}`;
+			let g = byGroup.get(key);
+			if (!g) {
+				g = { kind: 'group', groupKind, id: groupId, parts: [] };
+				byGroup.set(key, g);
+				blocks.push(g);
+			}
+			g.parts.push(p);
 		}
 		for (const assembly of ASSEMBLIES) {
 			if (assembly.section === sectionId && assembly.status === 'stub' && !represented.has(assembly.id)) {
@@ -313,7 +383,7 @@
 			(sum, p) =>
 				sum +
 				(isIncluded(p.id)
-					? effectiveGrams(p, supportOn(p.id)) * displayCount(p, sectionId, layers, variantCount)
+					? effectiveGrams(p, supportOn(p.id)) * displayCount(p, sectionId, layers, variantCount) * qtyScale(p.id)
 					: 0),
 			0
 		);
@@ -322,7 +392,11 @@
 	const asmSomeOn = (parts: Part[]) => parts.some((p) => isIncluded(p.id));
 	// bins are governed by the Print bins toggle, so the rollup checkbox skips them
 	function setAsm(parts: Part[], v: boolean) {
-		for (const p of parts) if (!('bins' in p.quantities)) selected[p.id] = v;
+		for (const p of parts) {
+			if ('bins' in p.quantities) continue;
+			if (v) resetQty(p.id);
+			else setQty(p.id, 0);
+		}
 	}
 
 	function openViewer(p: Part, seed?: { color?: string; version?: PartVersion | null }) {
@@ -337,6 +411,33 @@
 		if ((e.target as HTMLElement).closest('button, a, input, label, [role="tooltip"]')) return;
 		openViewer(p);
 	}
+	/** What to print, as rows: the same data the manifest and the zip both need. */
+	function manifestRows(parts: Part[]): ManifestRow[] {
+		return parts.map((p) => {
+			const url = partDownload(p, engraveIds);
+			const colorId = primaryColorId(p, roleColors);
+			return {
+				part: p,
+				qty: qtyOf(p.id),
+				defaultQty: machineNeeds(p.id),
+				gramsEach: effectiveGrams(p, supportOn(p.id)),
+				colorName: colorId ? (getBambuColor(colorId)?.name ?? colorId) : 'Any color',
+				file: url.slice(url.lastIndexOf('/') + 1),
+				usedIn: usedIn(p.id)
+			};
+		});
+	}
+	function downloadManifest() {
+		const spec = exportSpec(layers);
+		const body = printManifest(manifestRows(selectedParts), spec, funnelSizes);
+		const url = URL.createObjectURL(new Blob([body], { type: 'text/plain;charset=utf-8' }));
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = manifestFilename(spec);
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
 	async function downloadZip(parts: Part[], name: string) {
 		if (!parts.length) return;
 		zipping = true;
@@ -349,6 +450,11 @@
 				// so the id survives into whatever the slicer names the project
 				files[url.slice(url.lastIndexOf('/') + 1)] = new Uint8Array(await res.arrayBuffer());
 			}
+			// A zip of forty hash-named STLs says nothing about how many of each to
+			// run. The manifest rides along and answers exactly that.
+			files['print-manifest.txt'] = new TextEncoder().encode(
+				printManifest(manifestRows(parts), exportSpec(layers), funnelSizes)
+			);
 			const zipped = zipSync(files, { level: 6 });
 			const a = document.createElement('a');
 			a.href = URL.createObjectURL(new Blob([zipped as BlobPart], { type: 'application/zip' }));
@@ -475,7 +581,7 @@
 				{#if 'bins' in p.quantities}
 					<input class="setup-toggle h-4 w-4" type="checkbox" checked={printBins} onchange={() => (printBins = !printBins)} aria-label="Print bins (set in Build options)" title="Controlled by the Print bins toggle in Build options" />
 				{:else}
-					<input class="setup-toggle h-4 w-4" type="checkbox" bind:checked={selected[p.id]} aria-label="Select {p.name}" />
+					<input class="setup-toggle h-4 w-4" type="checkbox" checked={qtyOf(p.id) > 0} onchange={(e) => (e.currentTarget.checked ? resetQty(p.id) : setQty(p.id, 0))} aria-label="Print {p.name}" />
 				{/if}
 			</td>
 			<td class="pl-c-thumb">
@@ -492,6 +598,8 @@
 			<td class="pl-c-name">
 				<span class="pl-name">
 					{p.name}
+					{#if shared.has(p.id)}<span class="cursor-help border border-border px-1 text-xs text-text-muted" title="Also used in {usedIn(p.id).slice(1).join(', ')}">used in {usedIn(p.id).length} places</span>{/if}
+					{#if isEdited(p.id)}<span class="border border-primary/60 px-1 text-xs text-primary" title="Printing {qtyOf(p.id)}, the machine needs {machineNeeds(p.id)}">qty {qtyOf(p.id)}</span>{/if}
 					{#if p.optional}<Badge variant="warning">Optional</Badge>{/if}
 					{#if p.support_intentional}<Badge variant="info" title="Printed with support material — included in this part's grams">Supports</Badge>{/if}
 						{#if platesForPart(p.id).length}<button type="button" class="inline-flex items-center gap-0.5 border border-border px-1 text-xs text-text-muted hover:border-primary hover:text-primary" onclick={() => openPlatesModal(p.id)} title="Show plates with this part"><Layers3 size={11} /> {platesForPart(p.id).length} plate{platesForPart(p.id).length === 1 ? '' : 's'}</button>{/if}{#if os.version}<a href={os.version} target="_blank" rel="noopener" class="inline-flex items-center gap-0.5 border border-border px-1 text-xs text-text-muted hover:border-primary hover:text-primary" title="Open the exact OnShape version this STL came from">OnShape <ExternalLink size={11} /></a>{/if}{#if p.info}<Popover width="w-64" label="About {p.name}" text={p.info} />{/if}<ChangeStatus kind="parts" id={p.id} name={p.name} />{#if p.low_tolerance}<Popover width="w-72" label="Fit notes for {p.name}">{#snippet trigger({ toggle, open })}<Badge as="button" variant="warning" onclick={toggle} aria-expanded={open}><AlertTriangle size={11} /> Tight fit</Badge>{/snippet}<b class="text-text">Low tolerance.</b> This part has little room for dimensional error, so a test print is worth doing before you commit to the full set.{#if p.low_tolerance_note}<span class="mt-2 block border-t border-border pt-2 text-text">{p.low_tolerance_note}</span>{/if}</Popover>{/if}{#if p.attributes?.length}{#each p.attributes as a}<span class="border border-border bg-[var(--color-bg)] px-1 text-xs text-text-muted" title={a.label}>{a.label}: <span class="text-text">{a.value}</span></span>{/each}{/if}{#if p.versions && p.versions.length > 1}<Popover width="w-80" label="Version history for {p.name}">{#snippet trigger({ toggle, open })}<button type="button" onclick={toggle} aria-expanded={open} class="inline-flex items-center gap-0.5 border border-border px-1 text-xs text-text-muted hover:border-primary hover:text-primary" title="Version history"><History size={11} /> v{p.version} · {p.versions?.length ?? 0} versions</button>{/snippet}<b class="text-text">Version history</b><ul class="mt-1 space-y-2">{#each [...(p.versions ?? [])].reverse() as v}<li class="border-t border-border pt-2 first:border-t-0 first:pt-0"><div class="flex items-center gap-1.5 text-text"><b>v{v.version}</b><span class="text-text-muted">· {fmtDate(v.date)}</span>{#if commitUrl(v.commit)}<a href={commitUrl(v.commit)} target="_blank" rel="noopener" class="ml-auto inline-flex items-center gap-0.5 text-primary hover:text-primary-hover">{v.commit} <ExternalLink size={10} /></a>{:else}<span class="ml-auto italic text-text-muted/70">uncommitted</span>{/if}</div><div class="mt-0.5">{v.message}</div>{#if v.onshape_version}<div class="mt-1"><a href={v.onshape_version} target="_blank" rel="noopener" class="inline-flex items-center gap-0.5 text-primary hover:text-primary-hover">OnShape <ExternalLink size={10} /></a></div>{/if}</li>{/each}</ul></Popover>{/if}
@@ -548,6 +656,13 @@
 								>· {selectedParts.length ? `${selectedParts.length} selected` : `all ${PARTS.length}`}, {layers}
 								layers</span>
 						</button>
+						<button
+							class="ml-3 inline-flex items-center gap-1 text-primary hover:text-primary-hover"
+							onclick={downloadManifest}
+							title="What to print and how many of each, as plain text. The same file rides inside the STL zip."
+						>
+							<Download size={13} /> Manifest
+						</button>
 					</span>
 				{/if}
 			</div>
@@ -557,6 +672,98 @@
 					<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
 					<span class="shrink-0 font-semibold text-primary">View {CHANGES.length} changes →</span>
 				</a>
+				<div class="mb-4 flex flex-wrap items-center gap-2">
+					<div class="inline-flex border border-border">
+						<button
+							class="px-3 py-1.5 text-sm font-semibold {listView === 'assembly' ? 'bg-[var(--color-bg)] text-text' : 'text-text-muted hover:text-text'}"
+							onclick={() => (listView = 'assembly')}
+							aria-pressed={listView === 'assembly'}
+							title="Grouped by what bolts to what. A part used in several places is listed under the first and marked.">By assembly</button>
+						<button
+							class="border-l border-border px-3 py-1.5 text-sm font-semibold {listView === 'unique' ? 'bg-[var(--color-bg)] text-text' : 'text-text-muted hover:text-text'}"
+							onclick={() => (listView = 'unique')}
+							aria-pressed={listView === 'unique'}
+							title="Every part once, with the number you are printing. This is the list you print from.">By unique part</button>
+					</div>
+					<span class="text-xs text-text-muted">
+						{listView === 'assembly'
+							? 'Grouped by what bolts to what.'
+							: 'Every part once. Edit a quantity to print more or fewer than the machine needs.'}
+					</span>
+				</div>
+				{#if listView === 'unique'}
+					<div class="pl-scroll mb-6">
+						<table class="pl-tbl">
+							<thead>
+								<tr>
+									<th class="pl-c-thumb"></th>
+									<th class="pl-c-name">Part</th>
+									<th class="pl-c-each">Each</th>
+									<th class="pl-c-total">Qty</th>
+									<th class="pl-c-total">Total</th>
+									<th class="pl-c-dl"></th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each uniqueRows as { p, qty, need } (p.id)}
+									{@const each = effectiveGrams(p, supportOn(p.id))}
+									<tr class="pl-row group/row" class:opacity-50={qty === 0}>
+										<td class="pl-c-thumb">
+											<button type="button" class="pl-thumb group relative" onclick={() => openViewer(p)} title="View {p.name} in 3D">
+												<img src={p.render} alt={p.name} />
+												<span class="absolute inset-0 flex items-center justify-center bg-black/40 text-white opacity-0 transition-opacity group-hover:opacity-100"><ZoomIn size={16} /></span>
+											</button>
+										</td>
+										<td class="pl-c-name">
+											<span class="pl-name">
+												{p.name}
+												{#if shared.has(p.id)}<span class="cursor-help border border-border px-1 text-xs text-text-muted" title="Used in {usedIn(p.id).join(', ')}">used in {usedIn(p.id).length} places</span>{/if}
+												{#if p.optional}<Badge variant="warning">Optional</Badge>{/if}
+												<ChangeStatus kind="parts" id={p.id} name={p.name} />
+											</span>
+											<span class="pl-meta">{usedIn(p.id).join(' · ') || 'not placed yet'}</span>
+										</td>
+										<td class="pl-c-each">{grams(each)}</td>
+										<td class="pl-c-total">
+											<span class="inline-flex items-center gap-1">
+												<input
+													class="setup-control h-7 w-16 text-center text-sm"
+													type="number"
+													min="0"
+													value={qty}
+													aria-label="How many {p.name} to print"
+													onchange={(e) => setQty(p.id, e.currentTarget.valueAsNumber)}
+												/>
+												{#if isEdited(p.id)}
+													<button
+														type="button"
+														class="text-text-muted hover:text-primary"
+														onclick={() => resetQty(p.id)}
+														title="Back to {need}, what the machine needs"
+														aria-label="Reset {p.name} to {need}"><RotateCcw size={13} /></button>
+												{/if}
+											</span>
+										</td>
+										<td class="pl-c-total">{grams(each * qty)}</td>
+										<td class="pl-c-dl">
+											<a href={partDownload(p, engraveIds)} download class="text-text-muted hover:text-primary" title="Download {p.name}"><Download size={16} /></a>
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+							<tfoot>
+								<tr>
+									<td></td>
+									<td class="pl-c-name"><span class="pl-name">{uniqueRows.filter((r) => r.qty > 0).length} parts · {uniqueRows.reduce((n, r) => n + r.qty, 0)} pieces</span></td>
+									<td></td>
+									<td></td>
+									<td class="pl-c-total">{grams(uniqueGrams)}</td>
+									<td></td>
+								</tr>
+							</tfoot>
+						</table>
+					</div>
+				{:else}
 				{#each sectionRows as { section, parts, mult, selectedGrams } (section.id)}
 				<section class="pl-sec" id="section-{section.id}">
 					<h3 class="pl-sec-hd">
@@ -656,6 +863,7 @@
 					</div>
 				</section>
 			{/each}
+				{/if}
 			{:else}
 				<BuildPlates highlightPartId={null} />
 			{/if}


### PR DESCRIPTION
Stacked on #379. Structural option **B**: the assembly owns the relationship through its `lines`, the part stores nothing, and membership is derived.

## The bug, measured

The root list grouped parts by a single field on the part naming its assembly. **38 of 98 parts were filed wrong:**

| count | problem |
|---|---|
| 20 | loose at the bottom of a section, though the tree knows where they go (the stator, the NEMA bracket, the whole c-channel drive) |
| 10 | hidden inside a folder, so their assembly never showed |
| 4 | pointing at an assembly whose lines never mention them |
| 4 | used in two places, able to show in only one |

Grouping now comes from `lines`. `C-channel drive` went from an empty idea to holding Stator, Output gear, NEMA bracket, Idler gear and Input gear.

## Where the numbers come from

The tree cannot supply quantity: it reaches 73 of the 89 build parts and undercounts 5 more (`frame-90deg-bracket` is in both the `layer` and `interface` sections; the tree has only the layer copies). So `$lib/uses` reconciles them — **tree says where, sections say how many**, and whatever the tree cannot account for becomes one visible "not in the assembly tree yet" use.

The invariant the UI leans on: **a part's uses always sum to exactly what the machine needs.** Nothing can hide in the gap, and the gap is on screen rather than silent.

## Selection is a count now

A checkbox cannot say "one of the two fan brackets". A part defaults to what the machine needs and can be edited to anything including 0, and only *edited* counts persist — so a new part in the catalog needs no migration, and a v1 config's `false` folds into a `0`.

`buyList` takes a quantity instead of a boolean, with colour splits scaled by largest-remainder so an edited quantity never produces a fractional part.

## Two views

- **By assembly** — what bolts to what. Repeats are fine here per your call; a shared part is listed under the first assembly and carries a `used in 2 places` marker naming the others on hover.
- **By unique part** — every part once, editable quantity, reset icon back to the machine's number, running totals in the footer.

## The manifest

A zip of forty files named `<part>-<uid>-<hash8>.stl` says nothing about how many to run. `print-manifest.txt` now rides inside the zip and downloads on its own:

```
 QTY  PART                           UID      EACH     TOTAL  COLOR     FILE
────────────────────────────────────────────────────────────────────────────
   1  40 mm Fan Bracket              3ufy     27 g      27 g  Charcoal  fan-bracket-40mm-3ufy-d4757b35.stl
   4  NEMA bracket                   x09t     72 g     290 g  Charcoal  nema-bracket-x09t-8b2bea87.stl

4 parts · 10 pieces · 1.05 kg of filament

Edited quantities (the machine calls for a different number):
  40 mm Fan Bracket: printing 1, machine needs 2

Used in more than one place:
  40 mm Fan Bracket: Control board mount, Orange Pi mount
```

The uid on each line is the exact design revision, so a manifest kept beside a finished machine still says what went into it.

## Verified in a browser

Set the fan bracket to 1: its total went 55 g → 27 g, the footer went 361 → 360 pieces and 14.37 → 14.35 kg, and the reset offered "Back to 2, what the machine needs". 89 quantity boxes, one per build part, with the 9 candidate-only housing parts correctly absent. svelte-check 0 errors, production build clean.

## Not done

Per-use checkboxes in the by-assembly view. The quantity box covers the same ground and the checkbox stays a plain on/off, which is where I stopped.
