### PR TITLE
parts-calculator: read the catalog as JSON off the site

### DIFF
--- a/parts-calculator/README.md
+++ b/parts-calculator/README.md
@@ -172,6 +172,38 @@ time: the generated data travels in the same commits as the source that
 produced it, so the preview never waits on anything and nothing moves the
 branch head underneath you.
 
+## JSON API
+
+The catalog is readable as JSON straight off the site. The endpoints are
+prerendered, so they are plain files on the CDN rather than a running service:
+no query parameters, no filtering, and no auth. `Access-Control-Allow-Origin: *`
+is set for `/api/*` in [`static/_headers`](static/_headers), so a browser on any
+origin can fetch them.
+
+| endpoint | what it is |
+|---|---|
+| `/api/catalog.json` | everything the site reads: `settings`, `sections`, `changes`, `folders`, `color_roles`, `families`, `assemblies`, `parts`, `plates`, `hardware`, `lasercut`, `merges` |
+| `/api/parts.json` | the printed parts only |
+| `/api/hardware.json` | the bought parts: fasteners, extrusion, electronics |
+| `/api/changes.json` | the tracked changes behind `/changes` |
+
+The bodies are the catalog's own objects, unwrapped and unrenamed, so the API
+and the site are looking at the same fields. Live:
+
+```
+curl -s https://parts-calculator.basically.website/api/changes.json | jq '.[] | {id, priority, condition}'
+```
+
+Every printed part carries `created_at`, `updated_at` and a `versions` list with
+a date, a message and an STL URL per revision — that is all `/updates` ("what
+changed since…") computes from, so it is reproducible against `/api/parts.json`
+with no server involved.
+
+The endpoints are slices of the one generated file, so adding another is a
+`+server.ts` under `src/routes/api/` returning a different key. Nothing is
+hand-maintained: change `catalog/parts.json`, regenerate, and the API moves with
+the site.
+
 ## Dev
 
 ```

--- a/parts-calculator/src/routes/api/catalog.json/+server.ts
+++ b/parts-calculator/src/routes/api/catalog.json/+server.ts
@@ -1,0 +1,17 @@
+/**
+ * GET /api/catalog.json — the whole catalog, exactly as the site reads it.
+ *
+ * Every endpoint under /api is prerendered: the site is a static build, so
+ * these are plain files on the CDN, not a running server. That means no query
+ * parameters and no filtering server-side — fetch and slice it yourself. The
+ * narrower endpoints beside this one exist only to save you the download.
+ *
+ * Bodies are the catalog's own objects, unwrapped and unrenamed, so a consumer
+ * of the API and a reader of the site are looking at the same fields.
+ */
+import { json } from '@sveltejs/kit';
+import raw from '$lib/data/catalog.generated.json';
+
+export const prerender = true;
+
+export const GET = () => json(raw);

--- a/parts-calculator/src/routes/api/changes.json/+server.ts
+++ b/parts-calculator/src/routes/api/changes.json/+server.ts
@@ -1,0 +1,14 @@
+/**
+ * GET /api/changes.json — the tracked changes behind the /changes page.
+ *
+ * Small and the useful one to poll: it is what says whether a part is known
+ * broken or about to be revised, so a builder can hold off printing it. Each
+ * entry has a `priority`, a `description`, an optional `condition` and the
+ * `targets` it applies to. See /api/catalog.json for the rest.
+ */
+import { json } from '@sveltejs/kit';
+import raw from '$lib/data/catalog.generated.json';
+
+export const prerender = true;
+
+export const GET = () => json(raw.changes);

--- a/parts-calculator/src/routes/api/hardware.json/+server.ts
+++ b/parts-calculator/src/routes/api/hardware.json/+server.ts
@@ -1,0 +1,12 @@
+/**
+ * GET /api/hardware.json — the bought parts: fasteners, extrusion, electronics.
+ *
+ * Everything with `kind: "cots"` in the catalog, with its sourcing, stock and
+ * attributes. See /api/catalog.json for the rest.
+ */
+import { json } from '@sveltejs/kit';
+import raw from '$lib/data/catalog.generated.json';
+
+export const prerender = true;
+
+export const GET = () => json(raw.hardware);

--- a/parts-calculator/src/routes/api/parts.json/+server.ts
+++ b/parts-calculator/src/routes/api/parts.json/+server.ts
@@ -1,0 +1,14 @@
+/**
+ * GET /api/parts.json — the printed parts only.
+ *
+ * The slice most consumers want, and the one behind "what changed since": each
+ * part carries `created_at`, `updated_at` and a `versions` list with a date, a
+ * message and an STL URL per revision, which is everything /updates computes
+ * from. See /api/catalog.json for the rest of the catalog.
+ */
+import { json } from '@sveltejs/kit';
+import raw from '$lib/data/catalog.generated.json';
+
+export const prerender = true;
+
+export const GET = () => json(raw.parts);

--- a/parts-calculator/static/_headers
+++ b/parts-calculator/static/_headers
@@ -1,0 +1,9 @@
+# Cloudflare Pages reads this from the build output root.
+#
+# The /api/*.json endpoints are prerendered to plain files, so the Response
+# headers set in each +server.ts are discarded at build time — CORS for the
+# deployed site has to be declared here. The data is already public (the
+# repository is), and without this a browser on any other origin cannot read a
+# file the CDN will serve to curl without complaint.
+/api/*
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
The catalog is now readable as JSON straight off the site, rather than only as a raw file in this repo.

Four endpoints, all prerendered — the calculator is a static build, so these come out as plain files on the CDN, not a running service. No query parameters, no auth, no server-side filtering.

- `/api/catalog.json` — everything the site reads: `settings`, `sections`, `changes`, `folders`, `color_roles`, `families`, `assemblies`, `parts`, `plates`, `hardware`, `lasercut`, `merges`
- `/api/parts.json` — the 98 printed parts only
- `/api/hardware.json` — the 70 bought parts: fasteners, extrusion, electronics
- `/api/changes.json` — the 15 tracked changes behind `/changes`

Bodies are the catalog's own objects, unwrapped and unrenamed, so a consumer of the API and a reader of the site are looking at the same fields. The narrower three are slices of the first; they exist to save the download.

**CORS.** Prerendering discards the `Response` headers each `+server.ts` sets, so `Access-Control-Allow-Origin: *` for the deployed site is declared in `static/_headers` (Cloudflare Pages reads it from the build output root), scoped to `/api/*`. Without it a browser on another origin cannot read a file the CDN serves to `curl` without complaint. The data is already public, since this repository is.

**On "what changed since".** Every printed part already carries `created_at`, `updated_at` and a `versions` list with a date, a message and an STL URL per revision. That is everything the `/updates` page computes from, so the whole feature is reproducible against `/api/parts.json` with nothing running server-side. No new data was added for this.

Nothing is hand-maintained: change `catalog/parts.json`, regenerate, and the API moves with the site. Adding another endpoint is a `+server.ts` returning a different key.

**Checked:** `npm run check` 0 errors, `npm run build` clean, and all four files are emitted into `build/api/` and parse as the expected shapes (dict of 12 keys / 98 / 70 / 15).

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1540985091340116049/1540995799054295051
preview: /api/changes.json
-->
