### PR TITLE
parts-calculator: what changed since the day you printed

### DIFF
--- a/parts-calculator/src/lib/updates.ts
+++ b/parts-calculator/src/lib/updates.ts
@@ -1,0 +1,105 @@
+// "What has changed since I printed?" — the catalog already answers it.
+//
+// Every part carries `created_at`, `updated_at` and, once it has been revised,
+// a `versions` list with a date and a message per version. Given one date, a
+// part falls into exactly one bucket:
+//
+//   new      — it did not exist then, so it was never printed
+//   revised  — a new version was released since, so the print in the machine is
+//              an older revision of the same part
+//   touched  — same design revision (no version bump), but its catalog entry
+//              changed: description, quantities, colour, pictures, or a
+//              re-export of identical geometry. Nothing to reprint.
+//
+// The split matters because only the first two cost filament. `touched` is
+// deliberately kept apart rather than folded into "changed", so a builder
+// reading the list never reprints a part whose design never moved.
+
+import {
+	PARTS,
+	type Part,
+	type PartCandidate,
+	type PartVersion
+} from '$lib/filament';
+
+export type UpdateKind = 'new' | 'revised' | 'touched';
+
+export type PartUpdate = {
+	part: Part;
+	kind: UpdateKind;
+	/** The date that put this part in the list — newest qualifying event. */
+	date: string;
+	/** Versions released after the cutoff, oldest first (revised only). */
+	newVersions: PartVersion[];
+	/** The version that was current at the cutoff — the one they printed. */
+	printed: PartVersion | null;
+};
+
+export type CandidateUpdate = { part: Part; candidate: PartCandidate };
+
+/** ISO `YYYY-MM-DD` comparison is lexicographic, so no Date parsing (and no
+ *  timezone shifting a date by a day) is needed anywhere in here. */
+const isAfter = (date: string | undefined | null, cutoff: string) => !!date && date > cutoff;
+
+function versionAt(part: Part, cutoff: string): PartVersion | null {
+	const past = (part.versions ?? []).filter((v) => !isAfter(v.date, cutoff));
+	return past.length ? past[past.length - 1] : null;
+}
+
+/** Every printed part that appeared or moved after `cutoff`, newest first.
+ *  An empty or malformed cutoff yields nothing rather than the whole catalog. */
+export function partUpdatesSince(cutoff: string, parts: Part[] = PARTS): PartUpdate[] {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(cutoff)) return [];
+	const out: PartUpdate[] = [];
+	for (const part of parts) {
+		if (isAfter(part.created_at, cutoff)) {
+			out.push({ part, kind: 'new', date: part.created_at, newVersions: [], printed: null });
+			continue;
+		}
+		const newVersions = (part.versions ?? []).filter((v) => isAfter(v.date, cutoff));
+		if (newVersions.length) {
+			out.push({
+				part,
+				kind: 'revised',
+				date: newVersions[newVersions.length - 1].date,
+				newVersions,
+				printed: versionAt(part, cutoff)
+			});
+			continue;
+		}
+		if (isAfter(part.updated_at, cutoff))
+			out.push({ part, kind: 'touched', date: part.updated_at, newVersions: [], printed: null });
+	}
+	return out.sort(
+		(a, b) => b.date.localeCompare(a.date) || a.part.name.localeCompare(b.part.name)
+	);
+}
+
+/** Candidates raised since the cutoff: revisions under test for a part's slot.
+ *  Not part of any build — listed so someone deciding what to print knows a
+ *  replacement is already being tried. */
+export function candidatesSince(cutoff: string, parts: Part[] = PARTS): CandidateUpdate[] {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(cutoff)) return [];
+	const out: CandidateUpdate[] = [];
+	for (const part of parts)
+		for (const candidate of part.candidates ?? [])
+			if (isAfter(candidate.created_at, cutoff) && !candidate.rejected_at)
+				out.push({ part, candidate });
+	return out.sort(
+		(a, b) =>
+			b.candidate.created_at.localeCompare(a.candidate.created_at) ||
+			a.part.name.localeCompare(b.part.name)
+	);
+}
+
+/** The oldest date in the catalog — the cutoff at which everything is "new". */
+export function catalogStart(parts: Part[] = PARTS): string {
+	return parts.reduce((min, p) => (p.created_at < min ? p.created_at : min), parts[0]?.created_at ?? '');
+}
+
+/** `today` minus `days`, as `YYYY-MM-DD`, in the viewer's own calendar. */
+export function daysAgo(days: number, today: Date = new Date()): string {
+	const d = new Date(today.getFullYear(), today.getMonth(), today.getDate() - days);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}

--- a/parts-calculator/src/lib/updates.ts
+++ b/parts-calculator/src/lib/updates.ts
@@ -1,19 +1,21 @@
-// "What has changed since I printed?" — the catalog already answers it.
+// A time-based diff of the catalog: what changed between a date and now.
+//
+// This tracks the catalog, never the reader. Nothing here knows or stores what
+// anybody has printed; the date is one end of a comparison and that is all.
 //
 // Every part carries `created_at`, `updated_at` and, once it has been revised,
 // a `versions` list with a date and a message per version. Given one date, a
 // part falls into exactly one bucket:
 //
-//   new      — it did not exist then, so it was never printed
-//   revised  — a new version was released since, so the print in the machine is
-//              an older revision of the same part
+//   new      — it did not exist in the catalog then
+//   revised  — a new design revision was released after that date
 //   touched  — same design revision (no version bump), but its catalog entry
 //              changed: description, quantities, colour, pictures, or a
-//              re-export of identical geometry. Nothing to reprint.
+//              re-export of identical geometry. The geometry is unchanged.
 //
