### PR TITLE
engineering notes at /n/<id>/, and the tools that made the first one

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -59,6 +59,35 @@ asset spec, and the rules for adding a site live in
    arbitrarily deep).
 4. `python3 scripts/validate_frontmatter.py` must pass.
 
+## Engineering notes (`/n/<id>/`)
+
+A note is a permanent page about something that happened, written when a part
+or a decision needs a record that a changelog line cannot carry: why an export
+was replaced, what was measured, what was ruled out. They are deliberately
+unlike the rest of this site.
+
+- **Minted id, no slug.** `docs/src/content/notes/<id>.md` with
+  `permalink: /n/<id>/`. Get the id from
+  `parts-calculator/catalog/mint_uid.py`, which draws from the same pool as
+  part uids and skips ids already naming a note, so an id means one thing
+  wherever you type it. A slug would be a claim that goes stale; the words
+  live in the title, where being wrong later costs nothing.
+- **Not in `nav.yml`, ever.** That keeps it out of the sidebar and out of
+  search (both are built from the nav), so it is reachable only from whatever
+  links it. Leave `section:` unset and the page renders full width with no
+  sidebar.
+- **Not edited after the fact.** Say so at the foot of the page. If the
+  situation changes, mint a new note that supersedes it and leave the old one
+  exactly where it is.
+- **Link it from the thing it is about.** A part, version or candidate in
+  `parts-calculator/catalog/parts.json` takes `"note": "<id>"`, and the part
+  page renders "Engineering note <id>" pointing back here.
+
+Images follow the ordinary rules below (upload, content-addressed URL, never
+in git), under `notes/<id>/`. A detail image wants the full column: put a
+single `<figure>` inside an `img-row` rather than using `doc-figure`, which
+caps at 440px for assembly photos.
+
 ## Components (write these as raw HTML in the markdown)
 
 Liquid includes and `site.data` still work exactly as they did under Jekyll —

