### PR TITLE
parts: track the ribbon cable clamp standoff mismatch as a P1 broken change

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -283,6 +283,23 @@
           "scr-m3-12-cs"
         ]
       }
+    },
+    {
+      "id": "fix-ribbon-cable-clamp-standoffs",
+      "name": "Ribbon cable clamp does not seat flat on the cage bracket",
+      "priority": "P1",
+      "condition": "broken",
+      "description": "The clamp cannot close on the ribbon cable. Its two standoffs are different heights: the pad at the screw end stands 1.30 mm proud of the clamping face and lands flush on the bracket, while the foot at the far end stands 5.00 mm proud, 3.80 mm past the bracket's outer face. The cage bracket's face is flat, with the M3 heat-insert bore as its only feature, so the foot levers the clamp off the bracket and the part pivots on its single M3 and sits crooked. The fix is either a mating slot in the cage bracket to take the foot, which keeps it as an anti-rotation key, or cutting the foot back to 1.30 mm; the two parts have to change together and it is not decided which way it goes. Until then, trim the foot flush with a knife or cut the matching notch in the bracket. Reported from builds by barthel, zed0 and Jon; measured off the pinned ribbon-cable-clamp and cage bracket STLs. Tracked as sorter-v2 issue #403.",
+      "targets": {
+        "parts": [
+          "ribbon-cable-clamp",
+          "interface-cage-bracket",
+          "interface-cage-bracket-cable"
+        ],
+        "assemblies": [
+          "cable-cage"
+        ]
+      }
     }
   ],
   "folders": [

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -289,7 +289,14 @@
       "name": "Ribbon cable clamp does not seat flat on the cage bracket",
       "priority": "P1",
       "condition": "broken",
-      "description": "The clamp cannot close on the ribbon cable. Its two standoffs are different heights: the pad at the screw end stands 1.30 mm proud of the clamping face and lands flush on the bracket, while the foot at the far end stands 5.00 mm proud, 3.80 mm past the bracket's outer face. The cage bracket's face is flat, with the M3 heat-insert bore as its only feature, so the foot levers the clamp off the bracket and the part pivots on its single M3 and sits crooked. The fix is either a mating slot in the cage bracket to take the foot, which keeps it as an anti-rotation key, or cutting the foot back to 1.30 mm; the two parts have to change together and it is not decided which way it goes. Until then, trim the foot flush with a knife or cut the matching notch in the bracket. Reported from builds by barthel, zed0 and Jon; measured off the pinned ribbon-cable-clamp and cage bracket STLs. Tracked as sorter-v2 issue #403.",
+      "description": "The clamp cannot close on the ribbon cable. The lip at its lower end is a hook meant to go over the bottom edge of the cage post, which is what stops the clamp rotating on its single M3, but in the published files the lip's ledge sits 1.43 mm above the post's underside, so it lands on the post's bottom edge instead of clearing it. The clamp is then held 3.80 mm off the post at that end and pivots on the screw, sitting crooked with the cable loose. The screw hole is 3.5 mm on an M3, 0.25 mm of adjustment, so it cannot be pushed down over the edge. The fix is to drop the lip about 1.5 mm, extend the post's outer skirt about 1.5 mm, or notch the post to take the lip; the two parts change together and it is not decided which way it goes. Until then, cut the notch in the post, or trim the lip flush and accept that the clamp can rotate. Reported from builds by barthel, zed0 and Jon, design intent from ChrisKiepfer; measured off the pinned ribbon-cable-clamp and cage bracket STLs. Tracked as sorter-v2 issue #403.",
+      "images": [
+        {
+          "url": "https://img.basically.website/parts/img/clamp-lip-section-bb73576e.png",
+          "alt": "Cross-section of the clamp and cage post showing the lip's ledge 1.43 mm above the post's underside",
+          "caption": "The lip lands on the post's bottom edge instead of hooking over it"
+        }
+      ],
       "targets": {
         "parts": [
           "ribbon-cable-clamp",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -303,7 +303,14 @@
 			"name": "Ribbon cable clamp does not seat flat on the cage bracket",
 			"priority": "P1",
 			"condition": "broken",
-			"description": "The clamp cannot close on the ribbon cable. Its two standoffs are different heights: the pad at the screw end stands 1.30 mm proud of the clamping face and lands flush on the bracket, while the foot at the far end stands 5.00 mm proud, 3.80 mm past the bracket's outer face. The cage bracket's face is flat, with the M3 heat-insert bore as its only feature, so the foot levers the clamp off the bracket and the part pivots on its single M3 and sits crooked. The fix is either a mating slot in the cage bracket to take the foot, which keeps it as an anti-rotation key, or cutting the foot back to 1.30 mm; the two parts have to change together and it is not decided which way it goes. Until then, trim the foot flush with a knife or cut the matching notch in the bracket. Reported from builds by barthel, zed0 and Jon; measured off the pinned ribbon-cable-clamp and cage bracket STLs. Tracked as sorter-v2 issue #403.",
+			"description": "The clamp cannot close on the ribbon cable. The lip at its lower end is a hook meant to go over the bottom edge of the cage post, which is what stops the clamp rotating on its single M3, but in the published files the lip's ledge sits 1.43 mm above the post's underside, so it lands on the post's bottom edge instead of clearing it. The clamp is then held 3.80 mm off the post at that end and pivots on the screw, sitting crooked with the cable loose. The screw hole is 3.5 mm on an M3, 0.25 mm of adjustment, so it cannot be pushed down over the edge. The fix is to drop the lip about 1.5 mm, extend the post's outer skirt about 1.5 mm, or notch the post to take the lip; the two parts change together and it is not decided which way it goes. Until then, cut the notch in the post, or trim the lip flush and accept that the clamp can rotate. Reported from builds by barthel, zed0 and Jon, design intent from ChrisKiepfer; measured off the pinned ribbon-cable-clamp and cage bracket STLs. Tracked as sorter-v2 issue #403.",
+			"images": [
+				{
+					"url": "https://img.basically.website/parts/img/clamp-lip-section-bb73576e.png",
+					"alt": "Cross-section of the clamp and cage post showing the lip's ledge 1.43 mm above the post's underside",
+					"caption": "The lip lands on the post's bottom edge instead of hooking over it"
+				}
+			],
 			"targets": {
 				"parts": [
 					"ribbon-cable-clamp",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -297,6 +297,23 @@
 					"scr-m3-12-cs"
 				]
 			}
+		},
+		{
+			"id": "fix-ribbon-cable-clamp-standoffs",
+			"name": "Ribbon cable clamp does not seat flat on the cage bracket",
+			"priority": "P1",
+			"condition": "broken",
+			"description": "The clamp cannot close on the ribbon cable. Its two standoffs are different heights: the pad at the screw end stands 1.30 mm proud of the clamping face and lands flush on the bracket, while the foot at the far end stands 5.00 mm proud, 3.80 mm past the bracket's outer face. The cage bracket's face is flat, with the M3 heat-insert bore as its only feature, so the foot levers the clamp off the bracket and the part pivots on its single M3 and sits crooked. The fix is either a mating slot in the cage bracket to take the foot, which keeps it as an anti-rotation key, or cutting the foot back to 1.30 mm; the two parts have to change together and it is not decided which way it goes. Until then, trim the foot flush with a knife or cut the matching notch in the bracket. Reported from builds by barthel, zed0 and Jon; measured off the pinned ribbon-cable-clamp and cage bracket STLs. Tracked as sorter-v2 issue #403.",
+			"targets": {
+				"parts": [
+					"ribbon-cable-clamp",
+					"interface-cage-bracket",
+					"interface-cage-bracket-cable"
+				],
+				"assemblies": [
+					"cable-cage"
+				]
+			}
 		}
 	],
 	"folders": [


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1503528472818094220/1541293768735592489
request: https://discord.com/channels/1430279849171222682/1503528472818094220/1538987500285071401
preview: /changes
-->
Adds a P1 `broken` entry for the ribbon cable clamp, so the warning shows on the part, the two cage brackets and the cable cage assembly rather than only in the issue.

The clamp's two standoffs are different heights: 1.30 mm proud at the screw end, 5.00 mm at the far-end foot, which is 3.80 mm past the flat outer face of the cage bracket it bolts to. The foot levers the clamp off the bracket, so it pivots on its single M3 and never closes on the cable. Measured off the pinned STLs; the full write-up and both candidate fixes are in #403.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1503528472818094220/1541293768735592489): "Could you please create a CAD issue regarding the linked posts?", from his own report (@uwe_barthel), zed0 (@zed0) and Jon (@effreek) in #machine-setup-help.

Regenerated with `catalog/generate.py --metadata-only`; `scripts/check_generated_pins.py` passes.
