### PR TITLE
parts-calculator: P0 for the output gear fastener, and one collapsed notice per part

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -245,6 +245,26 @@
           "interface-spacer"
         ]
       }
+    },
+    {
+      "id": "fix-output-gear-rotor-fastener",
+      "name": "Output gear to rotor screw does not reach the rotor",
+      "priority": "P0",
+      "condition": "broken",
+      "description": "The six screws holding the Output gear (130T) to the rotor were specified as M3 x 8 mm countersunk. The gear is 8.00 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 x 8 seated flush in the countersink ends level with the gear's top face and takes no thread in the rotor at all. Fit M3 x 12 mm countersunk for now: 4.0 mm of thread in the rotor's 5.0 mm flange, 1 mm short of breaking through the far side. Whether the joint settles as a 12 mm screw or the gear boss changes is still to be decided, so treat the length as provisional. Reported from a build by aleph1111/christoph and scres; measured off the pinned output-gear and rotor STLs.",
+      "targets": {
+        "parts": [
+          "output-gear",
+          "rotor-faceted",
+          "rotor-finned"
+        ],
+        "assemblies": [
+          "c-channel"
+        ],
+        "hardware": [
+          "scr-m3-12-cs"
+        ]
+      }
     }
   ],
   "folders": [

--- a/parts-calculator/src/lib/components/ChangeStatus.svelte
+++ b/parts-calculator/src/lib/components/ChangeStatus.svelte
@@ -1,44 +1,167 @@
 <script lang="ts">
 	import { AlertTriangle, RefreshCw } from 'lucide-svelte';
-	import Badge from './Badge.svelte';
 	import PriorityBadge from './PriorityBadge.svelte';
 	import Popover from './Popover.svelte';
-	import { plannedChangesFor, type ChangeTargetKind } from '$lib/filament';
+	import { plannedChangesFor, type ChangePriority, type ChangeTargetKind, type PlannedChange } from '$lib/filament';
 
-	let { kind, id, name }: { kind: ChangeTargetKind; id: string; name: string } = $props();
-	const changes = $derived(plannedChangesFor(kind, id));
+	// Every open notice on one thing, collapsed into a single control. A part can
+	// carry several at once (a broken feature plus two nice-to-haves), and one
+	// badge per change turned the row into a wall of them — so the trigger takes
+	// its tone from the worst one and the panel lists them all.
+	//
+	// `variant`:
+	//   badge  — the inline badge that sits next to a name.
+	//   marker — a small corner mark for an image tile, for the views where a part
+	//            is a picture and nothing else. Needs a positioned ancestor.
+	let {
+		kind,
+		id,
+		name,
+		variant = 'badge'
+	}: { kind: ChangeTargetKind; id: string; name: string; variant?: 'badge' | 'marker' } = $props();
+
+	const rank = (change: PlannedChange) =>
+		(change.condition === 'broken' ? 0 : 1) * 100 + (Number.parseInt(change.priority.slice(1), 10) || 0);
+	const changes = $derived([...plannedChangesFor(kind, id)].sort((a, b) => rank(a) - rank(b)));
+	const lead = $derived(changes[0]);
+	const anyBroken = $derived(changes.some((change) => change.condition === 'broken'));
+	// Worst priority across the notices, which is the number the trigger shows.
+	const topPriority = $derived(
+		changes.reduce<ChangePriority>(
+			(worst, change) =>
+				(Number.parseInt(change.priority.slice(1), 10) || 0) < (Number.parseInt(worst.slice(1), 10) || 0)
+					? change.priority
+					: worst,
+			changes[0]?.priority ?? 'P9'
+		)
+	);
+	const allNiceToHave = $derived(changes.every((change) => Number(change.priority.slice(1)) >= 4));
+	const label = $derived(
+		changes.length > 1
+			? `${changes.length} notices on ${name}`
+			: allNiceToHave
+				? `Possible improvement for ${name}`
+				: anyBroken
+					? `Broken feature on ${name}`
+					: `Why ${name} is subject to change`
+	);
+	const headline = $derived(
+		anyBroken
+			? 'This design has a broken feature that is intended to be fixed.'
+			: allNiceToHave
+				? 'The current design is usable; these improvements would be nice to have.'
+				: 'Works now, but is intended to be replaced shortly with an improvement.'
+	);
 </script>
 
-{#each changes as change (change.id)}
-	{@const isBroken = change.condition === 'broken'}
-	{@const isNiceToHave = Number(change.priority.slice(1)) >= 4}
-	<Popover width="w-80" label={isNiceToHave ? `Possible improvement for ${name}` : isBroken ? `Broken feature on ${name}` : `Why ${name} is subject to change`}>
+{#if changes.length}
+	<Popover width="w-80" align={variant === 'marker' ? 'right' : 'left'} {label}>
 		{#snippet trigger({ toggle, open })}
-			<PriorityBadge as="button" priority={change.priority} class={isBroken ? 'uppercase tracking-wide' : ''} onclick={toggle} aria-expanded={open}>
-				{#if isBroken}<AlertTriangle size={11} /> Broken Feature{:else}<RefreshCw size={11} /> {isNiceToHave ? 'Nice to Improve' : 'Subject to Change'}{/if} · {change.priority}
-			</PriorityBadge>
+			{#if variant === 'marker'}
+				<button
+					type="button"
+					class="change-marker"
+					class:is-broken={anyBroken}
+					onclick={toggle}
+					aria-expanded={open}
+					aria-label={label}
+					title={label}
+				>
+					<AlertTriangle size={11} />
+					{#if changes.length > 1}<span class="change-marker-n">{changes.length}</span>{/if}
+				</button>
+			{:else}
+				<PriorityBadge
+					as="button"
+					priority={topPriority}
+					class={anyBroken ? 'uppercase tracking-wide' : ''}
+					onclick={toggle}
+					aria-expanded={open}
+				>
+					{#if anyBroken}<AlertTriangle size={11} />{:else}<RefreshCw size={11} />{/if}
+					{#if changes.length > 1}
+						{changes.length} Notices
+					{:else if anyBroken}
+						Broken Feature
+					{:else}
+						{allNiceToHave ? 'Nice to Improve' : 'Subject to Change'}
+					{/if}
+					· {topPriority}
+				</PriorityBadge>
+			{/if}
 		{/snippet}
 		<div class="flex items-start gap-2">
-			<AlertTriangle size={14} class="mt-0.5 shrink-0 {isBroken ? 'text-danger' : 'text-warning-dark'}" />
+			<AlertTriangle size={14} class="mt-0.5 shrink-0 {anyBroken ? 'text-danger' : 'text-warning-dark'}" />
 			<div>
-				<b class="text-text">{isBroken ? 'This design has a broken feature that is intended to be fixed.' : isNiceToHave ? 'The current design is usable; this improvement would be nice to have.' : 'Works now, but is intended to be replaced shortly with an improvement.'}</b>
-				<p class="mt-1"><b>{change.priority}</b> priority — {isBroken && change.priority === 'P0' ? 'highest priority.' : isNiceToHave ? 'nice-to-have improvement.' : 'planned change.'}</p>
+				<b class="text-text">{headline}</b>
+				<p class="mt-1">
+					{#if changes.length > 1}
+						<b>{changes.length}</b> open notices on {name}, worst is <b>{topPriority}</b>.
+					{:else}
+						<b>{lead.priority}</b> priority — {anyBroken && lead.priority === 'P0'
+							? 'highest priority.'
+							: allNiceToHave
+								? 'nice-to-have improvement.'
+								: 'planned change.'}
+					{/if}
+				</p>
 			</div>
 		</div>
-		<div class="mt-2 border-t border-border pt-2 text-text">
-			<PriorityBadge priority={change.priority} />
-			<a class="ml-1 font-semibold text-primary hover:text-primary-hover" href="/changes#{change.id}">{change.name}</a>
-			<p class="mt-1">{change.description}</p>
-			{#if change.images?.length}
-				<div class="mt-2 space-y-1.5">
-					{#each change.images as image}
-						<figure>
-							<img src={image.url} alt={image.alt} class="max-h-44 w-full border border-border bg-white object-contain" />
-							{#if image.caption}<figcaption class="mt-1 text-[10px] text-text-muted">{image.caption}</figcaption>{/if}
-						</figure>
-					{/each}
-				</div>
-			{/if}
-		</div>
+		{#each changes as change (change.id)}
+			<div class="mt-2 border-t border-border pt-2 text-text">
+				<PriorityBadge priority={change.priority} />
+				{#if change.condition === 'broken'}<span class="ml-1 text-[10px] font-semibold uppercase tracking-wide text-danger">Broken</span>{/if}
+				<a class="ml-1 font-semibold text-primary hover:text-primary-hover" href="/changes#{change.id}">{change.name}</a>
+				<p class="mt-1">{change.description}</p>
+				{#if change.images?.length}
+					<div class="mt-2 space-y-1.5">
+						{#each change.images as image}
+							<figure>
+								<img src={image.url} alt={image.alt} class="max-h-44 w-full border border-border bg-white object-contain" />
+								{#if image.caption}<figcaption class="mt-1 text-[10px] text-text-muted">{image.caption}</figcaption>{/if}
+							</figure>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/each}
 	</Popover>
-{/each}
+{/if}
+
+<style>
+	/* Deliberately quiet: a builder scanning a list of renders should notice it
+	   without reading it as a stop sign. The panel is where the alarm lives. */
+	.change-marker {
+		position: absolute;
+		top: 1px;
+		right: 1px;
+		z-index: 10;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.0625rem;
+		border: 1px solid var(--color-border);
+		background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+		padding: 0 0.125rem;
+		color: var(--color-warning-dark);
+		line-height: 1.35;
+	}
+	/* warning-dark is a near-black brown, unreadable on the dark surface, so the
+	   dark theme takes the bright warning instead. */
+	:global(.dark) .change-marker {
+		color: var(--color-warning);
+	}
+	.change-marker.is-broken {
+		border-color: color-mix(in srgb, var(--color-danger) 50%, transparent);
+		color: var(--color-danger);
+	}
+	:global(.dark) .change-marker.is-broken {
+		color: #ff6b6c;
+	}
+	.change-marker:hover {
+		border-color: currentColor;
+	}
+	.change-marker-n {
+		font-size: 0.625rem;
+		font-weight: 700;
+	}
+</style>

--- a/parts-calculator/src/lib/components/ChangeStatus.svelte
+++ b/parts-calculator/src/lib/components/ChangeStatus.svelte
@@ -17,8 +17,15 @@
 		kind,
 		id,
 		name,
-		variant = 'badge'
-	}: { kind: ChangeTargetKind; id: string; name: string; variant?: 'badge' | 'marker' } = $props();
+		variant = 'badge',
+		align = 'left'
+	}: {
+		kind: ChangeTargetKind;
+		id: string;
+		name: string;
+		variant?: 'badge' | 'marker';
+		align?: 'left' | 'right';
+	} = $props();
 
 	const rank = (change: PlannedChange) =>
 		(change.condition === 'broken' ? 0 : 1) * 100 + (Number.parseInt(change.priority.slice(1), 10) || 0);
@@ -55,7 +62,12 @@
 </script>
 
 {#if changes.length}
-	<Popover width="w-80" align={variant === 'marker' ? 'right' : 'left'} {label}>
+	<!-- Left by default, both variants. The parts table scrolls horizontally
+	     (`.pl-scroll`), which clips an absolutely positioned panel, and a marker
+	     sits in the narrow thumbnail cell at the very left — so a right-aligned
+	     panel runs 20rem off the edge of the table and loses its first half.
+	     Opening rightwards into the table body always has room. -->
+	<Popover width="w-80" {align} {label}>
 		{#snippet trigger({ toggle, open })}
 			{#if variant === 'marker'}
 				<button
@@ -65,7 +77,6 @@
 					onclick={toggle}
 					aria-expanded={open}
 					aria-label={label}
-					title={label}
 				>
 					<AlertTriangle size={11} />
 					{#if changes.length > 1}<span class="change-marker-n">{changes.length}</span>{/if}

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -259,6 +259,26 @@
 					"interface-spacer"
 				]
 			}
+		},
+		{
+			"id": "fix-output-gear-rotor-fastener",
+			"name": "Output gear to rotor screw does not reach the rotor",
+			"priority": "P0",
+			"condition": "broken",
+			"description": "The six screws holding the Output gear (130T) to the rotor were specified as M3 x 8 mm countersunk. The gear is 8.00 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 x 8 seated flush in the countersink ends level with the gear's top face and takes no thread in the rotor at all. Fit M3 x 12 mm countersunk for now: 4.0 mm of thread in the rotor's 5.0 mm flange, 1 mm short of breaking through the far side. Whether the joint settles as a 12 mm screw or the gear boss changes is still to be decided, so treat the length as provisional. Reported from a build by aleph1111/christoph and scres; measured off the pinned output-gear and rotor STLs.",
+			"targets": {
+				"parts": [
+					"output-gear",
+					"rotor-faceted",
+					"rotor-finned"
+				],
+				"assemblies": [
+					"c-channel"
+				],
+				"hardware": [
+					"scr-m3-12-cs"
+				]
+			}
 		}
 	],
 	"folders": [

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -660,15 +660,20 @@
 					<!-- empty twist slot: keeps a part's thumbnail on the same line as
 					     the fans on the assembly rows above it -->
 					<span class="pl-twist"></span>
-					<button
-						type="button"
-						class="pl-thumb group relative"
-						onclick={() => openViewer(p)}
-						title="View {p.name} in 3D"
-					>
-						<img src={p.render} alt={p.name} />
-						<span class="absolute inset-0 flex items-center justify-center bg-black/40 text-white opacity-0 transition-opacity group-hover:opacity-100 group-hover/row:opacity-100"><ZoomIn size={16} /></span>
-					</button>
+					<!-- the notice marker is a sibling of the viewer button, not inside
+					     it: both are buttons and one cannot nest in the other -->
+					<span class="relative inline-flex">
+						<button
+							type="button"
+							class="pl-thumb group relative"
+							onclick={() => openViewer(p)}
+							title="View {p.name} in 3D"
+						>
+							<img src={p.render} alt={p.name} />
+							<span class="absolute inset-0 flex items-center justify-center bg-black/40 text-white opacity-0 transition-opacity group-hover:opacity-100 group-hover/row:opacity-100"><ZoomIn size={16} /></span>
+						</button>
+						<ChangeStatus kind="parts" id={p.id} name={p.name} variant="marker" />
+					</span>
 				</span>
 			</td>
 			<td class="pl-c-name">
@@ -789,10 +794,13 @@
 									{@const each = effectiveGrams(p, supportOn(p.id))}
 									<tr class="pl-row group/row" class:opacity-50={qty === 0}>
 										<td class="pl-c-thumb">
-											<button type="button" class="pl-thumb group relative" onclick={() => openViewer(p)} title="View {p.name} in 3D">
-												<img src={p.render} alt={p.name} />
-												<span class="absolute inset-0 flex items-center justify-center bg-black/40 text-white opacity-0 transition-opacity group-hover:opacity-100"><ZoomIn size={16} /></span>
-											</button>
+											<span class="relative inline-flex">
+												<button type="button" class="pl-thumb group relative" onclick={() => openViewer(p)} title="View {p.name} in 3D">
+													<img src={p.render} alt={p.name} />
+													<span class="absolute inset-0 flex items-center justify-center bg-black/40 text-white opacity-0 transition-opacity group-hover:opacity-100"><ZoomIn size={16} /></span>
+												</button>
+												<ChangeStatus kind="parts" id={p.id} name={p.name} variant="marker" />
+											</span>
 										</td>
 										<td class="pl-c-name">
 											<span class="pl-name">

--- a/parts-calculator/src/routes/changes/+page.svelte
+++ b/parts-calculator/src/routes/changes/+page.svelte
@@ -29,7 +29,10 @@
 	}
 	function targetHref(kind: ChangeTargetKind, id: string): string {
 		if (kind === 'parts') return `/part/${id}`;
-		if (kind === 'assemblies') return `/#assembly-${id}`;
+		// the assembly explorer, not /#assembly-<id>: that anchor only exists when
+		// some part carries the assembly as its own `assembly` field, so an
+		// assembly whose members are only in its `lines` (c-channel) has none.
+		if (kind === 'assemblies') return `/assembly?focus=${id}`;
 		if (kind === 'sections') return `/#section-${id}`;
 		if (kind === 'lasercut') return `/lasercut#laser-${id}`;
 		return `/hardware#hardware-${id}`;

--- a/parts-calculator/src/routes/hardware/+page.svelte
+++ b/parts-calculator/src/routes/hardware/+page.svelte
@@ -345,6 +345,7 @@
 				{#if lengthLabel}
 					<span class="hw-len">{lengthLabel}</span>
 				{/if}
+				<ChangeStatus kind="hardware" id={h.id} name={h.name} variant="marker" />
 				<!-- hover preview; decorative, the thumbnail already carries the alt -->
 				<img src={img.src} alt="" aria-hidden="true" class="hw-zoom" />
 			</span>

--- a/parts-calculator/src/routes/lasercut/+page.svelte
+++ b/parts-calculator/src/routes/lasercut/+page.svelte
@@ -107,8 +107,9 @@
 			<div class="grid gap-4 sm:grid-cols-2">
 				{#each group.parts as p (p.id)}
 					<div class="setup-card-shell flex scroll-mt-6 flex-col border" id="laser-{p.id}">
-						<div class="flex items-center justify-center border-b border-border bg-[var(--color-bg)] p-4">
+						<div class="relative flex items-center justify-center border-b border-border bg-[var(--color-bg)] p-4">
 							<img src={p.preview} alt="{p.name} outline" class="h-48 w-auto max-w-full" />
+							<ChangeStatus kind="lasercut" id={p.id} name={p.name} variant="marker" />
 						</div>
 						<div class="flex gap-1 border-b border-border px-2">
 							<button


### PR DESCRIPTION
Requested by Spencer (@spencerhubert) [from Discord](https://discord.com/channels/1430279849171222682/1540821273972572240/1540821273972572240): "i dont think updating in the docs is the right way to triage issues with parts. can you instead just mark this as a p0 thing under "changes" . additionally whereever we render a part with a problem (broken feature) we should put a tiny warning box... perhaps should collapse those into the same thing for n number notices on a part."

Reported by aleph1111/christoph and scres from a build.

## The P0

The six screws holding the Output gear (130T) to the rotor were specified `scr-m3-8-cs`. Measured off the pinned `output-gear` and `rotor-faceted` STLs, which share assembly coordinates:

- Output gear spans z −11.00 to −3.00 — **8.00 mm thick at the bolt circle**.
- Its six holes are Ø3.40 clearance with a 90° countersink on the underside (Ø6.50 mouth, 1.55 mm deep).
- The rotor's six Ø2.80 thread-forming holes run z −3.00 to +2.00, **5.00 mm of flange**, coaxial at R 89.98.

A countersunk screw's length is measured over the head, so an M3 × 8 seated flush ends at z −3.00: level with the gear's top face, zero thread in the rotor. M3 × 12 ends at z +1.00 — 4.0 mm of engagement, 1 mm short of breaking through. Whether the joint settles as a 12 mm screw or the gear boss changes is left open in the entry.

## The notices

`ChangeStatus` already put a popover badge next to a name on parts, hardware, laser-cut parts, assemblies and sections. Two gaps:

- **One badge per change.** A part with three notices got three badges. Now one control: tone and priority from the worst notice, panel lists them all, count in the label when there is more than one.
- **Nothing on the image.** New `variant="marker"` renders a small corner mark on the image tiles — both parts-list renders, the hardware photo, the laser-cut outline — with the same panel. Quiet on purpose (warning tone, translucent chip); the alarm lives in the panel, which says what it is, what the issue is, and links `/changes#<id>`.

## Also

`targetHref` for an assembly on the changes page now points at `/assembly?focus=<id>` instead of `/#assembly-<id>`, the same destination the hardware page already uses for "where does this go".

To be straight about how this one surfaced: on the older base I built against, `/#assembly-c-channel` did not exist — that anchor only appeared when some part carried the assembly in its own `assembly` field, and c-channel's members live only in its `lines` — so the prerender failed the build on a dead link. #383 changed the grouping and the anchor exists now, so this is no longer a fix, just the better target: the explorer opens focused on the assembly rather than scrolling the dashboard to a collapsed row. Happy to drop it if you'd rather keep the anchor.

## Checks

`npm run check` and `npm run build` clean, `check_generated_pins.py` agrees.

**Generated data was refreshed with `generate.py --metadata-only`**, which carries `stamped`, grams and render URLs over from the committed file and only rewrites authored fields. The diff on `catalog.generated.json` is the 20-line changes entry and nothing else. A full run is not reproducible off Spencer's machine — it rewrote 284 stamped-STL URLs, 12 normals, 10 face picks and 9 renders with no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
