### PR TITLE
parts-calculator: the v1 mounts, a PSU candidate, and printing as a count

### DIFF
--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -158,6 +158,25 @@ def normalize_versions(part):
     return [entry]
 
 
+def normalize_assemblies(manifest):
+    """Assemblies pass through to the app as authored, with one fix-up: the
+    newest `versions` entry names the assembly's current uid, the way
+    normalize_versions() does it for a part. Only the SUPERSEDED entries carry
+    a uid in parts.json -- stamp_versions.py writes one there when a version is
+    replaced -- so without this the current revision reads back as uid null,
+    which is the one revision whose id is never in doubt."""
+    out = []
+    for asm in manifest.get("assemblies", []):
+        vs = asm.get("versions")
+        if vs and not vs[-1].get("uid"):
+            newest = vs[-1]
+            asm = dict(asm, versions=vs[:-1] + [{
+                "version": newest.get("version"), "uid": asm["uid"],
+                **{k: v for k, v in newest.items() if k != "version"}}])
+        out.append(asm)
+    return out
+
+
 def fetch_artifact(url, sha, dest):
     """Materialize a bucket object at dest, verifying its full sha256.
 
@@ -920,6 +939,16 @@ def main():
     duplicate_uids = sorted({x for x in uids if uids.count(x) > 1})
     if duplicate_uids:
         sys.exit(f"duplicate uid(s): {duplicate_uids} -- mint a fresh one")
+    # An id names exactly one thing. A line says `part:` or `assembly:` so a
+    # collision still resolves there, but getPart(id)/getAssembly(id) do not
+    # take a kind, and a planned change targeting `parts` and `assemblies` by
+    # the same string is two different targets wearing one name. Keep the two
+    # namespaces disjoint (2026-08-22: `light-post` and `camera-extension`
+    # were each both, and became `-assembly` on the assembly side).
+    collisions = sorted(set(part_ids) & {a["id"] for a in manifest.get("assemblies", [])})
+    if collisions:
+        sys.exit(f"id(s) used by both a part and an assembly: {collisions} -- "
+                 f"rename the assembly (e.g. '<id>-assembly')")
     check_assemblies(manifest, set(part_ids))
     check_images(manifest)
     if args.metadata_only:
@@ -1014,7 +1043,7 @@ def main():
         data["sections"] = manifest["sections"]
         data["changes"] = manifest.get("changes", [])
         data["folders"] = manifest.get("folders", [])
-        data["assemblies"] = manifest.get("assemblies", [])
+        data["assemblies"] = normalize_assemblies(manifest)
         data["hardware"] = build_hardware(manifest)
         data["families"] = build_families(manifest)
         data["lasercut"] = build_lasercut(manifest)
@@ -1196,7 +1225,7 @@ def main():
         "folders": manifest.get("folders", []),
         "color_roles": manifest["color_roles"],
         "families": families,
-        "assemblies": manifest.get("assemblies", []),
+        "assemblies": normalize_assemblies(manifest),
         "parts": out_parts,
         "plates": plates,
         "hardware": hardware,

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -87,7 +87,7 @@
           "camera-extension-mount"
         ],
         "assemblies": [
-          "camera-extension"
+          "camera-extension-assembly"
         ]
       }
     },
@@ -432,7 +432,7 @@
       "quantities": {
         "feeder": 2
       },
-      "assembly": "light-post",
+      "assembly": "light-post-assembly",
       "stl_hash": "4298d9e5383cef563903685c5ba8eb3f177793b7aa3555710a864e2a000660c9",
       "color": {
         "role": "feeder"
@@ -453,7 +453,7 @@
       "quantities": {
         "feeder": 2
       },
-      "assembly": "light-post",
+      "assembly": "light-post-assembly",
       "stl_hash": "8759618be4ccf9f764520921386a0eb1209733f15a9e34b673cd104265b3057a",
       "color": {
         "fixed": "ivory-white"
@@ -473,7 +473,7 @@
       "quantities": {
         "feeder": 2
       },
-      "assembly": "light-post",
+      "assembly": "light-post-assembly",
       "stl_hash": "230825d03733af289fdc5fbf3b28b59f2d4f4cbb1d87b9db9e640f3d8d0e4a34",
       "color": {
         "role": "feeder"
@@ -2048,7 +2048,7 @@
       "quantities": {
         "classification-channel": 1
       },
-      "assembly": "camera-extension",
+      "assembly": "camera-extension-assembly",
       "stl_hash": "c9cf562fd9a5b1f90bcdbbddb402b6bd7621e33b005c1c8a15d50ee6f7d9f524",
       "color": {
         "fixed": "ash-gray"
@@ -2089,7 +2089,7 @@
       "quantities": {
         "classification-channel": 1
       },
-      "assembly": "camera-extension",
+      "assembly": "camera-extension-assembly",
       "stl_hash": "a69def7f420a0ac70bcc1be0827d5cb9e46b322ea5dfa09fa075f746b5b7f6c8",
       "color": {
         "fixed": "ash-gray"
@@ -2431,7 +2431,7 @@
     {
       "id": "ctrl-board-housing-base",
       "uid": "204b",
-      "name": "Control board housing — base",
+      "name": "Control Board Housing — Base",
       "description": "Base of the basically Embedded Control Board housing. The board screws straight to it on four heat inserts and the cover screws down onto four more; no standoffs.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted. Eight standard M3 inserts (hsi-m3, RX-M3x5.7 -- Spencer said 'the long variant', which is this one relative to the short M3S): four under the board, four for the cover.",
       "version": "1",
@@ -2455,7 +2455,7 @@
     {
       "id": "ctrl-board-housing-cover",
       "uid": "ksh2",
-      "name": "Control board housing — cover",
+      "name": "Control Board Housing — Cover",
       "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 × 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 × 16 mm screws, and the plunger passes through it.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
@@ -2473,7 +2473,7 @@
     {
       "id": "ctrl-board-housing-plunger",
       "uid": "cljt",
-      "name": "Control board housing — plunger",
+      "name": "Control Board Housing — Plunger",
       "description": "Plunger that passes through the housing cover, held in by the plunger retainer.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
@@ -2491,7 +2491,7 @@
     {
       "id": "ctrl-board-housing-plunger-retainer",
       "uid": "g9sx",
-      "name": "Control board housing — plunger retainer",
+      "name": "Control Board Housing — Plunger Retainer",
       "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 × 8 mm countersunk screws.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted. Two countersunk holes either side of the plunger slot (counted off the STL).",
       "version": "1",
@@ -2505,6 +2505,164 @@
       },
       "optional": false,
       "support": false
+    },
+    {
+      "id": "ctrl-board-extrusion-mount",
+      "uid": "1d5n",
+      "name": "Control Board Extrusion Mount",
+      "description": "Plate the basically Embedded Control Board stands off, which bolts to the 2020 extrusion. The v1 mounting, in the machine today; the printed housing is the candidate that would replace it.",
+      "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Named 'basically board v1-3 open air fan - basically PCB to extrusion mount.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {
+        "electronics": 1
+      },
+      "assembly": "ctrl-board-mount",
+      "stl_hash": "f855b06c3b0f57fbd3756ebca08fa7e9a5aaf2f7c0b72d41c72ccb8cb5716873",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/6e1da7cee8967d584080406f"
+    },
+    {
+      "id": "orange-pi-extrusion-mount",
+      "uid": "nxh7",
+      "name": "Orange Pi Extrusion Mount",
+      "description": "Plate the Orange Pi 5 stands off, which bolts to the 2020 extrusion. Same design as the control board's mount with the opening and bolt pattern changed for the Pi.",
+      "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Named 'basically board v1-3 open air fan - Orange Pi 5 to extrusion mount.stl' (the zip's own prefix says 'basically board'; the part inside is the Pi's).",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {
+        "electronics": 1
+      },
+      "assembly": "orange-pi-mount",
+      "stl_hash": "4832b4065aef40589ccbe353e0e2214201f9ef5af1dd6c5df0af51fa079c4394",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/745c16803d318039967603f7"
+    },
+    {
+      "id": "fan-bracket-40mm",
+      "uid": "3ufy",
+      "name": "40 mm Fan Bracket",
+      "description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
+      "internal_notes": "From 'PCB Extrusion Mount (1).zip' (Sorter V2 STLs, 2026-08-22), a zip of two zips, one per board. Both zips carry a '40mm fan bracket.stl' -- Spencer: 'the fan bracket thing was identical on both'. The two files are NOT byte-identical (sha256 d4757b35... vs 7c3ea544...) but are the same solid: same 48x90x70 mm bounding box, same 7152 triangles, and the same volume to 7 significant figures (67894.9 mm3); no axis-aligned transform maps one onto the other, so it is one design re-exported at a different orientation. Exactly the case the uid model is for: one uid, and whichever bytes we pin are that design's stl_hash. Pinned from the control board's zip.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {
+        "electronics": 2
+      },
+      "assembly": null,
+      "stl_hash": "d4757b350b5690524838d0727a2e81c22135424104d47f4e102b73bbecdde995",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/6e1da7cee8967d584080406f"
+    },
+    {
+      "id": "meanwell-psu-housing-shell-rear",
+      "uid": "7qz3",
+      "name": "PSU Housing — Shell Rear Tray",
+      "description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell rear tray.stl'. Carries the self-tapping M3 holes for both lids.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "f4bc36015be125fe42a7027f667c3e3a8db46efe7e588000beb38ef1face83ec",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
+      "id": "meanwell-psu-housing-shell-front",
+      "uid": "1h8p",
+      "name": "PSU Housing — Shell Front Module",
+      "description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell front module.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "942fdcbb41979c057a8e2fb77fc7bbb69439284c76182f973eea802497ecfa9c",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
+      "id": "meanwell-psu-housing-lid-rear",
+      "uid": "m26o",
+      "name": "PSU Housing — Lid Rear",
+      "description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid rear.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "83f226b5531d7eae5310e53213eaa63ba3bc49996d7b43dc71e661be3b614706",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
+      "id": "meanwell-psu-housing-lid-front",
+      "uid": "avux",
+      "name": "PSU Housing — Lid Front",
+      "description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid front.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "126a70b01f4e677d0187902ad886ad4e310de50174889cb725b6edc8b46b0db0",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
+    },
+    {
+      "id": "meanwell-psu-housing-front-panel",
+      "uid": "n1oh",
+      "name": "PSU Housing — Front Panel",
+      "description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
+      "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - front panel.stl'.",
+      "version": "1",
+      "created_at": "2026-08-22",
+      "updated_at": "2026-08-22",
+      "quantities": {},
+      "assembly": null,
+      "stl_hash": "69dae822bcaf92f97b84be2b482a138e57b704db4104ab6440dbee550168964f",
+      "color": {
+        "role": "frame"
+      },
+      "optional": false,
+      "support": false,
+      "onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c"
     },
     {
       "id": "scr-m3-tbd",
@@ -5092,7 +5250,7 @@
   ],
   "assemblies": [
     {
-      "id": "light-post",
+      "id": "light-post-assembly",
       "uid": "v06x",
       "version": "1",
       "name": "Light post",
@@ -5486,10 +5644,65 @@
           "part": "scr-m4-6-cs",
           "qty": 4
         }
+      ],
+      "candidates": [
+        {
+          "uid": "1d0t",
+          "name": "Meanwell 24V PSU Housing",
+          "created_at": "2026-08-22",
+          "message": "A five-piece printed housing around the supply in place of the three plates screwed to its own case. The Meanwell bolts into the shell rear tray on four [[hw:scr-m4-12-cs]]; the rear lid closes onto the tray with four [[hw:scr-m3-8-cs]] and the front lid spans the joint with four more, two into the rear tray and two into the shell front module; the front panel carries the mains inlet and simply slots into the front module, held by the front lid. Being test-printed; may become the next version, and renames this assembly if it does.",
+          "joining": [
+            {
+              "method": "self-tap",
+              "note": "Every [[hw:scr-m3-8-cs]] here cuts its own thread -- the tapping holes are in the printed shell parts, not the lids, and there are no inserts."
+            }
+          ],
+          "images": [
+            {
+              "url": "https://img.basically.website/parts/img/meanwell-psu-housing-v2-render-1fd60da3.png",
+              "alt": "Onshape render of the v2 PSU housing, closed and mounted on a 2020 extrusion",
+              "caption": "The v2 housing closed: vented rear lid, front panel with the mains inlet, on its extrusion."
+            }
+          ],
+          "lines": [
+            {
+              "part": "meanwell-psu-housing-shell-rear",
+              "qty": 1
+            },
+            {
+              "part": "psu-24v-350w",
+              "qty": 1
+            },
+            {
+              "part": "scr-m4-12-cs",
+              "qty": 4
+            },
+            {
+              "part": "meanwell-psu-housing-shell-front",
+              "qty": 1
+            },
+            {
+              "part": "meanwell-psu-housing-front-panel",
+              "qty": 1
+            },
+            {
+              "part": "meanwell-psu-housing-lid-rear",
+              "qty": 1
+            },
+            {
+              "part": "meanwell-psu-housing-lid-front",
+              "qty": 1
+            },
+            {
+              "part": "scr-m3-8-cs",
+              "qty": 8
+            }
+          ]
+        }
       ]
     },
     {
-      "id": "camera-extension",
+      "id": "camera-extension-assembly",
       "uid": "dc2i",
       "version": "1",
       "name": "Camera extension",
@@ -5592,11 +5805,11 @@
           "qty": 1
         },
         {
-          "assembly": "camera-extension",
+          "assembly": "camera-extension-assembly",
           "qty": 1
         },
         {
-          "assembly": "light-post",
+          "assembly": "light-post-assembly",
           "qty": 2
         },
         {
@@ -6030,11 +6243,15 @@
       "uid": "u12m",
       "version": "1",
       "name": "Control board mount",
-      "description": "The basically Embedded Control Board standing off its bracket. The printed bracket is not in the parts registry yet.",
+      "description": "The basically Embedded Control Board standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
       "section": "electronics",
       "docs": "/hardware/electronics/installation/control-board-mount/",
-      "status": "stub",
+      "status": "partial",
       "lines": [
+        {
+          "part": "ctrl-board-extrusion-mount",
+          "qty": 1
+        },
         {
           "part": "ctrl-board-basically",
           "qty": 1
@@ -6050,12 +6267,20 @@
         {
           "part": "standoff-m3-10mm",
           "qty": 4
+        },
+        {
+          "part": "fan-bracket-40mm",
+          "qty": 1
+        },
+        {
+          "part": "fan-40mm-24v",
+          "qty": 1
         }
       ],
       "candidates": [
         {
           "uid": "rns2",
-          "name": "basically Embedded Control Board housing",
+          "name": "basically Embedded Control Board Housing",
           "created_at": "2026-08-22",
           "message": "A printed housing in place of the bracket and standoffs. The board screws straight to the base on four [[hw:hsi-m3]] with four [[hw:scr-m3-shcs-tbd]]; the cover closes onto four more inserts in the base with four [[hw:scr-m3-12-cs]] and carries a 40 mm 24 V fan; a plunger through the cover is held in by the plunger retainer on two [[hw:scr-m3-8-cs]]. Being test-printed; may become the next version, and renames this assembly if it does.",
           "joining": [
@@ -6119,6 +6344,13 @@
             }
           ]
         }
+      ],
+      "images": [
+        {
+          "url": "https://img.basically.website/parts/img/ctrl-board-mount-v1-render-d7411f58.png",
+          "alt": "Onshape render of the control board's v1 extrusion mount and fan bracket",
+          "caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
+        }
       ]
     },
     {
@@ -6126,11 +6358,15 @@
       "uid": "5vat",
       "version": "1",
       "name": "Orange Pi mount",
-      "description": "The Orange Pi 5 standing off its bracket. The printed bracket is not in the parts registry yet.",
+      "description": "The Orange Pi 5 standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
       "section": "electronics",
       "docs": "/hardware/electronics/installation/orange-pi-mount/",
-      "status": "stub",
+      "status": "partial",
       "lines": [
+        {
+          "part": "orange-pi-extrusion-mount",
+          "qty": 1
+        },
         {
           "part": "sbc-orange-pi-5",
           "qty": 1
@@ -6146,6 +6382,21 @@
         {
           "part": "standoff-m3-10mm",
           "qty": 4
+        },
+        {
+          "part": "fan-bracket-40mm",
+          "qty": 1
+        },
+        {
+          "part": "fan-40mm-24v",
+          "qty": 1
+        }
+      ],
+      "images": [
+        {
+          "url": "https://img.basically.website/parts/img/orange-pi-mount-v1-render-f5159489.png",
+          "alt": "Onshape render of the Orange Pi's v1 extrusion mount and fan bracket",
+          "caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
         }
       ]
     },

--- a/parts-calculator/src/lib/config.ts
+++ b/parts-calculator/src/lib/config.ts
@@ -13,7 +13,12 @@ export const CONFIG_KEY = 'sorter-filament-config-v1';
 export type StoredConfig = {
 	printBins: boolean;
 	surplus: number;
-	selected: Record<string, boolean>;
+	/** Parts whose printed count has been edited away from what the machine
+	 *  needs, id -> count (0 = not printing it). Absent means "follow the
+	 *  machine", so a new part in the catalog needs no migration. */
+	qty: Record<string, number>;
+	/** v1's per-part checkbox. Read once and folded into `qty`, never written. */
+	selected?: Record<string, boolean>;
 	inclSupport: Record<string, boolean>;
 };
 

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -11,8 +11,8 @@
 		"density_g_cm3": 1.32,
 		"cost_per_kg": 24.99,
 		"commit_base_url": "https://github.com/basicallysource/sorter-v2/commit/",
-		"all_parts_zip": "https://img.basically.website/parts/bundle/all-parts-d40cbfdd.zip",
-		"all_parts_plain_zip": "https://img.basically.website/parts/bundle/all-parts-plain-62f4820e.zip"
+		"all_parts_zip": "https://img.basically.website/parts/bundle/all-parts-003af578.zip",
+		"all_parts_plain_zip": "https://img.basically.website/parts/bundle/all-parts-plain-c7c76ca7.zip"
 	},
 	"sections": [
 		{
@@ -101,7 +101,7 @@
 					"camera-extension-mount"
 				],
 				"assemblies": [
-					"camera-extension"
+					"camera-extension-assembly"
 				]
 			}
 		},
@@ -368,7 +368,7 @@
 	],
 	"assemblies": [
 		{
-			"id": "light-post",
+			"id": "light-post-assembly",
 			"uid": "v06x",
 			"version": "1",
 			"name": "Light post",
@@ -762,10 +762,65 @@
 					"part": "scr-m4-6-cs",
 					"qty": 4
 				}
+			],
+			"candidates": [
+				{
+					"uid": "1d0t",
+					"name": "Meanwell 24V PSU Housing",
+					"created_at": "2026-08-22",
+					"message": "A five-piece printed housing around the supply in place of the three plates screwed to its own case. The Meanwell bolts into the shell rear tray on four [[hw:scr-m4-12-cs]]; the rear lid closes onto the tray with four [[hw:scr-m3-8-cs]] and the front lid spans the joint with four more, two into the rear tray and two into the shell front module; the front panel carries the mains inlet and simply slots into the front module, held by the front lid. Being test-printed; may become the next version, and renames this assembly if it does.",
+					"joining": [
+						{
+							"method": "self-tap",
+							"note": "Every [[hw:scr-m3-8-cs]] here cuts its own thread -- the tapping holes are in the printed shell parts, not the lids, and there are no inserts."
+						}
+					],
+					"images": [
+						{
+							"url": "https://img.basically.website/parts/img/meanwell-psu-housing-v2-render-1fd60da3.png",
+							"alt": "Onshape render of the v2 PSU housing, closed and mounted on a 2020 extrusion",
+							"caption": "The v2 housing closed: vented rear lid, front panel with the mains inlet, on its extrusion."
+						}
+					],
+					"lines": [
+						{
+							"part": "meanwell-psu-housing-shell-rear",
+							"qty": 1
+						},
+						{
+							"part": "psu-24v-350w",
+							"qty": 1
+						},
+						{
+							"part": "scr-m4-12-cs",
+							"qty": 4
+						},
+						{
+							"part": "meanwell-psu-housing-shell-front",
+							"qty": 1
+						},
+						{
+							"part": "meanwell-psu-housing-front-panel",
+							"qty": 1
+						},
+						{
+							"part": "meanwell-psu-housing-lid-rear",
+							"qty": 1
+						},
+						{
+							"part": "meanwell-psu-housing-lid-front",
+							"qty": 1
+						},
+						{
+							"part": "scr-m3-8-cs",
+							"qty": 8
+						}
+					]
+				}
 			]
 		},
 		{
-			"id": "camera-extension",
+			"id": "camera-extension-assembly",
 			"uid": "dc2i",
 			"version": "1",
 			"name": "Camera extension",
@@ -868,11 +923,11 @@
 					"qty": 1
 				},
 				{
-					"assembly": "camera-extension",
+					"assembly": "camera-extension-assembly",
 					"qty": 1
 				},
 				{
-					"assembly": "light-post",
+					"assembly": "light-post-assembly",
 					"qty": 2
 				},
 				{
@@ -1128,7 +1183,7 @@
 			"uid": "mttx",
 			"version": "1",
 			"name": "C-channel drive",
-			"description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-8-cs]] attach the output gear to the rotor, one per spoke (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+			"description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke \u2014 the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
 			"docs": "/hardware/assembly/feeder/c-channel/",
 			"status": "partial",
 			"lines": [
@@ -1162,11 +1217,7 @@
 				},
 				{
 					"part": "scr-m3-12-cs",
-					"qty": 4
-				},
-				{
-					"part": "scr-m3-8-cs",
-					"qty": 6
+					"qty": 10
 				},
 				{
 					"part": "scr-m3-8-shcs",
@@ -1310,11 +1361,15 @@
 			"uid": "u12m",
 			"version": "1",
 			"name": "Control board mount",
-			"description": "The basically Embedded Control Board standing off its bracket. The printed bracket is not in the parts registry yet.",
+			"description": "The basically Embedded Control Board standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
 			"section": "electronics",
 			"docs": "/hardware/electronics/installation/control-board-mount/",
-			"status": "stub",
+			"status": "partial",
 			"lines": [
+				{
+					"part": "ctrl-board-extrusion-mount",
+					"qty": 1
+				},
 				{
 					"part": "ctrl-board-basically",
 					"qty": 1
@@ -1330,12 +1385,20 @@
 				{
 					"part": "standoff-m3-10mm",
 					"qty": 4
+				},
+				{
+					"part": "fan-bracket-40mm",
+					"qty": 1
+				},
+				{
+					"part": "fan-40mm-24v",
+					"qty": 1
 				}
 			],
 			"candidates": [
 				{
 					"uid": "rns2",
-					"name": "basically Embedded Control Board housing",
+					"name": "basically Embedded Control Board Housing",
 					"created_at": "2026-08-22",
 					"message": "A printed housing in place of the bracket and standoffs. The board screws straight to the base on four [[hw:hsi-m3]] with four [[hw:scr-m3-shcs-tbd]]; the cover closes onto four more inserts in the base with four [[hw:scr-m3-12-cs]] and carries a 40 mm 24 V fan; a plunger through the cover is held in by the plunger retainer on two [[hw:scr-m3-8-cs]]. Being test-printed; may become the next version, and renames this assembly if it does.",
 					"joining": [
@@ -1399,6 +1462,13 @@
 						}
 					]
 				}
+			],
+			"images": [
+				{
+					"url": "https://img.basically.website/parts/img/ctrl-board-mount-v1-render-d7411f58.png",
+					"alt": "Onshape render of the control board's v1 extrusion mount and fan bracket",
+					"caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
+				}
 			]
 		},
 		{
@@ -1406,11 +1476,15 @@
 			"uid": "5vat",
 			"version": "1",
 			"name": "Orange Pi mount",
-			"description": "The Orange Pi 5 standing off its bracket. The printed bracket is not in the parts registry yet.",
+			"description": "The Orange Pi 5 standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
 			"section": "electronics",
 			"docs": "/hardware/electronics/installation/orange-pi-mount/",
-			"status": "stub",
+			"status": "partial",
 			"lines": [
+				{
+					"part": "orange-pi-extrusion-mount",
+					"qty": 1
+				},
 				{
 					"part": "sbc-orange-pi-5",
 					"qty": 1
@@ -1426,6 +1500,21 @@
 				{
 					"part": "standoff-m3-10mm",
 					"qty": 4
+				},
+				{
+					"part": "fan-bracket-40mm",
+					"qty": 1
+				},
+				{
+					"part": "fan-40mm-24v",
+					"qty": 1
+				}
+			],
+			"images": [
+				{
+					"url": "https://img.basically.website/parts/img/orange-pi-mount-v1-render-f5159489.png",
+					"alt": "Onshape render of the Orange Pi's v1 extrusion mount and fan bracket",
+					"caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
 				}
 			]
 		},
@@ -2109,7 +2198,7 @@
 			"quantities": {
 				"feeder": 2
 			},
-			"assembly": "light-post",
+			"assembly": "light-post-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -2195,7 +2284,7 @@
 			"quantities": {
 				"feeder": 2
 			},
-			"assembly": "light-post",
+			"assembly": "light-post-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -2321,7 +2410,7 @@
 			"quantities": {
 				"feeder": 2
 			},
-			"assembly": "light-post",
+			"assembly": "light-post-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -10184,7 +10273,7 @@
 			"quantities": {
 				"classification-channel": 1
 			},
-			"assembly": "camera-extension",
+			"assembly": "camera-extension-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -10230,10 +10319,10 @@
 				}
 			],
 			"grams": 28.37,
-			"support_grams": 0,
+			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 4106,
+			"print_seconds": 4105,
 			"color": {
 				"fixed": "ash-gray"
 			},
@@ -10339,7 +10428,7 @@
 			"quantities": {
 				"classification-channel": 1
 			},
-			"assembly": "camera-extension",
+			"assembly": "camera-extension-assembly",
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
@@ -12390,7 +12479,7 @@
 		{
 			"id": "ctrl-board-housing-base",
 			"uid": "204b",
-			"name": "Control board housing \u2014 base",
+			"name": "Control Board Housing \u2014 Base",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -12524,7 +12613,7 @@
 		{
 			"id": "ctrl-board-housing-cover",
 			"uid": "ksh2",
-			"name": "Control board housing \u2014 cover",
+			"name": "Control Board Housing \u2014 Cover",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -12655,7 +12744,7 @@
 		{
 			"id": "ctrl-board-housing-plunger",
 			"uid": "cljt",
-			"name": "Control board housing \u2014 plunger",
+			"name": "Control Board Housing \u2014 Plunger",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -12788,7 +12877,7 @@
 		{
 			"id": "ctrl-board-housing-plunger-retainer",
 			"uid": "g9sx",
-			"name": "Control board housing \u2014 plunger retainer",
+			"name": "Control Board Housing \u2014 Plunger Retainer",
 			"quantities": {},
 			"assembly": null,
 			"folder": null,
@@ -12869,6 +12958,974 @@
 					"size": [
 						8.96,
 						2.59
+					],
+					"cap": 2.5,
+					"depth": 0.6,
+					"note": "smaller text"
+				}
+			]
+		},
+		{
+			"id": "ctrl-board-extrusion-mount",
+			"uid": "1d5n",
+			"name": "Control Board Extrusion Mount",
+			"quantities": {
+				"electronics": 1
+			},
+			"assembly": "ctrl-board-mount",
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Plate the basically Embedded Control Board stands off, which bolts to the 2020 extrusion. The v1 mounting, in the machine today; the printed housing is the candidate that would replace it.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "1d5n",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/6e1da7cee8967d584080406f",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-f855b06c.stl",
+					"render": "https://img.basically.website/parts/render/ctrl-board-extrusion-mount-d9e570a6.png",
+					"grams": 32.58
+				}
+			],
+			"attributes": [],
+			"grams": 32.58,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3339,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-f855b06c.stl",
+			"render": "https://img.basically.website/parts/render/ctrl-board-extrusion-mount-d9e570a6.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-stamped-bottom-772743a4.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						124.22,
+						-4.84,
+						0.0
+					],
+					"size": [
+						12.1,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-stamped-top-3e806cdb.stl",
+					"normal": [
+						0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						-17.07,
+						-4.84,
+						8.0
+					],
+					"size": [
+						12.1,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-stamped-minus-y-side-921c15f1.stl",
+					"normal": [
+						-0.0,
+						-1.0,
+						0.0
+					],
+					"center": [
+						-16.37,
+						-8.0,
+						3.16
+					],
+					"size": [
+						12.1,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/ctrl-board-extrusion-mount-1d5n-stamped-plus-y-side-0634aa9d.stl",
+					"normal": [
+						-0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						103.52,
+						128.0,
+						3.16
+					],
+					"size": [
+						12.1,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				}
+			]
+		},
+		{
+			"id": "orange-pi-extrusion-mount",
+			"uid": "nxh7",
+			"name": "Orange Pi Extrusion Mount",
+			"quantities": {
+				"electronics": 1
+			},
+			"assembly": "orange-pi-mount",
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Plate the Orange Pi 5 stands off, which bolts to the 2020 extrusion. Same design as the control board's mount with the opening and bolt pattern changed for the Pi.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "nxh7",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/745c16803d318039967603f7",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-4832b406.stl",
+					"render": "https://img.basically.website/parts/render/orange-pi-extrusion-mount-fbabeb84.png",
+					"grams": 23.49
+				}
+			],
+			"attributes": [],
+			"grams": 23.49,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 2671,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-4832b406.stl",
+			"render": "https://img.basically.website/parts/render/orange-pi-extrusion-mount-fbabeb84.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-stamped-bottom-b22cd234.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						112.02,
+						-4.88,
+						0.0
+					],
+					"size": [
+						12.2,
+						3.5
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-stamped-top-21e7c631.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						-17.02,
+						-4.88,
+						8.0
+					],
+					"size": [
+						12.2,
+						3.5
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-stamped-minus-y-side-dd7500fc.stl",
+					"normal": [
+						0.0,
+						-1.0,
+						0.0
+					],
+					"center": [
+						-16.32,
+						-8.0,
+						3.12
+					],
+					"size": [
+						12.2,
+						3.5
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/orange-pi-extrusion-mount-nxh7-stamped-plus-y-side-a48b059d.stl",
+					"normal": [
+						-0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						91.32,
+						64.0,
+						3.12
+					],
+					"size": [
+						12.2,
+						3.5
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				}
+			]
+		},
+		{
+			"id": "fan-bracket-40mm",
+			"uid": "3ufy",
+			"name": "40 mm Fan Bracket",
+			"quantities": {
+				"electronics": 2
+			},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "3ufy",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/10ae43b609bb2df0f86cce4b/v/226293ea2e329f1f548b78a1/e/6e1da7cee8967d584080406f",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-d4757b35.stl",
+					"render": "https://img.basically.website/parts/render/fan-bracket-40mm-acca133f.png",
+					"grams": 27.34
+				}
+			],
+			"attributes": [],
+			"grams": 27.34,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 4396,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-d4757b35.stl",
+			"render": "https://img.basically.website/parts/render/fan-bracket-40mm-acca133f.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-stamped-bottom-e46be2a1.stl",
+					"normal": [
+						-0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						68.91,
+						-15.84,
+						-0.0
+					],
+					"size": [
+						12.57,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-stamped-minus-y-side-89a347bd.stl",
+					"normal": [
+						0.0,
+						-1.0,
+						0.0
+					],
+					"center": [
+						38.24,
+						-20.0,
+						65.84
+					],
+					"size": [
+						12.57,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-stamped-top-7e2cb9e3.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						38.24,
+						-15.84,
+						70.0
+					],
+					"size": [
+						12.57,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/fan-bracket-40mm-3ufy-stamped-plus-y-side-b430fa09.stl",
+					"normal": [
+						0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						68.91,
+						-8.0,
+						42.84
+					],
+					"size": [
+						12.57,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-shell-rear",
+			"uid": "7qz3",
+			"name": "PSU Housing \u2014 Shell Rear Tray",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "7qz3",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-f4bc3601.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-shell-rear-dbcabe40.png",
+					"grams": 207.01
+				}
+			],
+			"attributes": [],
+			"grams": 207.01,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 26626,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-f4bc3601.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-shell-rear-dbcabe40.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-stamped-bottom-e138db4a.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						7.46,
+						121.57,
+						-9.0
+					],
+					"size": [
+						12.18,
+						4.52
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-stamped-top-8491c2b0.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						23.46,
+						-1.37,
+						0.0
+					],
+					"size": [
+						12.18,
+						4.52
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-stamped-plus-y-side-be233f81.stl",
+					"normal": [
+						-0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						212.54,
+						126.0,
+						-4.57
+					],
+					"size": [
+						12.18,
+						4.52
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-rear-7qz3-stamped-minus-y-side-c5985a36.stl",
+					"normal": [
+						-0.0,
+						-1.0,
+						0.0
+					],
+					"center": [
+						7.46,
+						-11.0,
+						-4.57
+					],
+					"size": [
+						12.18,
+						4.52
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-shell-front",
+			"uid": "1h8p",
+			"name": "PSU Housing \u2014 Shell Front Module",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "1h8p",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-942fdcbb.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-shell-front-3ee222fa.png",
+					"grams": 56.13
+				}
+			],
+			"attributes": [],
+			"grams": 56.13,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 6676,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-942fdcbb.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-shell-front-3ee222fa.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-stamped-bottom-c042d4e0.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						-21.35,
+						44.4,
+						-9.0
+					],
+					"size": [
+						12.25,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-stamped-top-b8ca71e8.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						-42.5,
+						116.84,
+						0.0
+					],
+					"size": [
+						12.25,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "+y side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-stamped-plus-y-side-8dea25aa.stl",
+					"normal": [
+						-0.0,
+						1.0,
+						0.0
+					],
+					"center": [
+						-7.7,
+						126.0,
+						-5.04
+					],
+					"size": [
+						12.25,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "-y side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-shell-front-1h8p-stamped-minus-y-side-e7b60828.stl",
+					"normal": [
+						-0.0,
+						-1.0,
+						-0.0
+					],
+					"center": [
+						-44.8,
+						-11.0,
+						42.84
+					],
+					"size": [
+						12.25,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-lid-rear",
+			"uid": "m26o",
+			"name": "PSU Housing \u2014 Lid Rear",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "m26o",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-rear-m26o-83f226b5.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-lid-rear-94f18cfc.png",
+					"grams": 37.27
+				}
+			],
+			"attributes": [],
+			"grams": 37.27,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3979,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-rear-m26o-83f226b5.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-lid-rear-94f18cfc.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-rear-m26o-stamped-bottom-4a8feebd.stl",
+					"normal": [
+						0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						117.56,
+						-7.81,
+						46.2
+					],
+					"size": [
+						12.37,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-rear-m26o-stamped-top-afc23a17.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						118.36,
+						-7.01,
+						50.2
+					],
+					"size": [
+						12.37,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-lid-front",
+			"uid": "avux",
+			"name": "PSU Housing \u2014 Lid Front",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "avux",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-front-avux-126a70b0.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-lid-front-5480c80f.png",
+					"grams": 59.08
+				}
+			],
+			"attributes": [],
+			"grams": 59.08,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3969,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-front-avux-126a70b0.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-lid-front-5480c80f.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-front-avux-stamped-bottom-eacd61c0.stl",
+					"normal": [
+						0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						102.06,
+						-7.84,
+						46.2
+					],
+					"size": [
+						12.74,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-lid-front-avux-stamped-top-613f5ec5.stl",
+					"normal": [
+						0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						101.26,
+						-7.04,
+						50.2
+					],
+					"size": [
+						12.74,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				}
+			]
+		},
+		{
+			"id": "meanwell-psu-housing-front-panel",
+			"uid": "n1oh",
+			"name": "PSU Housing \u2014 Front Panel",
+			"quantities": {},
+			"assembly": null,
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
+			"version": "1",
+			"created_at": "2026-08-22",
+			"updated_at": "2026-08-22",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "n1oh",
+					"date": "2026-08-22",
+					"message": "Initial version.",
+					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/f7d34331a9a020dce9231dc1/v/13f56af58b306d7850aa3ea4/e/562fad1e09332ebe5efdd59c",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-69dae822.stl",
+					"render": "https://img.basically.website/parts/render/meanwell-psu-housing-front-panel-4aada3d4.png",
+					"grams": 15.7
+				}
+			],
+			"attributes": [],
+			"grams": 15.7,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3031,
+			"color": {
+				"role": "frame"
+			},
+			"optional": false,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-69dae822.stl",
+			"render": "https://img.basically.website/parts/render/meanwell-psu-housing-front-panel-4aada3d4.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-stamped-bottom-f858b9b9.stl",
+					"normal": [
+						-0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						-52.62,
+						-2.52,
+						-4.0
+					],
+					"size": [
+						2.59,
+						8.7
+					],
+					"cap": 2.5,
+					"depth": 0.6,
+					"note": "smaller text"
+				},
+				{
+					"face": "+x side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-stamped-plus-x-side-d35582d2.stl",
+					"normal": [
+						1.0,
+						0.0,
+						0.0
+					],
+					"center": [
+						-50.2,
+						-0.53,
+						-0.81
+					],
+					"size": [
+						12.18,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "-x side",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-stamped-minus-x-side-321212f7.stl",
+					"normal": [
+						-1.0,
+						0.0,
+						0.0
+					],
+					"center": [
+						-55.1,
+						115.53,
+						-0.81
+					],
+					"size": [
+						12.18,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/meanwell-psu-housing-front-panel-n1oh-stamped-top-2213f6e0.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						-52.68,
+						-2.52,
+						46.0
+					],
+					"size": [
+						2.59,
+						8.7
 					],
 					"cap": 2.5,
 					"depth": 0.6,

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -822,10 +822,35 @@ export function effectiveGrams(part: Part, inclSupport: boolean): number {
 /** Group the SELECTED parts' filament by resolved color, with bulk-tier pricing.
  *  `inclSupport(id)` decides whether a part's support material counts.
  *  `surplusPct` adds a buffer (incidental parts / failed prints) before spool counts. */
+/** Split `total` across `weights` as whole units, keeping the proportions and
+ *  summing to exactly `total` (largest remainder). Used when a part's printed
+ *  quantity has been edited away from what the machine needs and its colours
+ *  have to follow: 3 of 4 charcoal and 1 of 4 white, asked for 2, is 2 and 0
+ *  rather than a fractional spool. */
+export function apportion(weights: number[], total: number): number[] {
+	const sum = weights.reduce((a, b) => a + b, 0);
+	if (total <= 0 || weights.length === 0) return weights.map(() => 0);
+	if (sum <= 0) return weights.map((_, i) => (i === 0 ? total : 0));
+	const exact = weights.map((w) => (w / sum) * total);
+	const out = exact.map(Math.floor);
+	let left = total - out.reduce((a, b) => a + b, 0);
+	// hand the remainder to the largest fractional parts first
+	const order = exact
+		.map((v, i) => ({ i, frac: v - Math.floor(v) }))
+		.sort((a, b) => b.frac - a.frac);
+	for (const { i } of order) {
+		if (left <= 0) break;
+		out[i] += 1;
+		left -= 1;
+	}
+	return out;
+}
+
 export function buyList(
 	layers: number,
 	roleColors: Record<string, string>,
-	isSelected: (id: string) => boolean,
+	/** How many of this part are actually being printed (0 = not printing it). */
+	qtyOf: (id: string) => number,
 	inclSupport: (id: string) => boolean,
 	variantCount: (id: string) => number | null,
 	surplusPct = 0
@@ -838,24 +863,22 @@ export function buyList(
 } {
 	const byColor = new Map<string, number>();
 	for (const part of PARTS) {
-		if (!isSelected(part.id)) continue;
+		const want = qtyOf(part.id);
+		if (want <= 0) continue;
 		const each = effectiveGrams(part, inclSupport(part.id));
 		const vc = variantCount(part.id);
-		if (vc !== null) {
-			// variant part (e.g. funnel): total machine count chosen per layer
-			for (const u of colorUnits(part, vc, roleColors)) {
-				const key = u.colorId ?? '__any__';
-				byColor.set(key, (byColor.get(key) ?? 0) + each * u.count);
-			}
-			continue;
-		}
-		for (const [cat, qty] of Object.entries(part.quantities)) {
-			const mult = effectiveMult(part, cat, layers);
-			for (const u of colorUnits(part, qty, roleColors, cat)) {
-				const key = u.colorId ?? '__any__';
-				byColor.set(key, (byColor.get(key) ?? 0) + each * u.count * mult);
-			}
-		}
+		// The colour split is authored per machine, so scale it to whatever is
+		// actually being printed. Unedited, this is the identity.
+		const units =
+			vc !== null ? colorUnits(part, vc, roleColors) : machineColorUnits(part, layers, roleColors);
+		const counts = apportion(
+			units.map((u) => u.count),
+			want
+		);
+		units.forEach((u, i) => {
+			const key = u.colorId ?? '__any__';
+			byColor.set(key, (byColor.get(key) ?? 0) + each * counts[i]);
+		});
 	}
 	const buffer = 1 + surplusPct / 100;
 	const rows = [...byColor.entries()].map(([key, raw]) => {

--- a/parts-calculator/src/lib/manifest.ts
+++ b/parts-calculator/src/lib/manifest.ts
@@ -1,0 +1,95 @@
+/**
+ * The print manifest: what to print, how many of each, and which file is which.
+ *
+ * It is written as plain aligned text rather than CSV on purpose, because its
+ * main home is inside the STL zip, where the reader is a person who has just
+ * unzipped forty files named `<part>-<uid>-<hash8>.stl` and wants to know what
+ * they are and how many to run. It doubles as the record of a build: the uid
+ * on each line is the exact design revision, so a manifest kept next to a
+ * finished machine still says what went into it.
+ */
+import { SETTINGS, type Part } from './filament';
+import type { ExportSpec } from './csv';
+
+export type ManifestRow = {
+	part: Part;
+	qty: number;
+	/** Machine-required count, when it differs from `qty` (an edited quantity). */
+	defaultQty: number;
+	gramsEach: number;
+	colorName: string;
+	/** Basename of the STL as it appears in the zip. */
+	file: string;
+	/** Assemblies this part goes into, for the "used in" note. */
+	usedIn: string[];
+};
+
+const pad = (s: string, n: number) => (s.length >= n ? s : s + ' '.repeat(n - s.length));
+const padL = (s: string, n: number) => (s.length >= n ? s : ' '.repeat(n - s.length) + s);
+
+/** Aligned, human-first. Returns the whole file body. */
+export function printManifest(rows: ManifestRow[], spec: ExportSpec, layerSizes: string[]): string {
+	const live = rows.filter((r) => r.qty > 0).sort((a, b) => a.part.name.localeCompare(b.part.name));
+
+	const nameW = Math.max(4, ...live.map((r) => r.part.name.length));
+	const colorW = Math.max(5, ...live.map((r) => r.colorName.length));
+
+	const head = [
+		'Sorter V2 — print manifest',
+		`Generated ${spec.date} · release ${spec.release} · ${spec.layers} layer${spec.layers === 1 ? '' : 's'} (${layerSizes.join(', ')})`,
+		`${SETTINGS.printer} · ${SETTINGS.process} · ${SETTINGS.infill_density} ${SETTINGS.infill_pattern.replace('adaptivecubic', 'adaptive cubic')} · ${SETTINGS.filament}`,
+		''
+	];
+
+	const columns =
+		`${padL('QTY', 4)}  ${pad('PART', nameW)}  ${pad('UID', 4)}  ${padL('EACH', 7)}  ${padL('TOTAL', 8)}  ${pad('COLOR', colorW)}  FILE`;
+
+	const body = live.map((r) => {
+		const total = r.gramsEach * r.qty;
+		return (
+			`${padL(String(r.qty), 4)}  ${pad(r.part.name, nameW)}  ${pad(r.part.uid, 4)}  ` +
+			`${padL(`${r.gramsEach.toFixed(0)} g`, 7)}  ${padL(`${total.toFixed(0)} g`, 8)}  ` +
+			`${pad(r.colorName, colorW)}  ${r.file}`
+		);
+	});
+
+	const pieces = live.reduce((n, r) => n + r.qty, 0);
+	const grams = live.reduce((n, r) => n + r.gramsEach * r.qty, 0);
+	const foot = [
+		'',
+		`${live.length} part${live.length === 1 ? '' : 's'} · ${pieces} piece${pieces === 1 ? '' : 's'} · ${(grams / 1000).toFixed(2)} kg of filament`
+	];
+
+	// Only worth saying when it happened: a quantity that is not the machine's.
+	const edited = live.filter((r) => r.qty !== r.defaultQty);
+	if (edited.length) {
+		foot.push(
+			'',
+			'Edited quantities (the machine calls for a different number):',
+			...edited.map((r) => `  ${r.part.name}: printing ${r.qty}, machine needs ${r.defaultQty}`)
+		);
+	}
+
+	// A shared part is the one thing a flat list cannot show, so say it here.
+	const shared = live.filter((r) => r.usedIn.length > 1);
+	if (shared.length) {
+		foot.push(
+			'',
+			'Used in more than one place:',
+			...shared.map((r) => `  ${r.part.name}: ${r.usedIn.join(', ')}`)
+		);
+	}
+
+	const missing = rows.filter((r) => r.qty <= 0);
+	if (missing.length) {
+		foot.push('', `Not printing (${missing.length}): ${missing.map((r) => r.part.name).join(', ')}`);
+	}
+
+	return [...head, columns, '─'.repeat(columns.length), ...body, ...foot, ''].join('\n');
+}
+
+/** Filename for the standalone download; the copy inside the zip is always
+ *  `print-manifest.txt` so it sorts to the top and is obvious. */
+export function manifestFilename(spec: ExportSpec): string {
+	return `sorter-${spec.release}-print-manifest-${spec.layers}-layer-${spec.date}.txt`;
+}

--- a/parts-calculator/src/lib/uses.ts
+++ b/parts-calculator/src/lib/uses.ts
@@ -1,0 +1,161 @@
+/**
+ * Where each printed part is actually used, and how many go there.
+ *
+ * A part is not a thing you print once. It is a thing you print N times because
+ * it is needed in N places, and those places are what you tick on and off when
+ * you decide what to put on a plate. This module turns the catalog into that
+ * list: one `PartUse` per (part, assembly) pair, carrying the count for the
+ * current layer configuration.
+ *
+ * Two sources have to be reconciled, because neither is complete on its own:
+ *
+ *   - `part.quantities` (section -> count) covers every part in the build and
+ *     is what the totals have always been computed from. It is authoritative
+ *     for HOW MANY.
+ *   - the assembly tree's `lines` say WHERE, and are the only thing that knows
+ *     a part is used in two different places. But the tree is still filling in:
+ *     as of 2026-08-22 it reaches 73 of the 89 build parts, and for five more
+ *     it reaches only some of the copies (frame-90deg-bracket is in both the
+ *     `layer` and `interface` sections; the tree has only the layer ones).
+ *
+ * So the tree supplies the grouping, the sections supply the number, and
+ * whatever the tree cannot account for becomes one explicit "not in the
+ * assembly tree yet" use rather than quietly going missing. The invariant that
+ * makes the UI safe to build on: **a part's uses always sum to exactly the
+ * quantity the machine needs.** Nothing can hide in the gap.
+ */
+import {
+	ASSEMBLIES,
+	PARTS,
+	getAssembly,
+	lineQty,
+	machineQty,
+	type Part
+} from './filament';
+
+/** The id used for the bucket holding copies the assembly tree doesn't explain. */
+export const UNTRACKED = '~untracked';
+
+export type PartUse = {
+	/** Stable across re-renders and safe as a persisted key. */
+	key: string;
+	partId: string;
+	/** The assembly that lists this part, or null for the untracked bucket. */
+	assemblyId: string | null;
+	assemblyName: string;
+	qty: number;
+};
+
+const useKey = (partId: string, assemblyId: string | null) =>
+	`${partId}@${assemblyId ?? UNTRACKED}`;
+
+/** Walk the machine tree, attributing each part to the assembly that directly lists
+ *  it, multiplied by how many of that assembly the machine has. */
+function treeCounts(layers: number): Map<string, Map<string, number>> {
+	const out = new Map<string, Map<string, number>>();
+	const seen = new Set<string>();
+	function walk(assemblyId: string, mult: number) {
+		// Guard against a cycle in authored data; a machine tree has none, but a
+		// typo could make one and an infinite walk is a blank page.
+		const guard = `${assemblyId}:${mult}`;
+		if (seen.has(guard)) return;
+		seen.add(guard);
+		const asm = getAssembly(assemblyId);
+		if (!asm) return;
+		for (const line of asm.lines ?? []) {
+			const n = lineQty(line, layers) * mult;
+			if (line.assembly) {
+				walk(line.assembly, n);
+			} else if (line.part) {
+				const per = out.get(line.part) ?? new Map<string, number>();
+				per.set(assemblyId, (per.get(assemblyId) ?? 0) + n);
+				out.set(line.part, per);
+			}
+		}
+	}
+	walk('machine', 1);
+	return out;
+}
+
+/**
+ * Every part's uses for this layer configuration, keyed by part id.
+ *
+ * `variantCount` is the page's per-layer override for parts whose count comes
+ * from the funnel/bin size choices rather than from a fixed per-section count.
+ * Parts with no sections at all (a candidate's parts, which are not in the
+ * build) get no uses, which is what keeps them off the dashboard.
+ */
+export function buildUses(
+	layers: number,
+	variantCount: (id: string) => number | null
+): Map<string, PartUse[]> {
+	const tree = treeCounts(layers);
+	const byPart = new Map<string, PartUse[]>();
+
+	for (const part of PARTS) {
+		if (!Object.keys(part.quantities).length) continue; // not in the build
+		const needed = variantCount(part.id) ?? machineQty(part, layers);
+		if (needed <= 0) continue;
+
+		const uses: PartUse[] = [];
+		let placed = 0;
+		for (const [assemblyId, qty] of tree.get(part.id) ?? []) {
+			// Never let the tree claim more copies than the machine needs; the
+			// sections are the authority on the number.
+			const take = Math.min(qty, needed - placed);
+			if (take <= 0) break;
+			uses.push({
+				key: useKey(part.id, assemblyId),
+				partId: part.id,
+				assemblyId,
+				assemblyName: getAssembly(assemblyId)?.name ?? assemblyId,
+				qty: take
+			});
+			placed += take;
+		}
+		if (placed < needed) {
+			uses.push({
+				key: useKey(part.id, null),
+				partId: part.id,
+				assemblyId: null,
+				assemblyName: 'Not in the assembly tree yet',
+				qty: needed - placed
+			});
+		}
+		byPart.set(part.id, uses);
+	}
+	return byPart;
+}
+
+/** Assemblies that appear as a use somewhere, in machine-tree order, so the
+ *  by-assembly view lists them the way the tree walks them. */
+export function assemblyOrder(): string[] {
+	const order: string[] = [];
+	const seen = new Set<string>();
+	function walk(id: string) {
+		if (seen.has(id)) return;
+		seen.add(id);
+		order.push(id);
+		for (const line of getAssembly(id)?.lines ?? []) {
+			if (line.assembly) walk(line.assembly);
+		}
+	}
+	walk('machine');
+	// anything authored but not reachable from `machine` still deserves a place
+	for (const a of ASSEMBLIES) if (!seen.has(a.id)) order.push(a.id);
+	return order;
+}
+
+/** Total copies of a part the machine needs — always the sum of its uses. */
+export function defaultQty(uses: PartUse[] | undefined): number {
+	return (uses ?? []).reduce((n, u) => n + u.qty, 0);
+}
+
+/** Which parts are used in more than one assembly — the marker in both views. */
+export function sharedParts(byPart: Map<string, PartUse[]>): Set<string> {
+	const shared = new Set<string>();
+	for (const [id, uses] of byPart) if (uses.length > 1) shared.add(id);
+	return shared;
+}
+
+export type { Part };

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -41,6 +41,8 @@
 	import BuildPlates from '$lib/components/BuildPlates.svelte';
 	import Seo from '$lib/components/Seo.svelte';
 	import { zipSync } from 'fflate';
+	import { buildUses, defaultQty as sumUses, sharedParts } from '$lib/uses';
+	import { printManifest, manifestFilename, type ManifestRow } from '$lib/manifest';
 	import { onMount } from 'svelte';
 	import { loadConfig, saveConfig, clearConfig } from '$lib/config';
 	import { layerStore, addLayer as addLayerStore, removeLayerAt, setSize, setSizes } from '$lib/layers.svelte';
@@ -57,8 +59,6 @@
 
 	// ---- defaults (also used by "reset to default") -----------------------------
 	const defaultFunnelSizes = (): ('third' | 'half')[] => ['third', 'third', 'half'];
-	const defaultSelected = () =>
-		Object.fromEntries(PARTS.map((p) => [p.id, !('bins' in p.quantities)]));
 	// only parts that *opt into* support (support_intentional) expose the toggle; they
 	// default to counting their support. Parts the slicer auto-forced support on are
 	// left out entirely — no toggle, no support in the totals.
@@ -76,15 +76,46 @@
 	}
 	// colours live in the shared store so the assembly tab sees the same choices
 	const roleColors = $derived(colorStore.roles);
-	let selected = $state<Record<string, boolean>>(defaultSelected());
+	// What to print, as a count. Only parts whose quantity has been EDITED away
+	// from what the machine needs live here; everything else follows the machine,
+	// so adding a part to the catalog doesn't need a migration. 0 means "not
+	// printing it", which is what the row checkbox writes.
+	let qtyOverride = $state<Record<string, number>>({});
+	let listView = $state<'assembly' | 'unique'>('assembly');
 	let surplus = $state(15);
 	let printBins = $state(false); // top-level: print bins or not (auto-selects the right bins)
 	const partsById = new Map(PARTS.map((p) => [p.id, p]));
-	// bins are governed by the printBins toggle (+ per-layer size); everything else by its checkbox
-	function isIncluded(id: string): boolean {
+	// How many the machine needs, before any editing. Bins are governed by the
+	// printBins toggle rather than a count, so they are 0 until it is on.
+	function machineNeeds(id: string): number {
 		const p = partsById.get(id);
-		if (p && 'bins' in p.quantities) return printBins;
-		return selected[id];
+		if (!p) return 0;
+		if ('bins' in p.quantities && !printBins) return 0;
+		return sumUses(uses.get(id));
+	}
+	/** How many are actually being printed. */
+	function qtyOf(id: string): number {
+		const over = qtyOverride[id];
+		return over === undefined ? machineNeeds(id) : Math.max(0, over);
+	}
+	function isEdited(id: string): boolean {
+		return qtyOverride[id] !== undefined && qtyOverride[id] !== machineNeeds(id);
+	}
+	function setQty(id: string, n: number) {
+		const clean = Math.max(0, Math.round(Number(n) || 0));
+		if (clean === machineNeeds(id)) delete qtyOverride[id];
+		else qtyOverride[id] = clean;
+	}
+	function resetQty(id: string) {
+		delete qtyOverride[id];
+	}
+	function isIncluded(id: string): boolean {
+		return qtyOf(id) > 0;
+	}
+	/** Scale a machine-wide figure to the quantity actually being printed. */
+	function qtyScale(id: string): number {
+		const need = machineNeeds(id);
+		return need > 0 ? qtyOf(id) / need : 0;
 	}
 	// include each part's support material in totals — default on for the stator only
 	let inclSupport = $state<Record<string, boolean>>(defaultInclSupport());
@@ -99,7 +130,10 @@
 			// roleColors is not read here — colors.svelte owns it (and migrates the old blob)
 			if (typeof c.printBins === 'boolean') printBins = c.printBins;
 			if (typeof c.surplus === 'number') surplus = c.surplus;
-			if (c.selected) selected = { ...selected, ...c.selected };
+			if (c.qty) qtyOverride = { ...c.qty };
+			// v1 stored a checkbox per part; a false becomes "print none of it".
+			else if (c.selected)
+				for (const [id, on] of Object.entries(c.selected)) if (!on) qtyOverride[id] = 0;
 			if (c.inclSupport) inclSupport = { ...inclSupport, ...c.inclSupport };
 		}
 		configLoaded = true;
@@ -146,13 +180,13 @@
 		if (target !== location.pathname + location.search) replaceState(target, {});
 	});
 	$effect(() => {
-		const snapshot = { printBins, surplus, selected, inclSupport };
+		const snapshot = { printBins, surplus, qty: qtyOverride, inclSupport };
 		if (configLoaded) saveConfig($state.snapshot(snapshot));
 	});
 	function resetToDefaults() {
 		setSizes(defaultFunnelSizes());
 		resetRoleColors();
-		selected = defaultSelected();
+		qtyOverride = {};
 		inclSupport = defaultInclSupport();
 		surplus = 15;
 		printBins = false;
@@ -198,6 +232,21 @@
 		}
 	}
 
+	// Every part's places-it-is-used, reconciled against the section quantities
+	// (see $lib/uses). The assembly tree supplies the grouping; anything it can't
+	// account for lands in an explicit bucket so the counts always add up.
+	const uses = $derived(buildUses(layers, variantCount));
+	const shared = $derived(sharedParts(uses));
+	function usedIn(id: string): string[] {
+		return (uses.get(id) ?? []).map((u) => u.assemblyName);
+	}
+	/** The assembly a part is filed under in the by-assembly view: the first one
+	 *  the machine tree walks into. A part used in several places is listed once,
+	 *  under the first, and carries a marker naming the others. */
+	function primaryAssembly(id: string): string | null {
+		return (uses.get(id) ?? []).find((u) => u.assemblyId)?.assemblyId ?? null;
+	}
+
 	// per-layer size 'half' = 12 bins, 'third' = 18 bins
 	const sizePreview = {
 		half: { count: 12, bins: ['bin-half-left', 'bin-half-right'], funnel: 'funnel-half' },
@@ -208,35 +257,44 @@
 	}
 
 	const buy = $derived(
-		buyList(layers, roleColors, isIncluded, supportOn, variantCount, surplus)
+		buyList(layers, roleColors, qtyOf, supportOn, variantCount, surplus)
 	);
 
 	// theoretical total print time: every included part printed alone, sequentially,
 	// on one printer (one part per plate — no batching)
 	const totalPrintSeconds = $derived(
-		PARTS.reduce((sum, p) => {
-			if (!isIncluded(p.id)) return sum;
-			const vc = variantCount(p.id);
-			const count = vc !== null ? vc : machineQty(p, layers);
-			return sum + p.print_seconds * count;
-		}, 0)
+		PARTS.reduce((sum, p) => sum + p.print_seconds * qtyOf(p.id), 0)
 	);
 
 	const sectionRows = $derived(
 		SECTIONS.map((s) => {
 			const parts = PARTS.filter((p) => sectionQty(p, s.id) > 0);
 			const mult = categoryMultiplier(s.id, layers);
-			const selectedGrams = parts
-				.filter((p) => isIncluded(p.id))
-				.reduce(
-					(sum, p) => sum + effectiveGrams(p, supportOn(p.id)) * displayCount(p, s.id, layers, variantCount),
-					0
-				);
+			const selectedGrams = parts.reduce(
+				(sum, p) =>
+					sum +
+					effectiveGrams(p, supportOn(p.id)) *
+						displayCount(p, s.id, layers, variantCount) *
+						qtyScale(p.id),
+				0
+			);
 			return { section: s, parts, mult, selectedGrams };
 		}).filter((r) => r.parts.length > 0)
 	);
 
 	const selectedParts = $derived(PARTS.filter((p) => isIncluded(p.id)));
+
+	// The flat view: every part in the build exactly once, alphabetical, with the
+	// count it is being printed at. Parts with no section (a candidate's parts)
+	// are not in the build and are not listed.
+	const uniqueRows = $derived(
+		PARTS.filter((p) => Object.keys(p.quantities).length > 0)
+			.map((p) => ({ p, qty: qtyOf(p.id), need: machineNeeds(p.id) }))
+			.sort((a, b) => a.p.name.localeCompare(b.p.name))
+	);
+	const uniqueGrams = $derived(
+		uniqueRows.reduce((sum, r) => sum + effectiveGrams(r.p, supportOn(r.p.id)) * r.qty, 0)
+	);
 
 	// CSV of what's selected: quantities, real sliced weights, resolved colours,
 	// and the permanent STL link, so the file is enough to print from.
@@ -257,7 +315,7 @@
 			})
 		);
 	}
-	const allSelected = $derived(PARTS.every((p) => selected[p.id]));
+	const allSelected = $derived(PARTS.every((p) => machineNeeds(p.id) === 0 || qtyOf(p.id) > 0));
 
 	const prettyPattern = SETTINGS.infill_pattern.replace('adaptivecubic', 'adaptive cubic');
 	// both boxes at the top of the page start closed, so their one-line summary is
@@ -283,7 +341,11 @@
 	];
 
 	function setAll(v: boolean) {
-		selected = Object.fromEntries(PARTS.map((p) => [p.id, v]));
+		for (const p of PARTS) {
+			if ('bins' in p.quantities) continue; // the printBins toggle owns these
+			if (v) resetQty(p.id);
+			else setQty(p.id, 0);
+		}
 	}
 
 	type Block =
@@ -292,21 +354,29 @@
 	function groupBlocks(parts: Part[], sectionId: string): Block[] {
 		const blocks: Block[] = [];
 		const represented = new Set<string>();
-		let cur: Extract<Block, { kind: 'group' }> | null = null;
+		// The assembly comes from the machine tree (which assembly LISTS this part),
+		// never from a field on the part: one part is used in several assemblies and
+		// a single field cannot say so. Members of a group need not be adjacent in
+		// the catalog, so a group is placed where its first member appears and the
+		// rest join it there.
+		const byGroup = new Map<string, Extract<Block, { kind: 'group' }>>();
 		for (const p of parts) {
-			const groupKind = p.folder ? 'folder' : p.assembly ? 'assembly' : null;
-			const groupId = p.folder ?? p.assembly;
-			if (groupKind && groupId) {
-				if (groupKind === 'assembly') represented.add(groupId);
-				if (!cur || cur.id !== groupId || cur.groupKind !== groupKind) {
-					cur = { kind: 'group', groupKind, id: groupId, parts: [] };
-					blocks.push(cur);
-				}
-				cur.parts.push(p);
-			} else {
-				cur = null;
+			const asmId = primaryAssembly(p.id);
+			const groupKind = p.folder ? 'folder' : asmId ? 'assembly' : null;
+			const groupId = p.folder ?? asmId;
+			if (!groupKind || !groupId) {
 				blocks.push({ kind: 'part', part: p });
+				continue;
 			}
+			if (groupKind === 'assembly') represented.add(groupId);
+			const key = `${groupKind}:${groupId}`;
+			let g = byGroup.get(key);
+			if (!g) {
+				g = { kind: 'group', groupKind, id: groupId, parts: [] };
+				byGroup.set(key, g);
+				blocks.push(g);
+			}
+			g.parts.push(p);
 		}
 		for (const assembly of ASSEMBLIES) {
 			if (assembly.section === sectionId && assembly.status === 'stub' && !represented.has(assembly.id)) {
@@ -327,7 +397,7 @@
 			(sum, p) =>
 				sum +
 				(isIncluded(p.id)
-					? effectiveGrams(p, supportOn(p.id)) * displayCount(p, sectionId, layers, variantCount)
+					? effectiveGrams(p, supportOn(p.id)) * displayCount(p, sectionId, layers, variantCount) * qtyScale(p.id)
 					: 0),
 			0
 		);
@@ -336,7 +406,11 @@
 	const asmSomeOn = (parts: Part[]) => parts.some((p) => isIncluded(p.id));
 	// bins are governed by the Print bins toggle, so the rollup checkbox skips them
 	function setAsm(parts: Part[], v: boolean) {
-		for (const p of parts) if (!('bins' in p.quantities)) selected[p.id] = v;
+		for (const p of parts) {
+			if ('bins' in p.quantities) continue;
+			if (v) resetQty(p.id);
+			else setQty(p.id, 0);
+		}
 	}
 
 	function openViewer(p: Part, seed?: { color?: string; version?: PartVersion | null }) {
@@ -351,6 +425,33 @@
 		if ((e.target as HTMLElement).closest('button, a, input, label, [role="tooltip"]')) return;
 		openViewer(p);
 	}
+	/** What to print, as rows: the same data the manifest and the zip both need. */
+	function manifestRows(parts: Part[]): ManifestRow[] {
+		return parts.map((p) => {
+			const url = partDownload(p, engraveIds);
+			const colorId = primaryColorId(p, roleColors);
+			return {
+				part: p,
+				qty: qtyOf(p.id),
+				defaultQty: machineNeeds(p.id),
+				gramsEach: effectiveGrams(p, supportOn(p.id)),
+				colorName: colorId ? (getBambuColor(colorId)?.name ?? colorId) : 'Any color',
+				file: url.slice(url.lastIndexOf('/') + 1),
+				usedIn: usedIn(p.id)
+			};
+		});
+	}
+	function downloadManifest() {
+		const spec = exportSpec(layers);
+		const body = printManifest(manifestRows(selectedParts), spec, funnelSizes);
+		const url = URL.createObjectURL(new Blob([body], { type: 'text/plain;charset=utf-8' }));
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = manifestFilename(spec);
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
 	async function downloadZip(parts: Part[], name: string) {
 		if (!parts.length) return;
 		zipping = true;
@@ -363,6 +464,11 @@
 				// so the id survives into whatever the slicer names the project
 				files[url.slice(url.lastIndexOf('/') + 1)] = new Uint8Array(await res.arrayBuffer());
 			}
+			// A zip of forty hash-named STLs says nothing about how many of each to
+			// run. The manifest rides along and answers exactly that.
+			files['print-manifest.txt'] = new TextEncoder().encode(
+				printManifest(manifestRows(parts), exportSpec(layers), funnelSizes)
+			);
 			const zipped = zipSync(files, { level: 6 });
 			const a = document.createElement('a');
 			a.href = URL.createObjectURL(new Blob([zipped as BlobPart], { type: 'application/zip' }));
@@ -492,7 +598,7 @@
 				{#if 'bins' in p.quantities}
 					<input class="setup-toggle h-4 w-4" type="checkbox" checked={printBins} onchange={() => (printBins = !printBins)} aria-label="Print bins (set in Build options)" title="Controlled by the Print bins toggle in Build options" />
 				{:else}
-					<input class="setup-toggle h-4 w-4" type="checkbox" bind:checked={selected[p.id]} aria-label="Select {p.name}" />
+					<input class="setup-toggle h-4 w-4" type="checkbox" checked={qtyOf(p.id) > 0} onchange={(e) => (e.currentTarget.checked ? resetQty(p.id) : setQty(p.id, 0))} aria-label="Print {p.name}" />
 				{/if}
 			</td>
 			<td class="pl-c-thumb">
@@ -509,6 +615,8 @@
 			<td class="pl-c-name">
 				<span class="pl-name">
 					{p.name}
+					{#if shared.has(p.id)}<span class="cursor-help border border-border px-1 text-xs text-text-muted" title="Also used in {usedIn(p.id).slice(1).join(', ')}">used in {usedIn(p.id).length} places</span>{/if}
+					{#if isEdited(p.id)}<span class="border border-primary/60 px-1 text-xs text-primary" title="Printing {qtyOf(p.id)}, the machine needs {machineNeeds(p.id)}">qty {qtyOf(p.id)}</span>{/if}
 					{#if p.optional}<Badge variant="warning">Optional</Badge>{/if}
 					{#if p.support_intentional}<Badge variant="info" title="Printed with support material — included in this part's grams">Supports</Badge>{/if}
 						{#if platesForPart(p.id).length}<button type="button" class="inline-flex items-center gap-0.5 border border-border px-1 text-xs text-text-muted hover:border-primary hover:text-primary" onclick={() => openPlatesModal(p.id)} title="Show plates with this part"><Layers3 size={11} /> {platesForPart(p.id).length} plate{platesForPart(p.id).length === 1 ? '' : 's'}</button>{/if}{#if os.version}<a href={os.version} target="_blank" rel="noopener" class="inline-flex items-center gap-0.5 border border-border px-1 text-xs text-text-muted hover:border-primary hover:text-primary" title="Open the exact OnShape version this STL came from">OnShape <ExternalLink size={11} /></a>{/if}{#if p.info}<Popover width="w-64" label="About {p.name}" text={p.info} />{/if}<ChangeStatus kind="parts" id={p.id} name={p.name} />{#if p.low_tolerance}<Popover width="w-72" label="Fit notes for {p.name}">{#snippet trigger({ toggle, open })}<Badge as="button" variant="warning" onclick={toggle} aria-expanded={open}><AlertTriangle size={11} /> Tight fit</Badge>{/snippet}<b class="text-text">Low tolerance.</b> This part has little room for dimensional error, so a test print is worth doing before you commit to the full set.{#if p.low_tolerance_note}<span class="mt-2 block border-t border-border pt-2 text-text">{p.low_tolerance_note}</span>{/if}</Popover>{/if}{#if p.attributes?.length}{#each p.attributes as a}<span class="border border-border bg-[var(--color-bg)] px-1 text-xs text-text-muted" title={a.label}>{a.label}: <span class="text-text">{a.value}</span></span>{/each}{/if}{#if p.versions && p.versions.length > 1}<Popover width="w-80" label="Version history for {p.name}">{#snippet trigger({ toggle, open })}<button type="button" onclick={toggle} aria-expanded={open} class="inline-flex items-center gap-0.5 border border-border px-1 text-xs text-text-muted hover:border-primary hover:text-primary" title="Version history"><History size={11} /> v{p.version} · {p.versions?.length ?? 0} versions</button>{/snippet}<b class="text-text">Version history</b><ul class="mt-1 space-y-2">{#each [...(p.versions ?? [])].reverse() as v}<li class="border-t border-border pt-2 first:border-t-0 first:pt-0"><div class="flex items-center gap-1.5 text-text"><b>v{v.version}</b><span class="text-text-muted">· {fmtDate(v.date)}</span>{#if commitUrl(v.commit)}<a href={commitUrl(v.commit)} target="_blank" rel="noopener" class="ml-auto inline-flex items-center gap-0.5 text-primary hover:text-primary-hover">{v.commit} <ExternalLink size={10} /></a>{:else}<span class="ml-auto italic text-text-muted/70">uncommitted</span>{/if}</div><div class="mt-0.5">{v.message}</div>{#if v.onshape_version}<div class="mt-1"><a href={v.onshape_version} target="_blank" rel="noopener" class="inline-flex items-center gap-0.5 text-primary hover:text-primary-hover">OnShape <ExternalLink size={10} /></a></div>{/if}</li>{/each}</ul></Popover>{/if}
@@ -565,6 +673,13 @@
 								>· {selectedParts.length ? `${selectedParts.length} selected` : `all ${PARTS.length}`}, {layers}
 								layers</span>
 						</button>
+						<button
+							class="ml-3 inline-flex items-center gap-1 text-primary hover:text-primary-hover"
+							onclick={downloadManifest}
+							title="What to print and how many of each, as plain text. The same file rides inside the STL zip."
+						>
+							<Download size={13} /> Manifest
+						</button>
 					</span>
 				{/if}
 			</div>
@@ -574,6 +689,98 @@
 					<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
 					<span class="shrink-0 font-semibold text-primary">View {CHANGES.length} potential changes →</span>
 				</a>
+				<div class="mb-4 flex flex-wrap items-center gap-2">
+					<div class="inline-flex border border-border">
+						<button
+							class="px-3 py-1.5 text-sm font-semibold {listView === 'assembly' ? 'bg-[var(--color-bg)] text-text' : 'text-text-muted hover:text-text'}"
+							onclick={() => (listView = 'assembly')}
+							aria-pressed={listView === 'assembly'}
+							title="Grouped by what bolts to what. A part used in several places is listed under the first and marked.">By assembly</button>
+						<button
+							class="border-l border-border px-3 py-1.5 text-sm font-semibold {listView === 'unique' ? 'bg-[var(--color-bg)] text-text' : 'text-text-muted hover:text-text'}"
+							onclick={() => (listView = 'unique')}
+							aria-pressed={listView === 'unique'}
+							title="Every part once, with the number you are printing. This is the list you print from.">By unique part</button>
+					</div>
+					<span class="text-xs text-text-muted">
+						{listView === 'assembly'
+							? 'Grouped by what bolts to what.'
+							: 'Every part once. Edit a quantity to print more or fewer than the machine needs.'}
+					</span>
+				</div>
+				{#if listView === 'unique'}
+					<div class="pl-scroll mb-6">
+						<table class="pl-tbl">
+							<thead>
+								<tr>
+									<th class="pl-c-thumb"></th>
+									<th class="pl-c-name">Part</th>
+									<th class="pl-c-each">Each</th>
+									<th class="pl-c-total">Qty</th>
+									<th class="pl-c-total">Total</th>
+									<th class="pl-c-dl"></th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each uniqueRows as { p, qty, need } (p.id)}
+									{@const each = effectiveGrams(p, supportOn(p.id))}
+									<tr class="pl-row group/row" class:opacity-50={qty === 0}>
+										<td class="pl-c-thumb">
+											<button type="button" class="pl-thumb group relative" onclick={() => openViewer(p)} title="View {p.name} in 3D">
+												<img src={p.render} alt={p.name} />
+												<span class="absolute inset-0 flex items-center justify-center bg-black/40 text-white opacity-0 transition-opacity group-hover:opacity-100"><ZoomIn size={16} /></span>
+											</button>
+										</td>
+										<td class="pl-c-name">
+											<span class="pl-name">
+												{p.name}
+												{#if shared.has(p.id)}<span class="cursor-help border border-border px-1 text-xs text-text-muted" title="Used in {usedIn(p.id).join(', ')}">used in {usedIn(p.id).length} places</span>{/if}
+												{#if p.optional}<Badge variant="warning">Optional</Badge>{/if}
+												<ChangeStatus kind="parts" id={p.id} name={p.name} />
+											</span>
+											<span class="pl-meta">{usedIn(p.id).join(' · ') || 'not placed yet'}</span>
+										</td>
+										<td class="pl-c-each">{grams(each)}</td>
+										<td class="pl-c-total">
+											<span class="inline-flex items-center gap-1">
+												<input
+													class="setup-control h-7 w-16 text-center text-sm"
+													type="number"
+													min="0"
+													value={qty}
+													aria-label="How many {p.name} to print"
+													onchange={(e) => setQty(p.id, e.currentTarget.valueAsNumber)}
+												/>
+												{#if isEdited(p.id)}
+													<button
+														type="button"
+														class="text-text-muted hover:text-primary"
+														onclick={() => resetQty(p.id)}
+														title="Back to {need}, what the machine needs"
+														aria-label="Reset {p.name} to {need}"><RotateCcw size={13} /></button>
+												{/if}
+											</span>
+										</td>
+										<td class="pl-c-total">{grams(each * qty)}</td>
+										<td class="pl-c-dl">
+											<a href={partDownload(p, engraveIds)} download class="text-text-muted hover:text-primary" title="Download {p.name}"><Download size={16} /></a>
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+							<tfoot>
+								<tr>
+									<td></td>
+									<td class="pl-c-name"><span class="pl-name">{uniqueRows.filter((r) => r.qty > 0).length} parts · {uniqueRows.reduce((n, r) => n + r.qty, 0)} pieces</span></td>
+									<td></td>
+									<td></td>
+									<td class="pl-c-total">{grams(uniqueGrams)}</td>
+									<td></td>
+								</tr>
+							</tfoot>
+						</table>
+					</div>
+				{:else}
 				{#each sectionRows as { section, parts, mult, selectedGrams } (section.id)}
 				<section class="pl-sec" id="section-{section.id}">
 					<h3 class="pl-sec-hd">
@@ -673,6 +880,7 @@
 					</div>
 				</section>
 			{/each}
+				{/if}
 			{:else}
 				<BuildPlates highlightPartId={null} />
 			{/if}


### PR DESCRIPTION
Collapses #377, #379 and #381 into one commit. They were a three-deep stack
on `engrave`; that merged as #376, so this now sits directly on `main`. Same
content, three drafts closed. Three changes that turned out to be one, so they
land together.

## The revisions that were missing

The **v1 board mounts** — basically board, Orange Pi, and the fan bracket they
share — were never registered at all, so the parts that replaced them had
nothing to be a revision *of*. They are in now, with their Onshape version
links, filling in the `stub` entries rather than bumping any version.

The **MeanWell PSU housing** gets its v2 as an **assembly candidate**: a whole
alternative BOM sitting beside the current one, uncounted, waiting to be
promoted. This is the first real exercise of the candidate → version flow at
the assembly level, which is the point of the change.

The two zips ship byte-different `40mm fan bracket.stl` files. Identical
bounding box (48×90×70), identical 7,152 triangles, identical volume to seven
significant figures, and no axis-aligned transform maps one onto the other:
one design exported twice. So it is **one uid with one pinned hash**, which is
precisely the case the uid model exists for.

## An id names one thing

`light-post` and `camera-extension` were each both a part id *and* an assembly
id, so a bare reference meant different things depending on which table you
read first. They are `light-post-assembly` and `camera-extension-assembly`
now, and `generate.py` refuses a catalog whose two id spaces intersect, with
the fix in the error message.

An assembly's newest `versions` entry also gets stamped with the assembly's
own uid, mirroring what parts already did. Found by promoting a candidate on a
throwaway branch and watching the version being *introduced* read back
`uid: null`.

## Where a part goes, and how many you want

Grouping on the root page came from a back-pointer on the part, and it
disagreed with the assembly tree for **38 of 98 parts**: 20 sat loose at the
bottom of a section the tree could have placed, 10 were hidden inside a
folder, 4 pointed at an assembly whose `lines` never mention them, and 4 are
used twice and could only ever show once. Grouping now derives from `lines`,
so `C-channel drive` holds its Stator, Output gear, NEMA bracket, Idler gear
and Input gear instead of holding nothing.

The tree cannot supply the numbers, though — it reaches 73 of the 89 build
parts and undercounts five more. So `$lib/uses.ts` takes the **grouping from
the tree and the count from the sections**, and whatever the tree cannot
account for becomes a visible *"not in the assembly tree yet"* use. The
invariant the UI rests on:

> a part's uses always sum to exactly the quantity the machine needs

Nothing can hide in the gap, and the gap is on screen instead of silent.

**Selection becomes a count.** It defaults to what the machine needs, takes
any number including zero, and only an *edited* count persists, so a part
added to the catalog tomorrow needs no migration. `buyList` takes a quantity
instead of a predicate and splits colour units by largest remainder, because
an edited count must never yield a fraction of a part. Two views of the root
list: **by assembly**, where a part may appear in full more than once with a
marker naming its other homes, and **by unique part**, which is where the
quantity box and its reset live.

## The manifest

`$lib/manifest.ts` writes what falls out of all that: `print-manifest.txt`,
downloadable on its own and injected into the zip, saying how many of each
part to run, in what filament, from which file.

```
 QTY  PART                UID      EACH     TOTAL  COLOR     FILE
─────────────────────────────────────────────────────────────────
   2  Light post          oac5     25 g      50 g  Ash gray  light-post-oac5-3f9c2a71.stl
   4  NEMA bracket        x09t     12 g      49 g  Ash gray  nema-bracket-x09t-8b41d0e2.stl
```

Every line carries the uid, which is the whole point: a manifest kept beside a
finished machine still says exactly which design revision went into it, and
the 3MFs match up. It also calls out edited quantities, parts used in more
than one place, and anything set to zero.

## Verified

- `svelte-check` 4359 files, 0 errors · production build clean
- `check_generated_pins.py`: agrees with `parts.json`, 98 pinned parts
- `check_bucket_urls.py`: 632 URLs (453 binary, 179 image), all serve real bytes
- In the browser: 90 quantity boxes, the fan bracket at 1 moves its total 55 g
  → 27 g and the footer 16.53 → 16.50 kg, and the reset offers *"Back to 2,
  what the machine needs"*

## Not in here

Per-use checkboxes in the by-assembly view. The quantity box covers the same
ground; say the word if the checkboxes are still wanted.

Renaming `folder` → `group` and deleting the per-part `assembly` field, now
that grouping derives from `lines`. Separate change.
