### PR TITLE
docs: a part card opens the part, the way the calculator does

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,6 +13,7 @@
 				"@sveltejs/vite-plugin-svelte": "^6.2.1",
 				"@tailwindcss/vite": "^4.1.17",
 				"@types/js-yaml": "^4.0.9",
+				"@types/three": "^0.185.4",
 				"js-yaml": "^4.1.0",
 				"liquidjs": "^10.21.0",
 				"rehype-raw": "^7.0.0",
@@ -24,10 +25,18 @@
 				"svelte": "^5.45.6",
 				"svelte-check": "^4.3.4",
 				"tailwindcss": "^4.1.17",
+				"three": "^0.185.1",
 				"typescript": "^5.9.3",
 				"unified": "^11.0.5",
 				"vite": "^7.2.6"
 			}
+		},
+		"node_modules/@dimforge/rapier3d-compat": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+			"integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.28.2",
@@ -1285,6 +1294,13 @@
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
+		"node_modules/@tweenjs/tween.js": {
+			"version": "23.1.3",
+			"resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+			"integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1343,6 +1359,28 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/stats.js": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+			"integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/three": {
+			"version": "0.185.4",
+			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.4.tgz",
+			"integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@dimforge/rapier3d-compat": "~0.12.0",
+				"@tweenjs/tween.js": "~23.1.3",
+				"@types/stats.js": "*",
+				"@types/webxr": ">=0.5.17",
+				"fflate": "~0.8.2",
+				"meshoptimizer": "~1.1.1"
+			}
+		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -1354,6 +1392,13 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
 			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/webxr": {
+			"version": "0.5.24",
+			"resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+			"integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1730,6 +1775,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -2544,6 +2596,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
+		},
+		"node_modules/meshoptimizer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+			"integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/micromark": {
 			"version": "4.0.2",