--- a/docs/src/content/notes/3v2p.md
+++ b/docs/src/content/notes/3v2p.md
@@ -61,14 +61,15 @@ Version 1 stays resolvable at
 [`q7ns`](https://parts-calculator.basically.website/u/q7ns/), because prints of
 it exist.
 
-**Cable clamp (inner).** Still ships
-[the export Onshape gave us](https://parts-calculator.basically.website/u/3fue/),
-defects and all, so it carries no id stamp. A repair was written and proven,
-closing both sites with 12567 of the part's 12569 triangles untouched, 11
-triangles added inside the holes' own bounding boxes, and the bounding box
-unmoved. It was not adopted: a repaired mesh is not what the CAD produced, and
-choosing that over fixing the feature that tessellates badly is a decision on
-its own.
+**Cable clamp (inner).** Both sites were closed with `mesh_repair.py`, and
+[the download](https://parts-calculator.basically.website/u/3fue/) is now that
+repaired mesh, which carries an id stamp like every other part. 12567 of the
+part's 12569 triangles are untouched, the 2 deleted ones are the coincident
+pair, and the 11 added ones lie inside the holes' own bounding boxes, so the
+bounding box does not move and the surface grows by 0.05 mm2 out of 4331. It
+is still the same design, so it keeps the id `3fue`: a re-export is new bytes
+under the same id, and only a design change earns a new one. The feather edge
+that tessellates badly is worth fixing in CAD when the part is next touched.
 
 ## Running it again
 

--- a/docs/src/content/notes/3v2p.md
+++ b/docs/src/content/notes/3v2p.md
@@ -1,0 +1,92 @@
+---
+title: Two exported meshes that were not closed solids
+type: reference
+permalink: /n/3v2p/
+slug: note-3v2p
+kicker: Engineering notes — 3v2p
+lede: What was wrong with the camera extension and the inner cable clamp when they came out of CAD, and what was done about it.
+owner: hardware
+audience: anyone who followed a version link here
+applies_to: sorter v2 printed parts
+last_verified: 2026-08-22
+---
+
+Every printed part carries a four character version id, recessed into one face
+of the STL you download, which needs the exported mesh to be a closed solid.
+On 22 August 2026 two parts were not. Both defects are far too small to see at
+any normal zoom, and neither is a mistake in the CAD.
+
+| Part | uid | What was wrong |
+| --- | --- | --- |
+| Camera extension | `q7ns` | 4 zero-area triangles and the 4 non-manifold edges they made, inside the raised "50 mm" lettering |
+| Cable clamp (inner) | `3fue` | a 0.40 mm hole (11 open edges), plus a pair of coincident triangles 0.08 mm across |
+
+The two parts exported alongside them, the camera extension mount and the
+outer cable clamp, were clean.
+
+## Camera extension
+
+<div class="img-row">
+  <figure>
+  <img src="https://img.basically.website/web/notes/3v2p/camera-extension-q7ns-1253c651-site-1.e3c999146b1f1ff7.jpg" alt="Four views of the camera extension: the whole part with a red ring around a spot in its raised 50mm lettering, then two zooms showing a red sliver crossing the letter m, then the same view with every triangle drawn">
+  <figcaption>The only defect on the part, and it is inside the lettering. Red is the bad geometry, yellow the non-manifold edges. The bottom right panel draws every triangle: extruded text tessellates into slivers where the strokes meet, and four of them came out with no area at all.</figcaption>
+  </figure>
+</div>
+
+## Cable clamp (inner)
+
+Two sites, both on the feather edge at the bottom end of the part, 8 mm apart.
+
+<div class="img-row">
+  <figure>
+  <img src="https://img.basically.website/web/notes/3v2p/cable-clamp-inner-3fue-a77f4963-site-1.1da7e0eb5fa022ee.jpg" alt="Four views of the inner cable clamp: the whole part with a red ring near its lower tip, then zooms showing a red fan of triangles around a small hole outlined in yellow, then the same view with every triangle drawn">
+  <figcaption>Site 1: a hole 0.40 by 0.22 by 0.32 mm, its rim in yellow.</figcaption>
+  </figure>
+</div>
+
+<div class="img-row">
+  <figure>
+  <img src="https://img.basically.website/web/notes/3v2p/cable-clamp-inner-3fue-a77f4963-site-2.130f90f1459bb3d3.jpg" alt="Four views of the same part at a second spot, showing a thin red line where two triangles lie on top of each other, and the same spot with every triangle drawn">
+  <figcaption>Site 2: the same triangle twice, facing opposite ways. It is 0.10 mm long and 0.003 mm wide, so from every direction it draws as a line.</figcaption>
+  </figure>
+</div>
+
+## What was done
+
+**Camera extension.** The lettering is gone in
+[version 2](https://parts-calculator.basically.website/u/v684/), which is
+watertight. The tube is otherwise unchanged: same 58.25 by 58.25 by 54 mm
+envelope, volume within 0.12 percent, mesh 15904 triangles down to 5290.
+Version 1 stays resolvable at
+[`q7ns`](https://parts-calculator.basically.website/u/q7ns/), because prints of
+it exist.
+
+**Cable clamp (inner).** Still ships
+[the export Onshape gave us](https://parts-calculator.basically.website/u/3fue/),
+defects and all, so it carries no id stamp. A repair was written and proven,
+closing both sites with 12567 of the part's 12569 triangles untouched, 11
+triangles added inside the holes' own bounding boxes, and the bounding box
+unmoved. It was not adopted: a repaired mesh is not what the CAD produced, and
+choosing that over fixing the feature that tessellates badly is a decision on
+its own.
+
+## Running it again
+
+Both scripts live in the parts calculator and are deterministic, so the numbers
+above reproduce byte for byte:
+
+```
+python scripts/mesh_report.py part.stl --figures out/
+python scripts/mesh_repair.py part.stl repaired.stl
+```
+
+Pinned to the commit that added them:
+[`mesh_report.py`](https://github.com/basicallysource/sorter-v2/blob/896de392bacdd6703620015830f8ed36f0139cdc/parts-calculator/scripts/mesh_report.py),
+[`mesh_repair.py`](https://github.com/basicallysource/sorter-v2/blob/896de392bacdd6703620015830f8ed36f0139cdc/parts-calculator/scripts/mesh_repair.py),
+[`meshfig.py`](https://github.com/basicallysource/sorter-v2/blob/896de392bacdd6703620015830f8ed36f0139cdc/parts-calculator/scripts/meshfig.py).
+Every figure on this page came out of `mesh_report.py --figures`.
+
+<div class="callout">
+  <p>This note is permanent and is not edited after the fact. If the situation
+  changes, a new note supersedes it and this one stays where it is.</p>
+</div>

--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -150,7 +150,10 @@ def normalize_versions(part):
     date = part.get("created_at", part.get("date_added", ""))
     entry = {"version": part.get("version", "1"), "uid": part["uid"], "date": date,
              "message": "Initial version.", "commit": None}
-    # a single-version part can still carry OnShape links at the part level
+    # a single-version part can still carry an engineering note and OnShape
+    # links at the part level
+    if part.get("note"):
+        entry["note"] = part["note"]
     if part.get("onshape_version"):
         entry["onshape_version"] = part["onshape_version"]
     if part.get("onshape_doc"):

--- a/parts-calculator/catalog/mint_uid.py
+++ b/parts-calculator/catalog/mint_uid.py
@@ -10,9 +10,11 @@ laser-cut parts carry one too -- one scheme for everything on the machine.
 
   /opt/homebrew/opt/python@3.11/libexec/bin/python catalog/mint_uid.py [N]
 
-prints N (default 1) fresh uids, none of them anywhere in parts.json.
+prints N (default 1) fresh uids, none of them anywhere in parts.json or
+already naming a note.
 generate.py refuses a parts.json with a duplicate or missing uid.
 """
+import glob
 import json
 import os
 import random
@@ -22,6 +24,9 @@ import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 MANIFEST = os.path.join(HERE, "parts.json")
+# Engineering notes (docs/src/content/notes/<id>.md, served at /n/<id>/) are
+# named from this same pool, so an id means one thing whatever you type it into.
+NOTES = os.path.join(HERE, "..", "..", "docs", "src", "content", "notes", "*.md")
 
 ALPHABET = string.ascii_lowercase + string.digits
 UID = re.compile(r"[a-z0-9]{4}")
@@ -29,11 +34,11 @@ UID = re.compile(r"[a-z0-9]{4}")
 
 def taken_uids(manifest):
     """Every uid in use: each part's and assembly's current one, their superseded
-    versions' and their candidates'."""
+    versions' and their candidates', plus every note id."""
     return {u for item in manifest["parts"] + manifest.get("assemblies", [])
             for u in [item.get("uid")] + [v.get("uid") for v in item.get("versions") or []]
                      + [c.get("uid") for c in item.get("candidates") or []]
-            if u}
+            if u} | {os.path.basename(p)[:-3] for p in glob.glob(NOTES)}
 
 
 def mint(taken):

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1073,12 +1073,12 @@
       "internal_notes": "1 per interface. White. Pairs with the outer clamp (cable-clamp assembly).",
       "version": "1",
       "created_at": "2026-06-27",
-      "updated_at": "2026-06-27",
+      "updated_at": "2026-08-22",
       "quantities": {
         "interface": 1
       },
       "assembly": "cable-clamp",
-      "stl_hash": "a77f4963aada127b93e60161a8aa83685a03ce6f3beb318c270627f7641927af",
+      "stl_hash": "16cfdfea28d0f04e62014bc4caa8d32a7dd41eb495914824a64be629ab64b4a0",
       "color": {
         "role": "chute-core"
       },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1084,7 +1084,8 @@
       },
       "optional": false,
       "support": true,
-      "onshape": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/w/63d9095d8167813360e7753c/e/279fa8866ec0d8c56c8226cf"
+      "onshape": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/w/63d9095d8167813360e7753c/e/279fa8866ec0d8c56c8226cf",
+      "note": "3v2p"
     },
     {
       "id": "cable-clamp-outer",
@@ -2032,7 +2033,8 @@
           "message": "Dropped the raised \"50 mm\" lettering. Its geometry tessellated into zero-area slivers, which left the exported mesh non-manifold, so it could neither be checked nor stamped. The tube itself is unchanged.",
           "commit": "0aeff083",
           "onshape_doc": "https://cad.onshape.com/documents/249bded2198af476185014b6",
-          "onshape_version": "https://cad.onshape.com/documents/249bded2198af476185014b6/v/3ec354b28012f6c0ab41285a/e/48c64d61f1276c46f515d6bd"
+          "onshape_version": "https://cad.onshape.com/documents/249bded2198af476185014b6/v/3ec354b28012f6c0ab41285a/e/48c64d61f1276c46f515d6bd",
+          "note": "3v2p"
         }
       ],
       "attributes": [

--- a/parts-calculator/catalog/requirements.txt
+++ b/parts-calculator/catalog/requirements.txt
@@ -10,3 +10,7 @@ shapely==2.1.2
 manifold3d==3.5.2
 scipy==1.17.1
 boto3==1.42.44
+# scripts/mesh_report.py and mesh_repair.py: finding the places an export is not
+# a closed solid, and drawing them (meshfig.py rasterises with numpy + Pillow,
+# since a build box has no GL context)
+pillow==12.3.0

--- a/parts-calculator/scripts/mesh_repair.py
+++ b/parts-calculator/scripts/mesh_repair.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""Close the tessellation defects in an STL without moving any real geometry.
+
+For when a part is sound in CAD but its export is not a closed solid. Three
+steps, each refusing anything that is not obviously a slip of the tessellator:
+
+  1. delete coincident triangle pairs (the same triangle twice, facing opposite
+     ways: a flap with no thickness, which nothing can be printed from),
+  2. split each boundary into simple cycles, since a boundary pinched at one
+     vertex is two holes that touch rather than one big one,
+  3. fill each cycle as a fan from its own centroid, refusing any hole wider
+     than --max-span, which is what keeps this from quietly reshaping a part.
+
+Nothing already in the file is moved, so every added triangle lies inside the
+hole's own bounding box, and the report says exactly how many triangles were
+touched. A repaired export is not what the CAD gave you: prefer fixing the
+feature that tessellates badly, and treat this as the fallback.
+
+    python scripts/mesh_repair.py in.stl out.stl [--max-span 1.0]
+
+Exits 1 if the result is still not a closed volume.
+"""
+import argparse
+import sys
+from collections import Counter
+
+import numpy as np
+import trimesh
+
+
+def open_edges(mesh):
+    counts = Counter(tuple(e) for e in mesh.edges_sorted)
+    return [e for e, n in counts.items() if n == 1]
+
+
+def drop_coincident(mesh):
+    """Remove both halves of any triangle that appears twice. Two coincident
+    faces are not a surface, and keeping either one would leave a fin."""
+    keys = [tuple(sorted(f)) for f in mesh.faces]
+    seen = Counter(keys)
+    dup = [i for i, k in enumerate(keys) if seen[k] > 1]
+    if dup:
+        keep = np.ones(len(mesh.faces), bool)
+        keep[dup] = False
+        mesh.update_faces(keep)
+        mesh.remove_unreferenced_vertices()
+    return len(dup)
+
+
+def cycles(mesh):
+    """Simple cycles of the boundary graph. A vertex where two holes meet is
+    walked twice, once per hole, instead of yielding one figure-eight."""
+    edges = open_edges(mesh)
+    if not edges:
+        return []
+    adj = {}
+    for a, b in edges:
+        adj.setdefault(a, []).append(b)
+        adj.setdefault(b, []).append(a)
+    unused = {tuple(sorted(e)) for e in edges}
+    out = []
+    while unused:
+        a, b = next(iter(unused))
+        unused.discard((a, b))
+        path = [a, b]
+        while True:
+            cur = path[-1]
+            nxt = [v for v in adj[cur] if tuple(sorted((cur, v))) in unused]
+            if not nxt:
+                break
+            v = nxt[0]
+            unused.discard(tuple(sorted((cur, v))))
+            if v in path:                       # closed a loop: emit and back up
+                i = path.index(v)
+                out.append(path[i:])
+                path = path[:i + 1] if i else []
+                if not path:
+                    break
+            else:
+                path.append(v)
+    return [c for c in out if len(c) >= 3]
+
+
+def fill(mesh, max_span, log):
+    added = 0
+    for loop in cycles(mesh):
+        span = float(np.ptp(mesh.vertices[loop], axis=0).max())
+        if span > max_span:
+            log(f"  refusing a {len(loop)}-vertex hole spanning {span:.2f} mm "
+                f"(over --max-span {max_span}); fix this one in CAD")
+            continue
+        centroid = mesh.vertices[loop].mean(axis=0)
+        tip = len(mesh.vertices)
+        faces = [[loop[i], loop[(i + 1) % len(loop)], tip] for i in range(len(loop))]
+        mesh = trimesh.Trimesh(vertices=np.vstack([mesh.vertices, centroid]),
+                               faces=np.vstack([mesh.faces, faces]), process=False)
+        added += len(faces)
+        log(f"  filled a {len(loop)}-vertex hole spanning {span:.3f} mm with {len(faces)} triangles")
+    return mesh, added
+
+
+def repair(src, dst, max_span=1.0, log=print):
+    before = trimesh.load(src)
+    faces0, area0, bounds0 = len(before.faces), before.area, before.bounds.copy()
+    keys0 = Counter(tuple(sorted(map(tuple, f))) for f in np.round(before.vertices[before.faces], 4))
+
+    mesh = trimesh.load(src)
+    log(f"  deleted {drop_coincident(mesh)} coincident triangles")
+    for _ in range(8):
+        mesh, added = fill(mesh, max_span, log)
+        mesh.merge_vertices()
+        if not added or not open_edges(mesh):
+            break
+    trimesh.repair.fix_normals(mesh)
+    mesh.export(dst)
+
+    after = trimesh.load(dst)
+    keys1 = Counter(tuple(sorted(map(tuple, f))) for f in np.round(after.vertices[after.faces], 4))
+    kept = sum((keys0 & keys1).values())
+    log(f"  {kept} of {faces0} original triangles untouched, "
+        f"{sum((keys0 - keys1).values())} deleted, {sum((keys1 - keys0).values())} added")
+    log(f"  surface {area0:.4f} -> {after.area:.4f} mm2 · "
+        f"bounding box moved {float(np.abs(after.bounds - bounds0).max()):.6f} mm")
+    log(f"  watertight {after.is_watertight} · a volume {after.is_volume} · "
+        f"winding {after.is_winding_consistent}")
+    return after.is_volume
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--max-span", type=float, default=1.0, metavar="MM",
+                    help="refuse to fill a hole wider than this (default 1.0)")
+    args = ap.parse_args()
+    print(args.src.rsplit("/", 1)[-1])
+    sys.exit(0 if repair(args.src, args.dst, args.max_span) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/parts-calculator/scripts/mesh_report.py
+++ b/parts-calculator/scripts/mesh_report.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""Find the places an STL is not a closed solid, and picture them.
+
+A part that is not watertight cannot be stamped (engrave.py needs a volume to
+subtract from), and a slicer will guess at it rather than fail, so the defect
+is worth seeing before the bytes get pinned. Tessellators produce four kinds of
+slip, all of them here:
+
+  open edges        a hole: an edge with one face instead of two
+  non-manifold      an edge with three or more faces
+  zero-area faces   slivers with no extent, usually inside engraved lettering
+  coincident pairs  the same triangle twice, facing opposite ways (a flap)
+
+Defect vertices are clustered into sites, since one bad feature makes many bad
+edges, and each site is reported with its coordinates in the STL's own frame.
+
+    python scripts/mesh_report.py part.stl [more.stl ...] [--figures DIR]
+
+Exits 1 if anything is wrong with any file, so it can gate a pin.
+"""
+import argparse
+import sys
+from collections import Counter
+
+import numpy as np
+import trimesh
+from scipy.cluster.hierarchy import fcluster, linkage
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+import meshfig                                                    # noqa: E402
+
+CLUSTER_MM = 3.0   # defect vertices closer than this describe one bad feature
+
+
+def defects(mesh):
+    """Every defective edge and face, plus the vertices they touch."""
+    counts = Counter(tuple(e) for e in mesh.edges_sorted)
+    open_edges = np.array([e for e, n in counts.items() if n == 1], int).reshape(-1, 2)
+    nonmanifold = np.array([e for e, n in counts.items() if n > 2], int).reshape(-1, 2)
+    degenerate = np.where(mesh.area_faces < 1e-9)[0]
+    keys = [tuple(sorted(f)) for f in mesh.faces]
+    seen = Counter(keys)
+    coincident = np.array([i for i, k in enumerate(keys) if seen[k] > 1], int)
+
+    verts = [np.unique(a) for a in (open_edges, nonmanifold) if len(a)]
+    verts += [np.unique(mesh.faces[i]) for i in (degenerate, coincident) if len(i)]
+    verts = np.unique(np.concatenate(verts)) if verts else np.array([], int)
+    return dict(open_edges=open_edges, nonmanifold=nonmanifold,
+                degenerate=degenerate, coincident=coincident, verts=verts)
+
+
+def sites(mesh, d):
+    """Defect vertices grouped into bad features, worst (largest) first."""
+    if not len(d["verts"]):
+        return []
+    pts = mesh.vertices[d["verts"]]
+    labels = (fcluster(linkage(pts, "single"), t=CLUSTER_MM, criterion="distance")
+              if len(pts) > 1 else np.array([1]))
+    out = []
+    for k in np.unique(labels):
+        keep = labels == k
+        group, ids = pts[keep], d["verts"][keep]
+        counted = {
+            "open": int(np.isin(d["open_edges"], ids).any(axis=1).sum()) if len(d["open_edges"]) else 0,
+            "non-manifold": int(np.isin(d["nonmanifold"], ids).any(axis=1).sum()) if len(d["nonmanifold"]) else 0,
+            "zero-area": int(np.isin(mesh.faces[d["degenerate"]], ids).any(axis=1).sum()) if len(d["degenerate"]) else 0,
+            "coincident": int(np.isin(mesh.faces[d["coincident"]], ids).any(axis=1).sum()) if len(d["coincident"]) else 0,
+        }
+        out.append({"centre": group.mean(axis=0), "size": np.ptp(group, axis=0),
+                    "verts": ids, "counts": counted})
+    return sorted(out, key=lambda s: -float(s["size"].max()))
+
+
+def hot_faces(mesh, ids, d):
+    hot = np.isin(mesh.faces, ids).any(axis=1)
+    for i in np.concatenate([d["degenerate"], d["coincident"]]).astype(int):
+        hot[i] = True
+    return hot
+
+
+def figure(mesh, d, site, path, title):
+    """One sheet per site: the whole part with the spot ringed, then two zooms."""
+    ids = site["verts"]
+    hot = hot_faces(mesh, ids, d)
+    normals = mesh.face_normals[np.isin(mesh.faces, ids).any(axis=1)]
+    n = normals.mean(axis=0) if len(normals) else np.array([0, 0, 1.0])
+    if np.linalg.norm(n) < 1e-6:
+        n = np.array([0, 0, 1.0])
+    cam = meshfig.basis(n / np.linalg.norm(n) + 0.45 * np.array([0.5, -0.7, 0.5]))
+    centre = site["centre"]
+    whole = float(np.linalg.norm(np.ptp(mesh.bounds, axis=0))) * 1.03
+    close = min(max(float(site["size"].max()) * 5, 2.4), 12.0)
+    size = (900, 900)
+    bad = np.vstack([e for e in (d["open_edges"], d["nonmanifold"]) if len(e)]) \
+        if (len(d["open_edges"]) or len(d["nonmanifold"])) else np.zeros((0, 2), int)
+    near = bad[np.isin(bad, ids).any(axis=1)] if len(bad) else bad
+    panels = [
+        ("", meshfig.Panel(mesh, cam, centre, whole, size, hot).ring(centre).finish("whole part, spot ringed")),
+        ("", meshfig.Panel(mesh, cam, centre, 16.0, size, hot).ring(centre, 0.09).finish("16 mm across")),
+        ("", meshfig.Panel(mesh, cam, centre, close, size, hot).edges(near, (255, 210, 40, 255)).finish(f"{close:.1f} mm across")),
+        ("", meshfig.Panel(mesh, cam, centre, close, size, wireframe=True).edges(near, (255, 210, 40, 255)).finish("every triangle drawn")),
+    ]
+    where = "(%.2f, %.2f, %.2f) mm" % tuple(site["centre"])
+    counts = "  ·  ".join(f"{v} {k}" for k, v in site["counts"].items() if v)
+    return meshfig.sheet(path, title, f"{where}   ·   {counts}   ·   "
+                         + "%.2f x %.2f x %.2f mm" % tuple(site["size"]), panels)
+
+
+def report(path, figures=None):
+    mesh = trimesh.load(path)
+    name = path.rsplit("/", 1)[-1]
+    d = defects(mesh)
+    found = sites(mesh, d)
+    print(f"{name}")
+    print(f"  {len(mesh.faces)} faces · watertight {mesh.is_watertight} · a volume {mesh.is_volume}"
+          f" · winding {mesh.is_winding_consistent}")
+    if not found:
+        print("  no defects")
+        return True
+    for i, s in enumerate(found, 1):
+        counts = ", ".join(f"{v} {k}" for k, v in s["counts"].items() if v)
+        print("  site %d: %s at (%.3f, %.3f, %.3f), %.3f x %.3f x %.3f mm"
+              % (i, counts, *s["centre"], *s["size"]))
+        if figures:
+            out = f"{figures}/{name.rsplit('.', 1)[0]}-site-{i}.png"
+            figure(mesh, d, s, out, f"{name} — site {i}")
+            print(f"    wrote {out}")
+    return False
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("stl", nargs="+")
+    ap.add_argument("--figures", metavar="DIR", help="also write a PNG per defect site")
+    args = ap.parse_args()
+    ok = all([report(p, args.figures) for p in args.stl])
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/parts-calculator/scripts/meshfig.py
+++ b/parts-calculator/scripts/meshfig.py
@@ -1,0 +1,169 @@
+"""A tiny offscreen renderer, so a mesh problem can be shown rather than described.
+
+There is no GL context on a build box and none is wanted: this rasterises
+triangles with numpy and a z-buffer, which is enough for a flat-shaded part at
+any zoom, and it draws chosen edges on top so a defect measured in hundredths
+of a millimetre is visible at all. Used by mesh_report.py and mesh_repair.py.
+
+Backfaces are painted a dark red rather than culled, so looking through a hole
+in a surface reads as a hole instead of as background.
+"""
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+SS = 2                                    # supersample, downscaled at the end
+BG = (0.09, 0.10, 0.115)
+GREY = np.array([0.74, 0.765, 0.80])      # the part
+PALE = np.array([0.90, 0.91, 0.93])       # the part, under a wireframe
+INSIDE = np.array([0.30, 0.13, 0.15])     # backfaces: you are seeing through something
+HOT = np.array([0.93, 0.17, 0.17])
+LIGHT = np.array([-0.35, 0.45, 1.0])
+
+FONTS = ("/System/Library/Fonts/SFNS.ttf", "/System/Library/Fonts/Supplemental/Arial.ttf")
+MONO = ("/System/Library/Fonts/SFNSMono.ttf", "/System/Library/Fonts/Menlo.ttc")
+
+
+def font(size, mono=False):
+    for path in (MONO if mono else FONTS):
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            pass
+    return ImageFont.load_default()
+
+
+def basis(direction, up=(0, 0, 1)):
+    """Camera frame looking down `direction` at the subject, roughly z-up."""
+    z = np.asarray(direction, float)
+    z = z / np.linalg.norm(z)
+    up = np.array(up, float)
+    if abs(z @ up) > 0.95:
+        up = np.array([0.0, 1.0, 0.0])
+    x = np.cross(up, z)
+    x /= np.linalg.norm(x)
+    return np.stack([x, np.cross(z, x), z], axis=1)
+
+
+def render(mesh, hot, cam, w, h, centre, span, surface=GREY):
+    """Flat-shaded orthographic render. `hot` is a per-face bool, painted HOT.
+
+    Returns the float image and a projector from world points to pixels.
+    """
+    verts = mesh.vertices @ cam
+    ctr = np.asarray(centre, float) @ cam
+    scale = min(w, h) / span
+    px = np.stack([(verts[:, 0] - ctr[0]) * scale + w / 2,
+                   h / 2 - (verts[:, 1] - ctr[1]) * scale,
+                   verts[:, 2]], axis=1)
+    normals = mesh.face_normals @ cam
+    light = LIGHT / np.linalg.norm(LIGHT)
+    front = normals[:, 2] > 0
+    lam = np.clip(np.where(front[:, None], normals, -normals) @ light, 0, 1)
+    shade = 0.32 + 0.68 * lam ** 0.85
+    base = np.where(hot[:, None], HOT, np.where(front[:, None], surface, INSIDE))
+    colour = np.clip(base * shade[:, None], 0, 1)
+
+    img = np.ones((h, w, 3), np.float32) * np.array(BG, np.float32)
+    zbuf = np.full((h, w), -1e30, np.float32)
+    tris = px[mesh.faces]
+    for i in np.argsort(hot.astype(int)):        # hot faces last, so ties go to them
+        t = tris[i]
+        x0, x1 = max(int(t[:, 0].min()), 0), min(int(t[:, 0].max()) + 2, w)
+        y0, y1 = max(int(t[:, 1].min()), 0), min(int(t[:, 1].max()) + 2, h)
+        if x1 <= x0 or y1 <= y0:
+            continue
+        gx, gy = np.meshgrid(np.arange(x0, x1) + 0.5, np.arange(y0, y1) + 0.5)
+        (ax, ay), (bx, by), (cx, cy) = t[0, :2], t[1, :2], t[2, :2]
+        den = (by - cy) * (ax - cx) + (cx - bx) * (ay - cy)
+        if abs(den) < 1e-12:
+            continue
+        w0 = ((by - cy) * (gx - cx) + (cx - bx) * (gy - cy)) / den
+        w1 = ((cy - ay) * (gx - cx) + (ax - cx) * (gy - cy)) / den
+        w2 = 1 - w0 - w1
+        inside = (w0 >= 0) & (w1 >= 0) & (w2 >= 0)
+        if not inside.any():
+            continue
+        z = w0 * t[0, 2] + w1 * t[1, 2] + w2 * t[2, 2]
+        sub = zbuf[y0:y1, x0:x1]
+        win = inside & (z > sub)
+        if not win.any():
+            continue
+        sub[win] = z[win]
+        img[y0:y1, x0:x1][win] = colour[i]
+
+    def project(points):
+        p = np.atleast_2d(np.asarray(points, float)) @ cam
+        return (p[:, :2] - ctr[:2]) * np.array([scale, -scale]) + np.array([w / 2, h / 2])
+
+    return img, project
+
+
+class Panel:
+    """One rendered view, sized in final (not supersampled) pixels."""
+
+    def __init__(self, mesh, cam, centre, span, size, hot=None, wireframe=False):
+        self.mesh, self.size = mesh, size
+        w, h = size[0] * SS, size[1] * SS
+        hot = np.zeros(len(mesh.faces), bool) if hot is None else hot
+        img, self.project = render(mesh, hot, cam, w, h, centre, span,
+                                   surface=PALE if wireframe else GREY)
+        self.im = Image.fromarray((np.clip(img, 0, 1) * 255).astype(np.uint8)).convert("RGBA")
+        self.overlay = Image.new("RGBA", self.im.size, (0, 0, 0, 0))
+        self.draw = ImageDraw.Draw(self.overlay)
+        if wireframe:
+            self.wireframe()
+
+    def wireframe(self, colour=(88, 98, 114, 150), width=3):
+        """Every triangle, drawn over the surface, so nothing hides behind geometry."""
+        p = self.project(self.mesh.vertices)
+        w, h = self.im.size
+        on = (p[:, 0] > -w) & (p[:, 0] < 2 * w) & (p[:, 1] > -h) & (p[:, 1] < 2 * h)
+        for a, b in self.mesh.edges_unique:
+            if on[a] or on[b]:
+                self.draw.line([*p[a], *p[b]], fill=colour, width=width)
+
+    def edges(self, edges, colour, width=8):
+        if edges is None or not len(edges):
+            return self
+        p = self.project(self.mesh.vertices)
+        for a, b in edges:
+            self.draw.line([*p[a], *p[b]], fill=colour, width=width)
+        return self
+
+    def ring(self, point, radius_frac=0.055, colour=(255, 78, 78), label=None):
+        x, y = self.project(point)[0]
+        r = radius_frac * self.im.size[0]
+        self.draw.ellipse([x - r, y - r, x + r, y + r], outline=colour, width=6)
+        if label:
+            self.draw.text((x + r + 12, y - r - 10), label,
+                           font=font(int(1.4 * r)), fill=colour)
+        return self
+
+    def finish(self, caption):
+        im = Image.alpha_composite(self.im, self.overlay).convert("RGB")
+        im = im.resize(self.size, Image.LANCZOS)
+        d = ImageDraw.Draw(im)
+        f = font(max(14, self.size[0] // 37), mono=True)
+        w = d.textlength(caption, font=f)
+        pad, bottom = self.size[0] // 66, self.size[1]
+        d.rectangle([pad, bottom - 3 * pad, pad + w + 1.6 * pad, bottom - pad * 0.5], fill=(14, 16, 20))
+        d.text((pad * 1.8, bottom - 2.8 * pad), caption, font=f, fill=(200, 208, 220))
+        return im
+
+
+def sheet(path, title, subtitle, panels, cols=2):
+    """Lay finished panels out in a grid with a heading, and write a PNG."""
+    w, h = panels[0][1].size
+    pad, top, cap = 18, 116, 44
+    rows = (len(panels) + cols - 1) // cols
+    im = Image.new("RGB", (w * cols + pad * (cols + 1), top + rows * (h + cap) + pad - 10), (16, 18, 22))
+    d = ImageDraw.Draw(im)
+    d.text((pad + 2, 24), title, font=font(46), fill=(238, 241, 246))
+    d.text((pad + 2, 76), subtitle, font=font(30, True), fill=(150, 160, 175))
+    for i, (caption, panel) in enumerate(panels):
+        row, col = divmod(i, cols)
+        x, y = pad * (col + 1) + w * col, top + row * (h + cap)
+        d.text((x, y + 2), caption, font=font(30, True), fill=(150, 160, 175))
+        im.paste(panel, (x, y + cap - 6))
+    im.save(path)
+    return path

--- a/parts-calculator/src/lib/components/PartDetail.svelte
+++ b/parts-calculator/src/lib/components/PartDetail.svelte
@@ -12,8 +12,8 @@
 	import { getBambuColor } from '$lib/bambu-colors';
 	import { SITE_URL } from '$lib/seo';
 	import { copyText } from '$lib/clipboard';
-	import { duration, fmtDate, partOnshape, platesForPart, type Part, type PartCandidate, type PartVersion } from '$lib/filament';
-	import { ExternalLink, FlaskConical, History, Image, Layers3, Share2, Check } from 'lucide-svelte';
+	import { duration, fmtDate, noteUrl, partOnshape, platesForPart, type Part, type PartCandidate, type PartVersion } from '$lib/filament';
+	import { ExternalLink, FileText, FlaskConical, History, Image, Layers3, Share2, Check } from 'lucide-svelte';
 
 	// The 3D-printed part detail view: the preview with the id-stamp controls laid
 	// over it, then the facts, the download, and the history. Rendered two ways off
@@ -109,6 +109,7 @@
 	{@const grams = candidate ? candidate.grams : (active?.grams ?? part.grams)}
 	{@const seconds = candidate ? candidate.print_seconds : part.print_seconds}
 	{@const onshapeHref = candidate?.onshape_version ?? os.version}
+	{@const noteId = candidate?.note ?? active?.note ?? part.note}
 
 	<!-- the preview, with the id-stamp controls and the colour picker laid over it -->
 	<div class="relative {variant === 'modal' ? 'shrink-0' : ''}">
@@ -135,6 +136,11 @@
 						<div class="flex flex-wrap gap-1.5">
 							{#each part.attributes as a}<span class="border border-border bg-[var(--color-bg)] px-1.5 py-0.5 text-xs text-text-muted">{a.label}: <span class="text-text">{a.value}</span></span>{/each}
 						</div>
+					{/if}
+					{#if noteId}
+						<a class="inline-flex items-center gap-1 text-xs text-primary hover:text-primary-hover" href={noteUrl(noteId)} target="_blank" rel="noopener" title="A permanent write-up of something that happened to this part">
+							<FileText size={12} /> Engineering note {noteId}
+						</a>
 					{/if}
 				</div>
 				<div class="flex shrink-0 flex-col items-start gap-2 sm:items-end">

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -11,8 +11,8 @@
 		"density_g_cm3": 1.32,
 		"cost_per_kg": 24.99,
 		"commit_base_url": "https://github.com/basicallysource/sorter-v2/commit/",
-		"all_parts_zip": "https://img.basically.website/parts/bundle/all-parts-003af578.zip",
-		"all_parts_plain_zip": "https://img.basically.website/parts/bundle/all-parts-plain-c7c76ca7.zip"
+		"all_parts_zip": "https://img.basically.website/parts/bundle/all-parts-d0a9c297.zip",
+		"all_parts_plain_zip": "https://img.basically.website/parts/bundle/all-parts-plain-e1df71a9.zip"
 	},
 	"sections": [
 		{
@@ -5483,7 +5483,7 @@
 			"description": "Inner half of the ribbon cable clamp. White.",
 			"version": "1",
 			"created_at": "2026-06-27",
-			"updated_at": "2026-06-27",
+			"updated_at": "2026-08-22",
 			"versions": [
 				{
 					"version": "1",
@@ -5492,8 +5492,8 @@
 					"message": "Initial version.",
 					"commit": null,
 					"note": "3v2p",
-					"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-a77f4963.stl",
-					"render": "https://img.basically.website/parts/render/cable-clamp-inner-4f239270.png",
+					"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-16cfdfea.stl",
+					"render": "https://img.basically.website/parts/render/cable-clamp-inner-16baaea1.png",
 					"grams": 6.45
 				}
 			],
@@ -5516,9 +5516,92 @@
 			"caption": null,
 			"docs_page": null,
 			"conflicts": null,
-			"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-a77f4963.stl",
-			"render": "https://img.basically.website/parts/render/cable-clamp-inner-4f239270.png",
-			"stamped": []
+			"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-16cfdfea.stl",
+			"render": "https://img.basically.website/parts/render/cable-clamp-inner-16baaea1.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-stamped-bottom-ba82cb82.stl",
+					"normal": [
+						-0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						-81.38,
+						13.27,
+						204.62
+					],
+					"size": [
+						2.55,
+						8.79
+					],
+					"cap": 2.5,
+					"depth": 0.6,
+					"note": "smaller text"
+				},
+				{
+					"face": "bottom 2",
+					"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-stamped-bottom-2-6e3ce509.stl",
+					"normal": [
+						-0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						-83.66,
+						-6.92,
+						204.62
+					],
+					"size": [
+						2.55,
+						8.79
+					],
+					"cap": 2.5,
+					"depth": 0.6,
+					"note": "smaller text"
+				},
+				{
+					"face": "-x side",
+					"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-stamped-minus-x-side-0b6c48ad.stl",
+					"normal": [
+						-1.0,
+						0.0,
+						0.0
+					],
+					"center": [
+						-87.21,
+						32.09,
+						232.54
+					],
+					"size": [
+						12.3,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "+x side",
+					"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-stamped-plus-x-side-e4cb889e.stl",
+					"normal": [
+						1.0,
+						0.0,
+						0.0
+					],
+					"center": [
+						-79.21,
+						32.09,
+						232.54
+					],
+					"size": [
+						12.3,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				}
+			]
 		},
 		{
 			"id": "cable-clamp-outer",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -5491,6 +5491,7 @@
 					"date": "2026-06-27",
 					"message": "Initial version.",
 					"commit": null,
+					"note": "3v2p",
 					"stl": "https://img.basically.website/parts/stl/cable-clamp-inner-3fue-a77f4963.stl",
 					"render": "https://img.basically.website/parts/render/cable-clamp-inner-4f239270.png",
 					"grams": 6.45
@@ -10303,6 +10304,7 @@
 					"commit": "0aeff083",
 					"onshape_doc": "https://cad.onshape.com/documents/249bded2198af476185014b6",
 					"onshape_version": "https://cad.onshape.com/documents/249bded2198af476185014b6/v/3ec354b28012f6c0ab41285a/e/48c64d61f1276c46f515d6bd",
+					"note": "3v2p",
 					"stl": "https://img.basically.website/parts/stl/camera-extension-v684-c9cf562f.stl",
 					"render": "https://img.basically.website/parts/render/camera-extension-e53f4965.png",
 					"grams": 28.37
@@ -10319,10 +10321,10 @@
 				}
 			],
 			"grams": 28.37,
-			"support_grams": 0.0,
+			"support_grams": 0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 4105,
+			"print_seconds": 4106,
 			"color": {
 				"fixed": "ash-gray"
 			},

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -126,6 +126,15 @@ export type Assembly = {
  *  URL, so the two stay linkable if the host ever moves. */
 export const DOCS_BASE = 'https://docs.basically.website';
 
+/** Absolute URL of an engineering note: one permanent, unlisted page per
+ *  minted id, written when something happened to a part that a version line
+ *  cannot carry (why an export was replaced, what was measured, what was
+ *  ruled out). Ids come from the same pool as part uids, so one never means
+ *  two things. */
+export function noteUrl(id: string): string {
+	return `${DOCS_BASE}/n/${id}/`;
+}
+
 /** Absolute URL of an assembly's write-up on the docs site, or null when that
  *  assembly has no page there yet. */
 export function docsUrl(a: Assembly): string | null {
@@ -242,6 +251,7 @@ export type PartVersion = {
 	date: string;
 	message: string;
 	commit: string | null;
+	note?: string; // an engineering note's id, if this version has one
 	onshape_doc?: string | null;
 	onshape_version?: string | null;
 	// archived assets for this version (old geometry pulled from git); the current
@@ -272,6 +282,7 @@ export type PartCandidate = {
 	print_seconds?: number | null;
 	support_used?: boolean;
 	stamped?: PartStamp[];
+	note?: string; // an engineering note's id, if this candidate has one
 };
 /** A download with the uid recessed into one face (catalog/engrave.py). `face`
  *  names it ("bottom", "+x side", "angled face"); `center`, `normal` and
@@ -308,6 +319,7 @@ export type Part = {
 	version: string;
 	created_at: string;
 	updated_at: string;
+	note?: string; // an engineering note's id, when the part itself has one
 	versions?: PartVersion[]; // archetype history, newest last
 	candidates?: PartCandidate[]; // revisions under test for this slot, oldest first
 	images?: CatalogImage[]; // extra pictures beyond the render


### PR DESCRIPTION
## What

A place for one-off, permanent pages that document something that happened, linked from the thing they are about and listed nowhere.

A note is `docs/src/content/notes/<id>.md` published at `/n/<id>/`. The id comes from the same pool as part uids (`mint_uid.py` now also skips ids already naming a note), so an id means one thing wherever you type it. Notes are deliberately not in `nav.yml`, which keeps them out of both the sidebar and search, since both are built from the nav. No slug in the URL: a slug is a claim that goes stale, an id is not. Convention written up in `docs/AGENTS.md`.

Any part, version or candidate can carry `"note": "<id>"`, and the part page renders "Engineering note <id>" linking to it.

## The first note

[`/n/3v2p/`](https://docs.basically.website/n/3v2p/) records the two exported meshes that were not closed solids: `camera-extension` `q7ns`, whose only defect was four zero-area triangles inside its raised "50 mm" lettering, and `cable-clamp-inner` `3fue`, with a 0.40 mm hole and a coincident triangle pair. It is mostly pictures. `camera-extension` v2 and `cable-clamp-inner` both link to it.

## The tools

Three scripts in `parts-calculator/scripts/`, which the note links by permalink so the numbers on it are rerunnable:

- `mesh_report.py` — every open edge, non-manifold edge, zero-area face and coincident pair, clustered into sites with coordinates, and a PNG per site with `--figures`. Exits 1 on any defect, so it can gate a pin.
- `mesh_repair.py` — deletes coincident pairs and fills each hole under `--max-span` from its own centroid, moving nothing that was already there, and reports how many triangles it touched.
- `meshfig.py` — the renderer both use: numpy rasteriser with a z-buffer, no GL context needed.

Every figure on the note came out of `mesh_report.py --figures`.

## Checks

`check_generated_pins.py` agrees (98 pinned parts), `svelte-check` is clean, and the docs site builds, which runs `validate_images.py` over the new image URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)