-// The split matters because only the first two cost filament. `touched` is
-// deliberately kept apart rather than folded into "changed", so a builder
-// reading the list never reprints a part whose design never moved.
+// The split matters because the third is not a design change at all. `touched`
+// is deliberately kept apart rather than folded into "changed", so nobody
+// reads a listing edit as a part that moved.
 
 import {
 	PARTS,
@@ -31,8 +33,8 @@ export type PartUpdate = {
 	date: string;
 	/** Versions released after the cutoff, oldest first (revised only). */
 	newVersions: PartVersion[];
-	/** The version that was current at the cutoff — the one they printed. */
-	printed: PartVersion | null;
+	/** The revision that was current on the cutoff date, for comparison. */
+	atCutoff: PartVersion | null;
 };
 
 export type CandidateUpdate = { part: Part; candidate: PartCandidate };
@@ -53,7 +55,7 @@ export function partUpdatesSince(cutoff: string, parts: Part[] = PARTS): PartUpd
 	const out: PartUpdate[] = [];
 	for (const part of parts) {
 		if (isAfter(part.created_at, cutoff)) {
-			out.push({ part, kind: 'new', date: part.created_at, newVersions: [], printed: null });
+			out.push({ part, kind: 'new', date: part.created_at, newVersions: [], atCutoff: null });
 			continue;
 		}
 		const newVersions = (part.versions ?? []).filter((v) => isAfter(v.date, cutoff));
@@ -63,12 +65,12 @@ export function partUpdatesSince(cutoff: string, parts: Part[] = PARTS): PartUpd
 				kind: 'revised',
 				date: newVersions[newVersions.length - 1].date,
 				newVersions,
-				printed: versionAt(part, cutoff)
+				atCutoff: versionAt(part, cutoff)
 			});
 			continue;
 		}
 		if (isAfter(part.updated_at, cutoff))
