### PR TITLE
docs: let a page choose the photo its link unfurls with

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -50,6 +50,7 @@ asset spec, and the rules for adding a site live in
      - part: m4-12mm-countersunk
        qty: 8
    tools_needed: [Screwdriver]      # optional, plain strings
+   og_image: <full image URL>       # optional; see Link previews
    ---
    ```
    `audience`, `applies_to`, `owner`, `last_verified` come from per-section
@@ -58,6 +59,16 @@ asset spec, and the rules for adding a site live in
    section's `pages:` (nest with `children:` — the sidebar renders
    arbitrarily deep).
 4. `python3 scripts/validate_frontmatter.py` must pass.
+
+## Link previews (`og:image`)
+
+The `og:image` a page unfurls with is **its first `<img>`**, picked up
+automatically, so most pages need nothing. Assembly pages are the exception:
+they open with the parts laid out on a bench, which is a poor thumbnail for
+the finished thing. Set `og_image:` in front matter to a full
+`https://img.basically.website/...` URL to override it (relative paths are
+resolved against the site URL). The image stays wherever it already is in the
+body; this only changes what the embed shows.
 
 ## Engineering notes (`/n/<id>/`)
 

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -8,6 +8,7 @@ kicker: Electronics — Control board housing
 lede: Closing the control board into its printed housing, with the 40 mm fan on a GPIO-controlled port, and bolting it to the frame.
 permalink: /hardware/electronics/installation/control-board-housing/
 author: spencer
+og_image: https://img.basically.website/web/assembly/control-board-housing/housing-angled.c67cd89578b97f5f.jpg
 parts_needed:
   - part: ctrl-board-housing-base
     qty: 1

--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -552,8 +552,13 @@ export async function getPage(pathParam: string): Promise<Page | null> {
 		page.warning = String(await markdown.process(warned));
 	}
 
-	const img = html.match(/<img[^>]*src="([^"]+)"/);
-	if (img) page.ogImage = img[1].startsWith('http') ? img[1] : site.url + img[1];
+	// Social preview image: `og_image` in front matter wins, otherwise the first
+	// photo in the body. The first photo is usually the right one, but on a page
+	// that opens with parts laid out on a bench the finished thing is a long way
+	// down, and that is the shot worth unfurling in a link.
+	const explicit = typeof fm.og_image === 'string' ? fm.og_image.trim() : '';
+	const ogSrc = explicit || html.match(/<img[^>]*src="([^"]+)"/)?.[1];
+	if (ogSrc) page.ogImage = ogSrc.startsWith('http') ? ogSrc : site.url + ogSrc;
 
 	rendered.set(url, page);
 	return page;


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540987591023792228/1540994586988781578
preview: /hardware/electronics/installation/control-board-housing/
-->
The control board housing page unfurled with the parts-laid-out bench shot, because the `og:image` was always just the first `<img>` on the page. On an assembly page that is the worst possible thumbnail: a pile of loose parts standing in for the finished thing.

- **`og_image:` front matter** now overrides it, full URL or a site-relative path. Nothing set means the old behaviour, so every other page is untouched.
- **Control board housing** sets it to `housing-angled.jpg`, the finished housing at an angle. The photo stays where it already is in the body, this only changes the link preview.
- **`docs/AGENTS.md`** documents the key and when to reach for it.

Checked on the built output: the housing page carries the angled shot, and a spot check of other pages still picks up their first photo.

Requested by Spencer (@spencerhubert) [from Discord](https://discord.com/channels/1430279849171222682/1540987591023792228/1540994586988781578): "can you make the housing angled pic the main overview pic ...".
