### PR TITLE
docs(chute-core): mark the 18 heat-insert locations in Preparation

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -58,32 +58,24 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
     <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page. 2 for the servo bracket arms, 4 for the layer adapter board, and the rest for the funnel brackets, the bearing assembly and the layer connectors.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="URL_REAR" alt="Render of the chute core seen from the rear, with the four heat-insert pockets for the layer adapter board circled in purple on the recessed panel at the top end">
-    <figcaption>Rear face: the four inserts the layer adapter board screws into.</figcaption>
+    <img class="doc-figure" src="URL_REAR" alt="Render of the chute core from the rear, with the four heat-insert pockets on the rear panel filled orange and circled">
+    <figcaption>Rear face: 4 pockets.</figcaption>
   </figure>
 </div>
 
-The 18 pockets are on three faces of the core: **8 on the right side, 6 on the left, 4 on the rear**. Every one of them is the same Ø4.2 mm blind hole, 5.7 mm deep, and takes the same M3 insert, so nothing below changes what you press in. The letters only say what gets screwed into that pocket later, and are there so you can check none has been missed:
-
-- **F** — funnel brackets (orange)
-- **B** — bearing covers (blue)
-- **L** — layer connectors (green)
-- **S** — servo bracket arms (pink)
-- **P** — layer adapter board (purple), the four in the picture above
-
-All three views are rendered from the chute core STL, so a circle sits where the geometry actually puts the pocket. Both side views have the part lying on its side, base to the left, and are taken straight on to the face.
+Every one of the 18 is the same pocket, Ø4.2 mm and blind, 5.7 mm deep, so there is nothing to tell apart while you press them in. They sit on three faces of the core, **8 + 6 + 4**. Each view below is rendered from the chute core STL with the pocket itself filled orange, and marks only the pockets that are actually visible in that view.
 
 <div class="img-row">
   <figure>
-    <img src="URL_RIGHT" alt="Render of the right side of the chute core seen straight on, with eight heat-insert pockets circled: two orange for the funnel brackets, two blue for the bearing covers, two green for the layer connectors and two pink for the servo bracket arms">
-    <figcaption><strong>Right side, 8 inserts.</strong> This is the side with the two servo-bracket pockets (pink), which is what tells it apart from the other one.</figcaption>
+    <img src="URL_SIDE8" alt="Render of one long side of the chute core seen straight on, with eight heat-insert pockets filled orange and circled">
+    <figcaption><strong>One long side, 8 pockets.</strong> The round cut-out near the end is the giveaway: this side has two pockets together beside it, and one more on its own in the middle of the face.</figcaption>
   </figure>
 </div>
 
 <div class="img-row">
   <figure>
-    <img src="URL_LEFT" alt="Render of the left side of the chute core seen straight on, with six heat-insert pockets circled: two orange for the funnel brackets, two blue for the bearing covers and two green for the layer connectors">
-    <figcaption><strong>Left side, 6 inserts.</strong> The same as the right side without the two servo-bracket pockets.</figcaption>
+    <img src="URL_SIDE6" alt="Render of the other long side of the chute core seen straight on, with six heat-insert pockets filled orange and circled">
+    <figcaption><strong>The other long side, 6 pockets.</strong> The same face mirrored, without those two: one pocket either side of the round cut-out, and nothing in the middle.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -58,23 +58,23 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
     <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page. 2 for the servo bracket arms, 4 for the layer adapter board, and the rest for the funnel brackets, the bearing assembly and the layer connectors.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="URL_REAR" alt="Render of the chute core from the rear, with the four heat-insert pockets on the rear panel filled orange and circled">
-    <figcaption>Rear face: 4 pockets.</figcaption>
+    <img class="doc-figure" src="URL_REAR" alt="Close render of the rear end of the chute core at a slight angle, with the four heat-insert pockets on the rear panel circled in red">
+    <figcaption>Rear face: 4 pockets, seen close in.</figcaption>
   </figure>
 </div>
 
-Every one of the 18 is the same pocket, Ø4.2 mm and blind, 5.7 mm deep, so there is nothing to tell apart while you press them in. They sit on three faces of the core, **8 + 6 + 4**. Each view below is rendered from the chute core STL with the pocket itself filled orange, and marks only the pockets that are actually visible in that view.
+Every one of the 18 is the same pocket, Ø4.2 mm and blind, 5.7 mm deep, so there is nothing to tell apart while you press them in. They sit on three faces of the core, **8 + 6 + 4**. Each view below is rendered from the chute core STL, turned about 18° off the face so the pockets shade as holes rather than disappearing into the plate, and circles only the pockets that are actually visible in that view.
 
 <div class="img-row">
   <figure>