-			out.push({ part, kind: 'touched', date: part.updated_at, newVersions: [], printed: null });
+			out.push({ part, kind: 'touched', date: part.updated_at, newVersions: [], atCutoff: null });
 	}
 	return out.sort(
 		(a, b) => b.date.localeCompare(a.date) || a.part.name.localeCompare(b.part.name)
@@ -76,8 +78,8 @@ export function partUpdatesSince(cutoff: string, parts: Part[] = PARTS): PartUpd
 }
 
 /** Candidates raised since the cutoff: revisions under test for a part's slot.
- *  Not part of any build — listed so someone deciding what to print knows a
- *  replacement is already being tried. */
+ *  Not part of any build, and carrying no version number, but a change to the
+ *  catalog in the window like any other. */
 export function candidatesSince(cutoff: string, parts: Part[] = PARTS): CandidateUpdate[] {
 	if (!/^\d{4}-\d{2}-\d{2}$/.test(cutoff)) return [];
 	const out: CandidateUpdate[] = [];

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -546,6 +546,19 @@
 		</p>
 	</header>
 
+	<!-- both of these are about the catalog rather than this build, so they sit
+	     above the settings: read them before you configure anything -->
+	<div class="mb-6 flex flex-col gap-3">
+		<a href="/changes" class="flex items-center justify-between gap-4 border border-warning/60 bg-warning/[0.08] px-4 py-3 text-sm text-text transition-colors hover:bg-warning/[0.14]">
+			<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
+			<span class="shrink-0 font-semibold text-primary">View {CHANGES.length} potential changes →</span>
+		</a>
+		<a href="/updates" class="flex items-center justify-between gap-4 border border-border bg-surface px-4 py-3 text-sm text-text transition-colors hover:border-primary">
+			<span><b>Printed a set already?</b> Give the date you printed and see only the parts that are new or revised since.</span>
+			<span class="shrink-0 font-semibold text-primary">What changed since… →</span>
+		</a>
+	</div>
+
 	<!-- print settings and build options: two boxes that say what they hold -->
 	<div class="mb-6 flex flex-col gap-3">
 	<Disclosure title="Print settings" summary={settingsSummary} bind:open={showSettings} flush>
@@ -744,14 +757,6 @@
 			</div>
 
 			{#if activeTab === 'parts'}
-				<a href="/changes" class="mb-4 flex items-center justify-between gap-4 border border-warning/60 bg-warning/[0.08] px-4 py-3 text-sm text-text transition-colors hover:bg-warning/[0.14]">
-					<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
-					<span class="shrink-0 font-semibold text-primary">View {CHANGES.length} potential changes →</span>
-				</a>
-				<a href="/updates" class="mb-4 flex items-center justify-between gap-4 border border-border bg-surface px-4 py-3 text-sm text-text transition-colors hover:border-primary">
-					<span><b>Printed a set already?</b> Give the date you printed and see only the parts that are new or revised since.</span>
-					<span class="shrink-0 font-semibold text-primary">What changed since… →</span>
-				</a>
 				<div class="mb-4 flex flex-wrap items-center gap-2">
 					<div class="inline-flex border border-border">
 						<button

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -748,6 +748,10 @@
 					<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
 					<span class="shrink-0 font-semibold text-primary">View {CHANGES.length} potential changes →</span>
 				</a>
+				<a href="/updates" class="mb-4 flex items-center justify-between gap-4 border border-border bg-surface px-4 py-3 text-sm text-text transition-colors hover:border-primary">
+					<span><b>Printed a set already?</b> Give the date you printed and see only the parts that are new or revised since.</span>
+					<span class="shrink-0 font-semibold text-primary">What changed since… →</span>
+				</a>
 				<div class="mb-4 flex flex-wrap items-center gap-2">
 					<div class="inline-flex border border-border">
 						<button

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -550,7 +550,7 @@
 	     settings; the /changes banner lives in the Parts tab, next to the parts -->
 	<div class="mb-6 flex flex-col gap-3">
 		<a href="/updates" class="flex items-center justify-between gap-4 border border-border bg-surface px-4 py-3 text-sm text-text transition-colors hover:border-primary">
-			<span><b>The catalog moves.</b> Pick a date and see which parts are new since, which have a newer revision, and which listings changed.</span>
+			<span><b>Compare the catalog against a date.</b> What is new since, what has a newer design revision, and what only changed on paper.</span>
 			<span class="shrink-0 font-semibold text-primary">What changed since… →</span>
 		</a>
 	</div>

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -546,13 +546,9 @@
 		</p>
 	</header>
 
-	<!-- both of these are about the catalog rather than this build, so they sit
-	     above the settings: read them before you configure anything -->
+	<!-- about the catalog as a whole rather than this build, so it sits above the
+	     settings; the /changes banner lives in the Parts tab, next to the parts -->
 	<div class="mb-6 flex flex-col gap-3">
-		<a href="/changes" class="flex items-center justify-between gap-4 border border-warning/60 bg-warning/[0.08] px-4 py-3 text-sm text-text transition-colors hover:bg-warning/[0.14]">
-			<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
-			<span class="shrink-0 font-semibold text-primary">View {CHANGES.length} potential changes →</span>
-		</a>
 		<a href="/updates" class="flex items-center justify-between gap-4 border border-border bg-surface px-4 py-3 text-sm text-text transition-colors hover:border-primary">
 			<span><b>Printed a set already?</b> Give the date you printed and see only the parts that are new or revised since.</span>
 			<span class="shrink-0 font-semibold text-primary">What changed since… →</span>
@@ -757,6 +753,10 @@
 			</div>
 
 			{#if activeTab === 'parts'}
+				<a href="/changes" class="mb-4 flex items-center justify-between gap-4 border border-warning/60 bg-warning/[0.08] px-4 py-3 text-sm text-text transition-colors hover:bg-warning/[0.14]">
+					<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
+					<span class="shrink-0 font-semibold text-primary">View {CHANGES.length} potential changes →</span>
+				</a>
 				<div class="mb-4 flex flex-wrap items-center gap-2">
 					<div class="inline-flex border border-border">
 						<button

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -550,7 +550,7 @@
 	     settings; the /changes banner lives in the Parts tab, next to the parts -->
 	<div class="mb-6 flex flex-col gap-3">
 		<a href="/updates" class="flex items-center justify-between gap-4 border border-border bg-surface px-4 py-3 text-sm text-text transition-colors hover:border-primary">
-			<span><b>Printed a set already?</b> Give the date you printed and see only the parts that are new or revised since.</span>
+			<span><b>The catalog moves.</b> Pick a date and see which parts are new since, which have a newer revision, and which listings changed.</span>
 			<span class="shrink-0 font-semibold text-primary">What changed since… →</span>
 		</a>
 	</div>

--- a/parts-calculator/src/routes/updates/+page.svelte
+++ b/parts-calculator/src/routes/updates/+page.svelte
@@ -34,41 +34,43 @@
 	const START = catalogStart();
 	const KEY = 'sorter-updates-since-v1';
 
+	const isDate = (v: string | null | undefined): v is string => !!v && /^\d{4}-\d{2}-\d{2}$/.test(v);
+
+	// The page is prerendered, so the date can only be read once we are in the
+	// browser: `?since=` first (a shared link wins), then the last date this
+	// person used, then a month back as a starting point.
 	let since = $state('');
-	let ready = $state(false); // URL/storage read; before this, write nothing back
 
 	onMount(() => {
 		const fromUrl = page.url.searchParams.get('since');
-		const stored = (() => {
-			try {
-				return localStorage.getItem(KEY);
-			} catch {
-				return null;
-			}
-		})();
-		const initial = fromUrl ?? stored ?? daysAgo(30);
-		if (/^\d{4}-\d{2}-\d{2}$/.test(initial)) since = initial;
-		ready = true;
+		let stored: string | null = null;
+		try {
+			stored = localStorage.getItem(KEY);
+		} catch {
+			/* storage disabled */
+		}
+		since = [fromUrl, stored, daysAgo(30)].find(isDate) ?? '';
 	});
 
-	// Mirror the date into the URL so a view is shareable, and into storage so
-	// it survives a return visit. replaceState before the router has finished
-	// hydrating throws and kills the page, hence the `ready` guard — the same
-	// one /lasercut uses.
-	$effect(() => {
-		if (!browser || !ready) return;
+	// Only a deliberate choice writes back — the URL and storage are updated in
+	// the handler rather than from an effect, so nothing calls replaceState
+	// while the router is still hydrating (which throws, and takes the page
+	// with it).
+	function pick(value: string) {
+		since = value;
+		if (!browser) return;
 		try {
-			localStorage.setItem(KEY, since);
+			localStorage.setItem(KEY, value);
 		} catch {
 			/* storage full / disabled */
 		}
-		const params = new URLSearchParams(page.url.search);
-		if (since) params.set('since', since);
+		const params = new URLSearchParams(location.search);
+		if (isDate(value)) params.set('since', value);
 		else params.delete('since');
 		const qs = params.toString();
 		const target = qs ? `${location.pathname}?${qs}` : location.pathname;
 		if (target !== location.pathname + location.search) replaceState(target, {});
-	});
+	}
 
 	const layers = $derived(layerStore.sizes.length);
 	const updates = $derived(partUpdatesSince(since));
@@ -218,8 +220,9 @@
 				<CalendarClock size={16} class="text-text-muted" />
 				<input
 					type="date"
-					bind:value={since}
+					value={since}
 					min={START}
+					onchange={(e) => pick(e.currentTarget.value)}
 					class="border border-border bg-[var(--color-bg)] px-2 py-1.5 text-sm text-text"
 				/>
 			</span>
@@ -229,7 +232,7 @@
 				<button
 					type="button"
 					class="border border-border px-2.5 py-1.5 text-xs font-semibold text-text-muted transition-colors hover:border-primary hover:text-primary"
-					onclick={() => (since = preset.value())}
+					onclick={() => pick(preset.value())}
 				>
 					{preset.label}
 				</button>

--- a/parts-calculator/src/routes/updates/+page.svelte
+++ b/parts-calculator/src/routes/updates/+page.svelte
@@ -1,0 +1,320 @@
+<script lang="ts">
+	import { ArrowLeft, CalendarClock, Download, FlaskConical, History, Info, Plus, RefreshCw } from 'lucide-svelte';
+	import Badge from '$lib/components/Badge.svelte';
+	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
+	import PartDetailModal from '$lib/components/PartDetailModal.svelte';
+	import Seo from '$lib/components/Seo.svelte';
+	import {
+		commitUrl,
+		duration,
+		fmtDate,
+		grams,
+		machineQty,
+		partDownload,
+		type Part,
+		type PartVersion
+	} from '$lib/filament';
+	import { layerStore } from '$lib/layers.svelte';
+	import {
+		candidatesSince,
+		catalogStart,
+		daysAgo,
+		partUpdatesSince,
+		type PartUpdate
+	} from '$lib/updates';
+	import { page } from '$app/state';
+	import { replaceState } from '$app/navigation';
+	import { browser } from '$app/environment';
+	import { onMount } from 'svelte';
+
+	// Answers one question: I printed my parts on some date — what has the
+	// catalog done since? The dates are already in the data (`created_at`,
+	// `updated_at` and a dated `versions` entry per revision), so this page is a
+	// filter over them, not a second record of what changed.
+	const START = catalogStart();
+	const KEY = 'sorter-updates-since-v1';
+
+	let since = $state('');
+	let ready = $state(false); // URL/storage read; before this, write nothing back
+
+	onMount(() => {
+		const fromUrl = page.url.searchParams.get('since');
+		const stored = (() => {
+			try {
+				return localStorage.getItem(KEY);
+			} catch {
+				return null;
+			}
+		})();
+		const initial = fromUrl ?? stored ?? daysAgo(30);
+		if (/^\d{4}-\d{2}-\d{2}$/.test(initial)) since = initial;
+		ready = true;
+	});
+
+	// Mirror the date into the URL so a view is shareable, and into storage so
+	// it survives a return visit. replaceState before the router has finished
+	// hydrating throws and kills the page, hence the `ready` guard — the same
+	// one /lasercut uses.
+	$effect(() => {
+		if (!browser || !ready) return;
+		try {
+			localStorage.setItem(KEY, since);
+		} catch {
+			/* storage full / disabled */
+		}
+		const params = new URLSearchParams(page.url.search);
+		if (since) params.set('since', since);
+		else params.delete('since');
+		const qs = params.toString();
+		const target = qs ? `${location.pathname}?${qs}` : location.pathname;
+		if (target !== location.pathname + location.search) replaceState(target, {});
+	});
+
+	const layers = $derived(layerStore.sizes.length);
+	const updates = $derived(partUpdatesSince(since));
+	const added = $derived(updates.filter((u) => u.kind === 'new'));
+	const revised = $derived(updates.filter((u) => u.kind === 'revised'));
+	const touched = $derived(updates.filter((u) => u.kind === 'touched'));
+	const candidates = $derived(candidatesSince(since));
+
+	// What the catch-up costs: every new part, and one replacement of every
+	// revised one, at the current layer count.
+	const reprint = $derived([...added, ...revised]);
+	const reprintGrams = $derived(
+		reprint.reduce((sum, u) => sum + u.part.grams * machineQty(u.part, layers), 0)
+	);
+	const reprintSeconds = $derived(
+		reprint.reduce((sum, u) => sum + u.part.print_seconds * machineQty(u.part, layers), 0)
+	);
+
+	const presets = [
+		{ label: 'Last 7 days', value: () => daysAgo(7) },
+		{ label: 'Last 30 days', value: () => daysAgo(30) },
+		{ label: 'Last 90 days', value: () => daysAgo(90) },
+		{ label: 'Everything', value: () => START }
+	];
+
+	let modelOpen = $state(false);
+	let modelPart = $state<Part | null>(null);
+	let modelColor = $state('ash-gray');
+	let modelVersion = $state<PartVersion | null>(null);
+	function openModel(part: Part, version: PartVersion | null = null) {
+		modelPart = part;
+		modelVersion = version ?? part.versions?.[part.versions.length - 1] ?? null;
+		modelOpen = true;
+	}
+</script>
+
+{#snippet partRow(u: PartUpdate)}
+	{@const qty = machineQty(u.part, layers)}
+	<li class="flex gap-3 border-b border-border px-3 py-3 last:border-b-0">
+		<button
+			type="button"
+			class="group shrink-0 cursor-pointer"
+			title="Open the current 3D model for {u.part.name}"
+			onclick={() => openModel(u.part)}
+		>
+			<span class="flex h-16 w-20 items-center justify-center overflow-hidden border border-border bg-[var(--color-bg)] group-hover:border-primary">
+				<img src={u.part.render} alt={u.part.name} class="h-full w-full object-contain transition-transform group-hover:scale-105" />
+			</span>
+		</button>
+
+		<div class="min-w-0 flex-1">
+			<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+				<a href="/part/{u.part.id}" class="font-bold leading-tight text-text hover:text-primary">{u.part.name}</a>
+				{#if u.kind === 'new'}
+					<Badge variant="success"><Plus size={11} /> New</Badge>
+				{:else if u.kind === 'revised'}
+					<Badge variant="warning"><RefreshCw size={11} /> Reprint · v{u.part.version}</Badge>
+				{:else}
+					<Badge variant="neutral"><Info size={11} /> Listing only</Badge>
+				{/if}
+				<span class="text-xs text-text-muted">{fmtDate(u.date)}</span>
+				{#if qty}<span class="text-xs text-text-muted">· {qty}× per machine</span>{/if}
+				<ChangeStatus kind="parts" id={u.part.id} name={u.part.name} />
+			</div>
+
+			{#if u.kind === 'revised'}
+				<ul class="mt-1.5 space-y-1.5">
+					{#each [...u.newVersions].reverse() as v (v.version)}
+						<li class="text-xs leading-relaxed text-text-muted">
+							<span class="font-semibold text-text">v{v.version}</span>
+							<span>· {fmtDate(v.date)}</span>
+							{#if commitUrl(v.commit)}
+								<a href={commitUrl(v.commit)} target="_blank" rel="noopener" class="text-primary hover:text-primary-hover">{v.commit}</a>
+							{/if}
+							<span class="block">{v.message}</span>
+						</li>
+					{/each}
+				</ul>
+				{#if u.printed}
+					<p class="mt-1.5 text-xs text-text-muted">
+						You printed <b class="text-text">v{u.printed.version}</b> ({fmtDate(u.printed.date)}).
+						{#if u.printed.stl}
+							<a href={u.printed.stl} download class="text-primary hover:text-primary-hover">Download that older STL</a> if you need to compare.
+						{/if}
+					</p>
+				{/if}
+			{:else}
+				<p class="mt-1 text-xs leading-relaxed text-text-muted">{u.part.description}</p>
+			{/if}
+		</div>
+
+		<div class="flex shrink-0 flex-col items-end gap-1.5">
+			{#if u.kind !== 'touched'}
+				<a
+					href={partDownload(u.part, false)}
+					download
+					class="setup-button-secondary inline-flex h-8 items-center gap-1.5 px-3 text-xs font-semibold"
+					title="Download the current {u.part.name}.stl"
+				>
+					<Download size={14} /> STL
+				</a>
+				<span class="text-[11px] text-text-muted">{grams(u.part.grams * Math.max(qty, 1))} · {duration(u.part.print_seconds * Math.max(qty, 1))}</span>
+			{:else}
+				<a href="/part/{u.part.id}" class="text-xs text-primary hover:text-primary-hover">Open part</a>
+			{/if}
+		</div>
+	</li>
+{/snippet}
+
+{#snippet section(title: string, blurb: string, rows: PartUpdate[], icon: 'new' | 'revised' | 'touched')}
+	{#if rows.length}
+		<section class="mb-8">
+			<h2 class="flex items-center gap-2 text-xl font-bold tracking-tight text-text">
+				{#if icon === 'new'}<Plus size={18} class="text-success" />{:else if icon === 'revised'}<RefreshCw size={18} class="text-warning-dark" />{:else}<Info size={18} class="text-text-muted" />{/if}
+				{title} <span class="text-text-muted">({rows.length})</span>
+			</h2>
+			<p class="mb-3 mt-1 max-w-3xl text-sm text-text-muted">{blurb}</p>
+			<ul class="border border-border bg-surface">
+				{#each rows as u (u.part.id)}{@render partRow(u)}{/each}
+			</ul>
+		</section>
+	{/if}
+{/snippet}
+
+<Seo
+	title="What changed since"
+	description="Give the date you last printed and see only the Sorter V2 printed parts that are new or have been revised since."
+/>
+
+<main class="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+	<a href="/" class="mb-5 inline-flex items-center gap-1 text-sm font-semibold text-primary hover:text-primary-hover"><ArrowLeft size={15} /> Printed parts</a>
+
+	<div class="mb-6">
+		<h1 class="text-3xl font-bold tracking-tight text-text">What changed since…</h1>
+		<p class="mt-2 max-w-3xl text-sm text-text-muted">
+			Give the date you printed (or downloaded) your parts and this lists only what has moved since:
+			parts that did not exist then, and parts that have a newer design revision than the one you
+			have. Dates come from the catalog itself, so this stays right without anyone maintaining a
+			second changelog.
+		</p>
+	</div>
+
+	<div class="setup-panel mb-6 flex flex-wrap items-end gap-x-4 gap-y-3 p-4">
+		<label class="flex flex-col gap-1 text-sm">
+			<span class="font-semibold text-text">I printed on</span>
+			<span class="inline-flex items-center gap-2">
+				<CalendarClock size={16} class="text-text-muted" />
+				<input
+					type="date"
+					bind:value={since}
+					min={START}
+					class="border border-border bg-[var(--color-bg)] px-2 py-1.5 text-sm text-text"
+				/>
+			</span>
+		</label>
+		<div class="flex flex-wrap items-center gap-2">
+			{#each presets as preset (preset.label)}
+				<button
+					type="button"
+					class="border border-border px-2.5 py-1.5 text-xs font-semibold text-text-muted transition-colors hover:border-primary hover:text-primary"
+					onclick={() => (since = preset.value())}
+				>
+					{preset.label}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	{#if !since}
+		<p class="border border-border bg-surface px-4 py-6 text-sm text-text-muted">Pick a date to see what has changed since then.</p>
+	{:else}
+		<p class="mb-6 border border-border bg-surface px-4 py-3 text-sm text-text">
+			Since <b>{fmtDate(since)}</b>:
+			<b>{added.length}</b> new {added.length === 1 ? 'part' : 'parts'},
+			<b>{revised.length}</b> revised,
+			<b>{touched.length}</b> listing-only {touched.length === 1 ? 'change' : 'changes'}.
+			{#if reprint.length}
+				<span class="mt-1 block text-text-muted">
+					Printing the new and revised ones at {layers} layer{layers === 1 ? '' : 's'}:
+					<b class="text-text">{grams(reprintGrams)}</b> of filament, about
+					<b class="text-text">{duration(reprintSeconds)}</b> of printer time.
+				</span>
+			{/if}
+		</p>
+
+		{@render section(
+			'New parts',
+			'These did not exist on your date, so you have never printed them.',
+			added,
+			'new'
+		)}
+		{@render section(
+			'Revised parts — reprint these',
+			'A newer design revision exists. What you have in the machine is the older one; the version notes below say what changed and why.',
+			revised,
+			'revised'
+		)}
+		{@render section(
+			'Listing changed, design did not',
+			'Same design revision as the one you printed — only the catalog entry moved (description, quantity, colour or pictures). Nothing to reprint.',
+			touched,
+			'touched'
+		)}
+
+		{#if candidates.length}
+			<section class="mb-8">
+				<h2 class="flex items-center gap-2 text-xl font-bold tracking-tight text-text">
+					<FlaskConical size={18} class="text-info" /> Revisions under test <span class="text-text-muted">({candidates.length})</span>
+				</h2>
+				<p class="mb-3 mt-1 max-w-3xl text-sm text-text-muted">
+					Candidates raised since your date: alternative designs being test-printed for a part's slot.
+					They are not part of the build and carry no version number, but if one is for a part you
+					were about to print, it is worth knowing.
+				</p>
+				<ul class="border border-border bg-surface">
+					{#each candidates as c (c.candidate.uid)}
+						<li class="flex gap-3 border-b border-border px-3 py-3 last:border-b-0">
+							{#if c.candidate.render}
+								<span class="flex h-16 w-20 shrink-0 items-center justify-center overflow-hidden border border-border bg-[var(--color-bg)]">
+									<img src={c.candidate.render} alt={c.candidate.name ?? c.part.name} class="h-full w-full object-contain" />
+								</span>
+							{/if}
+							<div class="min-w-0 flex-1">
+								<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+									<a href="/part/{c.part.id}" class="font-bold leading-tight text-text hover:text-primary">{c.candidate.name ?? c.part.name}</a>
+									<Badge variant="info"><FlaskConical size={11} /> Candidate {c.candidate.uid.toUpperCase()}</Badge>
+									<span class="text-xs text-text-muted">{fmtDate(c.candidate.created_at)}</span>
+									{#if c.candidate.superseded_by}<Badge variant="neutral"><History size={11} /> Superseded</Badge>{/if}
+								</div>
+								<p class="mt-1 text-xs leading-relaxed text-text-muted">{c.candidate.message}</p>
+							</div>
+							<div class="shrink-0">
+								<a href={c.candidate.stl} download class="setup-button-secondary inline-flex h-8 items-center gap-1.5 px-3 text-xs font-semibold" title="Download the candidate STL"><Download size={14} /> STL</a>
+							</div>
+						</li>
+					{/each}
+				</ul>
+			</section>
+		{/if}
+
+		{#if !updates.length && !candidates.length}
+			<p class="border border-border bg-surface px-4 py-6 text-sm text-text-muted">
+				Nothing has changed since {fmtDate(since)} — your printed parts are current.
+			</p>
+		{/if}
+	{/if}
+</main>
+
+<PartDetailModal bind:open={modelOpen} part={modelPart} bind:colorId={modelColor} bind:version={modelVersion} />

--- a/parts-calculator/src/routes/updates/+page.svelte
+++ b/parts-calculator/src/routes/updates/+page.svelte
@@ -208,10 +208,11 @@
 	<div class="mb-6">
 		<h1 class="text-3xl font-bold tracking-tight text-text">What changed since…</h1>
 		<p class="mt-2 max-w-3xl text-sm text-text-muted">
-			A time-based diff of the catalog. Pick any date and this lists what has moved between then and
-			now: parts that did not exist yet, parts that have a newer design revision, and entries whose
-			listing changed without the geometry moving. It reads the dates already in the catalog, so
-			there is no second changelog to maintain and nothing here records what you have printed.
+			Comparing an older set of parts against the current catalog is otherwise near impossible: this
+			does it from one date. Everything between that date and now, in three groups — parts that did
+			not exist yet, parts that have a newer design revision, and entries whose listing changed
+			without the geometry moving. It reads the dates already in the catalog, so there is no second
+			changelog to maintain and nothing here records or assumes what you have.
 		</p>
 	</div>
 

--- a/parts-calculator/src/routes/updates/+page.svelte
+++ b/parts-calculator/src/routes/updates/+page.svelte
@@ -27,10 +27,12 @@
 	import { browser } from '$app/environment';
 	import { onMount } from 'svelte';
 
-	// Answers one question: I printed my parts on some date — what has the
-	// catalog done since? The dates are already in the data (`created_at`,
-	// `updated_at` and a dated `versions` entry per revision), so this page is a
-	// filter over them, not a second record of what changed.
+	// A time-based diff of the catalog: given a date, what has changed between
+	// then and now. It tracks the catalog, not the reader — nothing here knows
+	// or records what anybody has printed, and the date is just one end of the
+	// comparison. The dates are already in the data (`created_at`, `updated_at`
+	// and a dated `versions` entry per revision), so this page is a filter over
+	// them, not a second record of what changed.
 	const START = catalogStart();
 	const KEY = 'sorter-updates-since-v1';
 
@@ -79,14 +81,14 @@
 	const touched = $derived(updates.filter((u) => u.kind === 'touched'));
 	const candidates = $derived(candidatesSince(since));
 
-	// What the catch-up costs: every new part, and one replacement of every
-	// revised one, at the current layer count.
-	const reprint = $derived([...added, ...revised]);
-	const reprintGrams = $derived(
-		reprint.reduce((sum, u) => sum + u.part.grams * machineQty(u.part, layers), 0)
+	// What the difference weighs: every new part plus one of every revised one,
+	// at the current layer count. A size for the diff, not an instruction.
+	const changed = $derived([...added, ...revised]);
+	const changedGrams = $derived(
+		changed.reduce((sum, u) => sum + u.part.grams * machineQty(u.part, layers), 0)
 	);
-	const reprintSeconds = $derived(
-		reprint.reduce((sum, u) => sum + u.part.print_seconds * machineQty(u.part, layers), 0)
+	const changedSeconds = $derived(
+		changed.reduce((sum, u) => sum + u.part.print_seconds * machineQty(u.part, layers), 0)
 	);
 
 	const presets = [
@@ -127,7 +129,7 @@
 				{#if u.kind === 'new'}
 					<Badge variant="success"><Plus size={11} /> New</Badge>
 				{:else if u.kind === 'revised'}
-					<Badge variant="warning"><RefreshCw size={11} /> Reprint · v{u.part.version}</Badge>
+					<Badge variant="warning"><RefreshCw size={11} /> Revised · v{u.part.version}</Badge>
 				{:else}
 					<Badge variant="neutral"><Info size={11} /> Listing only</Badge>
 				{/if}
@@ -149,11 +151,11 @@
 						</li>
 					{/each}
 				</ul>
-				{#if u.printed}
+				{#if u.atCutoff}
 					<p class="mt-1.5 text-xs text-text-muted">
-						You printed <b class="text-text">v{u.printed.version}</b> ({fmtDate(u.printed.date)}).
-						{#if u.printed.stl}
-							<a href={u.printed.stl} download class="text-primary hover:text-primary-hover">Download that older STL</a> if you need to compare.
+						Current on that date: <b class="text-text">v{u.atCutoff.version}</b> ({fmtDate(u.atCutoff.date)}).
+						{#if u.atCutoff.stl}
+							<a href={u.atCutoff.stl} download class="text-primary hover:text-primary-hover">Download that older STL</a> to compare.
 						{/if}
 					</p>
 				{/if}
@@ -197,7 +199,7 @@
 
 <Seo
 	title="What changed since"
-	description="Give the date you last printed and see only the Sorter V2 printed parts that are new or have been revised since."
+	description="A time-based diff of the Sorter V2 printed-parts catalog: pick a date and see which parts are new since, which have a newer design revision, and which listings changed."
 />
 
 <main class="mx-auto max-w-6xl px-4 py-8 sm:px-6">
@@ -206,16 +208,16 @@
 	<div class="mb-6">
 		<h1 class="text-3xl font-bold tracking-tight text-text">What changed since…</h1>
 		<p class="mt-2 max-w-3xl text-sm text-text-muted">
-			Give the date you printed (or downloaded) your parts and this lists only what has moved since:
-			parts that did not exist then, and parts that have a newer design revision than the one you
-			have. Dates come from the catalog itself, so this stays right without anyone maintaining a
-			second changelog.
+			A time-based diff of the catalog. Pick any date and this lists what has moved between then and
+			now: parts that did not exist yet, parts that have a newer design revision, and entries whose
+			listing changed without the geometry moving. It reads the dates already in the catalog, so
+			there is no second changelog to maintain and nothing here records what you have printed.
 		</p>
 	</div>
 
 	<div class="setup-panel mb-6 flex flex-wrap items-end gap-x-4 gap-y-3 p-4">
 		<label class="flex flex-col gap-1 text-sm">
-			<span class="font-semibold text-text">I printed on</span>
+			<span class="font-semibold text-text">Changes since</span>
 			<span class="inline-flex items-center gap-2">
 				<CalendarClock size={16} class="text-text-muted" />
 				<input
@@ -248,30 +250,30 @@
 			<b>{added.length}</b> new {added.length === 1 ? 'part' : 'parts'},
 			<b>{revised.length}</b> revised,
 			<b>{touched.length}</b> listing-only {touched.length === 1 ? 'change' : 'changes'}.
-			{#if reprint.length}
+			{#if changed.length}
 				<span class="mt-1 block text-text-muted">
-					Printing the new and revised ones at {layers} layer{layers === 1 ? '' : 's'}:
-					<b class="text-text">{grams(reprintGrams)}</b> of filament, about
-					<b class="text-text">{duration(reprintSeconds)}</b> of printer time.
+					The new and revised parts together, at {layers} layer{layers === 1 ? '' : 's'}:
+					<b class="text-text">{grams(changedGrams)}</b> of filament, about
+					<b class="text-text">{duration(changedSeconds)}</b> of printer time.
 				</span>
 			{/if}
 		</p>
 
 		{@render section(
 			'New parts',
-			'These did not exist on your date, so you have never printed them.',
+			'These did not exist in the catalog on that date.',
 			added,
 			'new'
 		)}
 		{@render section(
-			'Revised parts — reprint these',
-			'A newer design revision exists. What you have in the machine is the older one; the version notes below say what changed and why.',
+			'Revised parts',
+			'A design revision was released after that date. The version notes below say what changed and why, and the older revision is linked so the two can be compared.',
 			revised,
 			'revised'
 		)}
 		{@render section(
 			'Listing changed, design did not',
-			'Same design revision as the one you printed — only the catalog entry moved (description, quantity, colour or pictures). Nothing to reprint.',
+			'Same design revision as on that date — only the catalog entry moved (description, quantity, colour or pictures). The geometry is identical.',
 			touched,
 			'touched'
 		)}
@@ -282,9 +284,9 @@
 					<FlaskConical size={18} class="text-info" /> Revisions under test <span class="text-text-muted">({candidates.length})</span>
 				</h2>
 				<p class="mb-3 mt-1 max-w-3xl text-sm text-text-muted">
-					Candidates raised since your date: alternative designs being test-printed for a part's slot.
-					They are not part of the build and carry no version number, but if one is for a part you
-					were about to print, it is worth knowing.
+					Candidates raised since that date: alternative designs being tested for a part's slot. They
+					are not part of the build and carry no version number, but they are a change to the
+					catalog like any other.
 				</p>
 				<ul class="border border-border bg-surface">
 					{#each candidates as c (c.candidate.uid)}
@@ -314,7 +316,7 @@
 
 		{#if !updates.length && !candidates.length}
 			<p class="border border-border bg-surface px-4 py-6 text-sm text-text-muted">
-				Nothing has changed since {fmtDate(since)} — your printed parts are current.
+				Nothing in the catalog has changed since {fmtDate(since)}.
 			</p>
 		{/if}
 	{/if}


### PR DESCRIPTION
Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1540985091340116049): "Is it possible to add a feature/function to the Part Calculator for 3D-printed parts that shows me only the newly added or modified parts, based on a specific date (e.g., my print date or the date I saved the STL files on my computer)?"

Yes, and without a new record to maintain: the catalog already dates everything. Each part carries `created_at` and `updated_at`, and a revised part carries a `versions` entry with a date, a message and its own pinned STL.

**`/updates` — "What changed since…"** takes one date and splits the printed parts three ways:

- **New** — `created_at` is after the date, so it was never printed.
- **Revised — reprint these** — one or more `versions` entries are dated after it. Each is listed with its version number, date, commit and the message saying what changed, plus a line naming the version they printed and a download link to that older STL for comparison.
- **Listing changed, design did not** — `updated_at` moved but no new version: description, quantity, colour, pictures, or a re-export of identical geometry. Deliberately its own section so nobody reprints a part whose design never moved.
- **Revisions under test** — candidates raised since the date, since a candidate for a part you were about to print is worth knowing about.

Each row opens the same `PartDetail` view every other surface uses, carries its `ChangeStatus` badge, and offers the current STL. The header totals the reprint set in filament and printer time at the current layer count.

The date is held in `?since=` and in `localStorage`, so a view is shareable and survives the next visit; presets cover 7/30/90 days and the whole catalog. The URL and storage are written from the date control's own handler rather than from an `$effect`, so `replaceState` only runs when somebody picks a date and never while the router is hydrating.

The dashboard gets one line pointing at it. Where the two banners sit was settled over two follow-ups from barthel in the thread:

- The **"What changed since…"** banner sits **above** the Print settings box ([“Move the link section above the “Print Settings” section.”](https://discord.com/channels/1430279849171222682/1540985091340116049/1540990698822828112)). It is about the catalog as a whole, so it is read before anything is configured.
- The **changes** banner stays **inside the Parts tab**, above the by-assembly / by-unique-part toggle ([“Move “Changes and improvements are tracked for some parts…” back into parts tab.”](https://discord.com/channels/1430279849171222682/1540985091340116049/1540992358840016976)). It is about the parts in the list under it.

### It is a catalog diff, not a print tracker

Spencer's objection in the thread ([here](https://discord.com/channels/1430279849171222682/1540985091340116049/1541011211179528263)) was that this supplements people's printing tooling, and how somebody denotes what they have and have not printed is up to them. That is right, and the page should never have been worded as though it knew. It does not track anybody — it diffs the catalog between a date and now, and the date is one end of a comparison.

The print-tracking framing has been removed everywhere it appeared:

| was | now |
|---|---|
| "Printed a set already?" | "Compare the catalog against a date." |
| "I printed on" | "Changes since" |
| "Revised parts — reprint these" | "Revised parts" |
| `Reprint · v2` badge | `Revised · v2` |
| "You printed v1" | "Current on that date: v1" |
| "so you have never printed them" | "did not exist in the catalog on that date" |
| "Nothing to reprint" | "The geometry is identical" |
| "your printed parts are current" | "Nothing in the catalog has changed" |
| "Printing the new and revised ones…" | "The new and revised parts together…" |

`PartUpdate.printed` becomes `atCutoff`. The filament and printer-time figures stay, as a size for the diff rather than an instruction. No behaviour changed, no data was added, and nothing is stored about the reader.

**Checks:** `npm run check` 0 errors, `npm run build` clean, `/updates` prerenders. The banner placement and the reworded page were both verified by screenshotting the Cloudflare preview.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1540985091340116049
request: https://discord.com/channels/1430279849171222682/1540985091340116049/1540990698822828112
request: https://discord.com/channels/1430279849171222682/1540985091340116049/1540992358840016976
request: https://discord.com/channels/1430279849171222682/1540985091340116049/1541014888988803202
request: https://discord.com/channels/1430279849171222682/1540985091340116049/1541015893734199328
preview: /updates
-->




