### PR TITLE
docs: images upload to the asset service, not the bucket

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,11 +1,10 @@
 name: Harness drawings
 
 # Renders the WireViz harness from electronics/wire_harness/*.yml and publishes
-# it to the assets bucket under this ref's name (harness/<branch>/...). The
-# docs derive the same prefix from the ref they're building
-# (resolveHarness() in docs/src/lib/server/content.ts), so a PR preview shows the PR's drawings
-# and production shows main's. Nothing rendered is ever committed to git, and
-# nothing is ever committed back to the branch.
+# it to the asset service (assets.basically.website, namespace sorter-harness).
+# Every object is content-addressed, so publishing only ever adds. Nothing
+# rendered is ever committed to git, and nothing is ever committed back to the
+# branch.
 #
 # The path filter is safe here because this job's inputs are completely
 # enumerable: the sources, the build script (in the same directory), and the
@@ -22,10 +21,10 @@ name: Harness drawings
 # fork gets a render-only check (proof the YAML builds). A maintainer's next
 # push to the merged result publishes for real.
 #
-# SPACES_KEY/SPACES_SECRET is a key scoped to the basically-docs bucket only.
-# Worst case if it leaks is defacing public docs assets: rotate the key, re-run
-# this workflow on main (workflow_dispatch), restore photos from the gravity
-# mirror. The bucket holds nothing irreplaceable that isn't mirrored.
+# ASSET_SERVICE_TOKEN is a key scoped to the sorter-harness namespace only.
+# Worst case if it leaks is somebody adding objects there: revoke the key
+# (asset-service keys revoke sorter-harness-ci), mint another, update this
+# secret. Nothing can be overwritten or deleted with it.
 
 on:
   pull_request:
@@ -56,7 +55,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - run: pip install wireviz==0.4.1 boto3
+      - run: pip install wireviz==0.4.1
 
       # Asserted on the PACKAGE version, not `dot -V`: Ubuntu's graphviz
       # 2.42.2-9ubuntu0.1 self-reports "2.43.0 (0)" (upstream bumped version.h
@@ -78,26 +77,23 @@ jobs:
 
       - run: ./electronics/wire_harness/build-harness.sh
 
-      # Uploading on every run is safe in a way it was not before: names carry
-      # a hash of their own bytes, so this can only ever add objects, never
-      # replace one somebody is already serving. A re-render of an unchanged
-      # drawing uploads nothing at all.
+      # Uploading on every run is safe: the service names objects after their
+      # own bytes, so this can only ever add, never replace one somebody is
+      # already serving. A re-render of an unchanged drawing is a no-op.
       #
       # Same-repo refs only: fork PRs have no secrets, so they stop at the
       # render (which is the actual correctness check anyway).
-      - name: Publish to the assets bucket
+      - name: Publish to the asset service
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
-          SPACES_KEY: ${{ secrets.SPACES_KEY }}
-          SPACES_SECRET: ${{ secrets.SPACES_SECRET }}
+          ASSET_SERVICE_TOKEN: ${{ secrets.ASSET_SERVICE_TOKEN }}
         run: python3 electronics/wire_harness/upload-harness.py
 
       # The URLs the docs serve are literal strings in the data file, pasted by
-      # whoever changed the drawing, exactly like every other asset in this
-      # bucket. This is what keeps that honest: change a drawing without
-      # pasting its new URLs and the job fails with the block to paste. It also
-      # means the objects are in the bucket before any commit names them, which
-      # is the property the old overwrite-in-place scheme lacked.
+      # whoever changed the drawing, exactly like every other asset. This is
+      # what keeps that honest: change a drawing without pasting its new URLs
+      # and the job fails with the block to paste. It also means the objects
+      # are published before any commit names them.
       - name: Check the docs point at this render
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: python3 electronics/wire_harness/upload-harness.py --check docs/src/liquid/_data/harness.yml

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -66,8 +66,7 @@ The `og:image` a page unfurls with is **its first `<img>`**, picked up
 automatically, so most pages need nothing. Assembly pages are the exception:
 they open with the parts laid out on a bench, which is a poor thumbnail for
 the finished thing. Set `og_image:` in front matter to a full
-asset URL (`https://assets.basically.website/...`; older pages still use
-`img.basically.website`) to override it (relative paths are
+`https://assets.basically.website/...` URL to override it (relative paths are
 resolved against the site URL). The image stays wherever it already is in the
 body; this only changes what the embed shows.
 
@@ -176,21 +175,6 @@ Desktop, VLC Snapshots, etc.). Then do all of this yourself:
 4. Commit the URL, never the image bytes. The URL works identically on PR
    previews and production, since the service is branch-independent.
 
-### The legacy image domain
-
-Existing pages are full of `https://img.basically.website/web/…` URLs — the
-previous home for docs images, a DO Spaces bucket behind the Cloudflare Worker
-in `scripts/img-worker/`. Those URLs stay live until every one is rewritten to
-the asset service, and `validate_images.py` still checks them. **Never mint a
-new one** — the upload path above is the only one; the old script that wrote
-to the bucket is gone.
-
-> If the worker itself needs touching before it retires: it is not deployed
-> by CI. It ships by hand — `CLOUDFLARE_API_TOKEN=… npx wrangler deploy` in
-> `docs/scripts/img-worker/` — and every response carries
-> `x-img-cache: hit|miss`, which to check before believing anything about
-> freshness.
-
 ## Video — the workflow
 
 A clip does **not** go in the images bucket. `upload_image.py` uploads exactly
@@ -239,9 +223,9 @@ binary is committed; a re-encode is a new URL.
 
 Three things to know.
 
-- **`validate_images.py` checks these URLs too** — both domains, same rule:
-  the hash in the name must match the bytes the URL serves. It cannot press
-  play for you, so load the page and do that before you push.
+- **`validate_images.py` checks these URLs too** — same rule as images: the
+  hash in the name must match the bytes the URL serves. It cannot press play
+  for you, so load the page and do that before you push.
 - **Size the player from the poster, not from an encode.** A phone shoots
   portrait into a landscape frame and sets a rotation flag, so the MP4 reports
   1920x1080 and plays 1080x1920 while the poster is a still with the rotation
@@ -280,8 +264,8 @@ cached forever. Name the upload by what it shows
 (`top-interface-step2-hole-red-square`), not by source filename — names are
 flat now, so the page or part belongs in the name itself.
 
-**This is the invariant.** Every asset URL in docs source — either domain —
-must contain the hash of its actual bytes. Never overwrite an object, use a
+**This is the invariant.** Every asset URL in docs source must contain the
+hash of its actual bytes. Never overwrite an object, use a
 descriptive stable URL, add a query-string cache buster, or add browser retry
 code. `npm run build` runs `scripts/validate_images.py`, which rejects a missing
 image, a non-content-addressed URL, or bytes that do not match the URL hash.
@@ -396,8 +380,7 @@ Moved off Vercel on 2026-08-09. Two reasons, in order: static asset requests
 on Pages are unmetered, and the site was generating ~40k Vercel edge requests
 a day against a 100-deploy-a-day Hobby account that had already rate-limited
 itself out of deploying; and everything else the docs depend on
-(`img.basically.website`, the DNS, the cache purge) already lives in the same
-Cloudflare account. The site is `@sveltejs/adapter-static` with
+already lived in the same Cloudflare account. The site is `@sveltejs/adapter-static` with
 `trailingSlash: 'always'` set in SvelteKit rather than in host config, so
 there was nothing host-specific to port. `vercel.json` is gone.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -279,8 +279,8 @@ render is 23 files at once.
 
 Sources live in `electronics/wire_harness/`. On any PR or main push touching
 them, `.github/workflows/harness.yml` renders with a pinned toolchain, uploads
-each artifact under a name containing a hash of its bytes
-(`harness/power.2c0ebc6cd1.png`), and then **fails the build unless
+each artifact to the asset service under a name containing a hash of its bytes
+(`sorter-harness/power-accd2693fc83.png`), and then **fails the build unless
 `src/liquid/_data/harness.yml` already names exactly those URLs**, printing the
 block to paste. So changing a drawing is: push, paste the URLs CI prints, push
 again.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -66,7 +66,8 @@ The `og:image` a page unfurls with is **its first `<img>`**, picked up
 automatically, so most pages need nothing. Assembly pages are the exception:
 they open with the parts laid out on a bench, which is a poor thumbnail for
 the finished thing. Set `og_image:` in front matter to a full
-`https://img.basically.website/...` URL to override it (relative paths are
+asset URL (`https://assets.basically.website/...`; older pages still use
+`img.basically.website`) to override it (relative paths are
 resolved against the site URL). The image stays wherever it already is in the
 body; this only changes what the embed shows.
 
@@ -95,7 +96,7 @@ unlike the rest of this site.
   page renders "Engineering note <id>" pointing back here.
 
 Images follow the ordinary rules below (upload, content-addressed URL, never
-in git), under `notes/<id>/`. A detail image wants the full column: put a
+in git), named `note-<id>-<what>`. A detail image wants the full column: put a
 single `<figure>` inside an `img-row` rather than using `doc-figure`, which
 caps at 440px for assembly photos.
 
@@ -107,7 +108,7 @@ pages are rendered through liquidjs at build time. Includes live in
 
 - **Step heading:** `{% include step.html n="1" title="Mount the thing" %}`
   → a small "Step 1" tag over the title.
-- **Figure:** `<img class="doc-figure" src="https://img.basically.website/web/…" alt="…">`
+- **Figure:** `<img class="doc-figure" src="https://assets.basically.website/sorter-docs/…" alt="…">`
 - **Side-by-side images** (share one full-width row, wrap on mobile):
   ```html
   <div class="img-row">
@@ -144,46 +145,51 @@ lines, so normal `{% for %}` loops are fine as-is.
 
 ## Images — the workflow
 
-**Images are not in git.** Originals and web versions live in the
-`basically-docs` DO Spaces bucket, served at `https://img.basically.website`
-(Cloudflare Worker in `scripts/img-worker/`). Ask the user **which folder the
-pics are in** (Downloads, Desktop, VLC Snapshots, etc.). Then do all of this
-yourself:
-
-> The worker is not deployed by CI. It ships by hand, from this directory:
-> `CLOUDFLARE_API_TOKEN=… npx wrangler deploy` in `docs/scripts/img-worker/`.
-> Merging a change to `worker.js` therefore changes nothing on its own —
-> deploy it, then check a real URL. Cloudflare keeps prior versions, so the
-> rollback is a redeploy of the previous one.
->
-> Two things to expect. `wrangler` exits non-zero on
-> `/zones/<id>/workers/routes` unless the token also carries Workers Routes
-> edit; the upload has already happened by then and the custom domain is
-> already attached, so it is noise. And every response carries
-> `x-img-cache: hit|miss` — check it before believing anything about
-> freshness, since a stale object and a fresh one look identical otherwise.
+**Images are not in git.** Every file a page embeds — image or video — goes
+to the **asset service** (`assets.basically.website`, public repo
+`basicallysource/asset-service`). You upload the original; the service stores
+it under a content-addressed name and builds the smaller copies a page should
+actually download. Ask the user **which folder the pics are in** (Downloads,
+Desktop, VLC Snapshots, etc.). Then do all of this yourself:
 
 1. **Look at each image** (Read tool) to understand what it shows before naming.
 2. **Upload it:**
    ```bash
-   python3 docs/scripts/upload_image.py <original-file> assembly/<page>/<name>
+   python3 docs/scripts/upload_image.py <original-file> <name>
    ```
-   The script generates the web version (long side ≤ 1600px, **opaque →
-   `.jpg`**, **transparent → `.png`**), uploads the full-res original to
-   `originals/<path>` and the web version to `web/<path>`, and prints both URLs.
-   Needs Pillow and boto3.
+   The service builds the ladder in the background (320–2048px wide, **opaque
+   → `.jpg`**, **transparent → `.png`**); the script waits for it and prints
+   two URLs: the ~1600px rung pages embed, then the original. Needs Pillow.
 
-   **Credentials** are the `SPACES_KEY` / `SPACES_SECRET` environment
-   variables, holding a key scoped to the `basically-docs` bucket. **Check for
-   them rather than assuming** — `echo $SPACES_KEY` — and do not conclude from
-   a past note, this file included, that you don't have them. Never commit
-   them. Only if they are genuinely absent, say so and use `img-placeholder`
-   divs (above) instead of guessing or embedding the image data directly in
-   the page.
-3. **Reference the printed web URL** in the page:
-   `https://img.basically.website/web/<path>.<hash>.<jpg|png>`. Plain URL, no Liquid.
+   **Credentials** are `ASSET_SERVICE_URL` / `ASSET_SERVICE_TOKEN`, from the
+   environment or `~/.config/asset-service/*.env`. **Check for them rather
+   than assuming** — and do not conclude from a past note, this file included,
+   that you don't have them. Never commit them. Anyone can mint their own
+   token by signing in with GitHub at the service's `/login` page — a
+   self-served account uploads images only, throttled; video and bigger files
+   take a contributor account, which whoever runs the service grants. Only if
+   a token is genuinely absent, say so and use `img-placeholder` divs (above)
+   instead of guessing or embedding the image data directly in the page.
+3. **Reference the first printed URL** in the page:
+   `https://assets.basically.website/sorter-docs/<name>-w1600-<hash>.jpg`.
+   Plain URL, no Liquid.
 4. Commit the URL, never the image bytes. The URL works identically on PR
-   previews and production, since the bucket is branch-independent.
+   previews and production, since the service is branch-independent.
+
+### The legacy image domain
+
+Existing pages are full of `https://img.basically.website/web/…` URLs — the
+previous home for docs images, a DO Spaces bucket behind the Cloudflare Worker
+in `scripts/img-worker/`. Those URLs stay live until every one is rewritten to
+the asset service, and `validate_images.py` still checks them. **Never mint a
+new one** — the upload path above is the only one; the old script that wrote
+to the bucket is gone.
+
+> If the worker itself needs touching before it retires: it is not deployed
+> by CI. It ships by hand — `CLOUDFLARE_API_TOKEN=… npx wrangler deploy` in
+> `docs/scripts/img-worker/` — and every response carries
+> `x-img-cache: hit|miss`, which to check before believing anything about
+> freshness.
 
 ## Video — the workflow
 
@@ -233,10 +239,9 @@ binary is committed; a re-encode is a new URL.
 
 Three things to know.
 
-- **`validate_images.py` does not check these URLs.** It walks
-  `img.basically.website/web/` only, and video is served from
-  `assets.basically.website`. Nothing catches a typo in a pasted video URL, so
-  load the page and press play before you push.
+- **`validate_images.py` checks these URLs too** — both domains, same rule:
+  the hash in the name must match the bytes the URL serves. It cannot press
+  play for you, so load the page and do that before you push.
 - **Size the player from the poster, not from an encode.** A phone shoots
   portrait into a landscape frame and sets a rotation flag, so the MP4 reports
   1920x1080 and plays 1080x1920 while the poster is a still with the rotation
@@ -246,10 +251,10 @@ Three things to know.
 - **Nothing deletes.** `DELETE /v1/assets/<key>` is 405. An upload you regret
   is an object that stays, so do not use the real namespace as a scratchpad.
 
-Credentials are `ASSET_SERVICE_URL` / `ASSET_SERVICE_TOKEN`, read from
-`~/.config/asset-service/*.env` or the environment. **Check rather than
-assume**, the same as with `SPACES_KEY`. If they are genuinely absent, say so
-and leave the clip out rather than shipping a still and calling it a video.
+Credentials are the same `ASSET_SERVICE_URL` / `ASSET_SERVICE_TOKEN` pair
+`upload_image.py` reads. **Check rather than assume.** If they are genuinely
+absent, say so and leave the clip out rather than shipping a still and
+calling it a video.
 
 **A still frame is not a substitute.** If the point of the shot is motion,
 something clicking or spinning or falling through, either it goes up as a video
@@ -267,15 +272,15 @@ not in git" and bloats the repo.
 pulled from `parts-calculator`'s own renders** instead of asking for a fresh
 photo: that repo's `static/renders/<part-id>.png` is a real OrcaSlicer
 thumbnail for every printed part in its catalog. Upload it the same way,
-under `parts/<page>/<part-id>`.
+named after the part id.
 
