### PR TITLE
docs: strip the screenshot hook that got merged into #388

### DIFF
--- a/docs/src/lib/components/Modal.svelte
+++ b/docs/src/lib/components/Modal.svelte
@@ -3,8 +3,8 @@
 
 	// The site's one modal. A native <dialog>, so Escape, the backdrop, focus
 	// trapping and inert-ing the page behind it are the browser's job rather than
-	// ours — the same thing SearchModal does, factored out so anything else that
-	// needs a panel (the part detail, for now) opens the same object.
+	// ours, the same way SearchModal already opens. Written generic so anything
+	// else that needs a panel (the part detail, for now) opens the same object.
 	let {
 		open = $bindable(false),
 		title,

--- a/docs/src/lib/components/PartModal.svelte
+++ b/docs/src/lib/components/PartModal.svelte
@@ -6,15 +6,18 @@
 	// What a "Parts needed" card opens: the same facts the parts calculator's own
 	// part modal shows, rendered in this site's styling, off the same generated
 	// catalog both sites build from. Deliberately not a copy of everything over
-	// there — versions, candidates, build plates and the cart maths stay one
-	// click away on the part's own calculator page, which every modal links to.
+	// there: versions, candidates, build plates and the cart maths stay one click
+	// away on the part's own calculator page, which every modal links to.
 	let { open = $bindable(false), part }: { open?: boolean; part: ResolvedPart | null } = $props();
 
 	const detail = $derived(part?.detail);
 
+	// Round to whole minutes first, then split: rounding the remainder on its own
+	// is what prints "3 h 60 min".
 	function duration(seconds: number): string {
-		const h = Math.floor(seconds / 3600);
-		const m = Math.round((seconds % 3600) / 60);
+		const total = Math.round(seconds / 60);
+		const h = Math.floor(total / 60);
+		const m = total % 60;
 		return h ? `${h} h ${m} min` : `${m} min`;
 	}
 

--- a/docs/src/lib/components/Requirements.svelte
+++ b/docs/src/lib/components/Requirements.svelte
@@ -9,13 +9,6 @@
 	let openPart = $state<ResolvedPart | null>(null);
 	let modalOpen = $state(false);
 
-	// TEMP screenshot hook, reverted before this branch is reviewed.
-	$effect(() => {
-		const all = (parts?.groups ?? []).flatMap((g) => g.parts);
-		const first = all.find((p) => p.detail?.stl) ?? all.find((p) => p.detail);
-		if (first) { openPart = first; modalOpen = true; }
-	});
-
 	function show(part: ResolvedPart) {
 		if (!part.detail) return; // an id the catalog does not describe: nothing to open
 		openPart = part;

--- a/docs/src/lib/components/StlViewer.svelte
+++ b/docs/src/lib/components/StlViewer.svelte
@@ -4,8 +4,8 @@
 	// The 3D preview of a printed part, the same one the parts calculator shows
 	// (parts-calculator/src/lib/components/StlViewer.svelte), trimmed to what a
 	// docs reader needs: orbit, zoom, two looks, no id-stamp controls or version
-	// flipping. Lit the way CAD lights a part — flat ambient plus one headlight
-	// riding on the camera, no tone mapping — so a face is brighter the more it
+	// flipping. Lit the way CAD lights a part (flat ambient plus one headlight
+	// riding on the camera, no tone mapping), so a face is brighter the more it
 	// faces you and that is all the shading there is.
 	//
 	// three is imported dynamically on mount, never at module scope: this

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -389,7 +389,7 @@ export type ResolvedPart = {
 };
 
 /** The detail of one catalog entry, in the three shapes the catalog has. Only
- *  the fields the docs modal renders are carried through — the calculator's own
+ *  the fields the docs modal renders are carried through. The calculator's own
  *  part page is one click away for the rest (versions, candidates, build
  *  plates, cart maths). */
 export type PartDetail = {


### PR DESCRIPTION
**#388 merged the wrong commit and this is the repair.**

To photograph the modal for Spencer I pushed a throwaway commit to that branch that forced the first part's modal open on page load, took the screenshot, and stripped it back off with a force-push. The board merged the approved commit, which was that throwaway one, so `main` currently opens a part modal by itself on every page with a parts list.

This branch:

- removes the `$effect` screenshot hook from `Requirements.svelte`
- brings back the two commits that were on the branch but not in the merged tree: print time rounds total minutes before splitting it (it printed **"3 h 60 min"** for the funnel), and the new comments lose their em dashes

Nothing else changes; the feature itself is exactly what #388 described.

`npm run build` and `npm run check` clean (0 errors; the 4 a11y warnings in `Requirements.svelte` are the pre-existing badge `tabindex`es).

Requested by Spencer (@spencerhubert) [from Discord](https://discord.com/channels/1430279849171222682/1540963547943804959/1540978622775697528): "make it so that the parts here get a similar modal to the one on the parts calculator".

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540963547943804959/1540978622775697528
preview: /hardware/assembly/distribution/chute/funnel/
-->
