### PR TITLE
parts-calculator: one way to search, and ⌘K to reach it

### DIFF
--- a/parts-calculator/src/lib/components/search/Highlight.svelte
+++ b/parts-calculator/src/lib/components/search/Highlight.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { Range } from '$lib/search';
+
+	// Text with the matched characters marked. The matcher hands back a range
+	// rather than a substring so the highlight lands on the actual characters
+	// that matched, not on every other place the same letters appear.
+	//
+	// Ranges are computed against the normalised (lowercased, accent-folded)
+	// form. For everything the catalog actually contains that is character-for-
+	// character the same length as the original, so the indices carry over; the
+	// bounds check below is what keeps an exotic decomposition from painting the
+	// wrong letters — it drops the highlight rather than misplacing it.
+	let { text, range = null }: { text: string; range?: Range | null } = $props();
+
+	const parts = $derived.by(() => {
+		if (!range) return null;
+		const [a, b] = range;
+		if (a < 0 || b > text.length || a >= b) return null;
+		return { before: text.slice(0, a), hit: text.slice(a, b), after: text.slice(b) };
+	});
+</script>
+
+{#if parts}{parts.before}<mark class="bg-primary/[0.14] font-semibold text-text">{parts.hit}</mark
+	>{parts.after}{:else}{text}{/if}

--- a/parts-calculator/src/lib/components/search/Kbd.svelte
+++ b/parts-calculator/src/lib/components/search/Kbd.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	// One keycap. Used for the ⌘K hint on the trigger and the hints along the
+	// bottom of the palette, so every shortcut on the site looks like a key.
+	let { children, class: cls = '' }: { children: import('svelte').Snippet; class?: string } = $props();
+</script>
+
+<kbd
+	class="inline-flex h-[1.15rem] min-w-[1.15rem] items-center justify-center border border-border bg-[var(--color-bg)] px-1 font-sans text-[0.6875rem] font-semibold leading-none text-text-muted {cls}"
+>
+	{@render children()}
+</kbd>

--- a/parts-calculator/src/lib/components/search/SearchField.svelte
+++ b/parts-calculator/src/lib/components/search/SearchField.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import { Search, X } from 'lucide-svelte';
+	import { palette } from '$lib/search.svelte';
+
+	// The inline filter that sits above a list. Deliberately plain: it owns
+	// nothing but the text, and the page it lives on decides what that text
+	// filters, ranking through the same matcher the palette uses.
+	//
+	// It also knows one thing about the palette: a list filter can only ever
+	// narrow the list it is attached to, so when what you typed finds nothing —
+	// or when you want the whole catalog rather than this page's slice — it hands
+	// the query over to the palette instead of leaving you at a dead end.
+	let {
+		value = $bindable(''),
+		placeholder = 'Filter…',
+		label,
+		/** How many rows survive the filter, and how many there were. */
+		found = null,
+		total = null,
+		noun = 'result',
+		nouns = '',
+		class: cls = ''
+	}: {
+		value?: string;
+		placeholder?: string;
+		label: string;
+		found?: number | null;
+		total?: number | null;
+		noun?: string;
+		/** Plural of `noun`, when adding an s is wrong ("match" → "matches"). */
+		nouns?: string;
+		class?: string;
+	} = $props();
+
+	const plural = $derived(nouns || `${noun}s`);
+	let input = $state<HTMLInputElement | null>(null);
+	const filtering = $derived(value.trim().length > 0);
+	const empty = $derived(filtering && found === 0);
+
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Escape' && value) {
+			// Clear before closing anything else — the field is what has focus.
+			e.stopPropagation();
+			value = '';
+		}
+	}
+</script>
+
+<div class="flex flex-wrap items-center gap-x-3 gap-y-1.5 {cls}">
+	<div class="relative min-w-0 flex-1 sm:max-w-xs">
+		<span class="pointer-events-none absolute inset-y-0 left-0 flex w-8 items-center justify-center text-text-muted">
+			<Search size={14} />
+		</span>
+		<input
+			bind:this={input}
+			bind:value
+			onkeydown={onKey}
+			type="search"
+			spellcheck="false"
+			autocomplete="off"
+			aria-label={label}
+			{placeholder}
+			class="setup-control h-9 w-full min-h-0 pl-8 pr-8 text-sm"
+		/>
+		{#if filtering}
+			<button
+				type="button"
+				class="absolute inset-y-0 right-0 flex w-8 items-center justify-center text-text-muted hover:text-text"
+				onclick={() => {
+					value = '';
+					input?.focus();
+				}}
+				aria-label="Clear the filter"
+			>
+				<X size={14} />
+			</button>
+		{/if}
+	</div>
+
+	{#if filtering && found !== null}
+		<span class="text-xs text-text-muted" aria-live="polite">
+			{#if empty}
+				Nothing here matches <span class="font-semibold text-text">{value}</span>.
+			{:else}
+				{found}{#if total !== null}<span class="text-text-muted">/{total}</span>{/if}
+				{found === 1 ? noun : plural}
+			{/if}
+		</span>
+	{/if}
+
+	{#if filtering}
+		<button
+			type="button"
+			class="text-xs font-semibold text-primary hover:text-primary-hover"
+			onclick={() => palette.show(value)}
+		>
+			Search everything for “{value}” →
+		</button>
+	{/if}
+</div>
+
+<style>
+	/* `type="search"` is right semantically, but the browser draws its own clear
+	   button for it — next to ours, which is styled and sits where the layout
+	   expects. Two Xs in one field is just a bug you can see. */
+	input[type='search']::-webkit-search-cancel-button,
+	input[type='search']::-webkit-search-decoration {
+		appearance: none;
+		display: none;
+	}
+</style>

--- a/parts-calculator/src/lib/components/search/SearchPalette.svelte
+++ b/parts-calculator/src/lib/components/search/SearchPalette.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { Search, X } from 'lucide-svelte';
+	import Kbd from './Kbd.svelte';
+	import SearchResult from './SearchResult.svelte';
+	import { palette } from '$lib/search.svelte';
+	import {
+		CATALOG_INDEX,
+		SCOPES,
+		itemByKey,
+		readScopePrefix,
+		searchCatalog,
+		type Hit,
+		type Ranked,
+		type SearchItem,
+		type SearchScope
+	} from '$lib/search';
+
+	// The palette. One instance for the whole site, mounted by the layout.
+	//
+	// Everything is recomputed on every keystroke against the in-memory index —
+	// a few hundred entries, so there is no debounce and no loading state, which
+	// is the entire feel of the thing: the list moves under your fingers as fast
+	// as you can type four characters off a print.
+
+	const open = $derived(palette.open);
+
+	// `#s1qc` / `id:s1qc` force the id scope from the keyboard, so the chips are
+	// a convenience rather than the only way in.
+	const parsed = $derived(readScopePrefix(palette.query));
+	const scope = $derived<SearchScope>(parsed.scope ?? palette.scope);
+	const query = $derived(parsed.query);
+	const typing = $derived(query.trim().length > 0);
+
+	const results = $derived<Ranked<SearchItem>[]>(typing ? searchCatalog(query, scope) : []);
+
+	// With nothing typed the palette is a launcher, not a filter: where you were,
+	// then where you can go.
+	const recents = $derived(palette.recent.map(itemByKey).filter((i): i is SearchItem => !!i));
+	const pages = $derived(CATALOG_INDEX.filter((i) => i.kind === 'page'));
+	const idle = $derived<SearchItem[]>([...recents, ...pages.filter((p) => !recents.some((r) => r.key === p.key))]);
+	/** What the list renders — a ranked hit while typing, a bare item when idle. */
+	type Row = { item: SearchItem; hit: Hit | null };
+	const rows = $derived<Row[]>(typing ? results : idle.map((item) => ({ item, hit: null })));
+
+	let active = $state(0);
+	let input = $state<HTMLInputElement | null>(null);
+	let listEl = $state<HTMLDivElement | null>(null);
+
+	// Any change to what is on screen puts the cursor back on the first row —
+	// the top result is the answer often enough that Enter should mean it.
+	$effect(() => {
+		rows.length;
+		query;
+		scope;
+		active = 0;
+	});
+
+	$effect(() => {
+		if (!open) return;
+		// Focus after the element exists; selecting the text means an opener that
+		// passed a starting query (a list filter widening its search) can be typed
+		// straight over.
+		input?.focus();
+		input?.select();
+	});
+
+	// Keep the cursor visible when it is driven by the keyboard rather than the
+	// mouse. `nearest` so a click-then-arrow doesn't yank the list around.
+	$effect(() => {
+		if (!open) return;
+		const el = listEl?.querySelector<HTMLElement>(`#search-opt-${active}`);
+		el?.scrollIntoView({ block: 'nearest' });
+	});
+
+	// The page behind a modal must not scroll under it.
+	$effect(() => {
+		if (!open) return;
+		const prev = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = prev;
+		};
+	});
+
+	function pick(item: SearchItem) {
+		palette.remember(item.key);
+		palette.hide();
+		palette.query = '';
+		goto(item.href);
+	}
+
+	function cycleScope(dir: 1 | -1) {
+		const i = SCOPES.findIndex((s) => s.id === palette.scope);
+		palette.scope = SCOPES[(i + dir + SCOPES.length) % SCOPES.length].id;
+	}
+
+	function onKey(e: KeyboardEvent) {
+		if (!open) return;
+		switch (e.key) {
+			case 'Escape':
+				e.preventDefault();
+				palette.hide();
+				return;
+			case 'ArrowDown':
+				e.preventDefault();
+				active = rows.length ? (active + 1) % rows.length : 0;
+				return;
+			case 'ArrowUp':
+				e.preventDefault();
+				active = rows.length ? (active - 1 + rows.length) % rows.length : 0;
+				return;
+			case 'Enter': {
+				const row = rows[active];
+				if (!row) return;
+				e.preventDefault();
+				pick(row.item);
+				return;
+			}
+			case 'Tab':
+				// Nothing inside the palette wants tab-order — there is one input and
+				// a list you drive with the arrows — so it is free to mean "next
+				// filter", which is what it means in every palette people have used.
+				e.preventDefault();
+				cycleScope(e.shiftKey ? -1 : 1);
+				return;
+		}
+	}
+
+	// A 4-character query that found nothing is almost certainly an id read off a
+	// print, so say so in those terms rather than shrugging.
+	const looksLikeUid = $derived(/^[a-z0-9]{4}$/i.test(query.trim()));
+</script>
+
+<svelte:window onkeydown={onKey} />
+
+{#if open}
+	<div class="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 pt-[8vh] sm:pt-[12vh]">
+		<!-- click-away; a sibling of the panel so a click inside never reaches it -->
+		<button class="absolute inset-0 cursor-default" aria-label="Close search" onclick={() => palette.hide()}
+		></button>
+
+		<div
+			class="setup-card-shell relative flex max-h-[76vh] w-full max-w-2xl flex-col border"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Search the catalog"
+		>
+			<!-- ---------------------------------------------------------- the input -->
+			<div class="flex items-center gap-2 border-b border-border px-3">
+				<Search size={17} class="shrink-0 text-text-muted" />
+				<input
+					bind:this={input}
+					bind:value={palette.query}
+					type="text"
+					spellcheck="false"
+					autocomplete="off"
+					autocapitalize="off"
+					placeholder="Search parts, assemblies, hardware — or type the id on a print"
+					aria-label="Search the catalog"
+					aria-autocomplete="list"
+					aria-controls="search-results"
+					aria-activedescendant={rows.length ? `search-opt-${active}` : undefined}
+					class="h-12 min-w-0 flex-1 bg-transparent text-[0.9375rem] text-text placeholder:text-text-muted focus:outline-none"
+				/>
+				{#if palette.query}
+					<button
+						type="button"
+						class="shrink-0 text-text-muted hover:text-text"
+						onclick={() => {
+							palette.query = '';
+							input?.focus();
+						}}
+						aria-label="Clear"><X size={15} /></button>
+				{/if}
+				<button
+					type="button"
+					class="setup-button-secondary hidden h-7 items-center px-2 text-xs font-semibold text-text-muted sm:inline-flex"
+					onclick={() => palette.hide()}>Esc</button>
+			</div>
+
+			<!-- --------------------------------------------------------- the scopes -->
+			<div class="flex flex-wrap items-center gap-1 border-b border-border px-2.5 py-1.5">
+				{#each SCOPES as s (s.id)}
+					<button
+						type="button"
+						class="border px-2 py-1 text-xs font-semibold transition-colors {scope === s.id
+							? 'border-primary bg-primary/[0.08] text-primary'
+							: 'border-transparent text-text-muted hover:border-border hover:text-text'}"
+						aria-pressed={scope === s.id}
+						title={s.hint}
+						onclick={() => {
+							// Picking a chip overrides a typed `#` prefix, which would
+							// otherwise silently win and make the chip look broken.
+							if (parsed.scope) palette.query = query;
+							palette.scope = s.id;
+							input?.focus();
+						}}>{s.label}</button>
+				{/each}
+				<span class="ml-auto hidden items-center gap-1 pr-1 text-[0.6875rem] text-text-muted sm:flex">
+					<Kbd>Tab</Kbd> to switch
+				</span>
+			</div>
+
+			<!-- --------------------------------------------------------- the results -->
+			<div bind:this={listEl} id="search-results" role="listbox" aria-label="Results" class="min-h-0 flex-1 overflow-y-auto py-1">
+				{#if !typing}
+					<p class="px-3 pb-1 pt-2 text-[0.6875rem] font-semibold uppercase tracking-wider text-text-muted">
+						{recents.length ? 'Recent and pages' : 'Jump to'}
+					</p>
+				{/if}
+
+				{#each rows as row, i (row.item.key)}
+					<SearchResult
+						id="search-opt-{i}"
+						item={row.item}
+						hit={row.hit}
+						active={i === active}
+						onpick={() => pick(row.item)}
+						onhover={() => (active = i)}
+					/>
+				{/each}
+
+				{#if typing && !rows.length}
+					<div class="px-4 py-8 text-center">
+						<p class="text-sm text-text">
+							{#if looksLikeUid}
+								Nothing in the catalog carries the id
+								<span class="font-mono font-bold tracking-wider text-text">{query.trim().toUpperCase()}</span>.
+							{:else}
+								No match for <span class="font-semibold">{query.trim()}</span>.
+							{/if}
+						</p>
+						<p class="mt-1.5 text-xs text-text-muted">
+							{#if scope !== 'all'}
+								Only <b>{SCOPES.find((s) => s.id === scope)?.label}</b> is being searched —
+								<button class="font-semibold text-primary hover:text-primary-hover" onclick={() => {
+									if (parsed.scope) palette.query = query;
+									palette.scope = 'all';
+								}}>search everything</button>.
+							{:else if looksLikeUid}
+								Ids are stamped on parts printed with "engrave version ids" on. Check for a
+								0/O or 1/l mix-up.
+							{:else}
+								Try fewer words, or part of the name.
+							{/if}
+						</p>
+					</div>
+				{/if}
+
+				{#if !typing}
+					<p class="border-t border-border px-3 py-2.5 text-xs text-text-muted">
+						Holding a printed part? Type the four characters engraved on it to land on exactly
+						the revision you are holding — including superseded ones.
+					</p>
+				{/if}
+			</div>
+
+			<!-- ---------------------------------------------------------- the hints -->
+			<div
+				class="hidden items-center gap-4 border-t border-border bg-[var(--color-bg)] px-3 py-1.5 text-[0.6875rem] text-text-muted sm:flex"
+			>
+				<span class="inline-flex items-center gap-1"><Kbd>↑</Kbd><Kbd>↓</Kbd> move</span>
+				<span class="inline-flex items-center gap-1"><Kbd>↵</Kbd> open</span>
+				<span class="inline-flex items-center gap-1"><Kbd>#</Kbd> id only</span>
+				{#if typing}
+					<span class="ml-auto">{results.length}{results.length === 40 ? '+' : ''} result{results.length === 1 ? '' : 's'}</span>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/parts-calculator/src/lib/components/search/SearchResult.svelte
+++ b/parts-calculator/src/lib/components/search/SearchResult.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import Highlight from './Highlight.svelte';
+	import { KIND_STYLES } from './kinds';
+	import type { Hit, SearchItem } from '$lib/search';
+
+	// One row of the palette. Four things, always in the same places: what it
+	// looks like, what it is called, what kind of thing it is, and the four
+	// characters that would be stamped on it. The uid sits hard right in mono so
+	// that scanning down the column while reading an id off a print works — that
+	// is the motion the whole palette exists for.
+	let {
+		id,
+		item,
+		hit = null,
+		active = false,
+		onpick,
+		onhover
+	}: {
+		id: string;
+		item: SearchItem;
+		hit?: Hit | null;
+		active?: boolean;
+		onpick: () => void;
+		onhover?: () => void;
+	} = $props();
+
+	const style = $derived(KIND_STYLES[item.kind]);
+	const Icon = $derived(style.icon);
+	const uid = $derived(item.uid?.toUpperCase() ?? '');
+</script>
+
+<button
+	{id}
+	type="button"
+	role="option"
+	aria-selected={active}
+	class="flex w-full items-center gap-3 border-l-2 px-3 py-2 text-left transition-colors {active
+		? 'border-primary bg-primary/[0.06]'
+		: 'border-transparent hover:bg-[var(--color-bg)]'}"
+	onclick={onpick}
+	onmousemove={onhover}
+>
+	<!-- the render when there is one, the kind's icon when there isn't -->
+	<span
+		class="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden border border-border bg-[var(--color-bg)] {style.mark}"
+	>
+		{#if item.image}
+			<img src={item.image} alt="" loading="lazy" class="h-full w-full object-contain" />
+		{:else}
+			<Icon size={16} />
+		{/if}
+	</span>
+
+	<span class="min-w-0 flex-1">
+		<span class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+			<span class="truncate text-sm font-semibold text-text">
+				<Highlight text={item.name} range={hit?.name ?? null} />
+			</span>
+			<span
+				class="inline-flex shrink-0 items-center gap-1 border px-1 text-[0.6875rem] font-semibold leading-[1.35] {style.chip}"
+			>
+				<Icon size={10} />
+				{item.label}
+				{#if item.note}<span class="font-normal opacity-70">{item.note}</span>{/if}
+			</span>
+		</span>
+		{#if item.subtitle}
+			<span class="mt-0.5 block truncate text-xs text-text-muted">{item.subtitle}</span>
+		{/if}
+	</span>
+
+	{#if uid}
+		<span
+			class="shrink-0 font-mono text-xs font-semibold tracking-wider {active
+				? 'text-text'
+				: 'text-text-muted'}"
+		>
+			<Highlight text={uid} range={hit?.uid ?? null} />
+		</span>
+	{/if}
+</button>

--- a/parts-calculator/src/lib/components/search/SearchTrigger.svelte
+++ b/parts-calculator/src/lib/components/search/SearchTrigger.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Search } from 'lucide-svelte';
+	import Kbd from './Kbd.svelte';
+	import { isMacKeyboard, palette } from '$lib/search.svelte';
+
+	// The way in, in the header. Reads as a search box rather than a button
+	// because that is what it replaces and what people aim at, and it carries the
+	// shortcut so the shortcut is discoverable rather than folklore.
+	// On a phone the header is logo + this + the menu, and the word "Search" costs
+	// the logo more room than it is worth next to a magnifier.
+	let { class: cls = '', compact = false }: { class?: string; compact?: boolean } = $props();
+
+	// The site is prerendered, so the shipped HTML can't know whose keyboard it
+	// lands on. Decide after mount and show nothing rather than the wrong key.
+	let mac = $state<boolean | null>(null);
+	onMount(() => (mac = isMacKeyboard()));
+</script>
+
+<button
+	type="button"
+	class="setup-control flex h-8 min-h-0 items-center gap-2 px-2 text-sm text-text-muted transition-colors hover:text-text {cls}"
+	onclick={() => palette.show()}
+	aria-label="Search the catalog"
+	aria-keyshortcuts="Meta+K Control+K"
+	title={compact ? 'Search the catalog' : undefined}
+>
+	<Search size={compact ? 16 : 14} class="shrink-0" />
+	{#if !compact}<span class="pr-1">Search</span>{/if}
+	{#if !compact && mac !== null}
+		<span class="ml-auto hidden items-center gap-0.5 md:flex">
+			<Kbd>{mac ? '⌘' : 'Ctrl'}</Kbd><Kbd>K</Kbd>
+		</span>
+	{/if}
+</button>

--- a/parts-calculator/src/lib/components/search/kinds.ts
+++ b/parts-calculator/src/lib/components/search/kinds.ts
@@ -1,0 +1,41 @@
+/**
+ * How each kind of result looks. One table, because the whole point is that a
+ * part, a superseded version of that part and a rejected test print of it are
+ * three different answers that carry the same name — the chip and the icon are
+ * the only things telling them apart, so they have to be decided together.
+ *
+ * Colour carries state rather than category: current things are inked, history
+ * is grey, anything under test is amber. Category is carried by the icon and
+ * the word.
+ */
+import { Bolt, Box, Boxes, FileText, FlaskConical, Folder, History, Ruler, Scissors } from 'lucide-svelte';
+import type { ComponentType } from 'svelte';
+import type { ResultKind } from '$lib/search';
+
+export type KindStyle = {
+	icon: ComponentType;
+	/** Classes for the chip: border, background, text. */
+	chip: string;
+	/** Classes for the icon square to the left of the row. */
+	mark: string;
+};
+
+const CURRENT_PART = 'border-primary/40 bg-primary/[0.07] text-primary';
+const CURRENT_ASM = 'border-success/40 bg-success/[0.07] text-success';
+const HISTORIC = 'border-border bg-[var(--color-bg)] text-text-muted';
+const TESTING = 'border-warning/60 bg-warning/[0.12] text-warning-dark';
+const THING = 'border-border bg-[var(--color-bg)] text-text';
+
+export const KIND_STYLES: Record<ResultKind, KindStyle> = {
+	part: { icon: Box, chip: CURRENT_PART, mark: 'text-primary' },
+	'part-version': { icon: History, chip: HISTORIC, mark: 'text-text-muted' },
+	'part-candidate': { icon: FlaskConical, chip: TESTING, mark: 'text-warning-dark' },
+	assembly: { icon: Boxes, chip: CURRENT_ASM, mark: 'text-success' },
+	'assembly-version': { icon: History, chip: HISTORIC, mark: 'text-text-muted' },
+	'assembly-candidate': { icon: FlaskConical, chip: TESTING, mark: 'text-warning-dark' },
+	hardware: { icon: Bolt, chip: THING, mark: 'text-text' },
+	lasercut: { icon: Scissors, chip: THING, mark: 'text-text' },
+	framing: { icon: Ruler, chip: THING, mark: 'text-text' },
+	section: { icon: Folder, chip: HISTORIC, mark: 'text-text-muted' },
+	page: { icon: FileText, chip: HISTORIC, mark: 'text-text-muted' }
+};

--- a/parts-calculator/src/lib/search.svelte.ts
+++ b/parts-calculator/src/lib/search.svelte.ts
@@ -1,0 +1,84 @@
+/**
+ * The one search palette, as shared state.
+ *
+ * There is a single palette for the whole site, mounted once in the layout, so
+ * anything that wants to open it — the header button, a keyboard shortcut, an
+ * inline list filter offering to widen the search — talks to this store rather
+ * than owning its own copy. Query and scope live here too, which is what lets a
+ * list filter hand its half-typed query over when you press ⌘K.
+ */
+import { browser } from '$app/environment';
+import type { SearchScope } from './search';
+
+const RECENT_KEY = 'sorter-search-recent-v1';
+const RECENT_MAX = 6;
+
+class Palette {
+	open = $state(false);
+	query = $state('');
+	scope = $state<SearchScope>('all');
+	/** Keys of items opened from the palette, newest first. */
+	recent = $state<string[]>([]);
+
+	/** Open with a starting query — the header button opens empty, a list filter
+	 *  hands over whatever was already typed into it. */
+	show(query = '', scope: SearchScope = 'all') {
+		this.query = query;
+		this.scope = scope;
+		this.open = true;
+	}
+
+	hide() {
+		this.open = false;
+	}
+
+	load() {
+		if (!browser) return;
+		try {
+			const raw = localStorage.getItem(RECENT_KEY);
+			const list = raw ? JSON.parse(raw) : [];
+			if (Array.isArray(list)) this.recent = list.filter((k) => typeof k === 'string').slice(0, RECENT_MAX);
+		} catch {
+			/* storage disabled — recents are a nicety, never a requirement */
+		}
+	}
+
+	remember(key: string) {
+		this.recent = [key, ...this.recent.filter((k) => k !== key)].slice(0, RECENT_MAX);
+		if (!browser) return;
+		try {
+			localStorage.setItem(RECENT_KEY, JSON.stringify(this.recent));
+		} catch {
+			/* ignore */
+		}
+	}
+}
+
+export const palette = new Palette();
+
+/** Which modifier this keyboard calls the command key. Only meaningful in a
+ *  browser, so callers set it after mount rather than during prerender — the
+ *  static HTML would otherwise ship one platform's shortcut to everyone. */
+export function isMacKeyboard(): boolean {
+	return browser && /mac|iphone|ipad|ipod/i.test(navigator.userAgent);
+}
+
+/** Is this keystroke the "open search" chord — ⌘K on a Mac, Ctrl-K elsewhere?
+ *  `/` counts too, the way it does in every other search box on the web, but
+ *  only when the user isn't already typing into something. */
+export function isSearchChord(e: KeyboardEvent): boolean {
+	if (e.key === 'k' && (e.metaKey || e.ctrlKey)) return true;
+	return e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey && !isTyping(e.target);
+}
+
+/** Is the event coming from somewhere the user is entering text? */
+function isTyping(target: EventTarget | null): boolean {
+	const el = target as HTMLElement | null;
+	if (!el?.tagName) return false;
+	return (
+		el.tagName === 'INPUT' ||
+		el.tagName === 'TEXTAREA' ||
+		el.tagName === 'SELECT' ||
+		el.isContentEditable
+	);
+}

--- a/parts-calculator/src/lib/search.ts
+++ b/parts-calculator/src/lib/search.ts
@@ -1,0 +1,620 @@
+/**
+ * Searching, as one thing the whole site shares.
+ *
+ * Two halves, deliberately split:
+ *
+ *   - the **matcher** (`scoreEntry`, `search`) knows nothing about the catalog.
+ *     It takes a query and a `Searchable` — a name, an optional 4-character
+ *     uid, a slug id, keywords, prose — and returns a score plus the character
+ *     ranges that matched, so a caller can highlight them. Any list on the site
+ *     filters through it, which is why the parts list, the hardware list and
+ *     the palette all rank the same way.
+ *   - the **index** (`CATALOG_INDEX`) is every thing the catalog names, flattened
+ *     into one array of `SearchItem`: parts, their superseded versions and their
+ *     candidates, assemblies and theirs, hardware, laser-cut sheets, framing
+ *     pieces, sections and the site's own pages.
+ *
+ * ## The ranking, and why it is shaped this way
+ *
+ * The load-bearing case is someone holding a printed part, reading the four
+ * characters engraved on it, and typing them. That has to beat everything else
+ * the moment it is complete — but it must not swamp the far more common case of
+ * typing the first letters of a name. So a *complete* uid outranks any name
+ * match, while a *partial* uid sits below a name that starts with the same
+ * letters. Typing `s` puts Stator first; typing `s1` leaves only the ids,
+ * because no part is called "s1". Nothing branches on query shape to do that —
+ * it falls out of the weights.
+ *
+ * Everything runs in the browser over a few hundred entries, so every keystroke
+ * re-scores the whole index and there is no debounce to feel.
+ */
+import {
+	ASSEMBLIES,
+	FOLDERS,
+	HARDWARE,
+	PARTS,
+	SECTIONS,
+	fmtDate,
+	getAssembly,
+	getFolder,
+	hardwareImage,
+	plainDescription,
+	type Assembly,
+	type Hardware,
+	type Part
+} from './filament';
+import { FRAMING_PIECES } from './framing';
+import { LASER_CUT_PARTS } from './lasercut';
+
+// ---------------------------------------------------------------- the matcher
+
+/** A half-open `[start, end)` slice of a field that the query matched. */
+export type Range = [number, number];
+
+/** Anything the matcher can rank. Every field is optional but `name`. */
+export type Searchable = {
+	name: string;
+	/** The 4 characters stamped into a print. Exact match wins outright. */
+	uid?: string;
+	/** The catalog slug, e.g. `fan-bracket-40mm`. */
+	id?: string;
+	/** Alternate names, categories, sizes — anything worth matching but not showing. */
+	keywords?: string[];
+	/** Prose. Matched last and weakly, since a word can appear in any description. */
+	text?: string;
+};
+
+export type Hit = {
+	score: number;
+	/** Where in the name it matched, when it did — for highlighting. */
+	name: Range | null;
+	/** Where in the uid it matched, when it did. */
+	uid: Range | null;
+};
+
+/** Lowercase, strip accents, and fold the typographic characters the catalog
+ *  actually uses (`M5 × 16`, `3/8″`) onto what a keyboard produces. */
+function norm(s: string): string {
+	return s
+		.toLowerCase()
+		.normalize('NFKD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.replace(/[×✕]/g, 'x')
+		.replace(/[″”“]/g, '"')
+		.replace(/[′’‘]/g, "'")
+		.replace(/[–—]/g, '-');
+}
+
+/** The same text with every separator gone, so `m3x8` finds `M3 × 8` and
+ *  `cchannel` finds `C-channel`. Positions are lost, so this only ever sets a
+ *  score, never a highlight range. */
+const squash = (s: string) => norm(s).replace(/[^a-z0-9]/g, '');
+
+/** Is `q` a subsequence of `text` — the loosest match we accept, and only for
+ *  queries long enough that it means something. `stbrk` finds `Stator bracket`. */
+function isSubsequence(q: string, text: string): boolean {
+	let i = 0;
+	for (const ch of text) {
+		if (ch === q[i]) i++;
+		if (i === q.length) return true;
+	}
+	return false;
+}
+
+/** Index of the first word in `text` that starts with `q`, or -1. Words break on
+ *  anything that isn't alphanumeric, so `bracket` hits `40 mm Fan Bracket` and
+ *  `channel` hits `C-channel`. */
+function wordStart(q: string, text: string): number {
+	let at = 0;
+	while (at <= text.length - q.length) {
+		const i = text.indexOf(q, at);
+		if (i < 0) return -1;
+		if (i === 0 || !/[a-z0-9]/.test(text[i - 1])) return i;
+		at = i + 1;
+	}
+	return -1;
+}
+
+// The weights. Read them as one table rather than as separate numbers: the
+// order between them IS the ranking rule, and the gaps are wide enough that a
+// tie-break (see `score` below) can never reorder two different rungs.
+const W = {
+	uidExact: 1200, // the whole point: four characters off a print
+	nameExact: 1000,
+	idExact: 900,
+	namePrefix: 820,
+	uidPrefix: 700, // below namePrefix, so `s` is Stator before it is an id
+	nameWord: 640,
+	idPrefix: 600,
+	idWord: 520,
+	keywordPrefix: 480,
+	nameSubstring: 420,
+	squashed: 380,
+	idSubstring: 300,
+	keywordSubstring: 260,
+	textSubstring: 160,
+	subsequence: 120
+} as const;
+
+/** Below this length a query only matches from the start of a name, a word, an
+ *  id or a uid. One or two characters appear inside almost every description,
+ *  and a result list that reacts to `a` by showing everything is worse than one
+ *  that shows the handful of things actually beginning with it. */
+const PREFIX_ONLY_BELOW = 3;
+
+function scoreToken(raw: string, s: Searchable): Hit | null {
+	const q = norm(raw);
+	if (!q) return null;
+	const loose = q.length >= PREFIX_ONLY_BELOW;
+
+	const name = norm(s.name);
+	const uid = s.uid ? norm(s.uid) : '';
+	const id = s.id ? norm(s.id) : '';
+
+	// A complete uid is unambiguous — nothing else it could have meant.
+	if (uid && uid === q) return { score: W.uidExact, name: null, uid: [0, q.length] };
+	if (name === q) return { score: W.nameExact, name: [0, name.length], uid: null };
+	if (id && id === q) return { score: W.idExact, name: null, uid: null };
+
+	if (name.startsWith(q)) return { score: W.namePrefix, name: [0, q.length], uid: null };
+	if (uid.startsWith(q)) return { score: W.uidPrefix, name: null, uid: [0, q.length] };
+
+	const nw = wordStart(q, name);
+	if (nw >= 0) return { score: W.nameWord, name: [nw, nw + q.length], uid: null };
+
+	if (id.startsWith(q)) return { score: W.idPrefix, name: null, uid: null };
+	if (wordStart(q, id) >= 0) return { score: W.idWord, name: null, uid: null };
+
+	for (const k of s.keywords ?? []) {
+		if (norm(k).startsWith(q)) return { score: W.keywordPrefix, name: null, uid: null };
+	}
+
+	if (!loose) return null;
+
+	const ns = name.indexOf(q);
+	if (ns >= 0) return { score: W.nameSubstring, name: [ns, ns + q.length], uid: null };
+
+	const sq = squash(raw);
+	if (sq && squash(s.name).includes(sq)) return { score: W.squashed, name: null, uid: null };
+
+	if (id.includes(q)) return { score: W.idSubstring, name: null, uid: null };
+	for (const k of s.keywords ?? []) {
+		if (norm(k).includes(q)) return { score: W.keywordSubstring, name: null, uid: null };
+	}
+	if (s.text && norm(s.text).includes(q)) return { score: W.textSubstring, name: null, uid: null };
+	if (isSubsequence(q, name)) return { score: W.subsequence, name: null, uid: null };
+
+	return null;
+}
+
+/**
+ * Rank one entry against a query. Null means it doesn't match at all.
+ *
+ * A multi-word query has to hit on *every* word — `fan bracket` must not return
+ * every bracket — but the whole phrase gets its own shot first, so a name that
+ * literally contains "fan bracket" outranks one that happens to contain both
+ * words far apart.
+ */
+export function scoreEntry(query: string, s: Searchable): Hit | null {
+	const words = query.trim().split(/\s+/).filter(Boolean);
+	if (!words.length) return null;
+	if (words.length === 1) return scoreToken(words[0], s);
+
+	let sum = 0;
+	let best: Hit | null = null;
+	for (const w of words) {
+		const hit = scoreToken(w, s);
+		if (!hit) return null;
+		sum += hit.score;
+		if (!best || hit.score > best.score) best = hit;
+	}
+	const phrase = scoreToken(words.join(' '), s);
+	const spread = sum / words.length;
+	return phrase && phrase.score >= spread ? phrase : { ...(best as Hit), score: spread };
+}
+
+/** A ranked entry, carrying the hit so the caller can highlight what matched. */
+export type Ranked<T> = { item: T; hit: Hit };
+
+/**
+ * Rank a list, best first. `boost` lets the caller nudge whole classes of thing
+ * — the catalog uses it to keep a current part above its own superseded
+ * versions when their names are identical, which they always are.
+ */
+export function search<T>(
+	query: string,
+	items: readonly T[],
+	toSearchable: (item: T) => Searchable,
+	opts: { limit?: number; boost?: (item: T) => number } = {}
+): Ranked<T>[] {
+	if (!query.trim()) return [];
+	const out: Ranked<T>[] = [];
+	for (const item of items) {
+		const s = toSearchable(item);
+		const hit = scoreEntry(query, s);
+		if (!hit) continue;
+		// Tie-break on brevity: for `s`, "Stator" is a better guess than "Stator
+		// bracket housing spacer". Kept well under the gap between two weights so
+		// it can only ever reorder within a rung.
+		const tune = (opts.boost?.(item) ?? 0) - Math.min(s.name.length, 60) * 0.4;
+		out.push({ item, hit: { ...hit, score: hit.score + tune } });
+	}
+	out.sort((a, b) => b.hit.score - a.hit.score);
+	return opts.limit ? out.slice(0, opts.limit) : out;
+}
+
+// ------------------------------------------------------------------ the index
+
+/** What a result *is*. Each gets its own chip in the palette, because "the
+ *  current stator" and "a rejected test print of the stator" answer very
+ *  different questions and read almost identically otherwise. */
+export type ResultKind =
+	| 'part'
+	| 'part-version'
+	| 'part-candidate'
+	| 'assembly'
+	| 'assembly-version'
+	| 'assembly-candidate'
+	| 'hardware'
+	| 'lasercut'
+	| 'framing'
+	| 'section'
+	| 'page';
+
+/** The palette's filter chips. `uid` is the explicit "I am reading characters
+ *  off a print" mode: it matches nothing but stamped ids. */
+export type SearchScope = 'all' | 'parts' | 'assemblies' | 'hardware' | 'uid';
+
+export type SearchItem = Searchable & {
+	/** Unique across the whole index; a uid isn't enough (a part and its current
+	 *  version share one) and neither is an id. */
+	key: string;
+	kind: ResultKind;
+	scope: Exclude<SearchScope, 'all' | 'uid'>;
+	/** What the chip says. */
+	label: string;
+	/** A qualifier on the chip: `v1.2`, `superseded`, `rejected`. */
+	note?: string;
+	/** Where the thing lives, one line. */
+	subtitle?: string;
+	href: string;
+	image?: string | null;
+	/** Ranking nudge — see `search`. */
+	boost: number;
+};
+
+export const SCOPES: { id: SearchScope; label: string; hint: string }[] = [
+	{ id: 'all', label: 'Everything', hint: 'Parts, assemblies, hardware, pages' },
+	{ id: 'parts', label: 'Parts', hint: 'Printed, laser-cut and framing pieces' },
+	{ id: 'assemblies', label: 'Assemblies', hint: 'What bolts to what' },
+	{ id: 'hardware', label: 'Hardware', hint: 'Screws, bearings, motors, boards' },
+	{ id: 'uid', label: 'Stamped id', hint: 'Only the 4 characters engraved on a print' }
+];
+
+const sectionNames = new Map(SECTIONS.map((s) => [s.id, s.name]));
+
+/** Where a printed part lives, for the second line of a result. Prefers the
+ *  assemblies that list it — that is what someone recognises — and falls back to
+ *  the sections it is counted in for the parts the tree hasn't reached. */
+function partHome(p: Part): string {
+	const asms = ASSEMBLIES.filter((a) => (a.lines ?? []).some((l) => l.part === p.id));
+	if (asms.length) return asms.map((a) => a.name).join(' · ');
+	const sections = Object.keys(p.quantities)
+		.map((id) => sectionNames.get(id))
+		.filter(Boolean);
+	if (sections.length) return sections.join(' · ');
+	return getFolder(p.folder ?? null)?.name ?? 'Not placed yet';
+}
+
+/** Every word worth matching on a part but not worth showing. */
+function partKeywords(p: Part): string[] {
+	return [
+		...(p.aliases ?? []),
+		...Object.keys(p.quantities).map((id) => sectionNames.get(id) ?? id),
+		getFolder(p.folder ?? null)?.name ?? '',
+		p.variant_name ?? '',
+		getAssembly(p.assembly)?.name ?? '',
+		...(p.attributes ?? []).map((a) => `${a.label} ${a.value}`)
+	].filter(Boolean);
+}
+
+function hardwareKeywords(h: Hardware): string[] {
+	const c = h.cots;
+	return [
+		h.category ?? '',
+		c?.type ?? '',
+		c?.size ?? '',
+		c?.variant ?? '',
+		c?.length_mm ? `${c.length_mm}mm` : '',
+		// The two ways people write a screw, so `m3x8` and `M3 8mm` both land.
+		c?.size && c.length_mm ? `${c.size}x${c.length_mm}` : '',
+		...(h.attributes ?? []).map((a) => `${a.label} ${a.value}`)
+	].filter(Boolean);
+}
+
+/** An assembly's members by name — searching "stator" should surface the
+ *  C-channel drive it belongs to, not only the stator itself. */
+function assemblyKeywords(a: Assembly): string[] {
+	return (a.lines ?? [])
+		.map((l) => (l.part ? l.part : l.assembly ? (getAssembly(l.assembly)?.name ?? '') : ''))
+		.filter(Boolean);
+}
+
+const PAGES: { name: string; href: string; text: string; keywords: string[] }[] = [
+	{ name: '3D printed parts', href: '/', text: 'Configure a build, pick colours and download the STLs.', keywords: ['stl', 'download', 'filament', 'print', 'calculator', 'manifest'] },
+	{ name: 'Aluminium framing', href: '/framing', text: 'Every 2020 extrusion cut length and how to get them out of 1 m bars.', keywords: ['extrusion', '2020', 'cut', 'bar', 'aluminum', 't-slot'] },
+	{ name: 'Laser cut parts', href: '/lasercut', text: 'The flat plywood DXFs, and how to cut them by hand.', keywords: ['dxf', 'plywood', 'sheet', 'jigsaw'] },
+	{ name: 'Hardware', href: '/hardware', text: 'Screws, nuts, inserts, bearings and where to buy them.', keywords: ['bom', 'buy', 'cart', 'sourcing', 'vendor', 'cots'] },
+	{ name: 'Machine assembly', href: '/assembly', text: 'The machine as a tree: what bolts to what, top to bottom.', keywords: ['tree', 'bom', 'structure'] },
+	{ name: 'Changes and improvements', href: '/changes', text: 'What is planned or broken on a part before you print it.', keywords: ['planned', 'broken', 'todo', 'revision'] },
+	{ name: 'Top plate hand-cut guide', href: '/lasercut/top-plate-guide', text: 'Cutting the top plate with a jigsaw and a drill instead of a laser.', keywords: ['handcut', 'jigsaw', 'guide', 'printable'] }
+];
+
+// Current things sit a rung above their own history, which matters because a
+// version carries the same name as its part and would otherwise tie with it.
+// Printed parts edge out everything else on a tie because this is a tool for
+// deciding what to print — typing `s` should land on the Stator before it lands
+// on framing piece B, which is also called a spoke and is also a shorter word.
+// Every value here is far smaller than the gap between two weights, so these can
+// only ever reorder things that already matched the same way.
+const BOOST = { printed: 70, current: 60, framing: 35, page: 30, historic: 0, retired: -40 } as const;
+
+function buildIndex(): SearchItem[] {
+	const items: SearchItem[] = [];
+
+	for (const p of PARTS) {
+		const home = partHome(p);
+		const keywords = partKeywords(p);
+		const text = plainDescription(p.description);
+		items.push({
+			key: `part:${p.id}`,
+			kind: 'part',
+			scope: 'parts',
+			label: '3D printed',
+			note: `v${p.version}`,
+			name: p.name,
+			uid: p.uid,
+			id: p.id,
+			keywords,
+			text,
+			subtitle: home,
+			href: `/part/${p.id}`,
+			image: p.render,
+			boost: BOOST.printed
+		});
+		// The part's own uid is the newest version's, and it is already indexed
+		// above as the part — listing it twice would answer one query with two
+		// rows saying the same thing.
+		for (const v of p.versions ?? []) {
+			if (!v.uid || v.uid === p.uid) continue;
+			items.push({
+				key: `part-version:${p.id}:${v.uid}`,
+				kind: 'part-version',
+				scope: 'parts',
+				label: 'Old version',
+				note: `v${v.version}`,
+				name: p.name,
+				uid: v.uid,
+				id: p.id,
+				keywords,
+				text: v.message,
+				subtitle: `Superseded ${fmtDate(v.date)} · now v${p.version}`,
+				href: `/u/${v.uid}`,
+				image: v.render ?? p.render,
+				boost: BOOST.historic
+			});
+		}
+		for (const c of p.candidates ?? []) {
+			const state = c.rejected_at
+				? `Rejected ${fmtDate(c.rejected_at)}`
+				: c.superseded_by
+					? `Superseded by ${c.superseded_by.toUpperCase()}`
+					: 'Under test';
+			items.push({
+				key: `part-candidate:${p.id}:${c.uid}`,
+				kind: 'part-candidate',
+				scope: 'parts',
+				label: 'Candidate',
+				note: c.rejected_at ? 'rejected' : c.superseded_by ? 'superseded' : 'under test',
+				name: c.name ? `${p.name} (${c.name})` : p.name,
+				uid: c.uid,
+				id: p.id,
+				keywords,
+				text: c.message,
+				subtitle: `A test revision for ${p.name} · ${state}`,
+				href: `/u/${c.uid}`,
+				image: c.render ?? p.render,
+				boost: c.rejected_at || c.superseded_by ? BOOST.retired : BOOST.historic
+			});
+		}
+	}
+
+	for (const a of ASSEMBLIES) {
+		const keywords = assemblyKeywords(a);
+		items.push({
+			key: `assembly:${a.id}`,
+			kind: 'assembly',
+			scope: 'assemblies',
+			label: 'Assembly',
+			note: a.version ? `v${a.version}` : a.status === 'stub' ? 'stub' : undefined,
+			name: a.name,
+			uid: a.uid,
+			id: a.id,
+			keywords,
+			text: plainDescription(a.description),
+			subtitle: `${(a.lines ?? []).length} member${(a.lines ?? []).length === 1 ? '' : 's'}`,
+			href: `/assembly?focus=${encodeURIComponent(a.id)}`,
+			boost: BOOST.current
+		});
+		for (const v of a.versions ?? []) {
+			if (!v.uid || v.uid === a.uid) continue;
+			items.push({
+				key: `assembly-version:${a.id}:${v.uid}`,
+				kind: 'assembly-version',
+				scope: 'assemblies',
+				label: 'Old structure',
+				note: `v${v.version}`,
+				name: a.name,
+				uid: v.uid,
+				id: a.id,
+				keywords,
+				text: v.message,
+				subtitle: `Superseded ${fmtDate(v.date)}`,
+				href: `/u/${v.uid}`,
+				boost: BOOST.historic
+			});
+		}
+		for (const c of a.candidates ?? []) {
+			items.push({
+				key: `assembly-candidate:${a.id}:${c.uid}`,
+				kind: 'assembly-candidate',
+				scope: 'assemblies',
+				label: 'Candidate',
+				note: c.rejected_at ? 'rejected' : c.superseded_by ? 'superseded' : 'under test',
+				name: c.name ? `${a.name} (${c.name})` : a.name,
+				uid: c.uid,
+				id: a.id,
+				keywords,
+				text: c.message,
+				subtitle: `An alternative bill of materials for ${a.name}`,
+				href: `/u/${c.uid}`,
+				boost: c.rejected_at || c.superseded_by ? BOOST.retired : BOOST.historic
+			});
+		}
+	}
+
+	for (const h of HARDWARE) {
+		items.push({
+			key: `hardware:${h.id}`,
+			kind: 'hardware',
+			scope: 'hardware',
+			label: 'Hardware',
+			name: h.name,
+			uid: h.uid,
+			id: h.id,
+			keywords: hardwareKeywords(h),
+			text: plainDescription(h.description),
+			subtitle: h.category ?? 'Off the shelf',
+			href: `/part/${h.id}`,
+			image: hardwareImage(h)?.src ?? null,
+			boost: BOOST.current
+		});
+	}
+
+	for (const l of LASER_CUT_PARTS) {
+		items.push({
+			key: `lasercut:${l.id}`,
+			kind: 'lasercut',
+			scope: 'parts',
+			label: 'Laser cut',
+			name: l.name,
+			uid: l.uid,
+			id: l.id,
+			keywords: ['dxf', 'plywood', 'sheet', l.thicknessIn, `${l.thicknessMm}mm`],
+			text: plainDescription(l.description),
+			subtitle: `${l.thicknessIn} plywood · ${Math.round(l.widthMm)} × ${Math.round(l.heightMm)} mm`,
+			href: '/lasercut',
+			image: l.preview,
+			boost: BOOST.current
+		});
+	}
+
+	for (const f of FRAMING_PIECES) {
+		items.push({
+			key: `framing:${f.letter}`,
+			kind: 'framing',
+			scope: 'parts',
+			label: 'Framing',
+			note: f.letter,
+			name: f.name,
+			id: f.letter.toLowerCase(),
+			keywords: ['2020', 'extrusion', 'aluminium', 'aluminum', `${f.len}mm`, f.category],
+			text: f.from,
+			subtitle: `Piece ${f.letter} · ${f.len} mm of 2020 extrusion`,
+			href: '/framing',
+			boost: BOOST.framing
+		});
+	}
+
+	for (const s of SECTIONS) {
+		items.push({
+			key: `section:${s.id}`,
+			kind: 'section',
+			scope: 'parts',
+			label: 'Section',
+			name: s.name,
+			id: s.id,
+			keywords: ['section', 'group'],
+			subtitle: s.scales_with_layers ? 'One per layer' : 'One per machine',
+			href: `/#section-${s.id}`,
+			boost: BOOST.page
+		});
+	}
+	for (const f of FOLDERS) {
+		items.push({
+			key: `folder:${f.id}`,
+			kind: 'section',
+			scope: 'parts',
+			label: 'Group',
+			name: f.name,
+			id: f.id,
+			text: f.description,
+			subtitle: 'A group in the parts list',
+			href: '/',
+			boost: BOOST.page
+		});
+	}
+
+	for (const p of PAGES) {
+		items.push({
+			key: `page:${p.href}`,
+			kind: 'page',
+			scope: 'parts',
+			label: 'Page',
+			name: p.name,
+			keywords: p.keywords,
+			text: p.text,
+			subtitle: p.text,
+			href: p.href,
+			boost: BOOST.page
+		});
+	}
+
+	return items;
+}
+
+/** Built once, at module load. A few hundred entries off already-parsed JSON —
+ *  cheaper than the work of deciding when to build it lazily. */
+export const CATALOG_INDEX: SearchItem[] = buildIndex();
+
+/** Pages and sections aren't things you hold, so they have no stamped id and
+ *  are simply absent from the id scope. */
+const inScope = (item: SearchItem, scope: SearchScope) =>
+	scope === 'all' ? true : scope === 'uid' ? !!item.uid : item.scope === scope;
+
+/** `#s1qc` and `id:s1qc` mean "this is a stamped id", so someone who knows what
+ *  they're typing can say so without reaching for the scope chips. */
+const ID_PREFIX = /^(?:#|id:)\s*/i;
+export function readScopePrefix(query: string): { query: string; scope: SearchScope | null } {
+	const m = query.match(ID_PREFIX);
+	return m ? { query: query.slice(m[0].length), scope: 'uid' } : { query, scope: null };
+}
+
+/** The palette's one call: rank the whole catalog inside a scope. In the id
+ *  scope only the uid is considered, so a part whose *name* contains the
+ *  characters can't crowd out the print you are holding. */
+export function searchCatalog(query: string, scope: SearchScope = 'all', limit = 40): Ranked<SearchItem>[] {
+	const pool = CATALOG_INDEX.filter((i) => inScope(i, scope));
+	const view: (item: SearchItem) => Searchable =
+		scope === 'uid' ? (i) => ({ name: i.uid ?? '', uid: i.uid }) : (i) => i;
+	const ranked = search(query, pool, view, { limit, boost: (i) => i.boost });
+	// In the id scope the matcher was handed the uid as the name, so the name
+	// range it reports points into the uid. Move it where the row expects it.
+	return scope === 'uid'
+		? ranked.map((r) => ({ ...r, hit: { ...r.hit, uid: r.hit.uid ?? r.hit.name, name: null } }))
+		: ranked;
+}
+
+/** Look one item up by the key the palette persists in "recent". */
+const byKey = new Map(CATALOG_INDEX.map((i) => [i.key, i]));
+export const itemByKey = (key: string): SearchItem | undefined => byKey.get(key);

--- a/parts-calculator/src/routes/+layout.svelte
+++ b/parts-calculator/src/routes/+layout.svelte
@@ -1,22 +1,13 @@
 <script lang="ts">
 	import './layout.css';
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
 	import { Menu, X } from 'lucide-svelte';
+	import SearchPalette from '$lib/components/search/SearchPalette.svelte';
+	import SearchTrigger from '$lib/components/search/SearchTrigger.svelte';
+	import { isSearchChord, palette } from '$lib/search.svelte';
 
 	let { children } = $props();
-
-	// The 4 characters stamped into a print: type them here, land on /u/<uid>.
-	// Uids are lowercase in the catalog; what is read off a part is uppercase.
-	let lookup = $state('');
-	function lookupUid(e: SubmitEvent) {
-		e.preventDefault();
-		const uid = lookup.trim().toLowerCase();
-		if (!uid) return;
-		lookup = '';
-		menuOpen = false;
-		goto(`/u/${encodeURIComponent(uid)}`);
-	}
 
 	const tabs = [
 		{ href: '/', label: '3D printed parts' },
@@ -39,17 +30,27 @@
 		$page.url.pathname;
 		menuOpen = false;
 	});
+
+	onMount(() => palette.load());
+
+	// The search chord works from anywhere on the site, which is the whole point
+	// of a chord. It is registered here rather than inside the palette so it
+	// still fires when the palette isn't mounted, and so it can't be swallowed
+	// by whatever has focus.
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') menuOpen = false;
+		if (palette.open || !isSearchChord(e)) return;
+		e.preventDefault();
+		menuOpen = false;
+		palette.show();
+	}
 </script>
 
 <svelte:head><link rel="icon" href="/favicon.ico" /></svelte:head>
-<svelte:window
-	onkeydown={(e) => {
-		if (e.key === 'Escape') menuOpen = false;
-	}}
-/>
+<svelte:window onkeydown={onKey} />
 
 <header class="relative border-b border-border bg-surface">
-	<div class="mx-auto flex max-w-6xl items-center gap-x-6 gap-y-2 px-4 py-3 sm:flex-wrap sm:px-6">
+	<div class="mx-auto flex max-w-6xl items-center gap-x-4 gap-y-2 px-4 py-3 sm:flex-wrap sm:px-6">
 		<a
 			href="/"
 			class="flex min-w-0 items-center gap-2 text-base font-bold tracking-tight text-text sm:text-lg"
@@ -58,23 +59,28 @@
 			<span class="truncate">Sorter Parts Calculator</span>
 		</a>
 
-		<!-- phone: the menu button, labelled with where you are -->
-		<button
-			class="ml-auto inline-flex shrink-0 items-center gap-1.5 border border-border px-2.5 py-1.5 text-sm text-text transition-colors hover:border-primary sm:hidden"
-			aria-expanded={menuOpen}
-			aria-controls="nav-menu"
-			onclick={() => (menuOpen = !menuOpen)}
-		>
-			{#if menuOpen}<X size={16} />{:else}<Menu size={16} />{/if}
-			<span class="max-w-[9rem] truncate font-medium">{current}</span>
-		</button>
+		<SearchTrigger class="hidden w-44 shrink-0 sm:flex" />
+
+		<!-- phone: search as an icon, then the menu button labelled with where you are -->
+		<div class="ml-auto flex shrink-0 items-center gap-2 sm:hidden">
+			<SearchTrigger compact class="w-auto px-2" />
+			<button
+				class="inline-flex shrink-0 items-center gap-1.5 border border-border px-2.5 py-1.5 text-sm text-text transition-colors hover:border-primary"
+				aria-expanded={menuOpen}
+				aria-controls="nav-menu"
+				onclick={() => (menuOpen = !menuOpen)}
+			>
+				{#if menuOpen}<X size={16} />{:else}<Menu size={16} />{/if}
+				<span class="max-w-[9rem] truncate font-medium">{current}</span>
+			</button>
+		</div>
 
 		<!-- desktop: the tabs inline, as before -->
-		<nav class="hidden items-center gap-1 sm:flex">
+		<nav class="ml-auto hidden items-center gap-1 sm:flex">
 			{#each tabs as tab (tab.href)}
 				<a
 					href={tab.href}
-					class="whitespace-nowrap border-b-2 px-3 py-2 text-sm font-semibold transition-colors {isActive(
+					class="whitespace-nowrap border-b-2 px-2.5 py-2 text-sm font-semibold transition-colors {isActive(
 						tab.href
 					)
 						? 'border-primary text-text'
@@ -84,20 +90,6 @@
 				</a>
 			{/each}
 		</nav>
-
-		<form onsubmit={lookupUid} class="ml-auto hidden items-center sm:flex" title="The id stamped into a print">
-			<input
-				bind:value={lookup}
-				type="search"
-				inputmode="text"
-				autocapitalize="characters"
-				spellcheck="false"
-				maxlength="4"
-				placeholder="id on a print"
-				aria-label="Look up the id stamped into a print"
-				class="h-8 w-32 border border-border bg-[var(--color-bg)] px-2 font-mono text-sm uppercase text-text placeholder:font-sans placeholder:normal-case placeholder:text-text-muted focus:border-primary focus:outline-none"
-			/>
-		</form>
 	</div>
 
 	{#if menuOpen}
@@ -124,21 +116,10 @@
 					{tab.label}
 				</a>
 			{/each}
-			<form onsubmit={lookupUid} class="flex items-center gap-2 border-t border-border px-4 py-3">
-				<input
-					bind:value={lookup}
-					type="search"
-					autocapitalize="characters"
-					spellcheck="false"
-					maxlength="4"
-					placeholder="id on a print"
-					aria-label="Look up the id stamped into a print"
-					class="h-9 w-36 border border-border bg-[var(--color-bg)] px-2 font-mono text-sm uppercase text-text placeholder:font-sans placeholder:normal-case placeholder:text-text-muted focus:border-primary focus:outline-none"
-				/>
-				<button type="submit" class="setup-button-secondary h-9 px-3 text-sm font-semibold">Look up</button>
-			</form>
 		</nav>
 	{/if}
 </header>
+
+<SearchPalette />
 
 {@render children()}

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -48,6 +48,8 @@
 	import { loadConfig, saveConfig, clearConfig } from '$lib/config';
 	import { layerStore, addLayer as addLayerStore, removeLayerAt, setSize, setSizes } from '$lib/layers.svelte';
 	import { colorStore, defaultRoleColors, resetRoleColors } from '$lib/colors.svelte';
+	import SearchField from '$lib/components/search/SearchField.svelte';
+	import { search, type Searchable } from '$lib/search';
 	import Popover from '$lib/components/Popover.svelte';
 	import Disclosure from '$lib/components/Disclosure.svelte';
 	import Badge from '$lib/components/Badge.svelte';
@@ -261,6 +263,25 @@
 		return (uses.get(id) ?? []).find((u) => u.assemblyId)?.assemblyId ?? null;
 	}
 
+	// ---- filtering the list ------------------------------------------------
+	// Narrows what is on screen and nothing else: the totals below still describe
+	// the whole build, because a filter answers "where is it" and must not quietly
+	// restate what you are about to print. It ranks through the same matcher as
+	// the ⌘K palette, so a part found one way is found the other way.
+	let partFilter = $state('');
+	const filtering = $derived(partFilter.trim().length > 0);
+	const partSearchable = (p: Part): Searchable => ({
+		name: p.name,
+		uid: p.uid,
+		id: p.id,
+		keywords: [...(p.aliases ?? []), ...usedIn(p.id), getFolder(p.folder ?? null)?.name ?? ''].filter(Boolean),
+		text: p.description
+	});
+	function filterParts(list: Part[]): Part[] {
+		if (!filtering) return list;
+		return search(partFilter, list, partSearchable).map((r) => r.item);
+	}
+
 	// per-layer size 'half' = 12 bins, 'third' = 18 bins
 	const sizePreview = {
 		half: { count: 12, bins: ['bin-half-left', 'bin-half-right'], funnel: 'funnel-half' },
@@ -282,9 +303,11 @@
 
 	const sectionRows = $derived(
 		SECTIONS.map((s) => {
-			const parts = PARTS.filter((p) => sectionQty(p, s.id) > 0);
+			const all = PARTS.filter((p) => sectionQty(p, s.id) > 0);
 			const mult = categoryMultiplier(s.id, layers);
-			const selectedGrams = parts.reduce(
+			// over the whole section, not the filtered view — the header states what
+			// the section weighs, which doesn't change because you typed something
+			const selectedGrams = all.reduce(
 				(sum, p) =>
 					sum +
 					effectiveGrams(p, supportOn(p.id)) *
@@ -292,8 +315,15 @@
 						qtyScale(p.id),
 				0
 			);
-			return { section: s, parts, mult, selectedGrams };
+			return { section: s, parts: filterParts(all), mult, selectedGrams };
 		}).filter((r) => r.parts.length > 0)
+	);
+	/** Rows on screen in the by-assembly view, against rows there would be with no
+	 *  filter. A part counted in two sections is listed in both, so both halves of
+	 *  the ratio count (part, section) pairs and the two agree. */
+	const sectionShown = $derived(sectionRows.reduce((n, r) => n + r.parts.length, 0));
+	const sectionTotal = $derived(
+		SECTIONS.reduce((n, s) => n + PARTS.filter((p) => sectionQty(p, s.id) > 0).length, 0)
 	);
 
 	const selectedParts = $derived(PARTS.filter((p) => isIncluded(p.id)));
@@ -306,6 +336,13 @@
 			.map((p) => ({ p, qty: qtyOf(p.id), need: machineNeeds(p.id) }))
 			.sort((a, b) => a.p.name.localeCompare(b.p.name))
 	);
+	// While filtering the rows come back in relevance order — alphabetical is only
+	// useful when you are scanning the whole list.
+	const uniqueShown = $derived.by(() => {
+		if (!filtering) return uniqueRows;
+		const keep = new Map(uniqueRows.map((r) => [r.p.id, r]));
+		return filterParts(uniqueRows.map((r) => r.p)).map((p) => keep.get(p.id)!);
+	});
 	const uniqueGrams = $derived(
 		uniqueRows.reduce((sum, r) => sum + effectiveGrams(r.p, supportOn(r.p.id)) * r.qty, 0)
 	);
@@ -392,11 +429,14 @@
 			}
 			g.parts.push(p);
 		}
-		for (const assembly of ASSEMBLIES) {
-			if (assembly.section === sectionId && assembly.status === 'stub' && !represented.has(assembly.id)) {
-				blocks.push({ kind: 'group', groupKind: 'assembly', id: assembly.id, parts: [] });
+		// Stubs are placeholders for assemblies with nothing in them yet. They match
+		// nothing, so while a filter is on they are noise around the thing you asked for.
+		if (!filtering)
+			for (const assembly of ASSEMBLIES) {
+				if (assembly.section === sectionId && assembly.status === 'stub' && !represented.has(assembly.id)) {
+					blocks.push({ kind: 'group', groupKind: 'assembly', id: assembly.id, parts: [] });
+				}
 			}
-		}
 		return blocks;
 	}
 	// Assemblies collapse to a single rollup row carrying the part count and the
@@ -721,11 +761,15 @@
 							aria-pressed={listView === 'unique'}
 							title="Every part once, with the number you are printing. This is the list you print from.">By unique part</button>
 					</div>
-					<span class="text-xs text-text-muted">
-						{listView === 'assembly'
-							? 'Grouped by what bolts to what.'
-							: 'Every part once. Edit a quantity to print more or fewer than the machine needs.'}
-					</span>
+					<SearchField
+						bind:value={partFilter}
+						label="Filter the parts list"
+						placeholder="Filter parts by name, id or where they go"
+						noun="part"
+						found={listView === 'unique' ? uniqueShown.length : sectionShown}
+						total={listView === 'unique' ? uniqueRows.length : sectionTotal}
+						class="min-w-0 flex-1"
+					/>
 				</div>
 				{#if listView === 'unique'}
 					<div class="pl-scroll mb-6">
@@ -741,7 +785,7 @@
 								</tr>
 							</thead>
 							<tbody>
-								{#each uniqueRows as { p, qty, need } (p.id)}
+								{#each uniqueShown as { p, qty, need } (p.id)}
 									{@const each = effectiveGrams(p, supportOn(p.id))}
 									<tr class="pl-row group/row" class:opacity-50={qty === 0}>
 										<td class="pl-c-thumb">
@@ -790,7 +834,7 @@
 							<tfoot>
 								<tr>
 									<td></td>
-									<td class="pl-c-name"><span class="pl-name">{uniqueRows.filter((r) => r.qty > 0).length} parts · {uniqueRows.reduce((n, r) => n + r.qty, 0)} pieces</span></td>
+									<td class="pl-c-name"><span class="pl-name">{uniqueRows.filter((r) => r.qty > 0).length} parts · {uniqueRows.reduce((n, r) => n + r.qty, 0)} pieces{#if filtering}<span class="font-normal text-text-muted"> · the whole build, not the filtered rows</span>{/if}</span></td>
 									<td></td>
 									<td></td>
 									<td class="pl-c-total">{grams(uniqueGrams)}</td>
@@ -840,7 +884,7 @@
 									{@const folder = getFolder(block.id)}
 									{@const group = block.groupKind === 'folder' ? folder : a}
 									{@const k = asmKey(section.id, `${block.groupKind}:${block.id}`)}
-									{@const open = expandedAsm[k]}
+									{@const open = expandedAsm[k] || filtering}
 									{@const allOn = asmAllOn(block.parts)}
 									<!-- svelte-ignore a11y_no_noninteractive_element_interactions a11y_click_events_have_key_events -->
 									<tr
@@ -896,7 +940,7 @@
 												</span>
 												<span class="pl-meta">
 													{block.parts.length ? `${block.parts.length} printed parts` : 'Parts and print details coming soon'}
-													{#if a}<span class="pl-hint">View assembly <ArrowUpRight size={12} /></span>{:else if block.parts.length}· click to {open ? 'collapse' : 'expand'}{/if}
+													{#if a}<span class="pl-hint">View assembly <ArrowUpRight size={12} /></span>{:else if block.parts.length && !filtering}· click to {open ? 'collapse' : 'expand'}{/if}
 												</span>
 											</span>
 										</td>

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -11,7 +11,9 @@
 	import HardwareDetailModal from '$lib/components/HardwareDetailModal.svelte';
 	import HardwareIcon from '$lib/components/HardwareIcon.svelte';
 	import ImageStrip from '$lib/components/ImageStrip.svelte';
+	import SearchField from '$lib/components/search/SearchField.svelte';
 	import Seo from '$lib/components/Seo.svelte';
+	import { scoreEntry } from '$lib/search';
 	import { colorStore } from '$lib/colors.svelte';
 	import {
 		docsUrl,
@@ -23,6 +25,7 @@
 		hardwareImage,
 		JOIN_LABELS,
 		lineQty,
+		plainDescription,
 		primaryColorId,
 		resolveHardwareTotals,
 		type AssemblyLine,
@@ -56,6 +59,101 @@
 		const timers = [0, 120, 400, 900].map((t) => setTimeout(aim, t));
 		return () => timers.forEach(clearTimeout);
 	});
+
+	// ---- filtering the tree --------------------------------------------------
+	// A tree can't be filtered like a list: hiding everything that doesn't match
+	// would also hide the branch that tells you WHERE the match is, which is the
+	// only reason to search a tree in the first place. So a node survives when it
+	// matches or when anything beneath it does, and the path down to a match stays
+	// on screen. An assembly that matches by its own name keeps its whole subtree
+	// — you asked for the chute core, you want what is in it.
+	let filter = $state('');
+	const filtering = $derived(filter.trim().length > 0);
+
+	/** Does this member — printed part, bought part or laser-cut sheet — match? */
+	function memberMatches(id: string): boolean {
+		const p = getPart(id);
+		if (p) return !!scoreEntry(filter, { name: p.name, uid: p.uid, id: p.id, keywords: p.aliases, text: p.description });
+		const h = getHardware(id);
+		if (h)
+			return !!scoreEntry(filter, {
+				name: h.name,
+				uid: h.uid,
+				id: h.id,
+				keywords: [h.category ?? '', h.cots?.size ?? '', h.cots?.type ?? ''].filter(Boolean),
+				text: plainDescription(h.description)
+			});
+		const l = getLasercut(id);
+		if (l) return !!scoreEntry(filter, { name: l.name, uid: l.uid, id: l.id, text: l.description });
+		return false;
+	}
+
+	const keep = $derived.by(() => {
+		const assemblies = new Set<string>();
+		const members = new Set<string>();
+		// What actually matched, as opposed to what is on screen: most of
+		// `assemblies` is the path down to a hit, and calling those matches would
+		// overstate what was found.
+		const matched = new Set<string>();
+		if (!filtering) return { assemblies, members, matched };
+
+		// An assembly that matched by name pulls everything under it along.
+		const whole = new Set<string>();
+		function includeAll(id: string) {
+			if (whole.has(id)) return;
+			whole.add(id);
+			assemblies.add(id);
+			for (const line of getAssembly(id)?.lines ?? []) {
+				if (line.assembly) includeAll(line.assembly);
+				else if (line.part) members.add(line.part);
+			}
+		}
+
+		// Memoised, and seeded false before recursing, so a subtree shared by two
+		// branches is walked once and an authoring typo can't spin forever.
+		const seen = new Map<string, boolean>();
+		function visit(id: string): boolean {
+			const memo = seen.get(id);
+			if (memo !== undefined) return memo;
+			seen.set(id, false);
+			const asm = getAssembly(id);
+			if (!asm) return false;
+			let hit = !!scoreEntry(filter, {
+				name: asm.name,
+				uid: asm.uid,
+				id: asm.id,
+				text: plainDescription(asm.description)
+			});
+			if (hit) {
+				matched.add(id);
+				includeAll(id);
+			}
+			else {
+				for (const line of asm.lines ?? []) {
+					if (line.assembly) {
+						if (visit(line.assembly)) hit = true;
+					} else if (line.part && memberMatches(line.part)) {
+						members.add(line.part);
+						matched.add(line.part);
+						hit = true;
+					}
+				}
+				if (hit) assemblies.add(id);
+			}
+			seen.set(id, hit);
+			return hit;
+		}
+		visit('machine');
+		return { assemblies, members, matched };
+	});
+
+	/** Is this line still on screen? Assemblies self-guard in `node`; members are
+	 *  checked here because they have nowhere else to do it. */
+	const lineShown = (line: AssemblyLine) =>
+		!filtering ||
+		(line.assembly ? keep.assemblies.has(line.assembly) : !!line.part && keep.members.has(line.part));
+
+	const matchCount = $derived(keep.matched.size);
 
 	// What the badges mean. The tree records that a node is incomplete but not
 	// which pieces are missing, so the tooltip says exactly that much and no more.
@@ -181,7 +279,9 @@
 	     same part, and a bare id key makes that a duplicate-key error that
 	     blanks the whole page on hydration. -->
 	{#each list as line, i (`${line.part ?? line.assembly}-${i}`)}
-		{#if line.assembly}
+		{#if !lineShown(line)}
+			<!-- filtered out -->
+		{:else if line.assembly}
 			{@render node(line.assembly, line.qty, lineQty(line, layers) * mult, depth + 1)}
 		{:else if line.part && getLasercut(line.part)}
 			{@const lc = getLasercut(line.part)!}
@@ -234,7 +334,7 @@
 
 {#snippet node(id: string, qty: AssemblyLine['qty'], mult: number, depth: number)}
 	{@const asm = getAssembly(id)}
-	{#if asm}
+	{#if asm && (!filtering || keep.assemblies.has(asm.id))}
 		<div
 			id="asm-{asm.id}"
 			class="border-l-2 {depth > 0 ? 'ml-1.5 pl-2 sm:ml-4 sm:pl-4' : 'pl-2 sm:pl-4'} py-2 {focus === asm.id
@@ -282,7 +382,7 @@
 			<!-- Alternative bills of materials under test. Rendered with the same line
 			     rows, but nothing here reaches the totals: resolveHardwareTotals walks
 			     only `lines`. -->
-			{#each asm.candidates ?? [] as c (c.uid)}
+			{#each (filtering ? [] : (asm.candidates ?? [])) as c (c.uid)}
 				{@const retired = !!(c.superseded_by || c.rejected_at)}
 				<div class="ml-1.5 mt-3 border border-dashed p-2 sm:ml-4 sm:p-3 {retired ? 'border-border opacity-60' : 'border-primary/60'}">
 					<div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
@@ -300,7 +400,7 @@
 				</div>
 			{/each}
 			<!-- Superseded structures, each line pinned to the member's uid of the day. -->
-			{#if (asm.versions?.length ?? 0) > 1}
+			{#if !filtering && (asm.versions?.length ?? 0) > 1}
 				<details class="ml-1.5 mt-3 sm:ml-4">
 					<summary class="inline-flex cursor-pointer items-center gap-1 text-xs font-semibold uppercase tracking-wider text-text-muted hover:text-text"><History size={11} /> Previous revisions · {(asm.versions?.length ?? 1) - 1}</summary>
 					{#each [...(asm.versions ?? [])].slice(0, -1).reverse() as v (v.version)}
@@ -360,6 +460,21 @@
 					<span class="font-normal text-text-muted">· {layers} layers</span>
 				</button>
 			</div>
+			<SearchField
+				bind:value={filter}
+				label="Filter the assembly tree"
+				placeholder="Find a part, a screw or an assembly in the tree"
+				noun="match"
+				nouns="matches"
+				found={filtering ? matchCount : null}
+				class="mb-3"
+			/>
+			{#if filtering && matchCount === 0}
+				<p class="px-1 py-6 text-center text-sm text-text-muted">
+					Nothing in the tree matches. Most branches are still stubs — the part may be in the
+					catalog without being placed here yet.
+				</p>
+			{/if}
 			{@render node('machine', 1, 1, 0)}
 		</section>
 

--- a/parts-calculator/src/routes/hardware/+page.svelte
+++ b/parts-calculator/src/routes/hardware/+page.svelte
@@ -17,6 +17,8 @@
 	import LayerControl from '$lib/components/LayerControl.svelte';
 	import HardwareDetailModal from '$lib/components/HardwareDetailModal.svelte';
 	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
+	import SearchField from '$lib/components/search/SearchField.svelte';
+	import { search, type Searchable } from '$lib/search';
 	import {
 		assembliesContaining,
 		bestUsVendor,
@@ -52,10 +54,36 @@
 	// it; the sheet's hand counts (sheet_qty) are the fallback for the rest.
 	const layers = $derived(layerStore.sizes.length);
 
+	// ---- filtering the list ------------------------------------------------
+	// A shopping list is the wrong shape for scrolling: you arrive knowing the
+	// screw. Ranked through the same matcher as the ⌘K palette, so `m3x8` finds
+	// the M3 × 8 whichever way you write it, and an id off a print works here too.
+	let filter = $state('');
+	const filtering = $derived(filter.trim().length > 0);
+	const hardwareSearchable = (h: Hardware): Searchable => ({
+		name: h.name,
+		uid: h.uid,
+		id: h.id,
+		keywords: [
+			h.category ?? '',
+			h.cots?.type ?? '',
+			h.cots?.size ?? '',
+			h.cots?.variant ?? '',
+			h.cots?.length_mm ? `${h.cots.length_mm}mm` : '',
+			h.cots?.size && h.cots.length_mm ? `${h.cots.size}x${h.cots.length_mm}` : '',
+			...h.attributes.map((a) => `${a.label} ${a.value}`),
+			...assembliesContaining(h.id).map((a) => a.name)
+		].filter(Boolean),
+		text: plainDescription(h.description)
+	});
+	const shown = $derived(
+		filtering ? search(filter, HARDWARE, hardwareSearchable).map((r) => r.item) : HARDWARE
+	);
+
 	// categories in manifest order, preserving first-seen order
 	const groups = $derived.by(() => {
 		const by = new Map<string, Hardware[]>();
-		for (const h of HARDWARE) {
+		for (const h of shown) {
 			const cat = h.category ?? 'Other';
 			if (!by.has(cat)) by.set(cat, []);
 			by.get(cat)!.push(h);
@@ -449,6 +477,15 @@
 					</span>
 				{/each}
 			</div>
+			<SearchField
+				bind:value={filter}
+				label="Filter the hardware list"
+				placeholder="Filter by name, size, id or where it goes"
+				noun="item"
+				found={shown.length}
+				total={HARDWARE.length}
+				class="mb-3"
+			/>
 			<div class="mb-3 flex flex-wrap items-center justify-between gap-2 border-b border-border pb-2">
 				<span class="text-xs font-semibold uppercase tracking-wider text-text-muted">
 					Rough US total <span class="font-bold normal-case tracking-normal text-text"

--- a/parts-calculator/src/routes/u/[uid]/+page.ts
+++ b/parts-calculator/src/routes/u/[uid]/+page.ts
@@ -6,7 +6,8 @@ import type { EntryGenerator, PageLoad } from './$types';
 // per uid the catalog has ever minted -- current parts, superseded versions,
 // candidates, assemblies, hardware, laser-cut sheets -- so the four characters
 // on a part found in a drawer a year from now still say what it is. Uids are
-// lowercase in the catalog; the header's lookup box lowercases what is typed.
+// lowercase in the catalog; the search palette lowercases what is typed and
+// resolves it before navigating, so this route's 404 is now the rare case.
 export const prerender = true;
 
 export const entries: EntryGenerator = () => allUids().map((uid) => ({ uid }));


### PR DESCRIPTION
The header carried a 4-character box that did one thing: type an id off a print, land on `/u/<uid>`. It could not find a part by name, it 404'd on a typo, and the three long lists on the site had no filter at all.

## One matcher backs everything

`$lib/search.ts` splits in two:

- a **scorer** that knows nothing about the catalog — name, uid, slug, keywords, prose in; a score plus the character ranges that matched out;
- an **index** of every thing the catalog names: parts, their superseded versions, their candidates, assemblies and theirs, hardware, laser-cut sheets, framing pieces, sections, pages.

So the palette, the parts list, the hardware list and the assembly tree all rank identically — a part found one way is found the other way.

## The ranking is the point

A **complete** uid outranks every other kind of match, because four characters read off a print are unambiguous. A **partial** uid sits just below a name starting with the same letters. So:

- `s` → **Stator** first
- `s2` → one row: the Interface bracket's superseded v1, `S2O9`

Neither is special-cased — it falls out of the weight table. Under 3 characters only prefixes match, so `a` doesn't return the whole catalog. `m3x8` finds `M3 × 8`; `cchannel` finds `C-channel`.

## The palette

⌘K / Ctrl-K / `/` over any page. Scopes: Everything · Parts · Assemblies · Hardware · **Stamped id**; `#` or `id:` forces id-only from the keyboard; Tab cycles; recents when empty.

Kind is carried by an icon and a chip whose colour means **state** — inked for current, grey for history, amber for under test — so a part and a rejected test print of it, which share a name, never read alike. Renders left, uid hard right in mono, so you can scan the column while reading an id off a print.

## Filters on the long lists

`SearchField` at the top of the parts, hardware and assembly lists.

- **Parts** — both views. Groups auto-expand so a match can't hide inside a collapsed folder. Totals stay the whole build, labelled as such, rather than quietly restating what you're about to print.
- **Hardware** — `m3x8` → 2/69.
- **Assembly** — a real tree filter: the path down to a match stays on screen, and an assembly matching by name keeps its whole subtree. `m3 nut` → 2 matches across 6 nodes.

Each offers "Search everything for X →", so a narrow list is never a dead end.

Skipped laser cut (3 parts), framing (10 rows) and changes (15) — a filter there is furniture.

## Also

A typo now says the id carries nothing and to check for a 0/O mix-up, instead of 404ing.

Removed the "Grouped by what bolts to what." hint next to the view toggle — both halves of it, since the toggle buttons already carry those exact sentences as tooltips.

## Checks

`svelte-check` 0 errors, production build clean, 213 `/u/<uid>` pages still prerendered. Cherry-picked onto current `main` with no conflicts.

**Not merged yet** — I'm chasing one interaction bug found after the branch was cut: after the palette is closed with Escape, the ⌘K chord doesn't reopen it (the trigger button still does). Fix incoming before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)