-**Names are content-addressed.** `upload_image.py` adds a hash of the generated
-bytes to each object name, so a changed image always prints a new URL that can
-be cached forever. Name the input path by what it shows (`step2-hole-red-square`),
-not by source filename. Group step images under `assembly/<page>/`, part renders
-under `parts/…`, tools under `tools/`.
+**Names are content-addressed.** The service appends a hash of the bytes to
+every object name, so a changed image always prints a new URL that can be
+cached forever. Name the upload by what it shows
+(`top-interface-step2-hole-red-square`), not by source filename — names are
+flat now, so the page or part belongs in the name itself.
 
-**This is the invariant.** Every `img.basically.website/web/` URL in docs source
+**This is the invariant.** Every asset URL in docs source — either domain —
 must contain the hash of its actual bytes. Never overwrite an object, use a
 descriptive stable URL, add a query-string cache buster, or add browser retry
 code. `npm run build` runs `scripts/validate_images.py`, which rejects a missing
@@ -364,7 +369,7 @@ directory `docs`, `npm run build` → `build/`, `NODE_VERSION=22`. Push to
 branch gets an automatic preview deployment** — no setup per PR. Take the
 preview URL from the PR comment or check (never derive it from the branch
 name; long names get truncated). Images render identically on previews and
-production because they come from `img.basically.website`, not the repo.
+production because they come from the asset domains, not the repo.
 
 **Build watch paths** limit which pushes build at all. They are a Pages
 project setting, not a file in this repo, so they are recorded here:

--- a/docs/scripts/upload_image.py
+++ b/docs/scripts/upload_image.py
@@ -18,14 +18,12 @@ same bytes is a no-op that prints the same URLs back.
 
 Credentials are ASSET_SERVICE_URL / ASSET_SERVICE_TOKEN, from the environment
 or ~/.config/asset-service/*.env -- the same pair video_embed.py reads.
-Requires Pillow, only for the EXIF workaround below.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import io
 import os
 import sys
 import time
@@ -64,32 +62,10 @@ def load_creds() -> tuple[str, str]:
 
 
 def prepare(src: Path) -> tuple[bytes, str]:
-    """The bytes to upload, and their content type.
-
-    Normally that is the file exactly as it is. The one exception: a photo
-    whose EXIF says "rotate me". The asset service decodes with Go's stdlib,
-    which ignores that tag, so an untouched phone photo would come back as a
-    sideways ladder. Until the service bakes orientation itself, bake it here
-    and upload the corrected pixels. Delete this whole branch when it does.
-    """
-    raw = src.read_bytes()
-    content_type = CONTENT_TYPES[src.suffix.lower()]
-
-    from PIL import Image, ImageOps
-
-    with Image.open(io.BytesIO(raw)) as img:
-        orientation = img.getexif().get(0x0112, 1)
-        if orientation == 1:
-            return raw, content_type
-        img.load()
-        img = ImageOps.exif_transpose(img)
-        buf = io.BytesIO()
-        if content_type == "image/png":
-            img.save(buf, format="PNG", optimize=True)
-        else:
-            img.convert("RGB").save(buf, format="JPEG", quality=95, optimize=True)
-            content_type = "image/jpeg"
-        return buf.getvalue(), content_type
+    """The bytes exactly as they are, and their content type. The service does
+    the rest itself: it turns a photo the way its EXIF says to, and it never
+    publishes the camera's own file -- pages get metadata-free copies."""
+    return src.read_bytes(), CONTENT_TYPES[src.suffix.lower()]
 
 
 def request(base: str, token: str, method: str, path: str, body: bytes | None = None,
@@ -112,6 +88,7 @@ def embed_url(manifest: dict) -> str:
     rungs = [
         r for r in manifest.get("renditions", [])
         if r.get("name") != "original"
+        and not r.get("url_expires")
         and r.get("content_type", "").startswith("image/")
         and (r.get("width") or 0) <= EMBED_WIDTH
     ]

--- a/docs/scripts/upload_image.py
+++ b/docs/scripts/upload_image.py
@@ -1,167 +1,159 @@
-"""Upload a docs image to the basically-docs bucket and print its URLs.
+"""Upload a docs image to the asset service and print the URLs to embed.
 
-Takes a full-resolution original and a destination path, generates the
-web-friendly version (long side capped at
-1600px, transparent -> PNG, opaque -> progressive JPEG), and uploads both:
-
-   originals/<dest-path>.<hash>.<original-ext>   full quality, archival
-   web/<dest-path>.<hash>.<jpg|png>              what pages embed
-
-Pages reference the web version via the CDN domain:
-
-  https://img.basically.website/web/<dest-path>.<hash>.<jpg|png>
+Every file the docs embed -- image or video -- lives in the asset service
+(`assets.basically.website`, public repo `basicallysource/asset-service`).
+This uploads the original; the service stores it under a content-addressed
+name and builds a JPEG/PNG ladder (320-2048px wide) beside it in the
+background. Docs pages embed the 1600px rung, which is the first URL this
+prints.
 
 Usage:
 
-    python3 docs/scripts/upload_image.py ~/Downloads/IMG_1234.jpg assembly/top-interface/step1
+    python3 docs/scripts/upload_image.py ~/Downloads/IMG_1234.jpg [name]
 
-Object names include a hash of their bytes, so a changed image always receives
-a new URL that can safely be cached indefinitely.
+`name` becomes the readable part of the URL (e.g. `top-interface-step1`); it
+defaults to the file's own name. The service appends a hash of the bytes, so
+a changed image is always a new URL that caches forever, and re-uploading the
+same bytes is a no-op that prints the same URLs back.
 
-Credentials come from ~/.config/basically/do-spaces.env (SPACES_KEY /
-SPACES_SECRET) or the environment. Requires Pillow and boto3.
+Credentials are ASSET_SERVICE_URL / ASSET_SERVICE_TOKEN, from the environment
+or ~/.config/asset-service/*.env -- the same pair video_embed.py reads.
+Requires Pillow, only for the EXIF workaround below.
 """
 
 from __future__ import annotations
 
 import argparse
-import hashlib
+import json
 import io
-import mimetypes
 import os
 import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
-import boto3
-from botocore.exceptions import ClientError
-from PIL import Image, ImageOps
+UA = "sorter-v2-docs/1.0 (+https://github.com/basicallysource/sorter-v2)"
+CONFIG_DIR = Path.home() / ".config" / "asset-service"
+NAMESPACE = "sorter-docs"
+EMBED_WIDTH = 1600
 
-MAX_PX = 1600
-JPEG_Q = 82
-SUFFIXES = {".png", ".jpg", ".jpeg", ".webp"}
-
-BUCKET = "basically-docs"
-ENDPOINT = "https://nyc3.digitaloceanspaces.com"
-PUBLIC_BASE = "https://img.basically.website"
-CACHE_CONTROL = "public, max-age=2592000"
-CREDS_FILE = Path.home() / ".config" / "basically" / "do-spaces.env"
+SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+CONTENT_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
 
 
 def load_creds() -> tuple[str, str]:
     env: dict[str, str] = {}
-    if CREDS_FILE.is_file():
-        for line in CREDS_FILE.read_text().splitlines():
+    for path in sorted(CONFIG_DIR.glob("*.env")) if CONFIG_DIR.is_dir() else []:
+        for line in path.read_text().splitlines():
             if "=" in line and not line.startswith("#"):
                 k, _, v = line.partition("=")
-                env[k.strip()] = v.strip()
-    key = os.environ.get("SPACES_KEY") or env.get("SPACES_KEY")
-    secret = os.environ.get("SPACES_SECRET") or env.get("SPACES_SECRET")
-    if not key or not secret:
-        sys.exit(f"missing SPACES_KEY/SPACES_SECRET (set env vars or {CREDS_FILE})")
-    return key, secret
+                env.setdefault(k.strip(), v.strip())
+    url = os.environ.get("ASSET_SERVICE_URL") or env.get("ASSET_SERVICE_URL")
+    token = os.environ.get("ASSET_SERVICE_TOKEN") or env.get("ASSET_SERVICE_TOKEN")
+    if not url or not token:
+        sys.exit(f"missing ASSET_SERVICE_URL/ASSET_SERVICE_TOKEN (env or {CONFIG_DIR}/*.env)")
+    return url.rstrip("/"), token
 
 
-def has_transparency(img: Image.Image) -> bool:
-    if img.mode in ("RGBA", "LA"):
-        alpha = img.getchannel("A")
-        return alpha.getextrema()[0] < 255
-    return img.mode == "P" and "transparency" in img.info
+def prepare(src: Path) -> tuple[bytes, str]:
+    """The bytes to upload, and their content type.
 
+    Normally that is the file exactly as it is. The one exception: a photo
+    whose EXIF says "rotate me". The asset service decodes with Go's stdlib,
+    which ignores that tag, so an untouched phone photo would come back as a
+    sideways ladder. Until the service bakes orientation itself, bake it here
+    and upload the corrected pixels. Delete this whole branch when it does.
+    """
+    raw = src.read_bytes()
+    content_type = CONTENT_TYPES[src.suffix.lower()]
 
-def downscale(img: Image.Image) -> Image.Image:
-    long_side = max(img.size)
-    if long_side <= MAX_PX:
-        return img
-    scale = MAX_PX / long_side
-    new_size = (round(img.width * scale), round(img.height * scale))
-    return img.resize(new_size, Image.LANCZOS)
+    from PIL import Image, ImageOps
 
-
-def make_web_version(src: Path) -> tuple[bytes, str]:
-    with Image.open(src) as img:
+    with Image.open(io.BytesIO(raw)) as img:
+        orientation = img.getexif().get(0x0112, 1)
+        if orientation == 1:
+            return raw, content_type
         img.load()
-        # Bake EXIF orientation into the pixels. A phone photo stores its frames
-        # landscape and carries "rotate me" in a tag; Pillow does not apply it and
-        # the tag does not survive the re-encode below, so without this the web
-        # copy ships sideways while every local preview looks upright.
         img = ImageOps.exif_transpose(img)
-        transparent = has_transparency(img)
-        img = downscale(img)
         buf = io.BytesIO()
-        if transparent:
+        if content_type == "image/png":
             img.save(buf, format="PNG", optimize=True)
-            return buf.getvalue(), ".png"
-        img.convert("RGB").save(
-            buf, format="JPEG", quality=JPEG_Q, optimize=True, progressive=True
-        )
-        return buf.getvalue(), ".jpg"
+        else:
+            img.convert("RGB").save(buf, format="JPEG", quality=95, optimize=True)
+            content_type = "image/jpeg"
+        return buf.getvalue(), content_type
 
 
-def key_exists(s3, key: str) -> bool:
+def request(base: str, token: str, method: str, path: str, body: bytes | None = None,
+            content_type: str | None = None) -> dict:
+    req = urllib.request.Request(base + path, data=body, method=method)
+    req.add_header("User-Agent", UA)
+    req.add_header("Authorization", "Bearer " + token)
+    if content_type:
+        req.add_header("Content-Type", content_type)
     try:
-        s3.head_object(Bucket=BUCKET, Key=key)
-        return True
-    except ClientError:
-        return False
+        with urllib.request.urlopen(req, timeout=300) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:300]
+        sys.exit(f"{method} {path}: HTTP {e.code}: {detail}")
 
 
-def upload(s3, key: str, body: bytes, content_type: str) -> None:
-    if key_exists(s3, key):
-        return
-    s3.put_object(
-        Bucket=BUCKET,
-        Key=key,
-        Body=body,
-        ACL="public-read",
-        ContentType=content_type,
-        CacheControl=CACHE_CONTROL,
-    )
+def embed_url(manifest: dict) -> str:
+    """The URL a docs page should reference: the widest rung <= 1600px."""
+    rungs = [
+        r for r in manifest.get("renditions", [])
+        if r.get("name") != "original"
+        and r.get("content_type", "").startswith("image/")
+        and (r.get("width") or 0) <= EMBED_WIDTH
+    ]
+    if rungs:
+        return max(rungs, key=lambda r: r.get("width") or 0)["url"]
+    # Too small to have a ladder: the original is already the right answer.
+    return manifest["url"]
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("original", type=Path, help="path to the full-resolution image")
-    parser.add_argument(
-        "dest",
-        help="destination path in the bucket, no extension (e.g. assembly/top-interface/step1)",
-    )
-    parser.add_argument(
-        "--skip-original", action="store_true", help="only upload the web version"
-    )
+    parser.add_argument("name", nargs="?", default=None,
+                        help="readable name for the URL (default: the file's own name)")
     args = parser.parse_args()
 
     src: Path = args.original
     if not src.is_file():
         sys.exit(f"no such file: {src}")
     if src.suffix.lower() not in SUFFIXES:
-        sys.exit(f"unsupported image type: {src.suffix}")
-    dest = args.dest.strip("/")
-    dest = str(Path(dest).with_suffix(""))
+        sys.exit(f"unsupported image type: {src.suffix} (HEIC and the like: convert first)")
 
-    key, secret = load_creds()
-    s3 = boto3.client(
-        "s3",
-        endpoint_url=ENDPOINT,
-        aws_access_key_id=key,
-        aws_secret_access_key=secret,
-    )
+    base, token = load_creds()
+    body, content_type = prepare(src)
+    ext = ".jpg" if content_type == "image/jpeg" else src.suffix.lower()
+    filename = (args.name or src.stem) + ext
 
-    web_bytes, web_ext = make_web_version(src)
-    web_hash = hashlib.sha256(web_bytes).hexdigest()[:16]
-    web_key = f"web/{dest}.{web_hash}{web_ext}"
-    web_type = "image/png" if web_ext == ".png" else "image/jpeg"
-    upload(s3, web_key, web_bytes, web_type)
-    print(f"{PUBLIC_BASE}/{web_key}")
+    query = urllib.parse.urlencode({"namespace": NAMESPACE, "filename": filename})
+    manifest = request(base, token, "POST", f"/v1/assets?{query}", body, content_type)
+    key = manifest["key"]
 
-    if not args.skip_original:
-        orig_ext = ".jpg" if src.suffix.lower() == ".jpeg" else src.suffix.lower()
-        orig_bytes = src.read_bytes()
-        orig_hash = hashlib.sha256(orig_bytes).hexdigest()[:16]
-        orig_key = f"originals/{dest}.{orig_hash}{orig_ext}"
-        orig_type = mimetypes.guess_type(str(src))[0] or "application/octet-stream"
-        upload(s3, orig_key, orig_bytes, orig_type)
-        print(f"{PUBLIC_BASE}/{orig_key}")
+    # The ladder is built in the background; for an image that is seconds.
+    deadline = time.monotonic() + 120
+    while manifest.get("renditions_status") == "pending":
+        if time.monotonic() > deadline:
+            print(f"ladder still pending; check later: {base}/v1/assets/{key}", file=sys.stderr)
+            break
+        time.sleep(2)
+        manifest = request(base, token, "GET", f"/v1/assets/{key}")
 
+    print(embed_url(manifest))
+    print(manifest["url"])
     return 0
 
 

--- a/docs/scripts/validate_images.py
+++ b/docs/scripts/validate_images.py
@@ -1,4 +1,13 @@
-"""Reject docs image URLs that are not immutable objects or cannot be fetched."""
+"""Reject docs asset URLs that are not immutable objects or cannot be fetched.
+
+Two URL shapes are checked, both content-addressed:
+
+  https://assets.basically.website/<ns>/<name>-<hash12>.<ext>   the asset service
+  https://img.basically.website/web/<path>.<hash16>.<ext>       legacy; no new ones
+
+Either way the hash in the name must be a prefix of the SHA-256 of the bytes
+the URL actually serves, so a URL can never drift from its content.
+"""
 
 import hashlib
 import re
@@ -7,24 +16,37 @@ import urllib.request
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1] / "src"
-URL = re.compile(r"https://img\.basically\.website/web/[^\s\"<>)]+")
-CONTENT_ADDRESSED = re.compile(r"\.([0-9a-f]{10,})\.")
 
-urls = {
-    url
-    for path in ROOT.rglob("*")
-    if path.suffix in {".md", ".yml"}
-    for url in URL.findall(path.read_text())
-}
+# (url pattern, pattern extracting the claimed hash from a matched url)
+SHAPES = [
+    (
+        re.compile(r"https://assets\.basically\.website/[a-z0-9-]+/[^\s\"<>)]+"),
+        re.compile(r"-([0-9a-f]{12})\.[A-Za-z0-9]+$"),
+    ),
+    (
+        re.compile(r"https://img\.basically\.website/web/[^\s\"<>)]+"),
+        re.compile(r"\.([0-9a-f]{10,})\."),
+    ),
+]
+
+urls: dict[str, re.Pattern] = {}
+for path in ROOT.rglob("*"):
+    if path.suffix not in {".md", ".yml"}:
+        continue
+    text = path.read_text()
+    for url_pattern, hash_pattern in SHAPES:
+        for url in url_pattern.findall(text):
+            urls[url] = hash_pattern
+
 errors = []
-for url in sorted(urls):
-    match = CONTENT_ADDRESSED.search(url)
+for url, hash_pattern in sorted(urls.items()):
+    match = hash_pattern.search(url)
     if not match:
         errors.append(f"not content-addressed: {url}")
         continue
     try:
         request = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-        with urllib.request.urlopen(request, timeout=15) as response:
+        with urllib.request.urlopen(request, timeout=30) as response:
             if response.status != 200:
                 errors.append(f"HTTP {response.status}: {url}")
             elif not hashlib.sha256(response.read()).hexdigest().startswith(match.group(1)):

--- a/docs/scripts/validate_images.py
+++ b/docs/scripts/validate_images.py
@@ -1,12 +1,9 @@
 """Reject docs asset URLs that are not immutable objects or cannot be fetched.
 
-Two URL shapes are checked, both content-addressed:
-
-  https://assets.basically.website/<ns>/<name>-<hash12>.<ext>   the asset service
-  https://img.basically.website/web/<path>.<hash16>.<ext>       legacy; no new ones
-
-Either way the hash in the name must be a prefix of the SHA-256 of the bytes
-the URL actually serves, so a URL can never drift from its content.
+Every asset a page references lives on the asset service and is
+content-addressed: the name ends in a hash of the bytes
+(`<name>-<hash12>.<ext>`), so a URL can never drift from its content. This
+fetches each one and holds it to that.
 """
 
 import hashlib
@@ -16,31 +13,18 @@ import urllib.request
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1] / "src"
+URL = re.compile(r"https://assets\.basically\.website/[a-z0-9-]+/[^\s\"<>)]+")
+CONTENT_ADDRESSED = re.compile(r"-([0-9a-f]{12})\.[A-Za-z0-9]+$")
 
-# (url pattern, pattern extracting the claimed hash from a matched url)
-SHAPES = [
-    (
-        re.compile(r"https://assets\.basically\.website/[a-z0-9-]+/[^\s\"<>)]+"),
-        re.compile(r"-([0-9a-f]{12})\.[A-Za-z0-9]+$"),
-    ),
-    (
-        re.compile(r"https://img\.basically\.website/web/[^\s\"<>)]+"),
-        re.compile(r"\.([0-9a-f]{10,})\."),
-    ),
-]
-
-urls: dict[str, re.Pattern] = {}
-for path in ROOT.rglob("*"):
-    if path.suffix not in {".md", ".yml"}:
-        continue
-    text = path.read_text()
-    for url_pattern, hash_pattern in SHAPES:
-        for url in url_pattern.findall(text):
-            urls[url] = hash_pattern
-
+urls = {
+    url
+    for path in ROOT.rglob("*")
+    if path.suffix in {".md", ".yml"}
+    for url in URL.findall(path.read_text())
+}
 errors = []
-for url, hash_pattern in sorted(urls.items()):
-    match = hash_pattern.search(url)
+for url in sorted(urls):
+    match = CONTENT_ADDRESSED.search(url)
     if not match:
         errors.append(f"not content-addressed: {url}")
         continue
@@ -53,6 +37,14 @@ for url, hash_pattern in sorted(urls.items()):
                 errors.append(f"hash mismatch: {url}")
     except OSError as error:
         errors.append(f"unavailable ({error}): {url}")
+
+stray = {
+    f"{path.relative_to(ROOT)}: {url}"
+    for path in ROOT.rglob("*")
+    if path.suffix in {".md", ".yml"}
+    for url in re.findall(r"https://img\.basically\.website/[^\s\"<>)]+", path.read_text())
+}
+errors += [f"retired domain: {line}" for line in sorted(stray)]
 
 if errors:
     print("\n".join(errors), file=sys.stderr)

--- a/docs/scripts/video_embed.py
+++ b/docs/scripts/video_embed.py
@@ -13,9 +13,9 @@ would drift:
     asset-service upload --derive --namespace sorter-docs <file>
 
 `--derive` matters. The service queues derivation rather than doing it, and
-the queue is only worked while someone runs `asset-service work` somewhere
-(hive-prod is pinned ASSET_RENDITIONS=false on purpose: ffmpeg next to prod
-hive is what that flag exists to prevent). With no worker up, an upload sits
+the queue is only worked while a worker process is up somewhere (the serving
+process deliberately is not one: transcoding next to whatever shares its host
+is what that separation exists for). With no worker up, an upload sits
 `renditions_status: pending` forever and you get no MP4 and no poster.
 `--derive` does the encode on this machine and uploads the results, so it
 never depends on a worker running.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -49,10 +49,10 @@ The bottom interface stacks the chute mount, the Lazy Susan washer, the Lazy Sus
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/exploded-view-cropped.1e520f8cdb04989d.jpg" alt="Exploded view of the bottom interface: chute mount on top, Lazy Susan washer, Lazy Susan bearing, and the corner mounting brackets below">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-exploded-view-cropped-full-b7caae0e6e6f.png" alt="Exploded view of the bottom interface: chute mount on top, Lazy Susan washer, Lazy Susan bearing, and the corner mounting brackets below">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/exploded-view-detail.43115f353ffc8e8a.png" alt="Close-up exploded view of the bottom interface parts separating from the mounting brackets">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-exploded-view-detail-full-43115f353ffc.png" alt="Close-up exploded view of the bottom interface parts separating from the mounting brackets">
   </figure>
 </div>
 
@@ -60,7 +60,7 @@ Once assembled, it mounts into the machine frame:
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/mounted-in-frame.476d171d148ec300.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-mounted-in-frame-full-476d171d148e.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
     <figcaption>Diagram pictures courtesy of Adrianbaker in the basically Discord.</figcaption>
   </figure>
 </div>
@@ -83,7 +83,7 @@ Press the heat inserts into both printed parts while they are still loose. Once 
     <p><strong>Lazy Susan bottom static:</strong> 4 × M4, evenly spaced around the top face.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/prep-bottom-static-inserts.c343287e535671de.jpg" alt="Close-up of the black Lazy Susan bottom static ring with three of its four brass M4 heat inserts clearly visible, pressed flush into the top face">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-prep-bottom-static-inserts-full-55b0a52a2cd1.png" alt="Close-up of the black Lazy Susan bottom static ring with three of its four brass M4 heat inserts clearly visible, pressed flush into the top face">
     <figcaption>Three of the four M4 inserts in the bottom static part. The fourth sits under the chute mount coming down on the right.</figcaption>
   </figure>
 </div>
@@ -98,11 +98,11 @@ Remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardw
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-insert-through-hole.78cbbc1254a95a1e.jpg" alt="Close-up down an aligned hole in the Lazy Susan, with the brass M4 heat insert in the chute mount visible at the bottom of it">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-insert-through-hole-full-a67b71f5c4a7.png" alt="Close-up down an aligned hole in the Lazy Susan, with the brass M4 heat insert in the chute mount visible at the bottom of it">
     <figcaption>Lined up: the brass insert sits at the bottom of the hole.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step1-drive-screw.622f05a7a4fe703e.jpg" alt="Driving a countersunk screw through the Lazy Susan into the chute mount">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step1-drive-screw-full-622f05a7a4fe.jpg" alt="Driving a countersunk screw through the Lazy Susan into the chute mount">
   </figure>
 </div>
 
@@ -111,7 +111,7 @@ Remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardw
   <p>The {% include fastener.html size="M4" variant="countersunk" length="12" %} screws must be very tight. A drill or electric screwdriver will not get them there, so finish them with a hex key by hand. Machine vibration works a loose one out of a spot that is a hassle to reach later.</p>
 </div>
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/lazy-susan-on-chute-mount.d478621b1f81e5ae.jpg" alt="Lazy Susan bearing mounted on the chute mount with the washer between them">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-lazy-susan-on-chute-mount-full-d478621b1f81.jpg" alt="Lazy Susan bearing mounted on the chute mount with the washer between them">
 
 {% include step.html n="3" title="Mount the Lazy Susan to the bottom static part" %}
 
@@ -119,11 +119,11 @@ The bearing's other disc screws down into the bottom static part. All four of th
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-holes-aligned.ebf0c303cdb41f27.jpg" alt="Lazy Susan hole aligned with the pass-through hole, seen from the top">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-holes-aligned-full-ebf0c303cdb4.jpg" alt="Lazy Susan hole aligned with the pass-through hole, seen from the top">
     <figcaption>Seen from the top, with the bearing hole over the pass-through.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-pass-through.0522b2c6e67778df.jpg" alt="Pass-through hole in the chute mount with the screw reachable underneath">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-pass-through-full-0522b2c6e677.jpg" alt="Pass-through hole in the chute mount with the screw reachable underneath">
     <figcaption>The pass-through hole in the chute mount.</figcaption>
   </figure>
 </div>
@@ -132,33 +132,33 @@ Set the chute mount and Lazy Susan assembly onto the bottom static part, then li
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-place-chute-adapter.5d3dfd2a5794d4ef.jpg" alt="Placing the chute mount and Lazy Susan assembly onto the bottom static part">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-place-chute-adapter-full-5d3dfd2a5794.jpg" alt="Placing the chute mount and Lazy Susan assembly onto the bottom static part">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-hole-red-square.fd314fd2c0a2a527.jpg" alt="Pass-through hole lined up over the heat insert, marked with a red square">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-hole-red-square-full-fd314fd2c0a2.jpg" alt="Pass-through hole lined up over the heat insert, marked with a red square">
     <figcaption>Lined up over the marked insert.</figcaption>
   </figure>
 </div>
 
 Drive the first {% include fastener.html size="M4" variant="countersunk" length="12" %} screw through the pass-through hole.
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/step2-screwed-in.92f81fc1417a1a21.jpg" alt="First screw driven through the pass-through hole">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-screwed-in-full-92f81fc1417a.jpg" alt="First screw driven through the pass-through hole">
 
 Rotate the chute on the Lazy Susan, the way it turns in normal operation rather than forcing the whole assembly, to bring the pass-through hole over the next insert. Repeat for all four screws.
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-rotate-90.7139a08a65e920ad.jpg" alt="Rotating the chute with the Lazy Susan to the next screw position">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-rotate-90-full-7139a08a65e9.jpg" alt="Rotating the chute with the Lazy Susan to the next screw position">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step2-after-rotate.cdec5eba44af1747.jpg" alt="Pass-through hole lined up over the next heat insert after rotating">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-after-rotate-full-cdec5eba44af.jpg" alt="Pass-through hole lined up over the next heat insert after rotating">
     <figcaption>Pass-through hole now over the next insert.</figcaption>
   </figure>
 </div>
 
 The bearing stack is now complete:
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-interface/complete.8aa4adc4ac4c5ad9.jpg" alt="The completed bottom interface with chute mount, Lazy Susan bearing, and bottom static part assembled">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-complete-full-8aa4adc4ac4c.jpg" alt="The completed bottom interface with chute mount, Lazy Susan bearing, and bottom static part assembled">
 
 {% include step.html n="4" title="Mount it into the frame" %}
 
@@ -166,11 +166,11 @@ Three Lazy Susan extrusion mounts fix the assembly to the external extrusion of 
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step4-extrusion-mount.875e1c5a694ae3de.jpg" alt="A Lazy Susan extrusion mount and a Lazy Susan hold in place bolted together, forming a grey wedge with a triangular window through its web and two counterbored holes along its bottom face">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-w1600-06391df95795.jpg" alt="A Lazy Susan extrusion mount and a Lazy Susan hold in place bolted together, forming a grey wedge with a triangular window through its web and two counterbored holes along its bottom face">
     <figcaption>The extrusion mount and the hold in place, bolted together.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/bottom-interface/step4-extrusion-mount-on-2020.c91601474f43c5a1.jpg" alt="The same pair with a length of 2020 aluminum extrusion seated in the channel along its sloped edge">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-on-2020-w1600-36f5200925fd.jpg" alt="The same pair with a length of 2020 aluminum extrusion seated in the channel along its sloped edge">
     <figcaption>With a length of 2020 in its channel. Photos by BrickCycleAlice.</figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -57,7 +57,7 @@ parts_needed:
 The bottom two layers are two ordinary bin layers built at the same time, because the vertical extrusion between them is one continuous piece per corner instead of one per layer. That piece is the machine's leg: the caster screws into the bottom of it, so running it up through the bottom layer and into the second gives the wheel something much stiffer to push against than a single layer's worth of extrusion would.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-two-layers/frame-on-casters.e335e00b93578e94.jpg" alt="The bottom of a built machine: two bin-frame layers on six swivel casters, with the extrusion legs running up past the bottom frame into the second, and the start of a third layer's hexagon ring above them">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-two-layers-frame-on-casters-w1600-6454aa70d746.jpg" alt="The bottom of a built machine: two bin-frame layers on six swivel casters, with the extrusion legs running up past the bottom frame into the second, and the start of a third layer's hexagon ring above them">
   <figcaption>The bottom two layers on their casters. The hexagon ring at the top is the next layer starting, not part of these two, so this is about two and a half layers of machine. Photo courtesy of Christoph in the basically Discord.</figcaption>
 </figure>
 
@@ -105,13 +105,13 @@ If you are using slide-in T-nuts, put them in as that guide says. The ends of th
 {% include step.html n="3" title="Run the foot extensions through both layers" %}
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/bottom-two-layers/c-and-d-extrusion.5346ddfabd8d9e45.jpg" alt="The bottom corner of a built machine, with the C layer vertical support marked between the second and third frames and the longer D foot extension marked running from the caster up past the bottom frame to the second">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-two-layers-c-and-d-extrusion-w1600-71a8f20c58c5.jpg" alt="The bottom corner of a built machine, with the C layer vertical support marked between the second and third frames and the longer D foot extension marked running from the caster up past the bottom frame to the second">
   <figcaption>C between the layers above; D from the caster, past the bottom layer's corner, to the second layer. Photo courtesy of Christoph in the basically Discord.</figcaption>
 </figure>
 
 <figure class="figure-float-right">
-  <a href="https://img.basically.website/originals/assembly/bottom-two-layers/foot-corner-section.6ec3353ee6cf01ff.png" target="_blank" rel="noopener">
-    <img src="https://img.basically.website/web/assembly/bottom-two-layers/foot-corner-section.337680f09407c66f.jpg" alt="Vertical cross-section through one corner at the bottom of the machine, showing piece D running through the bottom layer's bracket and up into the second layer, the foot cover around it, and the exposed end below">
+  <a href="https://assets.basically.website/sorter-docs/assembly-bottom-two-layers-foot-corner-section-full-6ec3353ee6cf.png" target="_blank" rel="noopener">
+    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-two-layers-foot-corner-section-full-6ec3353ee6cf.png" alt="Vertical cross-section through one corner at the bottom of the machine, showing piece D running through the bottom layer's bracket and up into the second layer, the foot cover around it, and the exposed end below">
   </a>
   <figcaption>One corner at floor level, cut through the centre of the profile. The bottom layer is blue, the second layer's collar purple. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
 </figure>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -52,10 +52,10 @@ The aluminum extrusion is cut to length; the [framing cut list](https://parts-ca
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/frame-corner-joint.8cbfd8b7506bf318.png" alt="Two A/G aluminum extrusions meeting at an External bracket — side, forming one corner of the hexagon">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-w1600-a47ad55fb797.png" alt="Two A/G aluminum extrusions meeting at an External bracket — side, forming one corner of the hexagon">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/frame-corner-joint-angled.e9321cce8978898d.png" alt="Angled view of the same corner joint, showing the fasteners along the extrusion">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-angled-w1600-6265c41bbf5f.png" alt="Angled view of the same corner joint, showing the fasteners along the extrusion">
   </figure>
 </div>
 
@@ -74,23 +74,23 @@ If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/extrusion-tnut-holes.51f13d97da6705d7.png" alt="Side view of an A/G extrusion showing the row of holes where T-nuts sit and the screws pass through">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-tnut-holes-w1600-b5863688aeea.png" alt="Side view of an A/G extrusion showing the row of holes where T-nuts sit and the screws pass through">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/extrusion-into-bracket.f7f3b91c6fa374d4.png" alt="An A/G extrusion sliding into an External bracket — side">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-into-bracket-w1600-1cd20074b56c.png" alt="An A/G extrusion sliding into an External bracket — side">
   </figure>
 </div>
 
 Repeat these steps to make two semi-circles of three sections of extrusion and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/two-half-hexagons.cfd5d241ba46d491.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-two-half-hexagons-full-5e7c0f80f57f.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/hexagon-assembled.9f17d897cec87f50.png" alt="The completed hexagon frame of six A/G extrusions and six corner brackets">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-hexagon-assembled-full-a1fb3a1b6fb4.png" alt="The completed hexagon frame of six A/G extrusions and six corner brackets">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/hexagon-assembled-top.b6db35fc036a5185.png" alt="Top-down view of the completed hexagon frame">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-hexagon-assembled-top-w1600-5a469702622a.png" alt="Top-down view of the completed hexagon frame">
   </figure>
 </div>
 
@@ -107,7 +107,7 @@ Prepare 12 Frame 90° brackets by drilling out the holes on the long side to all
     loading="lazy"></iframe>
 </div>
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/spoke-brackets-attached.bdf5459b2c7f06bc.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-brackets-attached-w1600-47b3c12e2344.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">
 
 Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
 
@@ -115,10 +115,10 @@ Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/spoke-installed.63790c0e4cedaa87.png" alt="A B/H spoke extrusion standing up in the two Frame 90° brackets">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-installed-w1600-536d49087ec4.png" alt="A B/H spoke extrusion standing up in the two Frame 90° brackets">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/spoke-crossbeams-first.4fbd6e2771158f5a.png" alt="A spoke with a Frame crossbeam slid into place on each side">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-crossbeams-first-full-dca5e96ee46d.png" alt="A spoke with a Frame crossbeam slid into place on each side">
   </figure>
 </div>
 
@@ -126,14 +126,14 @@ On each side of this B/H (Spoke / Interface spoke (short)) slide a Frame crossbe
 
 Perform these steps 2 more times, on every 2nd side of the hexagon.
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/spokes-crossbeams-top.fdcfbec44d9a095d.png" alt="Top-down view of three spokes with crossbeams, forming a partial inner ring">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-crossbeams-top-full-d16c233ea6e1.png" alt="Top-down view of three spokes with crossbeams, forming a partial inner ring">
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/spokes-progress-1.6856de61dff00eff.png" alt="The hexagon partway through spoke installation, some sides done">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-1-w1600-bfbe2a608499.png" alt="The hexagon partway through spoke installation, some sides done">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/spokes-progress-2.6b214ce9f91d3556.png" alt="More spokes and crossbeams filled in around the hexagon">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-2-w1600-5a478c564363.png" alt="More spokes and crossbeams filled in around the hexagon">
   </figure>
 </div>
 
@@ -141,14 +141,14 @@ On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html 
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/spokes-progress-3.46d6de1f2fd52a75.png" alt="Nearly all spokes and crossbeams installed">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-3-w1600-e63cf43ad122.png" alt="Nearly all spokes and crossbeams installed">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/spokes-nearly-complete.8aeb3500e2d37363.png" alt="The spoke ring almost complete, seen at an angle">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-nearly-complete-w1600-8911fb6fef42.png" alt="The spoke ring almost complete, seen at an angle">
   </figure>
 </div>
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/spokes-complete-top.517a329e0407cb17.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-complete-top-full-f9b0a154d84b.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
 
 Secure them in place with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket-button" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="socket-button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
 
@@ -160,10 +160,10 @@ Secure them in place with 2 {% include fastener.html size="M5" variant="socket-b
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/vertical-corner-detail.6f223d95295eb5c8.png" alt="A corner with piece C vertical extrusion held between the External bracket — cover and the External bracket — side, seen from below">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-vertical-corner-detail-w1600-81d31a256733.png" alt="A corner with piece C vertical extrusion held between the External bracket — cover and the External bracket — side, seen from below">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/verticals-installed.c9fb491ca7ad6eb3.png" alt="The hexagon with vertical supports standing up at each corner">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-verticals-installed-full-b1393c02452b.png" alt="The hexagon with vertical supports standing up at each corner">
   </figure>
 </div>
 
@@ -171,10 +171,10 @@ On each corner of your hexagon, slot an External bracket — cover onto the Exte
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/vertical-bottom-bracket.85c0929e5a4e4ed0.png" alt="Close-up of an External bracket — bottom vertical at the base of a corner vertical extrusion">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-vertical-bottom-bracket-w1600-a45e5b572247.png" alt="Close-up of an External bracket — bottom vertical at the base of a corner vertical extrusion">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/regular-layers/verticals-top.a0ee60c91903c400.png" alt="Top view of the layer with vertical supports and bottom brackets at every corner">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-verticals-top-w1600-400576ddb1b6.png" alt="Top view of the layer with vertical supports and bottom brackets at every corner">
   </figure>
 </div>
 
@@ -182,7 +182,7 @@ On each corner, slide an External bracket — bottom vertical onto piece C (Laye
 
 {% include step.html n="4" title="Add the bin retainers" %}
 
-<img class="doc-figure" src="https://img.basically.website/web/assembly/regular-layers/bin-retainers-installed.945ecff28147b1f1.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-bin-retainers-installed-w1600-31bf32089e71.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
 
 On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
 
@@ -191,8 +191,8 @@ A regular layer is now complete. You will also need to construct a [Chute core](
 {% include step.html n="5" title="Join the layer to the one below" %}
 
 <figure class="figure-float-right">
-  <a href="https://img.basically.website/originals/assembly/regular-layers/layer-joint-section.11acc0911bc91277.png" target="_blank" rel="noopener">
-    <img src="https://img.basically.website/web/assembly/regular-layers/layer-joint-section.21c4ee094a2c72b8.jpg" alt="Vertical cross-section through one corner of two stacked layers, with the lower layer's extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, the two screw pairs dashed in red, and six numbered callouts">
+  <a href="https://assets.basically.website/sorter-docs/assembly-regular-layers-layer-joint-section-full-71e3c366f4e7.png" target="_blank" rel="noopener">
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-layer-joint-section-w1600-b40f8b102c10.jpg" alt="Vertical cross-section through one corner of two stacked layers, with the lower layer's extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, the two screw pairs dashed in red, and six numbered callouts">
   </a>
   <figcaption>One corner where any two layers meet, cut through the centre of the profile. Blue is the lower layer, purple the layer above. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
 </figure>

--- a/docs/src/content/hardware/assembly/distribution/external-bracket.md
+++ b/docs/src/content/hardware/assembly/distribution/external-bracket.md
@@ -35,17 +35,17 @@ The fasteners and quantities are in the parts list above and are called out inli
 - Matching parts from the same print run are embossed with a shared set code (e.g. **"b2"**) on both the side bracket and the bottom-vertical part, keep marked pairs together so brackets don't get mixed across sets.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/parts-laid-out.0a59300a73b4f6c2.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-parts-laid-out-full-0a59300a73b4.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
   <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. The cover is fitted last, in Step 4.</figcaption>
 </figure>
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/side-bracket.6649e3954a498346.jpg" alt="Close-up of the side bracket alone, showing the U-shaped extrusion clamp and the two mounting-hole wings">
+    <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-side-bracket-full-6649e3954a49.jpg" alt="Close-up of the side bracket alone, showing the U-shaped extrusion clamp and the two mounting-hole wings">
     <figcaption>The side bracket on its own: the U-shaped opening clamps around the extrusion, and each of the two wings carries a pair of mounting holes.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/bottom-vertical-flange.4b9a511aea49346c.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
+    <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-bottom-vertical-flange-full-4b9a511aea49.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
     <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws in Step 1 go into.</figcaption>
   </figure>
 </div>
@@ -55,7 +55,7 @@ The fasteners and quantities are in the parts list above and are called out inli
 Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws down through the flange into the side bracket.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step1-screwed-underside.d3637471f50acb1b.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step1-screwed-underside-full-d3637471f50a.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
   <figcaption>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.</figcaption>
 </figure>
 
@@ -69,7 +69,7 @@ Set the bottom-vertical leg's flanged top into the U-shaped opening of the side 
 Slide the C-Layer vertical support (the vertical aluminum extrusion) down through the side bracket's U-shaped clamp and into the square socket in the bottom-vertical leg below. The socket is sized to the extrusion's profile, so it can only seat in the correct orientation.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/external-bracket/step2-extrusion-inserted.c56df607b17c4a6c.jpg" alt="C-Layer vertical support extrusion inserted down through the side bracket and into the square socket of the bottom-vertical leg">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step2-extrusion-inserted-full-c56df607b17c.jpg" alt="C-Layer vertical support extrusion inserted down through the side bracket and into the square socket of the bottom-vertical leg">
   <figcaption>C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3.</figcaption>
 </figure>
 
@@ -79,11 +79,11 @@ Two more {% include fastener.html size="M5" variant="socket-button" length="16" 
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-hole-empty.1086433be655ac1f.jpg" alt="Retention screw hole empty, before the screw is driven in">
+    <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step3-screw-hole-empty-full-1086433be655.jpg" alt="Retention screw hole empty, before the screw is driven in">
     <figcaption>Before: retention-screw hole empty.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/step3-screw-driven-in.259bbc4b6fdbb5b2.jpg" alt="Retention screw driven in, seated flush in the hex socket">
+    <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step3-screw-driven-in-full-259bbc4b6fdb.jpg" alt="Retention screw driven in, seated flush in the hex socket">
     <figcaption>After: {% include fastener.html size="M5" variant="socket-button" length="16" %} screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
   </figure>
 </div>
@@ -94,11 +94,11 @@ Clip the cover onto the side bracket to close it off. The cover takes no screws,
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/step4-cover-unattached.9b93d76f94596b23.jpg" alt="The unattached cover sitting next to the assembled bracket, at the face where it clips on">
+    <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step4-cover-unattached-full-9b93d76f9459.jpg" alt="The unattached cover sitting next to the assembled bracket, at the face where it clips on">
     <figcaption>The cover (left), not yet attached, next to the face of the assembly it clips onto.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/external-bracket/step4-cover-clipped-on.1fea5b9a357cc5df.jpg" alt="Finished bracket with the cover clipped into place">
+    <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step4-cover-clipped-on-full-1fea5b9a357c.jpg" alt="Finished bracket with the cover clipped into place">
     <figcaption>Cover clipped into place. It sits flush against the side bracket, which is why the seam is subtle in photos.</figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -127,7 +127,7 @@ The fasteners and quantities in the parts list come from the build notes and are
 Several steps below refer to holes in the Top plate by name (S2 and S3 for the stepper mount, I1 to I6 and O1 to O6 for the interface brackets). This map shows which hole is which:
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/top-plate-hole-map.756f0dae2288fdb2.jpg" alt="Hole map of the hexagonal top plate: three stepper holes S1 to S3 in a row left of the center opening, six inner-ring holes I1 to I6, six outer-ring holes O1 to O6, and five cable holes C1 to C5, colour-coded by group">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-top-plate-hole-map-full-423bbae45ba3.png" alt="Hole map of the hexagonal top plate: three stepper holes S1 to S3 in a row left of the center opening, six inner-ring holes I1 to I6, six outer-ring holes O1 to O6, and five cable holes C1 to C5, colour-coded by group">
   <figcaption>Top plate hole map. S = stepper trio, I = inner ring, O = outer ring, C = cable holes.</figcaption>
 </figure>
 
@@ -140,7 +140,7 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Interface upper fixed section:</strong> 4 × M4</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-upper-fixed-section-inserts-full.5f320973aa8f4976.jpg" alt="The Interface upper fixed section ring, underside with the NEMA 23 bracket attached, showing four brass M4 heat inserts around its face">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-upper-fixed-section-inserts-full-ful-4f73af3a5587.png" alt="The Interface upper fixed section ring, underside with the NEMA 23 bracket attached, showing four brass M4 heat inserts around its face">
     <figcaption>Underside, with the NEMA 23 bracket attached.</figcaption>
   </figure>
 </div>
@@ -150,8 +150,8 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Interface NEMA 23 bracket:</strong> 6 × M5 (4 on the top edges, 2 underneath) and 1 × M3 (on the tail)</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-nema23-inserts.51e9fc75c2c3840c.jpg" alt="The Interface NEMA 23 bracket held up, showing four brass M5 inserts on the top edges and one M3 insert on the long tail">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-nema23-inserts-underside.a2c5f24a51e32932.jpg" alt="The underside of the Interface NEMA 23 bracket, showing the two remaining brass M5 heat inserts">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-nema23-inserts-full-5fda8f6ef8c0.png" alt="The Interface NEMA 23 bracket held up, showing four brass M5 inserts on the top edges and one M3 insert on the long tail">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-nema23-inserts-underside-full-97cf1ce3e1b0.png" alt="The underside of the Interface NEMA 23 bracket, showing the two remaining brass M5 heat inserts">
     <figcaption>Top: four M5 on the edges and one M3 on the tail. Underside: the two remaining M5.</figcaption>
   </figure>
 </div>
@@ -162,11 +162,11 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
-      <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside.d9429f336757fc52.jpg" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
+      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-chute-mount-inserts-underside-full-ec67c0262221.png" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
       <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face.</figcaption>
     </figure>
     <figure>
-      <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-chute-mount-inserts-underside-grey.f48d2c86ebeb1716.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
+      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-chute-mount-inserts-underside-grey-w-52b54ffa44db.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
       <figcaption>A closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw.</figcaption>
     </figure>
   </div>
@@ -177,7 +177,7 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Interface bracket:</strong> 3 × M5 (each of the 6)</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-interface-bracket-inserts.d4d01073358fa475.jpg" alt="An Interface bracket held up, showing three brass M5 heat inserts: one on each long side and one on the tail end">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-interface-bracket-inserts-full-ab1f495c0778.png" alt="An Interface bracket held up, showing three brass M5 heat inserts: one on each long side and one on the tail end">
     <figcaption>One M5 on each long side and one on the tail end.</figcaption>
   </figure>
 </div>
@@ -187,7 +187,7 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Limit switch housing:</strong> 2 × M3</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-limit-switch-housing-inserts-grey.285c56f517498819.jpg" alt="The grey Limit switch housing, showing two brass M3 heat inserts on the angled face where the roller lever limit switch mounts, with the dowel pin hole above them">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-limit-switch-housing-inserts-grey-w1-ef9cced25713.jpg" alt="The grey Limit switch housing, showing two brass M3 heat inserts on the angled face where the roller lever limit switch mounts, with the dowel pin hole above them">
     <figcaption>The two M3 inserts, where the roller lever limit switch mounts.</figcaption>
   </figure>
 </div>
@@ -197,7 +197,7 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Limit switch hammer:</strong> 1 × M3</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-limit-switch-hammer-inserts.8f73ff6876cebff2.jpg" alt="The Limit switch hammer held up, showing a single brass M3 heat insert in its round disc">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-limit-switch-hammer-inserts-full-ff286afdd969.png" alt="The Limit switch hammer held up, showing a single brass M3 heat insert in its round disc">
     <figcaption>One M3 insert in the round disc.</figcaption>
   </figure>
 </div>
@@ -207,7 +207,7 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Cable cage bracket (cable mount):</strong> 1 × M3</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/prep-cable-cage-bracket-cable-inserts.72708f4941f1b0da.jpg" alt="The Cable cage bracket (cable mount) held up, showing a single brass M3 heat insert">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-cable-cage-bracket-cable-inserts-ful-9188d3883103.png" alt="The Cable cage bracket (cable mount) held up, showing a single brass M3 heat insert">
     <figcaption>The one M3 insert in the Cable cage bracket (cable mount).</figcaption>
   </figure>
 </div>
@@ -237,11 +237,11 @@ Attach the whole assembly to the bottom of the Top plate with {% include fastene
 
 <div class="img-row">
   <figure>
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/step2-ribs-upper-fixed-section.7d3f252818e7e1a9.jpg" alt="Six grey Interface ribs attached around the circular Interface upper fixed section">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step2-ribs-upper-fixed-section-w1600-4ebd47453115.jpg" alt="Six grey Interface ribs attached around the circular Interface upper fixed section">
     <figcaption>The 6 Interface ribs attached to the Interface upper fixed section.</figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/step2-nema23-bracket-underside.2b9fc415b05a6d76.jpg" alt="Underside of the Interface upper fixed section with the Interface NEMA 23 bracket seated in its notch">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step2-nema23-bracket-underside-w1600-cb1666b20cca.jpg" alt="Underside of the Interface upper fixed section with the Interface NEMA 23 bracket seated in its notch">
     <figcaption>Underside, with the Interface NEMA 23 bracket seated in its notch.</figcaption>
   </figure>
 </div>
@@ -343,11 +343,11 @@ Once complete, the free section of the Lazy Susan should rotate freely.
 
 <div class="img-row">
   <figure>
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/step6-chute-mount-gear-side.6ea1334010316081.jpg" alt="Gear side of the assembled Top interface chute mount, showing the chute gear, Lazy Susan, and Limit switch hammer">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step6-chute-mount-gear-side-w1600-c3ac0c996f20.jpg" alt="Gear side of the assembled Top interface chute mount, showing the chute gear, Lazy Susan, and Limit switch hammer">
     <figcaption>Gear side, with the Chute gear, Lazy Susan, and Limit switch hammer installed.</figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/step6-chute-mount-underside.9820f5b75d239018.jpg" alt="Chute side of the assembled Top interface chute mount with the Limit switch hammer extending from the edge">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step6-chute-mount-underside-w1600-ef7ef1645c43.jpg" alt="Chute side of the assembled Top interface chute mount with the Limit switch hammer extending from the edge">
     <figcaption>Chute side of the assembled gear and mount.</figcaption>
   </figure>
 </div>
@@ -411,15 +411,15 @@ At this point the chute should still rotate, but you will now feel resistance fr
 
 <div class="img-row">
   <figure>
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/step9-timing-pulley-on-motor.fdc302e89a48e23f.jpg" alt="Timing pulley installed on the shaft of a NEMA 23 stepper motor">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-timing-pulley-on-motor-w1600-0b0a8e04d17c.jpg" alt="Timing pulley installed on the shaft of a NEMA 23 stepper motor">
     <figcaption>Timing pulley installed on the NEMA 23 shaft.</figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/step9-interface-spur-gear.7c03bd4052826aaa.jpg" alt="Grey Interface spur gear secured over the timing pulley with five countersunk screws">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-interface-spur-gear-w1600-7dcec28e692a.jpg" alt="Grey Interface spur gear secured over the timing pulley with five countersunk screws">
     <figcaption>Interface spur gear secured over the Timing pulley with five M3 × 8 mm screws.</figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/step9-idler-gear-bearing.e4ae66ea7d10f086.jpg" alt="608 2RS bearing pressed into the centre of the grey Interface idler gear">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-idler-gear-bearing-w1600-2fe924b61150.jpg" alt="608 2RS bearing pressed into the centre of the grey Interface idler gear">
     <figcaption>608 2RS bearing pressed into the Interface idler gear.</figcaption>
   </figure>
 </div>
@@ -488,19 +488,19 @@ Insert an extrusion piece F (Interface vertical support) into each of the Interf
 **Do not push piece F all the way through the bracket.** Leave its end roughly 20 mm short of the far end of the channel: that is far enough in to cover both pairs of T-nut screws, and it leaves enough of the extrusion standing out to reach past the screws at the base of the layer's External bracket — side later in this step. [Step 14]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}#step-14) shows the whole corner in section.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-1.ae2ef835181f63bd.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-1-full-b8dacf182230.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">
 </figure>
 
 Slide an Interface spacer onto each piece of extrusion, with the lip at the top facing toward the center of the assembly.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-2.b6e8241ef78d74d0.jpg" alt="An interface spacer slid onto each vertical extrusion support, lips facing inward">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-2-w1600-f626512783f3.jpg" alt="An interface spacer slid onto each vertical extrusion support, lips facing inward">
 </figure>
 
 Follow the first two stages of [a regular layer]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}), then place the regular layer assembly onto the interface assembly.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-3.e49b6ce3304489d5.jpg" alt="A regular layer assembly lowered onto the interface assembly">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-3-full-b9ae16940954.jpg" alt="A regular layer assembly lowered onto the interface assembly">
 </figure>
 
 Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the holes at the base of the External bracket sides, bracing against the extrusion. These holes run parallel to the extrusion profile, and the screws are self-tapping. See the [external bracket]({{ '/hardware/assembly/distribution/external-bracket/' | relative_url }}) instructions for building the bracket itself.
@@ -508,15 +508,15 @@ Attach an External bracket cover to each of the External bracket sides, then fas
 {% include step.html n="14" title="How the interface joins the top layer" %}
 
 <figure>
-  <a href="https://img.basically.website/originals/assembly/top-interface/framing-joint.ed0a06d244ffe45d.png" target="_blank" rel="noopener">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-joint.be2cac2fd31d13c3.jpg" alt="The interface assembly upside down on its top plate with six vertical extrusions standing out of it, each held in an interface bracket and sleeved by an interface spacer">
+  <a href="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-joint-full-ed0a06d244ff.png" target="_blank" rel="noopener">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-joint-full-ed0a06d244ff.png" alt="The interface assembly upside down on its top plate with six vertical extrusions standing out of it, each held in an interface bracket and sleeved by an interface spacer">
   </a>
   <figcaption>The interface framing before the top layer goes on, with one arm marked 1 to 3. Click the photo to open it full size.</figcaption>
 </figure>
 
 <figure class="figure-float-right">
-  <a href="https://img.basically.website/originals/assembly/top-interface/joint-section.e96f8eb4493c6488.png" target="_blank" rel="noopener">
-    <img src="https://img.basically.website/web/assembly/top-interface/joint-section.78eb670eb255aa81.jpg" alt="Vertical cross-section through one interface corner, showing the interface bracket and spacer in purple, piece F in grey running down into the top layer's bracket in blue">
+  <a href="https://assets.basically.website/sorter-docs/assembly-top-interface-joint-section-full-e96f8eb4493c.png" target="_blank" rel="noopener">
+    <img src="https://assets.basically.website/sorter-docs/assembly-top-interface-joint-section-full-e96f8eb4493c.png" alt="Vertical cross-section through one interface corner, showing the interface bracket and spacer in purple, piece F in grey running down into the top layer's bracket in blue">
   </a>
   <figcaption>The same corner in section, cut through the centre of the profile. Purple is the interface, blue the top layer's bracket, grey the extrusion. Click to enlarge. The interface parts are not exported in a shared frame with the layer parts, so the part lengths are measured but their heights come from seating each one on the part below it.</figcaption>
 </figure>
@@ -540,6 +540,6 @@ The numbers on the photo and the drawing:
 The top interface is now complete.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/top-interface/framing-4.28f9d54d3c156c6b.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-4-full-b9ae16940954.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
   <figcaption>The finished interface, seen from above with the top plate on.</figcaption>
 </figure>

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -72,7 +72,7 @@ Bolt the Output gear onto the underside of the rotor with 6 {% include fastener.
 **Use the 12 mm, not the 8 mm.** The gear is 8 mm thick at the bolt circle, and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush in the countersink finishes level with the top of the gear and never enters the rotor at all. The 12 mm leaves 4 mm of thread in the rotor's 5 mm flange and stops short of breaking through the far side.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/c-channel/output-gear-bolted-to-rotor.71754b0d6ad3bd9a.jpg" alt="The grey 130-tooth output gear with a black-sealed 6806 bearing pressed into its centre, bolted onto a white rotor behind it, with a countersunk screw at the outer end of each of the six spokes">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-output-gear-bolted-to-rotor-w1600-7ca0b30ba41a.jpg" alt="The grey 130-tooth output gear with a black-sealed 6806 bearing pressed into its centre, bolted onto a white rotor behind it, with a countersunk screw at the outer end of each of the six spokes">
   <figcaption>Output gear, bearing pressed in, bolted to a rotor. Six screws, one per spoke.</figcaption>
 </figure>
 
@@ -83,7 +83,7 @@ The Input gear (12T, screw) has a hole through its boss, parallel to the shaft, 
 The head drops into a counterbore in the boss. Tighten until the head is seated and the gear does not turn on the shaft, and no further, it is threading into plastic.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/c-channel/input-gear-on-motor-shaft.3c0339a7ab383445.jpg" alt="A black NEMA 17 stepper motor lying on its side with the small grey 12-tooth input gear pushed fully onto its shaft, the clamping screw visible in the side of the gear boss">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-on-motor-shaft-w1600-be00a0374988.jpg" alt="A black NEMA 17 stepper motor lying on its side with the small grey 12-tooth input gear pushed fully onto its shaft, the clamping screw visible in the side of the gear boss">
   <figcaption>Pushed fully onto the shaft, clamp screw bearing on the flat.</figcaption>
 </figure>
 
@@ -94,7 +94,7 @@ Drop the Idler gear (24T) onto its post on the NEMA bracket **with the bearing f
 Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3" variant="socket-button" length="16" %} screws. Three, not four: one corner of the motor face is left free. The input gear meshes with the idler as the motor goes down.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/c-channel/idler-gear-and-motor-on-nema-bracket.51305bc394aeafbc.jpg" alt="The three-armed grey NEMA bracket seen from above, with the 24-tooth idler gear sitting on its post with the 608 bearing uppermost, the stepper motor bolted to the outer end of the bracket, and the raised hub at the centre of the bracket">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-idler-gear-and-motor-on-nema-bracket-w1600-dfefb06e2166.jpg" alt="The three-armed grey NEMA bracket seen from above, with the 24-tooth idler gear sitting on its post with the 608 bearing uppermost, the stepper motor bolted to the outer end of the bracket, and the raised hub at the centre of the bracket">
   <figcaption>Idler on its post, bearing up, with the stepper bolted on beside it.</figcaption>
 </figure>
 
@@ -107,7 +107,7 @@ Then lower the rotor, output gear and all, onto the raised hub in the middle of 
 Turn the stage by hand before wiring it. The train should run without a tight spot anywhere in a full revolution.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/assembly/c-channel/stator-and-rotor-fitted.e77448962bc1f578.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
   <figcaption>The finished stage, here the classification one with the finned rotor.</figcaption>
 </figure>
 

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -37,7 +37,7 @@ This page is the wiring. Where the PSU, the control board and the Orange Pi phys
 ## 2 &nbsp; Component layout
 
 <figure class="harness-figure">
-  <img src="https://img.basically.website/web/electronics/component-layout-topdown.2d38b86c4b2e4d05.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
+  <img src="https://assets.basically.website/sorter-docs/electronics-component-layout-topdown-full-2d38b86c4b2e.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
   <figcaption>Physical placement on the machine (top-down): PSU, Orange Pi, basically board v1.3, USB hub, Pico, the chute stepper and its limit switch, and the ribbon run.</figcaption>
 </figure>
 
@@ -226,7 +226,7 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
   </tbody>
 </table>
 
-<img class="doc-figure" src="https://img.basically.website/web/electronics/idc-ribbon-16pin.21fee4f419fb723d.jpg" alt="uxcell 16-pin IDC flat ribbon cable, gray, with FC connectors at both ends">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-idc-ribbon-16pin-full-21fee4f419fb.jpg" alt="uxcell 16-pin IDC flat ribbon cable, gray, with FC connectors at both ends">
 
 ## 5 &nbsp; Parts
 

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -8,7 +8,7 @@ kicker: Electronics — Control board housing
 lede: Closing the control board into its printed housing, with the 40 mm fan on a GPIO-controlled port, and bolting it to the frame.
 permalink: /hardware/electronics/installation/control-board-housing/
 author: spencer
-og_image: https://img.basically.website/web/assembly/control-board-housing/housing-angled.c67cd89578b97f5f.jpg
+og_image: https://assets.basically.website/sorter-docs/assembly-control-board-housing-housing-angled-w1600-d8c3ed33682d.jpg
 parts_needed:
   - part: ctrl-board-housing-base
     qty: 1
@@ -42,7 +42,7 @@ The board needs its drivers, Pico and jumpers in first: see [preparing the contr
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/parts-laid-out.ed286d04e3a094ca.jpg" alt="All the housing parts laid out on a bench: the black printed cover on the left, the populated green control board in the middle, the black printed base with brass inserts on the right, and above them the 40 mm fan, four groups of screws, the plunger retainer and the plunger">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-parts-laid-out-w1600-ce307f40e5fe.jpg" alt="All the housing parts laid out on a bench: the black printed cover on the left, the populated green control board in the middle, the black printed base with brass inserts on the right, and above them the 40 mm fan, four groups of screws, the plunger retainer and the plunger">
     <figcaption>Cover left, board centre, base right.</figcaption>
   </figure>
 </div>
@@ -58,7 +58,7 @@ Press 8 M3 inserts into the base while it is loose: four on the inner bosses for
     <p><strong>Control Board Housing base:</strong> 8 × M3</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://img.basically.website/web/assembly/control-board-housing/base-inserts.2e555ad4361b5ff9.jpg" alt="The printed housing base seen from above, showing the large honeycomb vent in its floor and eight brass M3 heat inserts, four on raised bosses inside and four at the outer corners">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-base-inserts-w1600-b45ee1e919a8.jpg" alt="The printed housing base seen from above, showing the large honeycomb vent in its floor and eight brass M3 heat inserts, four on raised bosses inside and four at the outer corners">
     <figcaption>Four inside, four at the corners.</figcaption>
   </figure>
 </div>
@@ -69,7 +69,7 @@ Sit the board on the four inner bosses and fix it with 4 {% include fastener.htm
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/board-on-base.cec346b931c22df7.jpg" alt="Left, the populated control board screwed flat onto the printed base with its two extrusion clamp bosses at the bottom. Right, the printed cover upside down with the 40 mm fan and the plunger retainer already fitted inside it">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-board-on-base-w1600-481484d82b53.jpg" alt="Left, the populated control board screwed flat onto the printed base with its two extrusion clamp bosses at the bottom. Right, the printed cover upside down with the 40 mm fan and the plunger retainer already fitted inside it">
   </figure>
 </div>
 
@@ -79,7 +79,7 @@ Fan on the inside of the cover, over the vent, label facing into the enclosure s
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/fan-in-cover.c945a84566cafed1.jpg" alt="The inside of the printed cover with the 40 mm WINSINN fan screwed down over its vent opening on four screws, its red and black lead running off to the left, and the rectangular plunger slot beside it">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-fan-in-cover-w1600-73bbe941cbdb.jpg" alt="The inside of the printed cover with the 40 mm WINSINN fan screwed down over its vent opening on four screws, its red and black lead running off to the left, and the rectangular plunger slot beside it">
   </figure>
 </div>
 
@@ -89,7 +89,7 @@ The plunger lands on the board's reset button, so the button can be pressed with
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/retainer-fitted.9b5186fe6c45a466.jpg" alt="Inside the cover, the retainer screwed down on two countersunk screws over the plunger, capturing it so it can slide but not fall out, with the fan behind">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-retainer-fitted-w1600-c7677da6c247.jpg" alt="Inside the cover, the retainer screwed down on two countersunk screws over the plunger, capturing it so it can slide but not fall out, with the fan behind">
   </figure>
 </div>
 
@@ -104,7 +104,7 @@ The fan runs off one of the board's four LED ports, which are 24 V switched to g
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/fan-into-led-port.74abe08742b086c0.jpg" alt="Looking down through the cover's corner cutout at the board below, where the fan's red and black lead is plugged into the two-pin connector silkscreened LED_1_2, with Controlled by GPIO6 printed beside it">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-fan-into-led-port-w1600-cfd2665dc48e.jpg" alt="Looking down through the cover's corner cutout at the board below, where the fan's red and black lead is plugged into the two-pin connector silkscreened LED_1_2, with Controlled by GPIO6 printed beside it">
     <figcaption>Into LED_1_2, driven by GPIO6.</figcaption>
   </figure>
 </div>
@@ -120,10 +120,10 @@ Lower the cover on, keeping the fan lead clear of the board, and fix it with 4 {
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/cover-on-base.8c6a304677a0aff3.jpg" alt="The cover set down on the base with the housing closed, the fan's lead emerging through the corner cutout, and four countersunk screws lying on the bench beside it ready to go in">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-cover-on-base-w1600-a77ec49b9e64.jpg" alt="The cover set down on the base with the housing closed, the fan's lead emerging through the corner cutout, and four countersunk screws lying on the bench beside it ready to go in">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/housing-angled.c67cd89578b97f5f.jpg" alt="The finished housing at an angle, showing the honeycomb vent and basically logo on the lid, the plunger standing proud of the surface, and the slots along the right edge that expose the stepper connectors">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-housing-angled-w1600-d8c3ed33682d.jpg" alt="The finished housing at an angle, showing the honeycomb vent and basically logo on the lid, the plunger standing proud of the surface, and the slots along the right edge that expose the stepper connectors">
   </figure>
 </div>
 
@@ -133,7 +133,7 @@ Press the plunger on the lid. You should hear the button click.
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/plunger-outside.2bf22968c23a6de8.jpg" alt="Close-up of the lid surface showing the small square head of the plunger standing proud of the textured black plastic, with the honeycomb vent and basically logo nearby">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-plunger-outside-w1600-737114636bdb.jpg" alt="Close-up of the lid surface showing the small square head of the plunger standing proud of the textured black plastic, with the honeycomb vent and basically logo nearby">
   </figure>
 </div>
 
@@ -153,7 +153,7 @@ The two clamp bosses go onto the 2020 extrusion on 2 <span class="fastener-todo"
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-housing/on-the-extrusion.e931ee126522ca7a.jpg" alt="The finished housing bolted down onto a 2020 aluminium extrusion under the machine's frame, with two socket head screws through its clamp bosses">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-on-the-extrusion-w1600-813fbb56a0d6.jpg" alt="The finished housing bolted down onto a 2020 aluminium extrusion under the machine's frame, with two socket head screws through its clamp bosses">
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/installation/control-board-prep.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-prep.md
@@ -23,7 +23,7 @@ Do this with the board loose, before the [housing]({{ '/hardware/electronics/ins
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-prep/board-and-drivers.d73a864873c01f96.jpg" alt="The bare green basically Embedded Control Board on a wooden bench with five blue-finned TMC2209 stepper driver modules laid out in a row above it">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-board-and-drivers-w1600-f6a7efe7c0f4.jpg" alt="The bare green basically Embedded Control Board on a wooden bench with five blue-finned TMC2209 stepper driver modules laid out in a row above it">
   </figure>
 </div>
 
@@ -33,10 +33,10 @@ Heatsink up, EN/MS1/MS2 edge towards the middle of the board. Module and socket 
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-prep/tmc2209-pin-labels.a0d27718998d52fe.jpg" alt="A single TMC2209 V1.3 driver module standing on a bench, blue heatsink upwards, with its pin names readable around the edge">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-tmc2209-pin-labels-w1600-aed1004e7d8a.jpg" alt="A single TMC2209 V1.3 driver module standing on a bench, blue heatsink upwards, with its pin names readable around the edge">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-prep/driver-seated.97aeb44b9afe65a1.jpg" alt="A TMC2209 driver pushed fully down into its socket on the control board, heatsink upwards, with the remaining drivers out of focus behind">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-driver-seated-w1600-6f0cbd6bc7ae.jpg" alt="A TMC2209 driver pushed fully down into its socket on the control board, heatsink upwards, with the remaining drivers out of focus behind">
   </figure>
 </div>
 
@@ -46,10 +46,10 @@ Into the two long sockets down the middle, USB end towards the edge of the board
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-prep/pico-seating.dd7bd2b6e2d04f4c.jpg" alt="A Raspberry Pi Pico held just above its two long header sockets on the control board, ready to be pushed down, with seated stepper drivers behind it">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-pico-seating-w1600-4b85e9758bc6.jpg" alt="A Raspberry Pi Pico held just above its two long header sockets on the control board, ready to be pushed down, with seated stepper drivers behind it">
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-prep/pico-seated.24130da97b181d5f.jpg" alt="The Raspberry Pi Pico fully seated in its sockets on the control board, sitting flat and parallel to the board">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-pico-seated-w1600-f0cbb025b91c.jpg" alt="The Raspberry Pi Pico fully seated in its sockets on the control board, sitting flat and parallel to the board">
   </figure>
 </div>
 
@@ -59,7 +59,7 @@ The drivers share a UART bus, so each needs an address, and the address is set b
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-prep/jumper-states.fec0b0daeeff2809.jpg" alt="Annotated close-up of one driver's MS1 and MS2 headers: MS1 boxed in green with its jumper on pins 1 and 2 for 3V3, MS2 boxed in blue with its jumper on pins 2 and 3 for GND, beside a table mapping the four combinations to addresses 0 to 3">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-jumper-states-w1600-5c293a831c56.jpg" alt="Annotated close-up of one driver's MS1 and MS2 headers: MS1 boxed in green with its jumper on pins 1 and 2 for 3V3, MS2 boxed in blue with its jumper on pins 2 and 3 for GND, beside a table mapping the four combinations to addresses 0 to 3">
   </figure>
 </div>
 
@@ -85,7 +85,7 @@ This is a correctly jumpered board.
 
 <div class="img-row">
   <figure>
-    <img src="https://img.basically.website/web/assembly/control-board-prep/all-jumpers-fitted.b17750ab6055f876.jpg" alt="Top-down view of the fully populated control board, with five TMC2209 drivers, the Raspberry Pi Pico, and ten yellow jumpers fitted across the MS1 and MS2 headers">
+    <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-all-jumpers-fitted-w1600-f470f24a8913.jpg" alt="Top-down view of the fully populated control board, with five TMC2209 drivers, the Raspberry Pi Pico, and ten yellow jumpers fitted across the MS1 and MS2 headers">
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -21,7 +21,7 @@ The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover wh
 The PSU, the control board and the Orange Pi each live in their own mount, and all three bolt to the machine's 2020 frame with 2 <span class="fastener-todo">M5, length not recorded</span> screws each, six in total.
 
 <figure>
-  <img class="doc-figure" src="https://img.basically.website/web/electronics/component-layout-topdown.2d38b86c4b2e4d05.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-component-layout-topdown-full-2d38b86c4b2e.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
   <figcaption>Where everything sits, top-down. This photo is currently the only record of the placement.</figcaption>
 </figure>
 

--- a/docs/src/content/hardware/electronics/psu-pigtail.md
+++ b/docs/src/content/hardware/electronics/psu-pigtail.md
@@ -23,7 +23,7 @@ The PSU box has three DC outputs, and each one is a short pigtail: two crimp spa
 </div>
 
 <figure class="harness-figure">
-  <img src="https://img.basically.website/web/harness/psu-pigtail-built.dc73ad657b30cce2.jpg" alt="An assembled PSU output pigtail: a panel-mount barrel jack with red and black 18 AWG leads, each ending in an insulated spade terminal">
+  <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-built-w1600-59554dc6b189.jpg" alt="An assembled PSU output pigtail: a panel-mount barrel jack with red and black 18 AWG leads, each ending in an insulated spade terminal">
   <figcaption>One assembled pigtail: panel-mount barrel jack, red +24V and black ground leads, an insulated spade terminal crimped on each.</figcaption>
 </figure>
 
@@ -56,19 +56,19 @@ The crimp is the fiddly part. Strip the wire, seat it fully in the terminal barr
 
 <div class="photo-grid">
   <figure>
-    <img src="https://img.basically.website/web/harness/psu-pigtail-step1-stripped.d4bb7664ad7ef113.png" alt="Stripped end of the 18 AWG wire showing bare strands">
+    <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step1-stripped-w1600-7fe6beee8efc.png" alt="Stripped end of the 18 AWG wire showing bare strands">
     <figcaption>1. Strip the wire back to bare strands.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/harness/psu-pigtail-step2-terminal.a6187f03935ad6ed.png" alt="Stripped wire seated in the spade terminal barrel, not yet crimped">
+    <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step2-terminal-w1600-6302bb6e8bc4.png" alt="Stripped wire seated in the spade terminal barrel, not yet crimped">
     <figcaption>2. Seat the bare strands fully in the terminal barrel.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/harness/psu-pigtail-step3-crimping.13c6e57cff511a3a.png" alt="Crimping the terminal in the red 22 to 16 AWG die of a ratcheting crimp tool">
+    <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step3-crimping-w1600-0ecacc7e17fd.png" alt="Crimping the terminal in the red 22 to 16 AWG die of a ratcheting crimp tool">
     <figcaption>3. Crimp in the matching die — the red (22–16 AWG) jaw suits the 18 AWG wire.</figcaption>
   </figure>
   <figure>
-    <img src="https://img.basically.website/web/harness/psu-pigtail-step4-crimped.5988df4ada6c0bb2.png" alt="The finished crimp with the insulation grip closed on the wire jacket">
+    <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step4-crimped-w1600-ba1c9b488c45.png" alt="The finished crimp with the insulation grip closed on the wire jacket">
     <figcaption>4. Finished: the grip is closed on the jacket and the wire will not pull out.</figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/helpers/heat-inserts.md
+++ b/docs/src/content/hardware/helpers/heat-inserts.md
@@ -22,8 +22,8 @@ You can install the brass inserts with a soldering iron or a dedicated heat-set 
 ## Using a soldering iron
 
 <div class="img-row">
-  <figure><img src="https://img.basically.website/web/assembly/heat-inserts/soldering-iron-insert-placed.79c096bde443b732.jpg" alt="Brass heat insert standing over its hole in a printed part, thinner end down, next to an insert already installed flush"><figcaption>Set each insert over its hole, thinner section first.</figcaption></figure>
-  <figure><img src="https://img.basically.website/web/assembly/heat-inserts/soldering-iron-pressing-insert.b9467173b8056483.jpg" alt="Soldering iron tip centered on a heat insert, pressing it straight down into the part"><figcaption>Center the tip and press gently while it heats.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-insert-placed-w1600-7615c6569fb3.jpg" alt="Brass heat insert standing over its hole in a printed part, thinner end down, next to an insert already installed flush"><figcaption>Set each insert over its hole, thinner section first.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-pressing-insert-w1600-b18b63647483.jpg" alt="Soldering iron tip centered on a heat insert, pressing it straight down into the part"><figcaption>Center the tip and press gently while it heats.</figcaption></figure>
 </div>
 
 Place each insert above its cavity, straight and centered, with the thinner section going in first. Line the soldering iron tip up with the center of the insert and apply slight pressure while it heats up, about 20 seconds. Once the insert passes the plastic's melt temperature it starts to descend into the part. Push it down straight into the hole, not at an angle.
@@ -37,7 +37,7 @@ It travels faster as it gets hotter, so keep a steady hand. Larger inserts take 
 
 ## Using a heat press
 
-<img class="doc-figure" src="https://img.basically.website/web/tools/heat-insert-press.3890a976bbb772d5.jpg" alt="Benchtop heat-set insert press with a set of tips">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/tools-heat-insert-press-full-3890a976bbb7.jpg" alt="Benchtop heat-set insert press with a set of tips">
 
 A {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-Heat-Insertion-Threaded-Components/dp/B0FRXF1ZH6" text="heat-set insert press" %} is the easiest way to install them: it holds the insert square and drives it straight down, so you just line it up over the hole and lower the arm. The video below shows the process.
 

--- a/docs/src/content/hardware/helpers/lazy-susan.md
+++ b/docs/src/content/hardware/helpers/lazy-susan.md
@@ -13,7 +13,7 @@ parts_needed:
 tools_needed: [Pliers]
 ---
 
-<img class="doc-figure" src="https://img.basically.website/web/helpers/lazy-susan.624357a2efa7d60e.jpg" alt="8-inch lazy Susan bearing; the rubber foot to remove is boxed in red">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/helpers-lazy-susan-full-624357a2efa7.jpg" alt="8-inch lazy Susan bearing; the rubber foot to remove is boxed in red">
 
 Background on the part — sourcing, load rating, the 8" variant — is on the [Lazy Susan part page]({{ '/hardware/parts/lazy-susan/' | relative_url }}).
 

--- a/docs/src/content/hardware/helpers/pulley-gear-mod.md
+++ b/docs/src/content/hardware/helpers/pulley-gear-mod.md
@@ -18,8 +18,8 @@ The 20-tooth timing pulley needs its top flange removed before it fits into the 
 ## Remove the top flange
 
 <div class="img-row">
-  <figure><img src="https://img.basically.website/web/helpers/timing-pulley/before-flange-removal.19deceb4e5706b6d.jpg" alt="20-tooth timing pulley before preparation, with the top flange attached"><figcaption>Before: top flange attached.</figcaption></figure>
-  <figure><img src="https://img.basically.website/web/helpers/timing-pulley/after-flange-removal.1dabaa6e3a0563d3.jpg" alt="20-tooth timing pulley after preparation, with the removed top flange beside it"><figcaption>After: top flange removed.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-before-flange-removal-w1600-cb631cc9caf6.jpg" alt="20-tooth timing pulley before preparation, with the top flange attached"><figcaption>Before: top flange attached.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-after-flange-removal-w1600-fbac3db7df0c.jpg" alt="20-tooth timing pulley after preparation, with the removed top flange beside it"><figcaption>After: top flange removed.</figcaption></figure>
 </div>
 
 Grip the top flange with needle-nose pliers and pry it upwards. It should pop off cleanly without damaging the pulley.

--- a/docs/src/content/hardware/parts/lazy-susan.md
+++ b/docs/src/content/hardware/parts/lazy-susan.md
@@ -10,7 +10,7 @@ permalink: /hardware/parts/lazy-susan/
 author: spencer
 ---
 
-<img class="doc-figure" src="https://img.basically.website/web/lazy-susan-top.f7085d147da1318c.jpg" alt="8-inch lazy Susan bearing, top view">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/lazy-susan-top-full-f7085d147da1.jpg" alt="8-inch lazy Susan bearing, top view">
 
 Repurposed from a dinner-table lazy Susan. It's rated for heavy loads — at least 50 lb, likely more — and holds up well over long run times, with no manufacturing issues seen across Amazon and AliExpress sources. Use the **8" variant**; see the [BOM](https://docs.google.com/spreadsheets/d/1aoxcyK0xa0i3iWYlO4u3-vsruOGU8V_U9XT65YhMZmY/edit?gid=0#gid=0) for sources.
 

--- a/docs/src/content/notes/3v2p.md
+++ b/docs/src/content/notes/3v2p.md
@@ -28,7 +28,7 @@ outer cable clamp, were clean.
 
 <div class="img-row">
   <figure>
-  <img src="https://img.basically.website/web/notes/3v2p/camera-extension-q7ns-1253c651-site-1.e3c999146b1f1ff7.jpg" alt="Four views of the camera extension: the whole part with a red ring around a spot in its raised 50mm lettering, then two zooms showing a red sliver crossing the letter m, then the same view with every triangle drawn">
+  <img src="https://assets.basically.website/sorter-docs/notes-3v2p-camera-extension-q7ns-1253c651-site-1-w1600-3e287e2afa64.jpg" alt="Four views of the camera extension: the whole part with a red ring around a spot in its raised 50mm lettering, then two zooms showing a red sliver crossing the letter m, then the same view with every triangle drawn">
   <figcaption>The only defect on the part, and it is inside the lettering. Red is the bad geometry, yellow the non-manifold edges. The bottom right panel draws every triangle: extruded text tessellates into slivers where the strokes meet, and four of them came out with no area at all.</figcaption>
   </figure>
 </div>
@@ -39,14 +39,14 @@ Two sites, both on the feather edge at the bottom end of the part, 8 mm apart.
 
 <div class="img-row">
   <figure>
-  <img src="https://img.basically.website/web/notes/3v2p/cable-clamp-inner-3fue-a77f4963-site-1.1da7e0eb5fa022ee.jpg" alt="Four views of the inner cable clamp: the whole part with a red ring near its lower tip, then zooms showing a red fan of triangles around a small hole outlined in yellow, then the same view with every triangle drawn">
+  <img src="https://assets.basically.website/sorter-docs/notes-3v2p-cable-clamp-inner-3fue-a77f4963-site-1-w1600-ceb025db8ec6.jpg" alt="Four views of the inner cable clamp: the whole part with a red ring near its lower tip, then zooms showing a red fan of triangles around a small hole outlined in yellow, then the same view with every triangle drawn">
   <figcaption>Site 1: a hole 0.40 by 0.22 by 0.32 mm, its rim in yellow.</figcaption>
   </figure>
 </div>
 
 <div class="img-row">
   <figure>
-  <img src="https://img.basically.website/web/notes/3v2p/cable-clamp-inner-3fue-a77f4963-site-2.130f90f1459bb3d3.jpg" alt="Four views of the same part at a second spot, showing a thin red line where two triangles lie on top of each other, and the same spot with every triangle drawn">
+  <img src="https://assets.basically.website/sorter-docs/notes-3v2p-cable-clamp-inner-3fue-a77f4963-site-2-w1600-05b88bb3f18c.jpg" alt="Four views of the same part at a second spot, showing a thin red line where two triangles lie on top of each other, and the same spot with every triangle drawn">
   <figcaption>Site 2: the same triangle twice, facing opposite ways. It is 0.10 mm long and 0.003 mm wide, so from every direction it draws as a line.</figcaption>
   </figure>
 </div>

--- a/docs/src/content/sorter/safe-shutdown.md
+++ b/docs/src/content/sorter/safe-shutdown.md
@@ -15,13 +15,13 @@ The machine's computer writes files continuously while it runs. Cutting power mi
 
 Click the dropdown at the top right of the UI and select **Full Machine Power Down**.
 
-<img class="doc-figure" src="https://img.basically.website/web/sorter/safe-shutdown/full-machine-power-down-menu.fb7d3867ed810a3c.jpg" alt="The top-right UI dropdown open, showing the Full Machine Power Down action">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/sorter-safe-shutdown-full-machine-power-down-menu-full-fb7d3867ed81.jpg" alt="The top-right UI dropdown open, showing the Full Machine Power Down action">
 
 ## Option 2: the button on the Orange Pi
 
 Press the small black button on the side of the Orange Pi once (circled below). That begins the shutdown procedure.
 
-<img class="doc-figure" src="https://img.basically.website/web/sorter/safe-shutdown/orange-pi-power-button.a39aa5a490fc08a0.jpg" alt="Orange Pi 5 board with the side power button circled in red">
+<img class="doc-figure" src="https://assets.basically.website/sorter-docs/sorter-safe-shutdown-orange-pi-power-button-full-a39aa5a490fc.jpg" alt="Orange Pi 5 board with the side power button circled in red">
 
 You'll know it's shut down when the red and green light on the board have stopped blinking.
 

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -1,8 +1,8 @@
 # The drawings on the WireViz page, in display order.
 #
 # The URLs below are literal on purpose. Every harness artifact is published
-# under a name containing a hash of its own bytes, nothing in the bucket is
-# ever overwritten, and nothing here is derived at build time -- so a drawing's
+# under a name containing a hash of its own bytes, nothing in the asset
+# service is ever overwritten, and nothing here is derived at build time -- so a drawing's
 # URL changes in the same commit that changes the drawing, and the docs can
 # never name bytes that have not been uploaded yet. Do not replace these with
 # anything computed; see electronics/wire_harness/AGENTS.md for the outage that
@@ -38,7 +38,7 @@ drawings:
       One output pigtail, x3 per PSU build. Spade terminals onto a +V/-V screw
       pair on the PSU terminal block (7 with 4, 8 with 5, 9 with 6),
       panel-mount jack on the other end.
-    photo: https://img.basically.website/web/harness/psu-pigtail-built.dc73ad657b30cce2.jpg
+    photo: https://assets.basically.website/sorter-docs/harness-psu-pigtail-built-w1600-59554dc6b189.jpg
     guide: /hardware/electronics/psu-pigtail/
     guide_label: How to make your own
     png: https://assets.basically.website/sorter-harness/psu-pigtail-full-e7a2cf6fc86b.png

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -15,7 +15,7 @@
 # an entry in the `drawings` list in electronics/wire_harness/build-harness.sh
 # (the supplier zip's member list), then the same paste.
 
-zip: https://img.basically.website/harness/sorter-v2-harness-rfq.991d26a95b.zip
+zip: https://assets.basically.website/sorter-harness/sorter-v2-harness-rfq-991d26a95b1a.zip
 
 drawings:
   - name: power
@@ -25,12 +25,12 @@ drawings:
       board, the USB hub and the Orange Pi buck. Dashed arrows are barrel
       jack/plug mates. This is the overview; the two buildable sub-harnesses
       it is made of are below it.
-    png: https://img.basically.website/harness/power.accd2693fc.png
-    svg: https://img.basically.website/harness/power.bb0170bcf7.svg
-    pdf: https://img.basically.website/harness/power.5a209a1996.pdf
-    html: https://img.basically.website/harness/power.18ee285018.html
-    bom_tsv: https://img.basically.website/harness/power.514757618c.bom.tsv
-    yml: https://img.basically.website/harness/power.a708057c45.yml
+    png: https://assets.basically.website/sorter-harness/power-full-accd2693fc83.png
+    svg: https://assets.basically.website/sorter-harness/power-bb0170bcf748.svg
+    pdf: https://assets.basically.website/sorter-harness/power-5a209a1996e1.pdf
+    html: https://assets.basically.website/sorter-harness/power-18ee285018a3.html
+    bom_tsv: https://assets.basically.website/sorter-harness/power-bom-514757618cb2.tsv
+    yml: https://assets.basically.website/sorter-harness/power-a708057c45fd.yml
   - name: psu-pigtail
     title: PSU output pigtail
     of: power
@@ -41,43 +41,43 @@ drawings:
     photo: https://img.basically.website/web/harness/psu-pigtail-built.dc73ad657b30cce2.jpg
     guide: /hardware/electronics/psu-pigtail/
     guide_label: How to make your own
-    png: https://img.basically.website/harness/psu-pigtail.e7a2cf6fc8.png
-    svg: https://img.basically.website/harness/psu-pigtail.7cdf562b21.svg
-    pdf: https://img.basically.website/harness/psu-pigtail.791cdb0604.pdf
-    html: https://img.basically.website/harness/psu-pigtail.f77e0cb7d1.html
-    bom_tsv: https://img.basically.website/harness/psu-pigtail.dc2ee3359b.bom.tsv
-    yml: https://img.basically.website/harness/psu-pigtail.78398a1b40.yml
+    png: https://assets.basically.website/sorter-harness/psu-pigtail-full-e7a2cf6fc86b.png
+    svg: https://assets.basically.website/sorter-harness/psu-pigtail-7cdf562b2118.svg
+    pdf: https://assets.basically.website/sorter-harness/psu-pigtail-791cdb0604d1.pdf
+    html: https://assets.basically.website/sorter-harness/psu-pigtail-f77e0cb7d14b.html
+    bom_tsv: https://assets.basically.website/sorter-harness/psu-pigtail-bom-dc2ee3359b91.tsv
+    yml: https://assets.basically.website/sorter-harness/psu-pigtail-78398a1b408a.yml
   - name: board-power
     title: 24V to basically board v1.3
     of: power
     caption: >-
       The board's own feed, W1 on the overview: barrel plug to JST VHR-2.
-    png: https://img.basically.website/harness/board-power.2077cc9520.png
-    svg: https://img.basically.website/harness/board-power.c950376537.svg
-    pdf: https://img.basically.website/harness/board-power.a486b9cc36.pdf
-    html: https://img.basically.website/harness/board-power.358cd9a9b1.html
-    bom_tsv: https://img.basically.website/harness/board-power.8a0dcbe9b9.bom.tsv
-    yml: https://img.basically.website/harness/board-power.4a74845402.yml
+    png: https://assets.basically.website/sorter-harness/board-power-full-2077cc9520d9.png
+    svg: https://assets.basically.website/sorter-harness/board-power-c95037653768.svg
+    pdf: https://assets.basically.website/sorter-harness/board-power-a486b9cc36b1.pdf
+    html: https://assets.basically.website/sorter-harness/board-power-358cd9a9b175.html
+    bom_tsv: https://assets.basically.website/sorter-harness/board-power-bom-8a0dcbe9b9db.tsv
+    yml: https://assets.basically.website/sorter-harness/board-power-4a748454026a.yml
   - name: steppers
     title: Stepper cables
     caption: >-
       The S1-S4 cable, board PHR-4 to the motor's own PHR-6 with positions 2
       and 5 empty, and the straight-through chute cable to bare labeled leads.
-    png: https://img.basically.website/harness/steppers.159f359901.png
-    svg: https://img.basically.website/harness/steppers.eacbb304ec.svg
-    pdf: https://img.basically.website/harness/steppers.8e0287634d.pdf
-    html: https://img.basically.website/harness/steppers.258dcdd1f1.html
-    bom_tsv: https://img.basically.website/harness/steppers.3ac179ba97.bom.tsv
-    yml: https://img.basically.website/harness/steppers.99da013432.yml
+    png: https://assets.basically.website/sorter-harness/steppers-full-159f35990114.png
+    svg: https://assets.basically.website/sorter-harness/steppers-eacbb304ec1e.svg
+    pdf: https://assets.basically.website/sorter-harness/steppers-8e0287634d6b.pdf
+    html: https://assets.basically.website/sorter-harness/steppers-258dcdd1f1c7.html
+    bom_tsv: https://assets.basically.website/sorter-harness/steppers-bom-3ac179ba971c.tsv
+    yml: https://assets.basically.website/sorter-harness/steppers-99da01343286.yml
   - name: leds
     title: LED drops and limit switch
     caption: >-
       LED feeds L1-L3 to their unplug-point jacks, pigtails L1p-L3p to the COB
       boards and strip, and the limit switch cable (keyed 1x3 dupont at the
       board, push-on blade terminals at the switch).
-    png: https://img.basically.website/harness/leds.065014faab.png
-    svg: https://img.basically.website/harness/leds.8969f2e3a5.svg
-    pdf: https://img.basically.website/harness/leds.2a2e3242ec.pdf
-    html: https://img.basically.website/harness/leds.a879d3ac53.html
-    bom_tsv: https://img.basically.website/harness/leds.8e56b3c7a6.bom.tsv
-    yml: https://img.basically.website/harness/leds.49b1ed5fd9.yml
+    png: https://assets.basically.website/sorter-harness/leds-full-065014faab6f.png
+    svg: https://assets.basically.website/sorter-harness/leds-8969f2e3a51e.svg
+    pdf: https://assets.basically.website/sorter-harness/leds-2a2e3242ec1d.pdf
+    html: https://assets.basically.website/sorter-harness/leds-a879d3ac5360.html
+    bom_tsv: https://assets.basically.website/sorter-harness/leds-bom-8e56b3c7a6d4.tsv
+    yml: https://assets.basically.website/sorter-harness/leds-49b1ed5fd9fd.yml

--- a/electronics/wire_harness/AGENTS.md
+++ b/electronics/wire_harness/AGENTS.md
@@ -10,12 +10,13 @@ into everything the docs and a cable vendor need.
 `power.yml`, `steppers.yml`, `leds.yml` and `rfq.txt` are the source of truth:
 small, diffable text. Reviewing a harness change means reviewing them.
 Everything derived (PNG, SVG, PDF, HTML, per-cable BOM, the supplier RFQ zip)
-is a build artifact, and build artifacts live in the `basically-docs` assets
-bucket under a name carrying a hash of their own bytes:
+is a build artifact, and build artifacts live in the **asset service**
+(`assets.basically.website`, public repo `basicallysource/asset-service`,
+namespace `sorter-harness`) under a name carrying a hash of their own bytes:
 
-    https://img.basically.website/harness/power.2c0ebc6cd1.png
+    https://assets.basically.website/sorter-harness/power-accd2693fc83.png
 
-**Nothing in the bucket is ever overwritten**, and nothing about these URLs is
+**Nothing in the store is ever overwritten**, and nothing about these URLs is
 derived at docs-build time. They are literal strings in
 `docs/src/liquid/_data/harness.yml`, pasted from the render that produced them
 — the same contract `docs/scripts/upload_image.py` has always had for photos,
@@ -50,29 +51,15 @@ incognito. A
 content-addressed name fixes all three at once, because the object now exists
 before any commit can name it.
 
-`img.basically.website` is a Cloudflare Worker (`docs/scripts/img-worker/`) in
-front of the bucket. Every response carries `x-img-cache: hit|miss`, which is
-the evidence when somebody says a drawing looks wrong:
+Caching is not load-bearing for correctness here, and that is the point of
+content-addressed names: a URL's bytes cannot change, so a stale cache entry
+and a fresh one are the same bytes.
 
-    curl -sI "https://img.basically.website/harness/power.<hash>.png" | grep -i x-img-cache
-
-The origin is public and never cached, so it is the tiebreaker if the two ever
-disagree:
-
-    https://basically-docs.nyc3.digitaloceanspaces.com/harness/power.<hash>.png
-
-Caching is no longer load-bearing for correctness here, and that is the point
-of content-addressed names: a URL's bytes cannot change, so a stale cache
-entry and a fresh one are the same bytes. Two caching bugs got fixed on the way
-to that and are worth not reintroducing. The worker used to fetch
-`ORIGIN + url.pathname`, dropping the query string before its subrequest, so
-every `?v=` we appended hit one cached object which a 24h `cacheTtlByStatus`
-pinned in place — a fresh render in the bucket, a day-old render on the page,
-and the YAML link disagreeing with the picture above it. Zone purge could not
-clear it either: the key was a `digitaloceanspaces.com` URL, not one in the
-`basically.website` zone, so `purge_cache` returned success and did nothing.
-The worker now caches under its own hostname with the full URL in the key
-(#284, 2026-08-09). Keep both properties if you touch that file.
+One thing the asset service adds: a PNG is an image, and the service never
+serves an image's uploaded file directly — pages get a byte-identical (for
+these renders) metadata-free copy under its own `-full-` name. The pasteable
+URL is whatever the upload tool prints, which reads it off the manifest;
+never hand-construct a PNG URL.
 
 **If a drawing ever looks wrong again, the first question is which URL the page
 is serving**, and the answer is in the page source and in
@@ -82,7 +69,7 @@ real cache bug worth chasing. If the URL is not the one you expect, somebody
 skipped the paste.
 
 Permanent, content-addressed copies are a release-time concern (the lockfile
-mechanism in the unified parts plan), not a live-docs one. The bucket is
+mechanism in the unified parts plan), not a live-docs one. The store is
 disposable by design: every object in it can be regenerated from git plus the
 pinned toolchain.
 
@@ -114,16 +101,16 @@ than CI's pinned 2.42.2 and the URLs will be for bytes CI would never produce.
 Local renders are for looking at a change. CI is the only renderer whose
 output gets pasted.
 
-Credentials are the `SPACES_KEY` / `SPACES_SECRET` environment variables; CI
-uses repo secrets holding a key scoped to this one bucket. Note CI is the
-canonical
-renderer: it pins WireViz 0.4.1 and graphviz 2.42.2, the graphviz version is
-part of the rendered pixels, and a local render on a different graphviz gets
-quietly normalized by the next CI run for that ref.
+Credentials are `ASSET_SERVICE_URL` / `ASSET_SERVICE_TOKEN`; CI uses a repo
+secret holding a key scoped to the `sorter-harness` namespace only. Note CI is
+the canonical renderer: it pins WireViz 0.4.1 and graphviz 2.42.2, the
+graphviz version is part of the rendered pixels, and a local render on a
+different graphviz gets quietly normalized by the next CI run for that ref.
 
-Disaster recovery, if the bucket is ever lost or defaced: rotate the key, run
-the workflow on main (`workflow_dispatch`), done. Photos elsewhere in the
-bucket are restored from an offline mirror held outside this repo.
+Disaster recovery: revoke the key (`asset-service keys revoke
+sorter-harness-ci`), mint another, update the repo secret, run the workflow on
+main (`workflow_dispatch`). Every object is regenerable from git plus the
+pinned toolchain, and nothing can be overwritten or deleted with the CI key.
 
 ## Linking someone to a preview
 
@@ -195,8 +182,9 @@ time would now be safe. It is still fetched at read time because there is no
 reason to change it and the `BOM (TSV)` download link above each table is the
 fallback when the fetch does not run.
 
-The bucket sends `access-control-allow-origin: *`, so the cross-origin fetch is
-fine, and the name contains the hash, so it is served immutable and honestly.
+The asset service sends `access-control-allow-origin: *`, so the cross-origin
+fetch is fine, and the name contains the hash, so it is served immutable and
+honestly.
 
 ## Where this shows up in the docs
 
@@ -207,7 +195,7 @@ Four pages under `docs/src/content/hardware/electronics/`:
 | `index.md` → `/hardware/electronics/` | Wire harness: PSU spec, interconnect diagram, wire schedule, parts, open items |
 | `steppers.md` → `/hardware/electronics/steppers/` | Board stepper pinout, board-to-motor mapping, the 4-to-6 position crossover |
 | `order.md` → `/hardware/electronics/order/` | Order-ready cable build list for a harness vendor, every guess marked |
-| `wireviz.md` → `/hardware/electronics/wireviz/` | The rendered drawings and the supplier zip. **The page that consumes the bucket.** |
+| `wireviz.md` → `/hardware/electronics/wireviz/` | The rendered drawings and the supplier zip. **The page that consumes the store.** |
 
 The wire IDs (`W1`, `L3p`, `S1-S4`, `CH`, `RIB`) are the join key across the
 schedule, the order spec, and the drawings. Renaming one means renaming it

--- a/electronics/wire_harness/upload-harness.py
+++ b/electronics/wire_harness/upload-harness.py
@@ -1,66 +1,63 @@
-"""Publish the rendered harness to the assets bucket and print the URLs to paste.
+"""Publish the rendered harness to the asset service and print the URLs to paste.
 
     ./electronics/wire_harness/build-harness.sh
     ./electronics/wire_harness/upload-harness.py
 
 Same contract as docs/scripts/upload_image.py, which is the convention every
-other asset in this bucket already follows: the tool puts bytes in the bucket
-and hands back URLs, and those URLs are pasted into the content as literal
-strings. A drawing's URL changes in the commit that changes the drawing, right
-next to it, and reviewing a harness change shows the new URLs in the diff.
+asset follows now: the tool puts bytes in the asset service
+(`assets.basically.website`, namespace `sorter-harness`) and hands back URLs,
+and those URLs are pasted into the content as literal strings. A drawing's URL
+changes in the commit that changes the drawing, right next to it, and
+reviewing a harness change shows the new URLs in the diff.
 
-Nothing is ever overwritten. Every object's name carries a hash of its own
-bytes:
+Nothing is ever overwritten: the service names every object after a hash of
+its own bytes, so a re-render of an unchanged drawing lands on the name it
+already has (a free no-op), and a changed drawing gets a name nothing has ever
+served. That is what makes the year-long `immutable` cache header true.
 
-    harness/power.a1b2c3d4e5.png
-
-so a re-render of an unchanged drawing lands on the name it already has (and
-uploads nothing), and a changed drawing gets a name nothing has ever served.
-That is what makes the year-long `immutable` cache header on these objects
-true, and it is what the previous scheme got wrong: it wrote every render to
-harness/<ref>/power.png, overwriting in place, and left the docs to invent a
-?v=<docs build sha> query that named bytes which might not exist yet. A reader
-who loaded a page inside that window pinned a stale or half-uploaded drawing
-in their browser cache for a year.
+One nuance the service adds: a PNG is an image, and the service never
+publishes an image's uploaded file directly -- pages get a metadata-free copy
+under its own name. So the pasteable URL for a PNG is not derivable from the
+bytes here; it is read off the asset's manifest. Everything else (svg, pdf,
+html, tsv, yml, zip) is served as uploaded.
 
 Renders are not reproducible across graphviz versions -- the version shifts
 glyph positions, so it is part of the output -- which makes CI the canonical
 renderer (it pins graphviz 2.42.2 and WireViz 0.4.1). Publishing from a local
 render on a different graphviz produces correct but non-canonical bytes, and
-the hash will disagree with what CI would have produced. Use
+the URLs will disagree with what CI would have produced. Use
 `gh workflow run harness.yml` and paste from the job log unless you know why
 you want otherwise.
 
-Credentials come from ~/.config/basically/do-spaces.env (SPACES_KEY /
-SPACES_SECRET) or the environment. Requires boto3.
+Credentials are ASSET_SERVICE_URL / ASSET_SERVICE_TOKEN, from the environment
+or ~/.config/asset-service/*.env. `--check` needs no credentials at all: it
+reads public manifests.
 """
 
 from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import mimetypes
 import os
+import re
 import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
-import boto3
-from botocore.exceptions import ClientError
-
-BUCKET = "basically-docs"
-ENDPOINT = "https://nyc3.digitaloceanspaces.com"
-PUBLIC_BASE = "https://img.basically.website"
-PREFIX = "harness"
-# Honest now: the name contains a hash of the bytes, so the bytes behind a URL
-# can never change. Nothing else in this pipeline may reintroduce a mutable
-# name under this cache header.
-CACHE_CONTROL = "public, max-age=31536000, immutable"
-HASH_CHARS = 10
-CREDS_FILE = Path.home() / ".config" / "basically" / "do-spaces.env"
+SERVICE = os.environ.get("ASSET_SERVICE_URL", "https://assets.basically.website").rstrip("/")
+NAMESPACE = "sorter-harness"
+HASH_CHARS = 12  # the service's assets.HashChars; how much digest is in a key
+CONFIG_DIR = Path.home() / ".config" / "asset-service"
+UA = "sorter-v2-harness/1.0 (+https://github.com/basicallysource/sorter-v2)"
 OUT = Path(__file__).resolve().parent / "out"
 
 # A render is ~2.3 MB / 23 files. These caps exist so a runaway render (or a
-# prompted-into-mischief CI run) can't stuff the bucket; raise them when a
+# prompted-into-mischief CI run) can't stuff the store; raise them when a
 # legitimate render actually grows past them.
 MAX_TOTAL_BYTES = 25 * 1024 * 1024
 MAX_FILES = 60
@@ -69,18 +66,17 @@ MAX_FILES = 60
 ZIP_NAME = "sorter-v2-harness-rfq.zip"
 
 
-def load_creds() -> tuple[str, str]:
+def load_token() -> str:
     env: dict[str, str] = {}
-    if CREDS_FILE.is_file():
-        for line in CREDS_FILE.read_text().splitlines():
+    for path in sorted(CONFIG_DIR.glob("*.env")) if CONFIG_DIR.is_dir() else []:
+        for line in path.read_text().splitlines():
             if "=" in line and not line.startswith("#"):
                 k, _, v = line.partition("=")
-                env[k.strip()] = v.strip()
-    key = os.environ.get("SPACES_KEY") or env.get("SPACES_KEY")
-    secret = os.environ.get("SPACES_SECRET") or env.get("SPACES_SECRET")
-    if not key or not secret:
-        sys.exit(f"missing SPACES_KEY/SPACES_SECRET (set env vars or {CREDS_FILE})")
-    return key, secret
+                env.setdefault(k.strip(), v.strip())
+    token = os.environ.get("ASSET_SERVICE_TOKEN") or env.get("ASSET_SERVICE_TOKEN")
+    if not token:
+        sys.exit(f"missing ASSET_SERVICE_TOKEN (env or {CONFIG_DIR}/*.env)")
+    return token
 
 
 def rendered_files() -> list[Path]:
@@ -108,16 +104,55 @@ def content_type(p: Path) -> str:
     return guessed or "application/octet-stream"
 
 
-def hashed_key(name: str, body: bytes) -> str:
-    """harness/power.bom.tsv + bytes -> harness/power.<hash>.bom.tsv
-
-    The hash goes after the first dot rather than before the last one so that
-    the whole suffix chain stays intact: `.bom.tsv` is how the docs page finds
-    a BOM and how a vendor knows what they were sent.
-    """
-    stem, _, rest = name.partition(".")
+def asset_key(name: str, body: bytes) -> str:
+    """The key the service will store these bytes under, computed its way:
+    the filename minus its last extension, slugged, then twelve hex characters
+    of the SHA-256, then the extension. `power.bom.tsv` becomes
+    `power-bom-<hash>.tsv`."""
+    ext = Path(name).suffix.lower()
+    stem = name[: -len(ext)] if ext else name
+    slug = re.sub(r"[^a-z0-9]+", "-", stem.lower()).strip("-")[:64].strip("-")
     digest = hashlib.sha256(body).hexdigest()[:HASH_CHARS]
-    return f"{PREFIX}/{stem}.{digest}.{rest}" if rest else f"{PREFIX}/{stem}.{digest}"
+    return f"{NAMESPACE}/{slug}-{digest}{ext}"
+
+
+def api(method: str, path: str, token: str | None = None, body: bytes | None = None,
+        content_type_header: str | None = None) -> dict | None:
+    req = urllib.request.Request(SERVICE + path, data=body, method=method)
+    req.add_header("User-Agent", UA)
+    if token:
+        req.add_header("Authorization", "Bearer " + token)
+    if content_type_header:
+        req.add_header("Content-Type", content_type_header)
+    try:
+        with urllib.request.urlopen(req, timeout=300) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        detail = e.read().decode(errors="replace")[:300]
+        sys.exit(f"{method} {path}: HTTP {e.code}: {detail}")
+
+
+def published_url(manifest: dict, key: str) -> str:
+    """What a page may reference: the manifest's own url, which for a PNG is
+    the metadata-free copy and for everything else the file as uploaded."""
+    url = manifest.get("url")
+    if not url:
+        sys.exit(f"{key}: no published form yet (renditions {manifest.get('renditions_status')})")
+    return url
+
+
+def wait_ready(key: str, token: str | None, manifest: dict) -> dict:
+    deadline = time.monotonic() + 300
+    while manifest.get("renditions_status") == "pending":
+        if time.monotonic() > deadline:
+            sys.exit(f"{key}: still pending after five minutes")
+        time.sleep(2)
+        manifest = api("GET", f"/v1/assets/{key}", token)
+        if manifest is None:
+            sys.exit(f"{key}: vanished while waiting for its renditions")
+    return manifest
 
 
 # What the docs page links per drawing. `.gv` is uploaded too (it is what the
@@ -128,7 +163,7 @@ LINKED = ("png", "svg", "pdf", "html", "bom.tsv", "yml")
 
 
 def by_drawing(urls: dict[str, str]) -> dict[str, dict[str, str]]:
-    """Group the rendered URLs by drawing, keeping only what the docs link.
+    """Group the published URLs by drawing, keeping only what the docs link.
 
     A stem counts as a drawing only if it produced a PNG, which is what makes
     rfq.txt fall out: WireViz renders a drawing to the whole set at once, so
@@ -166,9 +201,8 @@ def check(data_file: Path, urls: dict[str, str]) -> int:
     """Fail unless the data file's literal URLs are the ones this render produced.
 
     Without this the paste is optional, and a drawing change that forgot it
-    would publish new objects while the page kept serving the old ones -- the
-    same silent staleness the overwrite scheme had, just with a different
-    shape. CI runs it on every harness change.
+    would publish new objects while the page kept serving the old ones. CI
+    runs it on every harness change.
     """
     import yaml  # a wireviz dependency; CI has it wherever this runs
 
@@ -216,53 +250,39 @@ def main() -> int:
 
     files = rendered_files()
     bodies = {p.name: p.read_bytes() for p in files}
-    keys = {name: hashed_key(name, body) for name, body in bodies.items()}
-    urls = {name: f"{PUBLIC_BASE}/{key}" for name, key in keys.items()}
+    keys = {name: asset_key(name, body) for name, body in bodies.items()}
 
     if ZIP_NAME not in bodies:
         sys.exit(f"refusing: {ZIP_NAME} missing from {OUT}; run build-harness.sh first")
 
-    if args.check:
-        return check(args.check, urls)
-
     if args.dry_run:
         for name in sorted(keys):
             print(f"  would upload {keys[name]}")
-        print()
-        print(paste_block(urls))
         return 0
 
-    key_id, secret = load_creds()
-    s3 = boto3.client(
-        "s3",
-        endpoint_url=ENDPOINT,
-        aws_access_key_id=key_id,
-        aws_secret_access_key=secret,
-    )
+    if args.check:
+        # Manifests are public; the render must already be uploaded (CI checks
+        # right after publishing, so it always is).
+        urls = {}
+        for name in sorted(keys):
+            manifest = api("GET", f"/v1/assets/{keys[name]}")
+            if manifest is None:
+                sys.exit(f"{keys[name]} is not in the asset service; run the upload first")
+            urls[name] = published_url(wait_ready(keys[name], None, manifest), keys[name])
+        return check(args.check, urls)
 
-    uploaded = 0
+    token = load_token()
+    urls = {}
     for name in sorted(bodies):
-        key = keys[name]
-        # A name already in the bucket holds these exact bytes -- the name is a
-        # hash of them. Skipping keeps a re-render of an unchanged drawing free
-        # and makes it structurally impossible for this script to overwrite.
-        try:
-            s3.head_object(Bucket=BUCKET, Key=key)
-            continue
-        except ClientError as e:
-            if e.response["Error"]["Code"] not in ("404", "NoSuchKey", "NotFound"):
-                raise
-        s3.put_object(
-            Bucket=BUCKET,
-            Key=key,
-            Body=bodies[name],
-            ACL="public-read",
-            ContentType=content_type(Path(name)),
-            CacheControl=CACHE_CONTROL,
-        )
-        uploaded += 1
+        query = urllib.parse.urlencode({"namespace": NAMESPACE, "filename": name})
+        manifest = api("POST", f"/v1/assets?{query}", token, bodies[name], content_type(Path(name)))
+        if manifest is None:
+            sys.exit(f"{name}: upload returned nothing")
+        manifest = wait_ready(manifest["key"], token, manifest)
+        urls[name] = published_url(manifest, manifest["key"])
+        print(f"  {manifest['key']}")
 
-    print(f"uploaded {uploaded} new object(s); {len(bodies) - uploaded} already present\n")
+    print()
     print(paste_block(urls))
     return 0
 


### PR DESCRIPTION
**One atomic cutover.** When this merges, docs have zero `img.basically.website` references, zero documentation of it, and a validator that fails the build if one ever reappears ("retired domain"). There is no committed in-between state where the old domain is described as a live thing.

## What's on the branch

- **`upload_image.py`** → thin asset-service uploader (namespace `sorter-docs`): POST the original, wait for the ladder, print the ~1600px embed rung + original URL. boto3 / bucket / `SPACES_*` gone. Temporary EXIF bake (marked for deletion) until asset-service#3 deploys.
- **`validate_images.py`** → knows only `assets.basically.website` (fetch-and-hash, now covering video URLs too) and **rejects any old-domain URL**.
- **`docs/AGENTS.md`** → one upload story for any file; no old-domain mentions anywhere.
- **`video_embed.py`** → deployment hostname scrubbed from the public repo.

## Still to land on this branch before merge (the validator enforces it)

1. Re-upload the 114 images (90 full-res originals, 24 web-only) and rewrite all 118 content URLs — gated on asset-service#3 (EXIF orientation) and #4 (serve-the-minimum metadata) deploying first, so raw camera originals don't ladder sideways or publish GPS at immutable URLs.
2. Harness pipeline cutover: CI uploads to the asset service, `harness.yml`'s 31 URLs rewritten.
3. Delete the temporary EXIF bake from `upload_image.py` once #3 is live.

After merge (separate, operational): retire the img-worker, disable the Spaces keys.

## Verified so far

- Live end-to-end upload through the new script (scratch namespace): ladder built, w1600 rung serves `200 image/jpeg`, idempotent re-upload.
- EXIF branch unit-checked (orientation-6 comes back upright; untagged bytes pass through untouched).
- Migration dry run: 118 URLs → 114 uploads, no name collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)