-    <img src="URL_SIDE8" alt="Render of one long side of the chute core seen straight on, with eight heat-insert pockets filled orange and circled">
+    <img src="URL_SIDE8" alt="Render of one long side of the chute core at a slight angle, with eight heat-insert pockets circled in red">
     <figcaption><strong>One long side, 8 pockets.</strong> The round cut-out near the end is the giveaway: this side has two pockets together beside it, and one more on its own in the middle of the face.</figcaption>
   </figure>
 </div>
 
 <div class="img-row">
   <figure>
-    <img src="URL_SIDE6" alt="Render of the other long side of the chute core seen straight on, with six heat-insert pockets filled orange and circled">
+    <img src="URL_SIDE6" alt="Render of the other long side of the chute core at a slight angle, with six heat-insert pockets circled in red">
     <figcaption><strong>The other long side, 6 pockets.</strong> The same face mirrored, without those two: one pocket either side of the round cut-out, and nothing in the middle.</figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -57,9 +57,34 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
   <div class="prep-item-body">
     <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page. 2 for the servo bracket arms, 4 for the layer adapter board, and the rest for the funnel brackets, the bearing assembly and the layer connectors.</p>
   </div>
-  <div class="prep-item-figure">
-    <div class="img-placeholder">Image coming</div>
-  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="URL_REAR" alt="Render of the chute core seen from the rear, with the four heat-insert pockets for the layer adapter board circled in purple on the recessed panel at the top end">
+    <figcaption>Rear face: the four inserts the layer adapter board screws into.</figcaption>
+  </figure>
+</div>
+
+The 18 pockets are on three faces of the core: **8 on the right side, 6 on the left, 4 on the rear**. Every one of them is the same Ø4.2 mm blind hole, 5.7 mm deep, and takes the same M3 insert, so nothing below changes what you press in. The letters only say what gets screwed into that pocket later, and are there so you can check none has been missed:
+
+- **F** — funnel brackets (orange)
+- **B** — bearing covers (blue)
+- **L** — layer connectors (green)
+- **S** — servo bracket arms (pink)
+- **P** — layer adapter board (purple), the four in the picture above
+
+All three views are rendered from the chute core STL, so a circle sits where the geometry actually puts the pocket. Both side views have the part lying on its side, base to the left, and are taken straight on to the face.
+
+<div class="img-row">
+  <figure>
+    <img src="URL_RIGHT" alt="Render of the right side of the chute core seen straight on, with eight heat-insert pockets circled: two orange for the funnel brackets, two blue for the bearing covers, two green for the layer connectors and two pink for the servo bracket arms">
+    <figcaption><strong>Right side, 8 inserts.</strong> This is the side with the two servo-bracket pockets (pink), which is what tells it apart from the other one.</figcaption>
+  </figure>
+</div>
+
+<div class="img-row">
+  <figure>
+    <img src="URL_LEFT" alt="Render of the left side of the chute core seen straight on, with six heat-insert pockets circled: two orange for the funnel brackets, two blue for the bearing covers and two green for the layer connectors">
+    <figcaption><strong>Left side, 6 inserts.</strong> The same as the right side without the two servo-bracket pockets.</figcaption>
+  </figure>
 </div>
 
 {% include step.html n="2" title="Fit the funnel brackets" %}

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -60,15 +60,15 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
-      <img class="doc-figure" src="URL_SIDE8" alt="Render of one long side of the chute core at a slight angle, with eight heat-insert pockets circled in red">
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-8-full-9f0f3b659b63.png" alt="Render of one long side of the chute core at a slight angle, with eight heat-insert pockets circled in red">
       <figcaption>One long side: 8. The round cut-out near the end is the giveaway, this side has two pockets together beside it and one on its own in the middle of the face.</figcaption>
     </figure>
     <figure>
-      <img class="doc-figure" src="URL_SIDE6" alt="Render of the other long side of the chute core at a slight angle, with six heat-insert pockets circled in red">
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-6-full-c4074e29338f.png" alt="Render of the other long side of the chute core at a slight angle, with six heat-insert pockets circled in red">
       <figcaption>The other long side: 6. The same face mirrored, without those two.</figcaption>
     </figure>
     <figure>
-      <img class="doc-figure" src="URL_REAR" alt="Close render of the rear end of the chute core at a slight angle, with the four heat-insert pockets on the rear panel circled in red">
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-rear-full-ad4c2cc7869c.png" alt="Close render of the rear end of the chute core at a slight angle, with the four heat-insert pockets on the rear panel circled in red">
       <figcaption>Rear face: the last 4, all on the panel at the top end. Shown closer in than the other two.</figcaption>
     </figure>
   </div>

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -56,27 +56,22 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
 <div class="prep-item">
   <div class="prep-item-body">
     <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page. 2 for the servo bracket arms, 4 for the layer adapter board, and the rest for the funnel brackets, the bearing assembly and the layer connectors.</p>