@@ -3593,6 +3652,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
+		},
+		"node_modules/three": {
+			"version": "0.185.1",
+			"resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+			"integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.17",

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/vite": "^4.1.17",
 		"@types/js-yaml": "^4.0.9",
+		"@types/three": "^0.185.4",
 		"js-yaml": "^4.1.0",
 		"liquidjs": "^10.21.0",
 		"rehype-raw": "^7.0.0",
@@ -28,6 +29,7 @@
 		"svelte": "^5.45.6",
 		"svelte-check": "^4.3.4",
 		"tailwindcss": "^4.1.17",
+		"three": "^0.185.1",
 		"typescript": "^5.9.3",
 		"unified": "^11.0.5",
 		"vite": "^7.2.6"

--- a/docs/src/lib/components/Modal.svelte
+++ b/docs/src/lib/components/Modal.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	// The site's one modal. A native <dialog>, so Escape, the backdrop, focus
+	// trapping and inert-ing the page behind it are the browser's job rather than
+	// ours — the same thing SearchModal does, factored out so anything else that
+	// needs a panel (the part detail, for now) opens the same object.
+	let {
+		open = $bindable(false),
+		title,
+		subtitle,
+		children
+	}: {
+		open?: boolean;
+		title?: string;
+		subtitle?: string;
+		children: Snippet;
+	} = $props();
+
+	let dialog: HTMLDialogElement | undefined = $state();
+
+	$effect(() => {
+		if (open) {
+			if (!dialog?.open) dialog?.showModal();
+		} else if (dialog?.open) {
+			dialog.close();
+		}
+	});
+</script>
+
+<dialog
+	class="modal"
+	bind:this={dialog}
+	onclose={() => (open = false)}
+	onclick={(e) => {
+		if (e.target === dialog) open = false;
+	}}
+>
+	<div class="modal-panel">
+		<header class="modal-header">
+			<div class="modal-heading">
+				<h2 class="modal-title">{title ?? ''}</h2>
+				{#if subtitle}<p class="modal-subtitle">{subtitle}</p>{/if}
+			</div>
+			<button class="modal-close" type="button" onclick={() => (open = false)} aria-label="Close">
+				<svg viewBox="0 0 20 20" fill="none" aria-hidden="true">
+					<path
+						d="M5 5l10 10M15 5L5 15"
+						stroke="currentColor"
+						stroke-width="1.7"
+						stroke-linecap="round"
+					/>
+				</svg>
+			</button>
+		</header>
+		<div class="modal-body">
+			{@render children()}
+		</div>
+	</div>
+</dialog>

--- a/docs/src/lib/components/PartModal.svelte
+++ b/docs/src/lib/components/PartModal.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import Modal from '$lib/components/Modal.svelte';
+	import StlViewer from '$lib/components/StlViewer.svelte';
+	import type { ResolvedPart } from '$lib/server/content';
+
+	// What a "Parts needed" card opens: the same facts the parts calculator's own
+	// part modal shows, rendered in this site's styling, off the same generated
+	// catalog both sites build from. Deliberately not a copy of everything over
+	// there — versions, candidates, build plates and the cart maths stay one
+	// click away on the part's own calculator page, which every modal links to.
+	let { open = $bindable(false), part }: { open?: boolean; part: ResolvedPart | null } = $props();
+
+	const detail = $derived(part?.detail);
+
+	function duration(seconds: number): string {
+		const h = Math.floor(seconds / 3600);
+		const m = Math.round((seconds % 3600) / 60);
+		return h ? `${h} h ${m} min` : `${m} min`;
+	}
+
+	function fmtDate(value?: string): string {
+		if (!value) return '—';
+		const d = new Date(value);
+		return isNaN(+d)
+			? value
+			: d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+	}
+</script>
+
+<Modal bind:open title={part?.name} subtitle={part?.id}>
+	{#if part && detail}
+		<div class="part-modal">
+			<div class="part-modal-media">
+				{#if detail.kind === 'printed' && detail.stl}
+					{#key detail.stl}
+						<StlViewer url={detail.stl} poster={part.image} />
+					{/key}
+				{:else if part.image}
+					<img class="part-modal-img" src={part.image} alt={part.name} />
+				{:else}
+					<p class="part-modal-noimg">No image for this part yet.</p>
+				{/if}
+			</div>
+
+			<div class="part-modal-detail">
+				{#each detail.changes ?? [] as change (change.id)}
+					{@const broken = change.condition === 'broken'}
+					<div class="callout {broken ? 'callout-warning' : ''} part-modal-change">
+						<span class="callout-icon" aria-hidden="true">{broken ? '⚠' : '↻'}</span>
+						<p>
+							<strong
+								>{broken ? 'Broken feature' : 'Subject to change'} · {change.priority} · {change.name}</strong
+							><br />{change.description}
+						</p>
+					</div>
+				{/each}
+
+				{#if detail.description}<p class="part-modal-desc">{detail.description}</p>{/if}
+				{#if detail.info}<p class="part-modal-note">{detail.info}</p>{/if}
+				{#if detail.note}<p class="part-modal-note">{detail.note}</p>{/if}
+				{#if detail.low_tolerance}
+					<div class="callout callout-warning part-modal-change">
+						<span class="callout-icon" aria-hidden="true">⚠</span>
+						<p>
+							<strong>Low tolerance, test print suggested.</strong>
+							{detail.low_tolerance_note ??
+								'This part has little room for dimensional error. Print one first and confirm the fit before committing to the full set.'}
+						</p>
+					</div>
+				{/if}
+
+				{#if detail.attributes?.length}
+					<ul class="part-modal-attrs">
+						{#each detail.attributes as attr (attr.label)}
+							<li><span>{attr.label}</span> {attr.value}</li>
+						{/each}
+					</ul>
+				{/if}
+
+				{#if detail.kind === 'printed'}
+					<dl class="part-modal-facts">
+						<div>
+							<dt>Version</dt>
+							<dd>v{detail.version ?? '1'}</dd>
+						</div>
+						<div>
+							<dt>Updated</dt>
+							<dd>{fmtDate(detail.updated_at)}</dd>
+						</div>
+						<div>
+							<dt>Filament</dt>
+							<dd>{detail.grams != null ? `${detail.grams.toFixed(0)} g` : '—'}</dd>
+						</div>
+						<div>
+							<dt>Print time</dt>
+							<dd>{detail.print_seconds != null ? duration(detail.print_seconds) : '—'}</dd>
+						</div>
+					</dl>
+				{/if}
+
+				{#if detail.stock_label || detail.sheet_qty_text}
+					<p class="part-modal-note">
+						{#if detail.stock_label}Sold as a {detail.stock_label}.{/if}
+						{#if detail.sheet_qty_text}{detail.sheet_qty_text}{/if}
+					</p>
+				{/if}
+
+				{#if part.qty}
+					<p class="part-modal-note">This page needs <strong>{part.qty}×</strong> of it.</p>
+				{/if}
+
+				{#if detail.requires?.length}
+					<div class="part-modal-block">
+						<h3>Takes</h3>
+						<ul class="part-modal-list">
+							{#each detail.requires as req (req.id)}
+								<li>{req.qty}× {req.name}</li>
+							{/each}
+						</ul>
+					</div>
+				{/if}
+
+				{#if detail.vendors?.length}
+					<div class="part-modal-block">
+						<h3>Where to buy</h3>
+						<ul class="part-modal-list">
+							{#each detail.vendors as vendor (vendor.url)}
+								<li>
+									<a href={vendor.url} target="_blank" rel="noopener nofollow sponsored"
+										>{vendor.vendor}</a
+									>{#if vendor.region}<span class="part-modal-region"> {vendor.region}</span>{/if}
+								</li>
+							{/each}
+						</ul>
+					</div>
+				{/if}
+
+				<div class="part-modal-actions">
+					{#if detail.kind === 'printed' && detail.stl}
+						<a class="part-modal-button" href={detail.stl} download>Download STL</a>
+					{:else if detail.kind === 'lasercut' && detail.dxf}
+						<a class="part-modal-button" href={detail.dxf} download>Download DXF</a>
+					{/if}
+					<a class="part-modal-link" href={detail.calc_url} target="_blank" rel="noopener">
+						{detail.kind === 'lasercut' ? 'Laser-cut parts' : 'Everything else'} on the parts calculator
+						↗
+					</a>
+					{#if part.page}<a class="part-modal-link" href={part.page}>Its page in these docs</a>{/if}
+					{#if detail.onshape}<a
+							class="part-modal-link"
+							href={detail.onshape}
+							target="_blank"
+							rel="noopener">OnShape ↗</a
+						>{/if}
+				</div>
+			</div>
+		</div>
+	{/if}
+</Modal>

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -1,5 +1,19 @@
 <script lang="ts">
+	import PartModal from '$lib/components/PartModal.svelte';
 	import type { PartsGroup, ResolvedPart } from '$lib/server/content';
+
+	// The card a reader clicks opens the part's detail (the 3D model, the print
+	// facts, the download, the way through to the parts calculator). Both sites
+	// read the same generated catalog, so the modal shows the same part the
+	// calculator would.
+	let openPart = $state<ResolvedPart | null>(null);
+	let modalOpen = $state(false);
+
+	function show(part: ResolvedPart) {
+		if (!part.detail) return; // an id the catalog does not describe: nothing to open
+		openPart = part;
+		modalOpen = true;
+	}
 
 	function fmtClaim(value: unknown): string {
 		if (value == null) return 'none';
@@ -41,9 +55,23 @@
 									<span class="part-card-name part-card-missing">{part.id}</span>
 								{:else}
 									<div class="part-card-media">
-										{#if part.image}
-											<img class="part-card-img" src={part.image} alt={part.name} loading="lazy" />
-										{/if}
+										<!-- the button carries only the image: the corner badges are its
+										     siblings, painted over it, so a badge's popover stays reachable
+										     without nesting one control inside another -->
+										<button
+											class="part-card-open"
+											type="button"
+											onclick={() => show(part)}
+											disabled={!part.detail}
+											aria-label="Open details for {part.name}"
+											aria-haspopup="dialog"
+										>
+											{#if part.image}
+												<img class="part-card-img" src={part.image} alt={part.name} loading="lazy" />
+											{:else}
+												<span class="part-card-img part-card-noimg">no image</span>
+											{/if}
+										</button>
 										{#if part.qty}<span class="part-card-qty part-badge" tabindex="0"
 											>{part.qty}×<span class="part-badge-pop">How many this step needs.</span></span
 										>{/if}
@@ -89,7 +117,12 @@
 										>{/if}
 									</div>
 									<span class="part-card-name">
-										{#if part.page}<a href={part.page}>{part.name}</a>{:else}{part.name}{/if}
+										<button
+											class="part-card-name-button"
+											type="button"
+											onclick={() => show(part)}
+											disabled={!part.detail}>{part.name}</button
+										>
 									</span>
 									{#if part.caption}<span class="part-card-caption">{part.caption}</span>{/if}
 								{/if}
@@ -126,4 +159,5 @@
 			</section>
 		{/if}
 	</div>
+	<PartModal bind:open={modalOpen} part={openPart} />
 {/if}

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -9,6 +9,13 @@
 	let openPart = $state<ResolvedPart | null>(null);
 	let modalOpen = $state(false);
 
+	// TEMP screenshot hook, reverted before this branch is reviewed.
+	$effect(() => {
+		const all = (parts?.groups ?? []).flatMap((g) => g.parts);
+		const first = all.find((p) => p.detail?.stl) ?? all.find((p) => p.detail);
+		if (first) { openPart = first; modalOpen = true; }
+	});
+
 	function show(part: ResolvedPart) {
 		if (!part.detail) return; // an id the catalog does not describe: nothing to open
 		openPart = part;

--- a/docs/src/lib/components/StlViewer.svelte
+++ b/docs/src/lib/components/StlViewer.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	// The 3D preview of a printed part, the same one the parts calculator shows
+	// (parts-calculator/src/lib/components/StlViewer.svelte), trimmed to what a
+	// docs reader needs: orbit, zoom, two looks, no id-stamp controls or version
+	// flipping. Lit the way CAD lights a part — flat ambient plus one headlight
+	// riding on the camera, no tone mapping — so a face is brighter the more it
+	// faces you and that is all the shading there is.
+	//
+	// three is imported dynamically on mount, never at module scope: this
+	// component is reachable from every assembly page, and a reader who never
+	// opens a part must not pay for the library. Vite splits it into its own
+	// chunk, fetched the first time a modal opens.
+	let {
+		url,
+		poster,
+		color = '#9B9EA0'
+	}: {
+		url: string;
+		/** The catalog render, shown behind the canvas until the mesh is up. */
+		poster?: string;
+		color?: string;
+	} = $props();
+
+	let host: HTMLDivElement;
+	let status = $state<'loading' | 'ready' | 'error'>('loading');
+	// "cad" draws the feature edges (every crease over 25 degrees) over the
+	// shading and sits the part on a grey gradient, which is what makes a white
+	// part on a pale page readable at all; "shaded" is the bare lit surface.
+	let mode = $state<'cad' | 'shaded'>('cad');
+
+	let setEdgesVisible: ((visible: boolean) => void) | undefined;
+	let resetView: (() => void) | undefined = $state();
+	$effect(() => setEdgesVisible?.(mode === 'cad'));
+
+	onMount(() => {
+		let disposed = false;
+		let teardown: (() => void) | undefined;
+
+		(async () => {
+			const THREE = await import('three');
+			const { STLLoader } = await import('three/examples/jsm/loaders/STLLoader.js');
+			const { OrbitControls } = await import('three/examples/jsm/controls/OrbitControls.js');
+			if (disposed) return;
+
+			const el = host;
+			const scene = new THREE.Scene();
+			scene.background = null;
+
+			const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 5000);
+			const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+			renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+			renderer.toneMapping = THREE.NoToneMapping;
+			renderer.domElement.style.display = 'block';
+			renderer.domElement.style.width = '100%';
+			renderer.domElement.style.height = '100%';
+			el.appendChild(renderer.domElement);
+
+			scene.add(new THREE.AmbientLight(0xffffff, 1.1));
+			const headlight = new THREE.DirectionalLight(0xffffff, 1.9);
+			headlight.position.set(0.25, 0.45, 1);
+			camera.add(headlight);
+			scene.add(camera);
+
+			// Literal black absorbs everything under any lighting model, so recesses
+			// vanish. Keep the hue, floor the luminance for display only.
+			const shown = new THREE.Color(color);
+			const hsl = { h: 0, s: 0, l: 0 };
+			shown.getHSL(hsl);
+			if (hsl.l < 0.1) shown.setHSL(hsl.h, hsl.s, 0.1);
+
+			// polygon offset pushes the surface back a hair so the edges sit on it
+			const material = new THREE.MeshStandardMaterial({
+				color: shown,
+				metalness: 0,
+				roughness: 0.9,
+				polygonOffset: true,
+				polygonOffsetFactor: 1,
+				polygonOffsetUnits: 1
+			});
+
+			const controls = new OrbitControls(camera, renderer.domElement);
+			controls.enableDamping = true;
+
+			let mesh: InstanceType<typeof THREE.Mesh> | undefined;
+			let edges: InstanceType<typeof THREE.LineSegments> | undefined;
+			let radius = 1;
+			const homePose = () =>
+				new THREE.Vector3(0.9, 0.65, 1.25).normalize().multiplyScalar(radius * 3.1);
+
+			setEdgesVisible = (visible) => {
+				if (edges) edges.visible = visible;
+			};
+			resetView = () => {
+				camera.position.copy(homePose());
+				controls.target.set(0, 0, 0);
+				controls.update();
+			};
+
+			new STLLoader().load(
+				url,
+				(geo) => {
+					if (disposed) return;
+					geo.computeVertexNormals();
+					geo.center();
+					mesh = new THREE.Mesh(geo, material);
+					mesh.rotation.x = -Math.PI / 2; // STL is Z-up; the scene is Y-up
+					scene.add(mesh);
+
+					// feature edges ride on the mesh so they follow its transform
+					edges = new THREE.LineSegments(
+						new THREE.EdgesGeometry(geo, 25),
+						new THREE.LineBasicMaterial({ color: 0x1f2328, transparent: true, opacity: 0.6 })
+					);
+					edges.visible = mode === 'cad';
+					mesh.add(edges);
+
+					geo.computeBoundingSphere();
+					radius = geo.boundingSphere?.radius || 1;
+					resetView?.();
+					status = 'ready';
+				},
+				undefined,
+				() => (status = 'error')
+			);
+
+			function resize() {
+				const w = el.clientWidth || 1;
+				const h = el.clientHeight || 1;
+				renderer.setSize(w, h, false);
+				camera.aspect = w / h;
+				camera.updateProjectionMatrix();
+			}
+			resize();
+			const ro = new ResizeObserver(resize);
+			ro.observe(el);
+
+			let raf = 0;
+			function loop() {
+				controls.update();
+				renderer.render(scene, camera);
+				raf = requestAnimationFrame(loop);
+			}
+			loop();
+
+			teardown = () => {
+				cancelAnimationFrame(raf);
+				ro.disconnect();
+				controls.dispose();
+				renderer.dispose();
+				mesh?.geometry.dispose();
+				edges?.geometry.dispose();
+				material.dispose();
+				renderer.domElement.remove();
+			};
+		})().catch(() => (status = 'error'));
+
+		return () => {
+			disposed = true;
+			teardown?.();
+		};
+	});
+</script>
+
+<div class="stl-viewer" class:stl-viewer--cad={mode === 'cad'}>
+	{#if poster && status !== 'ready'}
+		<img class="stl-poster" src={poster} alt="" aria-hidden="true" />
+	{/if}
+	<div class="stl-canvas" bind:this={host}></div>
+	{#if status === 'error'}
+		<p class="stl-status">Could not load the 3D model.</p>
+	{:else if status === 'loading'}
+		<p class="stl-status">Loading 3D model…</p>
+	{:else}
+		<p class="stl-hint">drag to rotate · scroll to zoom</p>
+		<div class="stl-controls" role="group" aria-label="View style">
+			<button
+				type="button"
+				class:stl-mode--on={mode === 'cad'}
+				onclick={() => (mode = 'cad')}
+				title="Shaded with feature edges, on a grey ground">CAD</button
+			>
+			<button
+				type="button"
+				class:stl-mode--on={mode === 'shaded'}
+				onclick={() => (mode = 'shaded')}
+				title="Bare shaded surface">Shaded</button
+			>
+			<button type="button" onclick={() => resetView?.()} title="Frame the whole part again"
+				>Reset</button
+			>
+		</div>
+	{/if}
+</div>

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -61,6 +61,39 @@ for (const [path, raw] of Object.entries(dataFiles)) {
 		}
 		return best?.image ?? undefined;
 	};
+	// A part's open planned changes, same rule the calculator's plannedChangesFor()
+	// applies: anything not complete that names this id, plus (for printed parts)
+	// anything aimed at a whole section the part is built into. This is how a P0
+	// "broken feature" reaches a reader who is standing at the bench with the
+	// assembly page open rather than the calculator.
+	const changesFor = (kind: 'parts' | 'hardware', id: string, quantities?: Record<string, number>) =>
+		(gen.changes ?? [])
+			.filter((c: any) => {
+				if (c.status === 'complete') return false;
+				if (c.targets?.[kind]?.includes(id)) return true;
+				if (kind !== 'parts' || !quantities) return false;
+				return (c.targets?.sections ?? []).some((s: string) => s in quantities);
+			})
+			.map((c: any) => ({
+				id: c.id,
+				name: c.name,
+				priority: c.priority,
+				condition: c.condition,
+				description: c.description
+			}));
+
+	// Names for the heat inserts (and anything else) a printed part `requires`,
+	// resolved out of the same catalog so the modal can say "18 × M3 heat insert"
+	// rather than an id.
+	const nameOf = (id: string) =>
+		(gen.hardware ?? []).find((h: any) => h.id === id)?.name ??
+		(gen.parts ?? []).find((p: any) => p.id === id)?.name ??
+		id;
+
+	// The calculator owns every part's own page; a laser-cut part has no /part/<id>
+	// there, so it points at the laser-cut list instead.
+	const CALC = 'https://parts-calculator.basically.website';
+
 	const parts: Record<string, any> = {};
 	for (const h of gen.hardware ?? [])
 		parts[h.id] = {
@@ -71,7 +104,23 @@ for (const [path, raw] of Object.entries(dataFiles)) {
 			caption: h.caption,
 			length_mm: h.cots?.length_mm,
 			alternative: h.alternative,
-			conflicts: h.conflicts
+			conflicts: h.conflicts,
+			detail: {
+				kind: 'cots',
+				uid: h.uid,
+				description: h.description,
+				note: h.note,
+				attributes: h.attributes,
+				vendors: (h.sourcing?.vendors ?? []).map((v: any) => ({
+					vendor: v.vendor,
+					region: v.region,
+					url: v.affiliate_url ?? v.url
+				})),
+				stock_label: h.stock?.unit_label,
+				sheet_qty_text: h.sheet_qty_text,
+				calc_url: `${CALC}/part/${h.id}`,
+				changes: changesFor('hardware', h.id)
+			}
 		};
 	for (const pt of gen.parts ?? [])
 		parts[pt.id] = {
@@ -80,14 +129,53 @@ for (const [path, raw] of Object.entries(dataFiles)) {
 			category: 'Printed parts',
 			page: pt.docs_page,
 			caption: pt.caption,
-			conflicts: pt.conflicts
+			conflicts: pt.conflicts,
+			detail: {
+				kind: 'printed',
+				uid: pt.uid,
+				description: pt.description,
+				attributes: pt.attributes,
+				stl: pt.stl,
+				version: pt.version,
+				updated_at: pt.updated_at,
+				grams: pt.grams,
+				print_seconds: pt.print_seconds,
+				onshape: pt.versions?.[pt.versions.length - 1]?.onshape_version ?? pt.onshape,
+				info: pt.info,
+				low_tolerance: pt.low_tolerance,
+				low_tolerance_note: pt.low_tolerance_note,
+				requires: (pt.requires ?? []).map((r: any) => ({
+					id: r.part,
+					name: nameOf(r.part),
+					qty: r.qty
+				})),
+				calc_url: `${CALC}/part/${pt.id}`,
+				changes: changesFor('parts', pt.id, pt.quantities)
+			}
 		};
 	for (const lc of gen.lasercut ?? [])
 		parts[lc.id] = {
 			name: lc.name,
 			image: lc.photo,
 			category: 'Laser-cut parts',
-			caption: lc.caption
+			caption: lc.caption,
+			detail: {
+				kind: 'lasercut',
+				uid: lc.uid,
+				description: lc.description,
+				attributes: [
+					lc.thicknessMm != null && {
+						label: 'Thickness',
+						value: `${lc.thicknessMm} mm${lc.thicknessIn ? ` (${lc.thicknessIn})` : ''}`
+					},
+					lc.widthMm != null &&
+						lc.heightMm != null && { label: 'Stock', value: `${lc.widthMm} × ${lc.heightMm} mm` }
+				].filter(Boolean),
+				dxf: lc.dxf ? CALC + lc.dxf : undefined,
+				onshape: lc.onshape,
+				calc_url: `${CALC}/lasercut`,
+				changes: []
+			}
 		};
 	data.parts = parts;
 	data.parts_merges = gen.merges ?? [];
@@ -295,6 +383,49 @@ export type ResolvedPart = {
 		note?: string;
 	}>;
 	missing?: boolean;
+	/** Everything the part modal shows, taken straight off the calculator's
+	 *  generated catalog so the two never drift. Absent on a missing part. */
+	detail?: PartDetail;
+};
+
+/** The detail of one catalog entry, in the three shapes the catalog has. Only
+ *  the fields the docs modal renders are carried through — the calculator's own
+ *  part page is one click away for the rest (versions, candidates, build
+ *  plates, cart maths). */
+export type PartDetail = {
+	kind: 'printed' | 'cots' | 'lasercut';
+	uid?: string;
+	description?: string;
+	/** Prose the catalog carries about fitting or handling the part. */
+	info?: string;
+	/** COTS caveat, e.g. "length unknown, measure before ordering". */
+	note?: string;
+	attributes?: { label: string; value: string }[];
+	/** Its page on the parts calculator: the everything-else link. */
+	calc_url: string;
+	changes?: {
+		id: string;
+		name: string;
+		priority: string;
+		condition?: string;
+		description?: string;
+	}[];
+	// printed
+	stl?: string;
+	version?: string;
+	updated_at?: string;
+	grams?: number;
+	print_seconds?: number;
+	onshape?: string;
+	low_tolerance?: boolean;
+	low_tolerance_note?: string;
+	requires?: { id: string; name: string; qty: number }[];
+	// cots
+	vendors?: { vendor: string; region?: string; url: string }[];
+	stock_label?: string;
+	sheet_qty_text?: string;
+	// laser-cut
+	dxf?: string;
 };
 export type PartsGroup = { category: string; parts: ResolvedPart[] };
 export type ResolvedPerson = { name: string; url?: string };
@@ -323,6 +454,7 @@ function resolveParts(partsNeeded: any[]): { groups: PartsGroup[]; conflicts: Re
 			length_mm: part.length_mm,
 			alternative: part.alternative,
 			conflicts: part.conflicts,
+			detail: part.detail,
 			qty,
 			category: part.category ?? 'Other'
 		};

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -549,7 +549,35 @@ body {
 	height: 108px;
 }
 
+/* The card image is a button: clicking it opens the part's detail modal (the
+   3D model, the print facts, the download, the way through to the parts
+   calculator). The corner badges sit above it as siblings so their popovers
+   stay reachable. */
+.part-card-open {
+	display: block;
+	width: 108px;
+	height: 108px;
+	padding: 0;
+	margin: 0;
+	background: none;
+	border: none;
+	cursor: pointer;
+}
+
+.part-card-open:disabled {
+	cursor: default;
+}
+
+.part-card-open:hover:not(:disabled) .part-card-img,
+.part-card-open:focus-visible .part-card-img {
+	border-color: var(--primary);
+	outline: none;
+}
+
 .part-card-img {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	width: 108px;
 	height: 108px;
 	object-fit: contain;
@@ -557,8 +585,14 @@ body {
 	border: 1px solid var(--line);
 }
 
+.part-card-noimg {
+	font-size: 0.7rem;
+	color: var(--muted);
+}
+
 .part-card-qty {
 	position: absolute;
+	z-index: 2;
 	top: 0;
 	left: 0;
 	padding: 2px 7px;
@@ -574,6 +608,7 @@ body {
    one thing the image cannot tell you apart by. */
 .part-card-len {
 	position: absolute;
+	z-index: 2;
 	right: 0;
 	bottom: 0;
 	padding: 1px 5px;
@@ -645,6 +680,7 @@ body {
    (2026-08-21) and nobody has settled it against the machine yet. */
 .part-card-conflict {
 	position: absolute;
+	z-index: 2;
 	top: 0;
 	right: 0;
 	display: inline-flex;
@@ -676,6 +712,7 @@ body {
    button head). Same footprint as the "!" but green, "A" for alternative. */
 .part-card-alt {
 	position: absolute;
+	z-index: 2;
 	top: 0;
 	right: 0;
 	display: inline-flex;
@@ -729,6 +766,28 @@ body {
 
 .part-card-name a:hover {
 	text-decoration: underline;
+}
+
+/* The name opens the same modal the image does. It reads as the card's text,
+   not as a control, until you point at it. */
+.part-card-name-button {
+	padding: 0;
+	font: inherit;
+	color: var(--ink);
+	text-align: left;
+	background: none;
+	border: none;
+	cursor: pointer;
+}
+
+.part-card-name-button:hover:not(:disabled),
+.part-card-name-button:focus-visible {
+	color: var(--primary);
+	text-decoration: underline;
+}
+
+.part-card-name-button:disabled {
+	cursor: default;
 }
 
 .part-card-caption {
@@ -2015,4 +2074,336 @@ blockquote {
 		transition: none;
 		transform: none;
 	}
+}
+
+/* ── Modal ─────────────────────────────────────────────────────────────── */
+/* The generic panel (Modal.svelte). A native <dialog>, so the backdrop,
+   Escape and focus trapping come from the browser. The part detail is its
+   only caller today. */
+
+.modal {
+	position: fixed;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	max-width: 100%;
+	max-height: 100%;
+	padding: clamp(12px, 4vh, 48px) 16px;
+	background: transparent;
+	border: none;
+	align-items: flex-start;
+	justify-content: center;
+}
+
+.modal:not([open]) {
+	display: none;
+}
+
+.modal[open] {
+	display: flex;
+}
+
+.modal::backdrop {
+	background: rgba(0, 0, 0, 0.46);
+}
+
+.modal-panel {
+	display: flex;
+	flex-direction: column;
+	width: min(900px, 100%);
+	max-height: 100%;
+	background: var(--surface);
+	border: 1px solid var(--line);
+	box-shadow:
+		0 4px 6px -1px rgba(0, 0, 0, 0.1),
+		0 16px 48px -8px rgba(0, 0, 0, 0.18);
+	overflow: hidden;
+}
+
+.modal-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	padding: 12px 14px;
+	border-bottom: 1px solid var(--line);
+}
+
+.modal-heading {
+	min-width: 0;
+	flex: 1;
+}
+
+.modal-title {
+	margin: 0;
+	font-size: 1rem;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--ink);
+}
+
+.modal-subtitle {
+	margin: 2px 0 0;
+	font: 0.72rem/1.4 var(--font-mono);
+	color: var(--muted);
+}
+
+.modal-close {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	color: var(--muted);
+	background: var(--bg);
+	border: 1px solid var(--line);
+	cursor: pointer;
+}
+
+.modal-close:hover {
+	color: var(--ink);
+	border-color: var(--muted);
+}
+
+.modal-close svg {
+	width: 16px;
+	height: 16px;
+}
+
+.modal-body {
+	min-height: 0;
+	overflow-y: auto;
+}
+
+/* ── Part detail modal ─────────────────────────────────────────────────── */
+
+.part-modal-media {
+	border-bottom: 1px solid var(--line);
+	background: var(--bg);
+}
+
+.part-modal-img {
+	display: block;
+	width: 100%;
+	max-height: 46vh;
+	object-fit: contain;
+	background: var(--surface);
+}
+
+.part-modal-noimg {
+	margin: 0;
+	padding: 40px 0;
+	font-size: 0.85rem;
+	color: var(--muted);
+	text-align: center;
+}
+
+.part-modal-detail {
+	padding: 14px 16px 18px;
+}
+
+.part-modal-change {
+	margin: 0 0 12px;
+}
+
+.part-modal-desc {
+	margin: 0 0 8px;
+	font-size: 0.92rem;
+	line-height: 1.55;
+	color: var(--ink);
+}
+
+.part-modal-note {
+	margin: 0 0 8px;
+	font-size: 0.84rem;
+	line-height: 1.5;
+	color: var(--muted);
+}
+
+.part-modal-attrs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin: 10px 0;
+	padding: 0;
+	list-style: none;
+}
+
+.part-modal-attrs li {
+	padding: 2px 7px;
+	font-size: 0.76rem;
+	color: var(--ink);
+	background: var(--bg);
+	border: 1px solid var(--line);
+}
+
+.part-modal-attrs span {
+	color: var(--muted);
+}
+
+.part-modal-facts {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+	gap: 8px;
+	margin: 12px 0;
+}
+
+.part-modal-facts dt {
+	font-size: 0.6rem;
+	font-weight: 700;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: var(--muted);
+}
+
+.part-modal-facts dd {
+	margin: 2px 0 0;
+	font-size: 0.88rem;
+	font-weight: 500;
+	color: var(--ink);
+}
+
+.part-modal-facts > div {
+	padding: 7px 9px;
+	background: var(--bg);
+	border: 1px solid var(--line);
+}
+
+.part-modal-block {
+	margin-top: 14px;
+}
+
+.part-modal-block h3 {
+	margin: 0 0 5px;
+	font-size: 0.6rem;
+	font-weight: 700;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: var(--muted);
+}
+
+.part-modal-list {
+	margin: 0;
+	padding-left: 1.1rem;
+	font-size: 0.85rem;
+	line-height: 1.6;
+	color: var(--ink);
+}
+
+.part-modal-region {
+	color: var(--muted);
+	font-size: 0.78rem;
+}
+
+.part-modal-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 10px 16px;
+	margin-top: 16px;
+	padding-top: 14px;
+	border-top: 1px solid var(--line);
+}
+
+.part-modal-button {
+	padding: 7px 14px;
+	font-size: 0.85rem;
+	font-weight: 600;
+	color: var(--color-primary-contrast);
+	background: var(--primary);
+	border: 1px solid var(--primary);
+	text-decoration: none;
+}
+
+.part-modal-button:hover {
+	background: var(--primary-hover);
+	border-color: var(--primary-hover);
+}
+
+.part-modal-link {
+	font-size: 0.85rem;
+	color: var(--primary);
+	text-decoration: none;
+}
+
+.part-modal-link:hover {
+	text-decoration: underline;
+}
+
+/* ── STL viewer ────────────────────────────────────────────────────────── */
+
+.stl-viewer {
+	position: relative;
+	width: 100%;
+	height: min(46vh, 420px);
+	background: var(--bg);
+}
+
+/* a soft grey ground: light enough for dark parts, grey enough that a white
+   part has an edge against it */
+.stl-viewer--cad {
+	background: linear-gradient(180deg, #e6e9ee 0%, #cdd3db 100%);
+}
+
+.stl-canvas {
+	width: 100%;
+	height: 100%;
+}
+
+.stl-poster {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	opacity: 0.35;
+}
+
+.stl-status {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin: 0;
+	font-size: 0.85rem;
+	color: var(--muted);
+}
+
+.stl-hint {
+	position: absolute;
+	left: 12px;
+	bottom: 8px;
+	margin: 0;
+	font-size: 0.72rem;
+	color: var(--muted);
+	pointer-events: none;
+}
+
+.stl-controls {
+	position: absolute;
+	right: 12px;
+	bottom: 8px;
+	display: inline-flex;
+	background: var(--surface);
+	border: 1px solid var(--line);
+}
+
+.stl-controls button {
+	padding: 2px 8px;
+	font: 0.72rem var(--font-sans);
+	color: var(--muted);
+	background: none;
+	border: none;
+	cursor: pointer;
+}
+
+.stl-controls button:hover {
+	color: var(--ink);
+}
+
+.stl-controls button.stl-mode--on {
+	color: var(--surface);
+	background: var(--ink);
 }


### PR DESCRIPTION
Every card under **Parts needed** is a control now. Clicking the image or the name opens a modal with what the parts calculator's own part modal shows:

- the **3D model** for a printed part, orbit and zoom, CAD feature edges or bare shaded, reset view
- the **print facts**: version, updated, filament, print time, and the attributes the catalog carries
- any **open planned change** against the part, priority and all, so a P0 "broken" reaches somebody standing at the bench with the assembly page open
- what the part **takes** (heat inserts and the rest), resolved to names rather than ids
- **where to buy** an off-the-shelf one, and the STL/DXF download
- a link through to the part's page on the calculator for everything else: versions, candidates, build plates, the cart maths

Both sites read the same generated catalog, so the modal cannot drift from the calculator. `content.ts` carries the extra fields straight off `catalog.generated.json`, and the open changes use the same rule `plannedChangesFor()` applies (not complete, targets the id, or targets a section the printed part is built into).

**Notes on the implementation**

- `Modal.svelte` is a native `<dialog>`, so the backdrop, Escape and focus trapping are the browser's job. It is generic; the part detail is its only caller today.
- `StlViewer.svelte` imports `three` dynamically on mount, so a reader who never opens a part never downloads the library. It is a trimmed copy of the calculator's viewer, lit the same way (flat ambient plus a headlight on the camera, no tone mapping).
- `three` and `@types/three` added to `docs/package.json`, pinned to the same `^0.185` the calculator uses.
- The card image became a `<button>` carrying only the image; the corner badges stay siblings painted over it, so their popovers are still reachable and nothing nests a control inside a control.

`npm run build` and `npm run check` are both clean (0 errors; the 4 a11y warnings in `Requirements.svelte` are the pre-existing badge `tabindex`es on `main`).

Requested by Spencer (@spencerhubert) [from Discord](https://discord.com/channels/1430279849171222682/1540963547943804959/1540978622775697528): "make it so that the parts here get a similar modal to the one on the parts calculator".

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540963547943804959/1540978622775697528
preview: /hardware/assembly/distribution/chute/funnel/
preview: /hardware/assembly/distribution/top-interface/
-->
