### PR TITLE
docs: drop the leftover pointers to the retired Preparation page

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -62,8 +62,6 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
   </div>
 </div>
 
-The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists every part in the machine that needs inserts.
-
 {% include step.html n="2" title="Fit the funnel brackets" %}
 
 Fit the Funnel bracket (left) and the Funnel bracket (right) to the chute core. Together with the door module and the layer connectors these use the chute's 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, all into the core's inserts.

--- a/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
@@ -56,8 +56,6 @@ Press the inserts into the housing while it is still bare. See [installing heat 
   </div>
 </div>
 
-The [Preparation]({{ '/hardware/preparation/' | relative_url }}) page lists every part in the machine that needs inserts.
-
 {% include step.html n="2" title="Seat the servo in the housing" %}
 
 Drop the MG995 into the housing and fasten it with 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the servo's own mounting ears.

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -33,7 +33,7 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 {% include step.html n="1" title="Preparation" %}
 
-Press the chute core's inserts before the chute is assembled, the four PCB inserts among them. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique, and the [Preparation]({{ '/hardware/preparation/' | relative_url }}) page for every part in the machine that takes inserts.
+Press the chute core's inserts before the chute is assembled, the four PCB inserts among them. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
 
 {% include step.html n="2" title="Screw the board onto the chute core" %}
 


### PR DESCRIPTION
The central `/hardware/preparation/` page was retired in #335; every assembly page carries its own numbered **Preparation** step now. Three chute pages still ended their Preparation step by pointing readers at it, so the link is dead and the sentence is wrong.

Swept all 76 docs pages for references to it. These were the only three:

- `chute/chute-core.md` — removed the trailing sentence
- `chute/mg995-servo/servo-mount.md` — removed the trailing sentence
- `chute/pcb.md` — kept the "installing heat inserts" technique link, dropped only the Preparation clause

No other page, include, nav entry or config references `/hardware/preparation/`. `docs/AGENTS.md` already documents the current pattern, so it needed no change.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1541097572683489360): "Check all doc pages and remove sentence like "The Preparation page lists every part in the machine that needs inserts." The single preperation page is gone and each page has ist's own preperation section."

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1541097572683489360
request: https://discord.com/channels/1430279849171222682/1541097572683489360/1541132532391608402
preview: /hardware/assembly/distribution/chute/chute-core/
preview: /hardware/assembly/distribution/chute/pcb/
preview: /hardware/assembly/distribution/chute/mg995-servo/servo-mount/
-->