### PR TITLE
parts-calculator: an assembly is a thing you can open

### DIFF
--- a/parts-calculator/CLAUDE.md
+++ b/parts-calculator/CLAUDE.md
@@ -69,6 +69,28 @@ OrcaSlicer's own output. Do not compute weight from volume/density.
 /opt/homebrew/opt/python@3.11/libexec/bin/python catalog/generate.py
 ```
 
+## One detail view per thing
+
+A part, a hardware item and an assembly each have exactly one detail view, and
+every surface opens that same one: `PartDetail`, `HardwareDetail`,
+`AssemblyDetail`, each with a thin `*DetailModal` wrapper. The parts dashboard
+and the assembly tab both open the same component, so "view the PSU box" cannot
+come to mean two different screens. A new place that needs to show one of these
+imports the existing view; it does not write a second rendering of the same
+data.
+
+`AssemblyDetail` renders **one level**. Sub-assemblies are rows you open in
+turn, and the modal keeps its own back trail — the tree page already shows the
+whole thing nested, and this view exists for the opposite need: one box at a
+time. Parts and hardware are handed back to the host through `onPart` /
+`onHardware`, because the host already owns those modals.
+
+**Modals stack.** Opening a part from inside an assembly puts one on top of the
+other, and `Modal.svelte` keeps a module-level stack so Escape closes the front
+one instead of the whole pile. Stacked modals are ordered by where they appear
+in the markup, so a modal that can be opened *from* another must be rendered
+before it.
+
 ## Artifacts and the bucket
 
 Large binaries (STLs, 3MFs) sync to a DigitalOcean Space, every filename

--- a/parts-calculator/src/lib/components/AssemblyDetail.svelte
+++ b/parts-calculator/src/lib/components/AssemblyDetail.svelte
@@ -1,0 +1,437 @@
+<script lang="ts">
+	import { ArrowRight, BookOpen, Boxes, ExternalLink, FlaskConical, History, Zap } from 'lucide-svelte';
+	import AlternativeBadge from '$lib/components/AlternativeBadge.svelte';
+	import AssemblyDescription from '$lib/components/AssemblyDescription.svelte';
+	import Badge from '$lib/components/Badge.svelte';
+	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
+	import ConflictBadge from '$lib/components/ConflictBadge.svelte';
+	import HardwareIcon from '$lib/components/HardwareIcon.svelte';
+	import ImageStrip from '$lib/components/ImageStrip.svelte';
+	import {
+		docsUrl,
+		fmtDate,
+		getAssembly,
+		getHardware,
+		getLasercut,
+		getPart,
+		hardwareImage,
+		JOIN_LABELS,
+		lineQty,
+		type Assembly,
+		type AssemblyLine,
+		type Hardware,
+		type Joining,
+		type Part
+	} from '$lib/filament';
+
+	/**
+	 * One assembly as a single object: what it is, what it looks like, and every
+	 * line it is made of. The same view backs the rollup rows on the parts
+	 * dashboard and the nodes of the assembly tree, so "open the PSU box" means
+	 * the same thing wherever you click it.
+	 *
+	 * It renders exactly one level. A sub-assembly is a row you can open in turn
+	 * rather than an inline tree — the tree page already shows the whole thing
+	 * nested, and the point of this view is the opposite: one box at a time.
+	 */
+	let {
+		assembly,
+		layers,
+		onPart,
+		onHardware,
+		onAssembly
+	}: {
+		assembly: Assembly;
+		layers: number;
+		onPart?: (p: Part) => void;
+		onHardware?: (h: Hardware) => void;
+		onAssembly?: (id: string) => void;
+	} = $props();
+
+	// Same wording as the tree: the data records that a node is incomplete, never
+	// which pieces are missing, so the tooltip claims nothing more than that.
+	const STATUS_NOTE = {
+		stub: 'Placeholder — nothing has been recorded inside this assembly yet. What it actually contains is not captured anywhere in the data.',
+		partial:
+			'Some of this assembly is recorded, but not all of it. The parts and hardware shown are real; the list is known to be missing pieces, and the data does not say which.'
+	};
+
+	/** Printed parts reachable below an assembly, id -> count, quantities
+	 *  multiplied down. Depth-capped rather than cycle-checked: authored data has
+	 *  no cycles, and a `seen` set would undercount a part used in two branches. */
+	function partsUnder(id: string, mult = 1, acc = new Map<string, number>(), depth = 0) {
+		if (depth > 8) return acc;
+		for (const line of getAssembly(id)?.lines ?? []) {
+			const q = lineQty(line, layers) * mult;
+			if (line.assembly) partsUnder(line.assembly, q, acc, depth + 1);
+			else if (line.part && getPart(line.part)) acc.set(line.part, (acc.get(line.part) ?? 0) + q);
+		}
+		return acc;
+	}
+	const grams = (counts: Map<string, number>) =>
+		[...counts].reduce((g, [id, n]) => g + (getPart(id)?.grams ?? 0) * n, 0);
+
+	// The header always shows something visual. An assembly's own pictures come
+	// first when it has them; the members' renders stand in when it doesn't.
+	const own = $derived(partsUnder(assembly.id));
+	const fan = $derived([...own.keys()].map((id) => getPart(id)!).filter(Boolean).slice(0, 5));
+	const totalGrams = $derived(grams(own));
+	const totalPieces = $derived([...own.values()].reduce((n, q) => n + q, 0));
+
+	const fmtG = (g: number) => (g >= 1000 ? `${(g / 1000).toFixed(2)} kg` : `${g.toFixed(0)} g`);
+</script>
+
+{#snippet joining(list: Joining[] | undefined)}
+	{#each list ?? [] as j (j.method)}
+		<div class="mt-1 flex flex-wrap items-baseline gap-x-2">
+			<Badge variant="warning"><Zap size={10} />{JOIN_LABELS[j.method]}</Badge>
+			{#if j.note}<AssemblyDescription text={j.note} as="span" class="text-xs text-text-muted" />{/if}
+		</div>
+	{/each}
+{/snippet}
+
+<!-- One BOM line. Which of the four kinds it is comes from where the id
+     resolves, the same lookup order the tree uses. -->
+{#snippet lineRow(line: AssemblyLine)}
+	{@const each = lineQty(line, layers)}
+	{#if line.assembly}
+		{@const sub = getAssembly(line.assembly)}
+		{#if sub}
+			{@const counts = partsUnder(sub.id)}
+			<button type="button" class="ad-row ad-row-open" onclick={() => onAssembly?.(sub.id)}>
+				<span class="ad-fan">
+					{#each [...counts.keys()].slice(0, 3) as pid, i (pid)}
+						<span class="ad-thumb" style="z-index:{3 - i}"
+							><img src={getPart(pid)?.render} alt="" /></span>
+					{/each}
+					{#if !counts.size}<span class="ad-thumb ad-thumb-empty"><Boxes size={16} /></span>{/if}
+				</span>
+				<span class="ad-body">
+					<span class="ad-name">{sub.name} <Badge variant="info">Assembly</Badge></span>
+					<span class="ad-meta"
+						>{counts.size
+							? `${counts.size} printed part${counts.size === 1 ? '' : 's'} · ${fmtG(grams(counts))}`
+							: 'Nothing recorded inside yet'}</span>
+				</span>
+				<span class="ad-qty">×{each}</span>
+				<ArrowRight size={14} class="ad-go" />
+			</button>
+		{/if}
+	{:else if line.part && getLasercut(line.part)}
+		{@const lc = getLasercut(line.part)!}
+		<div class="ad-row">
+			<span class="ad-fan"><span class="ad-thumb"><img src={lc.preview} alt="" /></span></span>
+			<span class="ad-body">
+				<span class="ad-name">{lc.name} <Badge variant="neutral">Laser cut</Badge></span>
+				<span class="ad-meta">{lc.thicknessIn} plywood · {lc.widthMm}×{lc.heightMm} mm</span>
+			</span>
+			<span class="ad-qty">×{each}</span>
+		</div>
+	{:else if line.part && getHardware(line.part)}
+		{@const hw = getHardware(line.part)!}
+		{@const img = hardwareImage(hw)}
+		<button type="button" class="ad-row ad-row-open" onclick={() => onHardware?.(hw)}>
+			<span class="ad-fan">
+				<span class="ad-thumb">
+					{#if img}<img src={img.src} alt="" />{:else}<HardwareIcon {hw} size={18} />{/if}
+				</span>
+			</span>
+			<span class="ad-body">
+				<span class="ad-name">
+					<HardwareIcon {hw} size={14} />{hw.name}
+					<AlternativeBadge value={hw.alternative} size={14} />
+					<ConflictBadge conflicts={hw.conflicts} size={14} />
+				</span>
+				<span class="ad-meta">Off the shelf</span>
+			</span>
+			<span class="ad-qty">×{each}</span>
+			<ArrowRight size={14} class="ad-go" />
+		</button>
+	{:else if line.part && getPart(line.part)}
+		{@const part = getPart(line.part)!}
+		<button type="button" class="ad-row ad-row-open" onclick={() => onPart?.(part)}>
+			<span class="ad-fan"><span class="ad-thumb"><img src={part.render} alt="" /></span></span>
+			<span class="ad-body">
+				<span class="ad-name">
+					{part.name} <Badge variant="neutral">3D printed</Badge>
+					<ChangeStatus kind="parts" id={part.id} name={part.name} />
+				</span>
+				<span class="ad-meta">{part.grams.toFixed(0)} g each · {part.uid}</span>
+			</span>
+			<span class="ad-qty">×{each}</span>
+			<ArrowRight size={14} class="ad-go" />
+		</button>
+	{/if}
+{/snippet}
+
+<div class="ad">
+	<header class="ad-head">
+		{#if assembly.images?.length}
+			<ImageStrip images={assembly.images} />
+		{:else if fan.length}
+			<div class="ad-fan ad-fan-lg">
+				{#each fan as p, i (p.id)}
+					<span class="ad-thumb ad-thumb-lg" style="z-index:{5 - i}"
+						><img src={p.render} alt={p.name} /></span>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="mt-2 flex flex-wrap items-center gap-2">
+			<span class="font-mono text-xs text-text">{assembly.uid}</span>
+			{#if assembly.version}<span class="text-xs text-text-muted">v{assembly.version}</span>{/if}
+			{#if assembly.status === 'stub'}
+				<span
+					class="cursor-help border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
+					title={STATUS_NOTE.stub}>stub — not yet detailed</span>
+			{:else if assembly.status === 'partial'}
+				<span
+					class="cursor-help border border-warning/50 bg-warning/[0.08] px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-warning-dark"
+					title={STATUS_NOTE.partial}>partial</span>
+			{/if}
+			<ChangeStatus kind="assemblies" id={assembly.id} name={assembly.name} />
+		</div>
+
+		{#if assembly.description}
+			<AssemblyDescription text={assembly.description} class="mt-1.5 text-sm text-text-muted" />
+		{/if}
+		{@render joining(assembly.joining)}
+		{#if docsUrl(assembly)}
+			<a
+				href={docsUrl(assembly)}
+				target="_blank"
+				rel="noopener"
+				class="mt-1.5 inline-flex items-center gap-1 text-xs font-medium text-primary hover:text-primary-hover"
+			>
+				<BookOpen size={12} /> Assembly guide <ExternalLink size={10} />
+			</a>
+		{/if}
+	</header>
+
+	<section class="ad-sec">
+		<h3 class="ad-hd">
+			Contents
+			{#if totalPieces}
+				<span class="ad-hd-note"
+					>{totalPieces} printed piece{totalPieces === 1 ? '' : 's'} · {fmtG(totalGrams)}</span>
+			{/if}
+		</h3>
+		{#if assembly.lines?.length}
+			{#each assembly.lines as line, i (`${line.part ?? line.assembly}-${i}`)}
+				{@render lineRow(line)}
+			{/each}
+		{:else}
+			<p class="text-sm text-text-muted">
+				Nothing has been recorded inside this assembly yet.
+			</p>
+		{/if}
+	</section>
+
+	<!-- Alternative bills of materials under test. Nothing here reaches any total:
+	     the resolvers walk `lines` only. This is the one place the dashboard could
+	     previously not show that a revision was on the table. -->
+	{#each assembly.candidates ?? [] as c (c.uid)}
+		{@const retired = !!(c.superseded_by || c.rejected_at)}
+		<section class="ad-cand {retired ? 'ad-cand-retired' : ''}">
+			<div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+				<span
+					class="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-primary"
+					><FlaskConical size={11} /> Candidate</span>
+				{#if c.name}<span class="text-sm font-semibold text-text">{c.name}</span>{/if}
+				<span class="font-mono text-xs text-text">{c.uid}</span>
+				<span class="text-xs text-text-muted">· {fmtDate(c.created_at)}</span>
+				{#if retired}
+					<span
+						class="border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
+						>{c.rejected_at ? 'rejected' : 'superseded'}</span>
+				{/if}
+			</div>
+			<AssemblyDescription text={c.message} class="mt-0.5 text-xs text-text-muted" />
+			{#if c.images?.length}<div class="mt-2"><ImageStrip images={c.images} /></div>{/if}
+			{@render joining(c.joining)}
+			<p class="mt-1 text-xs italic text-text-muted/70">
+				An alternative bill of materials under test — not part of the build and not in the totals.
+			</p>
+			{#each c.lines as line, i (`${line.part ?? line.assembly}-${i}`)}
+				{@render lineRow(line)}
+			{/each}
+		</section>
+	{/each}
+
+	{#if (assembly.versions?.length ?? 0) > 1}
+		<details class="ad-sec">
+			<summary
+				class="inline-flex cursor-pointer items-center gap-1 text-xs font-semibold uppercase tracking-wider text-text-muted hover:text-text"
+				><History size={11} /> Previous revisions · {(assembly.versions?.length ?? 1) - 1}</summary>
+			{#each [...(assembly.versions ?? [])].slice(0, -1).reverse() as v (v.version)}
+				<div class="mt-2 border border-border bg-surface p-2 text-xs sm:p-3">
+					<div class="flex flex-wrap items-baseline gap-x-2">
+						<b class="text-text">v{v.version}</b>
+						{#if v.uid}<span class="font-mono text-text-muted">{v.uid}</span>{/if}
+						<span class="text-text-muted">· {fmtDate(v.date)}</span>
+					</div>
+					<AssemblyDescription text={v.message} class="mt-0.5 text-text-muted" />
+					{#if v.images?.length}<div class="mt-2"><ImageStrip images={v.images} /></div>{/if}
+					<ul class="mt-1.5 space-y-0.5 text-text-muted">
+						{#each v.lines ?? [] as l, i (`${l.part ?? l.assembly}-${i}`)}
+							{@const name =
+								(l.part &&
+									(getPart(l.part)?.name ??
+										getHardware(l.part)?.name ??
+										getLasercut(l.part)?.name)) ??
+								(l.assembly && getAssembly(l.assembly)?.name) ??
+								l.part ??
+								l.assembly}
+							<li>
+								<span class="tabular-nums">×{l.qty}</span>
+								{name}{#if l.uid}<span class="ml-1 font-mono">{l.uid}</span>{/if}
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/each}
+		</details>
+	{/if}
+</div>
+
+<style>
+	.ad {
+		padding: 0.75rem 1rem 1rem;
+	}
+	.ad-head {
+		padding-bottom: 0.75rem;
+		border-bottom: 1px solid var(--color-border);
+	}
+	.ad-sec {
+		margin-top: 1rem;
+	}
+	.ad-hd {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.5rem;
+		margin-bottom: 0.375rem;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--color-text-muted);
+	}
+	.ad-hd-note {
+		text-transform: none;
+		letter-spacing: 0;
+		font-weight: 400;
+		font-size: 0.75rem;
+		font-variant-numeric: tabular-nums;
+	}
+
+	/* One line of the bill. A row that opens something carries the arrow and the
+	   hover ring; a laser-cut line, which has no detail view yet, does not. */
+	.ad-row {
+		display: flex;
+		width: 100%;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.5rem;
+		border: 1px solid var(--color-border);
+		background: var(--color-surface);
+		text-align: left;
+	}
+	.ad-row + .ad-row {
+		margin-top: -1px;
+	}
+	.ad-row-open {
+		cursor: pointer;
+		transition:
+			border-color 120ms ease,
+			background-color 120ms ease;
+	}
+	.ad-row-open:hover,
+	.ad-row-open:focus-visible {
+		outline: none;
+		position: relative;
+		z-index: 1;
+		border-color: var(--color-primary);
+		background: color-mix(in oklab, var(--color-primary) 5%, var(--color-surface));
+	}
+	.ad-body {
+		display: flex;
+		min-width: 0;
+		flex: 1;
+		flex-direction: column;
+	}
+	.ad-name {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.375rem;
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--color-text);
+	}
+	.ad-meta {
+		margin-top: 0.125rem;
+		font-size: 0.75rem;
+		color: var(--color-text-muted);
+	}
+	.ad-qty {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		color: var(--color-text);
+	}
+	:global(.ad-go) {
+		flex: none;
+		color: var(--color-text-muted);
+	}
+	.ad-row-open:hover :global(.ad-go) {
+		color: var(--color-primary);
+	}
+
+	.ad-fan {
+		display: flex;
+		flex: none;
+	}
+	.ad-thumb {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.25rem;
+		height: 2.25rem;
+		flex: none;
+		border: 1px solid var(--color-border);
+		background: var(--color-bg);
+		padding: 0.125rem;
+	}
+	.ad-thumb img {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+	.ad-thumb + .ad-thumb {
+		margin-left: -0.625rem;
+	}
+	.ad-thumb-empty {
+		color: var(--color-text-muted);
+	}
+	.ad-fan-lg .ad-thumb-lg {
+		width: 3.5rem;
+		height: 3.5rem;
+	}
+	.ad-fan-lg .ad-thumb-lg + .ad-thumb-lg {
+		margin-left: -0.875rem;
+	}
+
+	.ad-cand {
+		margin-top: 1rem;
+		padding: 0.625rem;
+		border: 1px dashed color-mix(in oklab, var(--color-primary) 60%, transparent);
+	}
+	.ad-cand-retired {
+		border-color: var(--color-border);
+		opacity: 0.6;
+	}
+	.ad-cand .ad-row:first-of-type {
+		margin-top: 0.5rem;
+	}
+</style>

--- a/parts-calculator/src/lib/components/AssemblyDetailModal.svelte
+++ b/parts-calculator/src/lib/components/AssemblyDetailModal.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { ChevronLeft } from 'lucide-svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import AssemblyDetail from '$lib/components/AssemblyDetail.svelte';
+	import { getAssembly, type Hardware, type Part } from '$lib/filament';
+
+	// Thin modal wrapper around the shared AssemblyDetail view, used by the parts
+	// dashboard and the assembly tab so both open the same thing. Parts and
+	// hardware are handed back to the caller, which already owns those modals;
+	// sub-assemblies are navigated inside this one, since opening a fourth copy of
+	// the same modal to see a child box helps nobody.
+	let {
+		open = $bindable(false),
+		id,
+		layers,
+		onPart,
+		onHardware
+	}: {
+		open?: boolean;
+		id: string | null;
+		layers: number;
+		onPart?: (p: Part) => void;
+		onHardware?: (h: Hardware) => void;
+	} = $props();
+
+	// The trail below whatever the opener named. Tied to the root it was built
+	// from, so pointing the modal at a different assembly drops it without an
+	// effect having to notice.
+	let trail = $state<string[]>([]);
+	let trailRoot = $state<string | null>(null);
+	const path = $derived(id ? (trailRoot === id ? [id, ...trail] : [id]) : []);
+	const current = $derived(getAssembly(path[path.length - 1] ?? ''));
+	const parent = $derived(path.length > 1 ? getAssembly(path[path.length - 2]) : null);
+
+	function go(next: string) {
+		if (trailRoot !== id) {
+			trailRoot = id;
+			trail = [];
+		}
+		trail = [...trail, next];
+	}
+</script>
+
+<Modal bind:open title={current?.name} maxW="max-w-3xl">
+	{#if current}
+		{#if parent}
+			<button
+				type="button"
+				class="flex w-full items-center gap-1 border-b border-border px-4 py-1.5 text-xs font-medium text-text-muted hover:text-primary"
+				onclick={() => (trail = trail.slice(0, -1))}
+			>
+				<ChevronLeft size={13} /> Back to {parent.name}
+			</button>
+		{/if}
+		<AssemblyDetail assembly={current} {layers} {onPart} {onHardware} onAssembly={go} />
+	{/if}
+</Modal>

--- a/parts-calculator/src/lib/components/Modal.svelte
+++ b/parts-calculator/src/lib/components/Modal.svelte
@@ -1,3 +1,10 @@
+<script lang="ts" module>
+	// Modals stack: an assembly opens a part on top of itself. Escape has to close
+	// the one in front rather than the whole pile, so each open instance registers
+	// here and only the last one registered acts on the key.
+	const stack: symbol[] = [];
+</script>
+
 <script lang="ts">
 	import { X } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
@@ -16,8 +23,18 @@
 		children: Snippet;
 	} = $props();
 
+	const token = Symbol('modal');
+	$effect(() => {
+		if (!open) return;
+		stack.push(token);
+		return () => {
+			const i = stack.lastIndexOf(token);
+			if (i >= 0) stack.splice(i, 1);
+		};
+	});
+
 	function onKey(e: KeyboardEvent) {
-		if (e.key === 'Escape') open = false;
+		if (e.key === 'Escape' && stack[stack.length - 1] === token) open = false;
 	}
 </script>
 

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -37,6 +37,7 @@
 	import ColorPicker from '$lib/components/ColorPicker.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import PartDetailModal from '$lib/components/PartDetailModal.svelte';
+	import AssemblyDetailModal from '$lib/components/AssemblyDetailModal.svelte';
 	import IdStamp from '$lib/components/IdStamp.svelte';
 	import BuildPlates from '$lib/components/BuildPlates.svelte';
 	import Seo from '$lib/components/Seo.svelte';
@@ -52,7 +53,7 @@
 	import Badge from '$lib/components/Badge.svelte';
 	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
 	import MissingImage from '$lib/components/MissingImage.svelte';
-	import { Download, Package, ZoomIn, Loader, Info, Plus, X, RotateCcw, Clock, Layers3, ExternalLink, AlertTriangle, History, ChevronRight, ChevronDown } from 'lucide-svelte';
+	import { Download, Package, ZoomIn, Loader, Info, Plus, X, RotateCcw, Clock, Layers3, ExternalLink, AlertTriangle, History, ChevronRight, ChevronDown, ArrowUpRight, FlaskConical } from 'lucide-svelte';
 	import { page } from '$app/state';
 	import { replaceState } from '$app/navigation';
 	import { browser } from '$app/environment';
@@ -152,6 +153,8 @@
 				version: v ? p.versions?.find((x) => String(x.version) === v) : undefined
 			});
 		}
+		const aid = sp.get('assembly');
+		if (aid && getAssembly(aid)) openAssembly(aid);
 		urlReady = true;
 	});
 
@@ -175,6 +178,8 @@
 			params.delete('color');
 			params.delete('v');
 		}
+		if (asmOpen && asmId) params.set('assembly', asmId);
+		else params.delete('assembly');
 		const qs = params.toString();
 		const target = qs ? `${location.pathname}?${qs}` : location.pathname;
 		if (target !== location.pathname + location.search) replaceState(target, {});
@@ -204,6 +209,15 @@
 	function openPlatesModal(id: string) {
 		platesModalPartId = id;
 		platesModalOpen = true;
+	}
+	// The assembly modal: the rollup rows and the assembly tab open the same view
+	// of one box. Held here (not inside the modal) so it can be deep-linked, the
+	// same way the part viewer is.
+	let asmOpen = $state(false);
+	let asmId = $state<string | null>(null);
+	function openAssembly(id: string) {
+		asmId = id;
+		asmOpen = true;
 	}
 	let viewerOpen = $state(false);
 	let viewerPart = $state<Part | null>(null);
@@ -602,15 +616,20 @@
 				{/if}
 			</td>
 			<td class="pl-c-thumb">
-				<button
-					type="button"
-					class="pl-thumb group relative"
-					onclick={() => openViewer(p)}
-					title="View {p.name} in 3D"
-				>
-					<img src={p.render} alt={p.name} />
-					<span class="absolute inset-0 flex items-center justify-center bg-black/40 text-white opacity-0 transition-opacity group-hover:opacity-100 group-hover/row:opacity-100"><ZoomIn size={16} /></span>
-				</button>
+				<span class="pl-thumbwrap">
+					<!-- empty twist slot: keeps a part's thumbnail on the same line as
+					     the fans on the assembly rows above it -->
+					<span class="pl-twist"></span>
+					<button
+						type="button"
+						class="pl-thumb group relative"
+						onclick={() => openViewer(p)}
+						title="View {p.name} in 3D"
+					>
+						<img src={p.render} alt={p.name} />
+						<span class="absolute inset-0 flex items-center justify-center bg-black/40 text-white opacity-0 transition-opacity group-hover:opacity-100 group-hover/row:opacity-100"><ZoomIn size={16} /></span>
+					</button>
+				</span>
 			</td>
 			<td class="pl-c-name">
 				<span class="pl-name">
@@ -824,46 +843,72 @@
 									{@const open = expandedAsm[k]}
 									{@const allOn = asmAllOn(block.parts)}
 									<!-- svelte-ignore a11y_no_noninteractive_element_interactions a11y_click_events_have_key_events -->
-									<tr class="pl-row" id="assembly-{block.id}" onclick={() => toggleAsm(k)}>
+									<tr
+										class="pl-row"
+										id="assembly-{block.id}"
+										onclick={() => (a ? openAssembly(a.id) : toggleAsm(k))}
+										title={a ? `View ${a.name}` : undefined}
+									>
 										<td class="pl-c-check">
-										<input
+											<input
 												class="setup-toggle h-4 w-4"
 												type="checkbox"
 												checked={allOn}
 												indeterminate={!allOn && asmSomeOn(block.parts)}
 												onclick={(e) => e.stopPropagation()}
 												onchange={() => setAsm(block.parts, !allOn)}
-											aria-label="Select every part in {group?.name}"
-											disabled={!block.parts.length}
+												aria-label="Select every part in {group?.name}"
+												disabled={!block.parts.length}
 											/>
 										</td>
 										<td class="pl-c-thumb">
-										<span class="pl-fan">
-											{#if !block.parts.length}<MissingImage class="pl-thumb" />{/if}
-												{#each block.parts.slice(0, 3) as bp, i (bp.id)}
-													<span class="pl-thumb" style="z-index:{3 - i}"><img src={bp.render} alt={bp.name} /></span>
-												{/each}
+											<span class="pl-thumbwrap">
+												<!-- The only control that expands the members in place. Everything
+												     else on the row opens the assembly itself. -->
+												{#if block.parts.length}
+													<button
+														type="button"
+														class="pl-twist"
+														onclick={(e) => { e.stopPropagation(); toggleAsm(k); }}
+														aria-expanded={!!open}
+														aria-label="{open ? 'Hide' : 'Show'} the parts inside {group?.name}"
+														title="{open ? 'Hide' : 'Show'} the {block.parts.length} parts inside"
+													>
+														{#if open}<ChevronDown size={15} />{:else}<ChevronRight size={15} />{/if}
+													</button>
+												{:else}<span class="pl-twist"></span>{/if}
+												<span class="pl-fan">
+													{#if !block.parts.length}<MissingImage class="pl-thumb" />{/if}
+													{#each block.parts.slice(0, 3) as bp, i (bp.id)}
+														<span class="pl-thumb" style="z-index:{3 - i}"><img src={bp.render} alt={bp.name} /></span>
+													{/each}
+												</span>
 											</span>
 										</td>
 										<td class="pl-c-name">
-											<span class="pl-name">
-												{#if open}<ChevronDown size={15} class="text-text-muted" />{:else}<ChevronRight size={15} class="text-text-muted" />{/if}
-												{group?.name}
-												<Badge variant={block.groupKind === 'folder' ? 'neutral' : 'info'}>{block.groupKind === 'folder' ? 'Folder' : 'Assembly'}</Badge>
-												{#if block.groupKind === 'assembly' && a?.status === 'stub'}<Badge variant="neutral">Coming soon</Badge>{/if}
-												{#if block.groupKind === 'assembly' && a}<ChangeStatus kind="assemblies" id={a.id} name={a.name} />{/if}
+											<span class="pl-nameblock" class:pl-open={!!a}>
+												<span class="pl-name">
+													{group?.name}
+													<Badge variant={block.groupKind === 'folder' ? 'neutral' : 'info'}>{block.groupKind === 'folder' ? 'Folder' : 'Assembly'}</Badge>
+													{#if block.groupKind === 'assembly' && a?.status === 'stub'}<Badge variant="neutral">Coming soon</Badge>{/if}
+													{#if a?.candidates?.some((c) => !c.superseded_by && !c.rejected_at)}<Badge variant="info"><FlaskConical size={11} /> Candidate</Badge>{/if}
+													{#if block.groupKind === 'assembly' && a}<ChangeStatus kind="assemblies" id={a.id} name={a.name} />{/if}
+												</span>
+												<span class="pl-meta">
+													{block.parts.length ? `${block.parts.length} printed parts` : 'Parts and print details coming soon'}
+													{#if a}<span class="pl-hint">View assembly <ArrowUpRight size={12} /></span>{:else if block.parts.length}· click to {open ? 'collapse' : 'expand'}{/if}
+												</span>
 											</span>
-										<span class="pl-meta">{block.parts.length ? `${block.parts.length} parts · click to ${open ? 'collapse' : 'expand'}` : 'Parts and print details coming soon'}</span>
 										</td>
-									<td class="pl-c-each">{block.parts.length ? `${block.parts.length} parts` : '—'}</td>
-									<td class="pl-c-total">{block.parts.length ? grams(asmGrams(block.parts, section.id)) : '—'}</td>
+										<td class="pl-c-each">{block.parts.length ? `${block.parts.length} parts` : '—'}</td>
+										<td class="pl-c-total">{block.parts.length ? grams(asmGrams(block.parts, section.id)) : '—'}</td>
 										<td class="pl-c-dl">
-										{#if block.parts.length}<button
-												type="button"
-												class="pl-dl"
-												onclick={(e) => { e.stopPropagation(); downloadZip(block.parts, `${block.id}.zip`); }}
-												title="Download every STL in {group?.name}"
-										><Download size={16} /></button>{/if}
+											{#if block.parts.length}<button
+													type="button"
+													class="pl-dl"
+													onclick={(e) => { e.stopPropagation(); downloadZip(block.parts, `${block.id}.zip`); }}
+													title="Download every STL in {group?.name}"
+											><Download size={16} /></button>{/if}
 										</td>
 									</tr>
 									{#if open}
@@ -984,6 +1029,7 @@
 	</footer>
 </div>
 
+<AssemblyDetailModal bind:open={asmOpen} id={asmId} {layers} onPart={(p) => openViewer(p)} />
 <PartDetailModal bind:open={viewerOpen} part={viewerPart} bind:colorId={viewerColor} bind:version={viewerVersion} />
 
 <Modal bind:open={platesModalOpen} title="Build plates · {partsById.get(platesModalPartId ?? '')?.name ?? ''}">
@@ -1050,16 +1096,22 @@
 		.pl-row > td:first-child { padding-left: 0.5rem; }
 		.pl-kid > td:first-child { padding-left: 1.25rem; }
 		.pl-c-each { display: none; }
-		.pl-c-check { width: 1.75rem; }
-		.pl-c-thumb { width: 2.75rem; }
-		.pl-c-thumb img { width: 2.25rem; height: 2.25rem; }
+		/* Prefixed with .pl-tbl on purpose: the desktop column widths below are
+		   written after this block, so a bare .pl-c-* here loses to them and the
+		   phone layout silently keeps desktop widths. Costs one class of
+		   specificity; buys the tightening this block exists for. */
+		.pl-tbl .pl-c-check { width: 1.75rem; }
+		/* twist slot + thumbnail have to fit inside the fixed column, borders and
+		   all, or the name cell begins underneath the image */
+		.pl-tbl .pl-c-thumb { width: 4.75rem; }
+		.pl-c-thumb .pl-thumb { width: 2.25rem; height: 2.25rem; }
 		/* the rollup's fan of three thumbnails has nowhere to go in a phone's thumb
 		   column — it spilled over the name. One stands in; the badge and the
 		   "3 parts" line already say it's an assembly. */
 		.pl-fan .pl-thumb + .pl-thumb { display: none; }
 		.pl-c-name { width: auto; }
-		.pl-c-total { width: 3.5rem; }
-		.pl-c-dl { width: 1.5rem; }
+		.pl-tbl .pl-c-total { width: 3.5rem; }
+		.pl-tbl .pl-c-dl { width: 1.5rem; }
 		.pl-sec { margin-bottom: 1.75rem; }
 		/* long unbroken part names would otherwise force the column wider */
 		.pl-name,
@@ -1101,6 +1153,34 @@
 	.pl-fan { display: flex; }
 	.pl-fan .pl-thumb { border: 1px solid var(--color-border); background: var(--color-surface); }
 	.pl-fan .pl-thumb + .pl-thumb { margin-left: -0.75rem; }
+
+	/* An assembly row is a door, not a disclosure widget. The name and its count
+	   are drawn as one object you open; the chevron beside the thumbnails is the
+	   only thing that expands the members in place. Part rows keep an empty twist
+	   slot so their single thumbnail lines up with the fans above it. */
+	.pl-thumbwrap { display: flex; align-items: center; gap: 0.25rem; }
+	.pl-twist {
+		display: inline-flex; align-items: center; justify-content: center;
+		width: 1.125rem; height: 1.5rem; flex: none;
+		color: var(--color-text-muted);
+	}
+	button.pl-twist { cursor: pointer; transition: color 120ms; }
+	button.pl-twist:hover, button.pl-twist:focus-visible { outline: none; color: var(--color-primary); }
+
+	.pl-nameblock { display: block; }
+	.pl-open {
+		/* No negative margin to pull the text back into line with the part rows
+		   below: at 375px the name cell is narrow enough that the box would slide
+		   under the thumbnail. The half-rem inset reads as hierarchy anyway. */
+		display: inline-block; padding: 0.3125rem 0.5rem;
+		border: 1px solid var(--color-border); background: var(--color-bg);
+		transition: border-color 120ms ease, background-color 120ms ease;
+	}
+	.pl-row:hover .pl-open, .pl-row:focus-within .pl-open {
+		border-color: var(--color-primary);
+		background: color-mix(in oklab, var(--color-primary) 6%, var(--color-bg));
+	}
+	.pl-hint { display: inline-flex; align-items: center; gap: 0.125rem; color: var(--color-primary); }
 
 	.pl-dl { display: inline-flex; color: var(--color-primary); }
 	.pl-dl:hover { color: var(--color-primary-hover); }

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -7,6 +7,7 @@
 	import Callout from '$lib/components/Callout.svelte';
 	import LayerControl from '$lib/components/LayerControl.svelte';
 	import PartDetailModal from '$lib/components/PartDetailModal.svelte';
+	import AssemblyDetailModal from '$lib/components/AssemblyDetailModal.svelte';
 	import HardwareDetailModal from '$lib/components/HardwareDetailModal.svelte';
 	import HardwareIcon from '$lib/components/HardwareIcon.svelte';
 	import ImageStrip from '$lib/components/ImageStrip.svelte';
@@ -91,6 +92,15 @@
 	function openHardware(h: Hardware) {
 		hwModal = h;
 		hwOpen = true;
+	}
+	// A node's name pulls it out of the tree into the same one-box view the parts
+	// dashboard opens, which is the point of having the view at all: on this page
+	// an assembly is a branch among hundreds, and sometimes you want just the box.
+	let asmOpen = $state(false);
+	let asmId = $state<string | null>(null);
+	function openAssembly(id: string) {
+		asmId = id;
+		asmOpen = true;
 	}
 
 	// The whole tree flattened, one row per node, with STL/DXF links on anything
@@ -232,7 +242,7 @@
 				: 'border-border'}"
 		>
 			<div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-				<span class="text-sm font-semibold text-text">{asm.name}</span>
+				<button type="button" class="asm-open text-sm font-semibold text-text" onclick={() => openAssembly(asm.id)} title="View {asm.name} on its own">{asm.name}</button>
 				<span class="text-xs tabular-nums text-text-muted">
 					{#if qty === 'per-layer'}×{layers} (1 per layer)
 					{:else if qty === 'middle-layers'}×{Math.max(0, layers - 2)} (layers between the interfaces)
@@ -419,6 +429,7 @@
 	</div>
 </div>
 
+<AssemblyDetailModal bind:open={asmOpen} id={asmId} {layers} onPart={openPart} onHardware={openHardware} />
 <PartDetailModal bind:open={partOpen} part={partModal} bind:colorId={partColor} bind:version={partVersion} />
 <HardwareDetailModal bind:open={hwOpen} hardware={hwModal} {layers} />
 
@@ -434,5 +445,18 @@
 	.asm-thumb:focus-visible {
 		outline: none;
 		box-shadow: 0 0 0 2px var(--color-primary);
+	}
+	/* The node's name opens the assembly on its own. Underlined on hover rather
+	   than always, so a tree of two hundred names doesn't read as a link farm. */
+	.asm-open {
+		cursor: pointer;
+		text-align: left;
+		text-underline-offset: 3px;
+	}
+	.asm-open:hover,
+	.asm-open:focus-visible {
+		outline: none;
+		color: var(--color-primary);
+		text-decoration: underline;
 	}
 </style>


### PR DESCRIPTION
An assembly had no detail view. A part has one, hardware has one, and both open
from anywhere they appear — but the only way to see what was inside an assembly
was to read it off the tree page in situ, surrounded by every other branch. The
rollup rows on the parts dashboard could not show it at all, which is also why a
candidate revision sitting beside an adopted assembly was invisible there while
being fully rendered one tab over.

## The view

`AssemblyDetail` joins `PartDetail` and `HardwareDetail`, same thin
`*DetailModal` wrapper, and **both surfaces open the same one**. It shows the
assembly as a single object:

- its own pictures when it has them, its members' renders fanned out when it
  doesn't
- uid, version, status, description, the docs guide link, joining method
- every line of the bill — printed, off-the-shelf, laser cut — each row opening
  its own detail view
- **candidates**, so the dashboard finally says a revision is on the table
- previous revisions, collapsed, each line pinned to the member uid of the day

It renders **one level**. A sub-assembly is a row carrying its own fan of member
renders, printed-part count and grams; opening it navigates inside the modal
with a back trail. Nesting the tree here would just rebuild the tree page, which
is the view this one exists to be an alternative to.

**Modals stack now.** Opening a part from inside an assembly puts it on top
rather than replacing it, and Escape closes the front one instead of the whole
pile. `Modal` keeps a module-level stack for that; stacking order follows markup
order, so a modal openable from another is rendered before it.

`?assembly=<id>` deep-links it, the same as `?part=`.

## The rollup row

It was built around being a disclosure widget, which left nothing saying you
could look at the assembly itself. It is a door now:

- the **chevron moves out of the title and in beside the thumbnails**, where it
  is the one control that expands the members in place
- the **name and its count sit in a box** drawn as the object you open, with a
  `View assembly ↗` hint
- **the row opens it**, exactly like a part row already opened a part
- part rows keep an empty twist slot so a single thumbnail still lines up with
  the fans above it — measured, both land on x=180 desktop / x=67 at 375px

On the tree page the same view opens from a node's name, underlined on hover
rather than always, so 42 openable names don't read as a link farm.

## Two phone bugs fell out

The name box slid under the thumbnail at 375px, because the fixed column had no
room for a twist slot. The reason it had no room is that **every column-width
override in the phone block was dead**: the desktop widths are written after it,
so a bare `.pl-c-*` there always lost. The phone layout has been quietly running
desktop column widths. Prefixed with `.pl-tbl` so they win, which is what the
block was written to do.

## Verified

- `svelte-check` 4361 files, 0 errors · production build clean
- Assembly modal from both the dashboard row and a tree node, same component
- Part modal opens **on top** of the assembly modal; Escape closes only the part
- `Feeder` → `C-channel drive` → `← Back to Feeder` navigates and the back
  button disappears at the root
- Chevron expands without opening the modal; checkbox and download button don't
  open it either, and selection survives
- 375px: no overlap, no horizontal page scroll