+    <p>All 18 are the same pocket, Ø4.2 mm and blind, 5.7 mm deep, split <strong>8 + 6 + 4</strong> across three faces. The views are rendered from the chute core STL, turned slightly off each face so the pockets shade as holes, and circle only the pockets visible in that view.</p>
   </div>
-  <figure class="prep-item-figure">
-    <img class="doc-figure" src="URL_REAR" alt="Close render of the rear end of the chute core at a slight angle, with the four heat-insert pockets on the rear panel circled in red">
-    <figcaption>Rear face: 4 pockets, seen close in.</figcaption>
-  </figure>
-</div>
-
-Every one of the 18 is the same pocket, Ø4.2 mm and blind, 5.7 mm deep, so there is nothing to tell apart while you press them in. They sit on three faces of the core, **8 + 6 + 4**. Each view below is rendered from the chute core STL, turned about 18° off the face so the pockets shade as holes rather than disappearing into the plate, and circles only the pockets that are actually visible in that view.
-
-<div class="img-row">
-  <figure>
-    <img src="URL_SIDE8" alt="Render of one long side of the chute core at a slight angle, with eight heat-insert pockets circled in red">
-    <figcaption><strong>One long side, 8 pockets.</strong> The round cut-out near the end is the giveaway: this side has two pockets together beside it, and one more on its own in the middle of the face.</figcaption>
-  </figure>
-</div>
-
-<div class="img-row">
-  <figure>
-    <img src="URL_SIDE6" alt="Render of the other long side of the chute core at a slight angle, with six heat-insert pockets circled in red">
-    <figcaption><strong>The other long side, 6 pockets.</strong> The same face mirrored, without those two: one pocket either side of the round cut-out, and nothing in the middle.</figcaption>
-  </figure>
+  <div class="prep-item-figure prep-item-figure-split">
+    <figure>
+      <img class="doc-figure" src="URL_SIDE8" alt="Render of one long side of the chute core at a slight angle, with eight heat-insert pockets circled in red">
+      <figcaption>One long side: 8. The round cut-out near the end is the giveaway, this side has two pockets together beside it and one on its own in the middle of the face.</figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="URL_SIDE6" alt="Render of the other long side of the chute core at a slight angle, with six heat-insert pockets circled in red">
+      <figcaption>The other long side: 6. The same face mirrored, without those two.</figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="URL_REAR" alt="Close render of the rear end of the chute core at a slight angle, with the four heat-insert pockets on the rear panel circled in red">
+      <figcaption>Rear face: the last 4, all on the panel at the top end. Shown closer in than the other two.</figcaption>
+    </figure>
+  </div>
 </div>
 
 {% include step.html n="2" title="Fit the funnel brackets" %}


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1541303416951804014
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541311508208816219
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541316059590557697
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541319145277096056
preview: /hardware/assembly/distribution/chute/chute-core/
-->
Puts three rendered views of the chute core into the **Preparation** step, in place of the `Image coming` placeholder, marking where all 18 M3 heat inserts go.

![One long side, 8 inserts](https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-8-full-9f0f3b659b63.png)

### What is in it

- **8 + 6 + 4 across three faces**, marked on one view each: the two long sides and the rear panel. Every pocket position was measured off `chute-core`'s STL rather than taken from the assembly tree, and they are all the same hole: Ø4.20 mm, blind, 5.70 mm deep, with 11.3 mm of solid plastic behind and no relief hole.
- Each view is turned about 18° off its face. Straight on, a blind flat-bottomed pocket shades identically to the plate around it and is invisible; the tilt is what puts enough of the wall in shadow for it to read as a hole. Only a thin circle marks each one.
- Each pocket is ray-tested per view, so a circle is only drawn where nothing is standing in front of it.
- Layout follows the **Top interface chute mount** prep item on `top-interface.md`: one `prep-item` whose figure column is a `prep-item-figure-split` holding a `figure` per view, each with its own caption.

The renders come from `parts-calculator/scripts/meshfig.py` against the published `chute-core` STL, and are hosted on the asset service. They are in the `sorter-parts` namespace rather than `sorter-docs` because `basically-balloon`'s token has no `write:sorter-docs` scope. That, and the ~75 minute rendition stall that held this PR on placeholder URLs, are tracked in #408.

### Checks

- `npm run build` in `docs/` on Node 20, clean.
- `docs/scripts/validate_images.py`: 152 assets, passes, including these three.
- `docs/scripts/validate_frontmatter.py`: the 5 errors already on `main`, no new ones.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1541303416951804014): "In the Docs, there is a Chute Core page where the 18 heat inserts are mentioned in the “Preparation” section. Please create views from the Chute Core STL file that show the locations where the heat inserts are to be inserted, and mark them. You can create multiple images. It’s important that it’s easy to see where the heat inserts need to be placed. Add the rendered images to the “Preparation” section of Chute Core."
