### PR TITLE
docs(chute): reorder the section, fix the door module, and stop repeating parts across its pages

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -62,25 +62,17 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
   </div>
 </div>
 
-{% include step.html n="2" title="Fit the funnel brackets" %}
+{% include step.html n="2" title="Bolt the four sub-assemblies on" %}
 
-Fit the Funnel bracket (left) and the Funnel bracket (right) to the chute core. Together with the door module and the layer connectors these use the chute's 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, all into the core's inserts.
+Fit them in this order: the funnel brackets, the door module, the layer connectors, then the layer adapter board. Each has its own page for the procedure. What follows is the one thing those pages do not repeat, which screw goes into which insert, worked out from the STLs by comparing each mating part's wall thickness at its screw hole against the core's blind 5.70 mm pockets.
 
-The split across those 14, worked out from the STLs by comparing each mating part's wall thickness at its screw hole against the core's blind 5.70 mm insert pockets:
+- **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**, left and right: 4 × {% include fastener.html size="M3" variant="countersunk" length="12" %}, 2 per bracket. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the insert and an 8 mm one would not reach it at all.
+- **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**, bolted on as a unit: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, 2 per cover into 5.00 mm of wall, plus 2 × {% include fastener.html size="M3" variant="countersunk" length="12" %} for the servo bracket arms.
+- **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** A and B: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %}, 2 per connector. The strap is 3.78 mm thick, so an 8 mm screw reaches 4.22 mm in and stops 1.5 mm short of the pocket bottom, while a 12 mm screw would bottom out before the head seated.
+- **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**: 4 × {% include fastener.html size="M3" variant="button" length="6" %} on the four inserts in the rear face, the only button heads on the chute. They are in that page's parts list, not this one.
 
-- **Funnel brackets:** 4 × {% include fastener.html size="M3" variant="countersunk" length="12" %} (8.16 mm wall, so an 8 mm screw would not reach the insert at all)
-- **Bearing covers:** 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} (5.00 mm wall, 2 per cover)
-- **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}):** 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} (3.78 mm strap, 2 per connector)
-- **Servo bracket arms:** the remaining 2 × {% include fastener.html size="M3" variant="countersunk" length="12" %}. No published part sits on those two inserts, so this one is by elimination rather than measured.
+That accounts for all 14 countersunk screws in the list above, 6 twelves and 8 eights. The servo-bracket row is the only one nothing published confirms: no STL sits on those two inserts, so 12 mm is by elimination from the other three rather than measured.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="3" title="Fit the door module" %}
-
-Build the [door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}) as a unit (door, bearing assembly, servo adapter, servo in its bracket) and bolt it to the chute core. The servo bracket lands on **two** of the core's M3 inserts.
-
-{% include step.html n="4" title="Fit the layer connectors and the PCB" %}
-
-Attach Layer connector A and Layer connector B, then the [layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) on its four PCB inserts.
-
-The chute is now complete. Repeat for every layer.
+The chute is complete when all four are on. Repeat for every layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -10,9 +10,25 @@ permalink: /hardware/assembly/distribution/chute/door-module/
 author: spencer
 ---
 
-The door module is made up of:
+The door module is the moving half of the chute. It is built on the bench as one unit and then bolted to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), which is where all of its mounting screws land. One per chute, so one per layer.
 
-1. **[MG995 servo]({{ '/hardware/assembly/distribution/chute/mg995-servo/' | relative_url }})** — the servo that drives the door, and how to mount and install it.
-2. **[Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})** — the funnel that guides parts through the door.
-3. **[PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})** — the board that drives the servo.
-4. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** — the connectors that chain layers together.
+Four things make it up:
+
+1. **Chute door**. The flap itself, one printed part.
+2. **Bearing assembly**. What the door swings on: the Bearing race, a Bearing holder (left) and a Bearing holder (right), a Bearing cover (covered side) and a Bearing cover (servo side), and two 6704-2RS bearings. It carries 10 M3 heat inserts of its own, 4 in the race and 3 in each holder, and takes 10 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws: 6 hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each. Those are separate from the chute core's 18 inserts.
+3. **Servo adapter**. Two printed parts, a servo side and a flap side, that couple the servo's output to the door.
+4. **[MG995 servo]({{ '/hardware/assembly/distribution/chute/mg995-servo/' | relative_url }})** in its four-part bracket. Build it and clock the horn on the [Servo mount]({{ '/hardware/assembly/distribution/chute/mg995-servo/servo-mount/' | relative_url }}) page, then see [How to install]({{ '/hardware/assembly/distribution/chute/mg995-servo/how-to-install/' | relative_url }}).
+
+## How it mounts to the chute core
+
+Six of the core's 18 inserts are for this module, and the screws come out of the core's own set rather than being extra:
+
+- **2 bearing covers**, 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} in total, 2 per cover.
+- **Servo bracket arms**, 2 {% include fastener.html size="M3" variant="countersunk" length="12" %}.
+
+The full split across the core's 14 countersunk screws is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, which is the one place it is written down.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Only the servo has build pages so far. The door, the bearing assembly and the servo adapter have no assembly steps written yet, and nothing on this page has been checked against a machine.</p>
+</div>

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -8,6 +8,12 @@ kicker: Chute — Door module
 lede: The per-layer door mechanism that releases parts into a bin.
 permalink: /hardware/assembly/distribution/chute/door-module/
 author: spencer
+warning: >-
+  **AI-generated first draft.** Written from the machine assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=flap-module), not from
+  an actual build. Nothing here has been checked against a machine, and only the servo has
+  build pages: the door, the bearing assembly and the servo adapter have no assembly steps
+  written yet. Correct it as you build.
 ---
 
 The door module is the moving half of the chute. It is built on the bench as one unit and then bolted to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), which is where all of its mounting screws land. One per chute, so one per layer.
@@ -27,8 +33,3 @@ Six of the core's 18 inserts are for this module, and the screws come out of the
 - **Servo bracket arms**, 2 {% include fastener.html size="M3" variant="countersunk" length="12" %}.
 
 The full split across the core's 14 countersunk screws is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, which is the one place it is written down.
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Only the servo has build pages so far. The door, the bearing assembly and the servo adapter have no assembly steps written yet, and nothing on this page has been checked against a machine.</p>
-</div>

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -23,8 +23,6 @@ parts_needed:
     qty: 1
   - part: funnel-bracket-right
     qty: 1
-  - part: scr-m3-12-cs
-    qty: 4
 ---
 
 The funnel catches what the door releases and guides it into the bin below. It hangs off two printed brackets that are part of the chute.
@@ -34,8 +32,8 @@ The fasteners and quantities are in the parts list above and are called out inli
 {% include fastener-legend.html %}
 
 - **One funnel per layer**, in one of two sizes. Print the size that matches that layer's bins.
-- The 6 {% include fastener.html size="M3" variant="countersunk" length="12" %} and 8 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws in the list are the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s whole set, shared between the funnel brackets, the door module and the layer connectors. Only some of them land here.
-- The brackets screw into the chute core's M3 heat inserts, so there is nothing to tap.
+- The brackets screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, so there is nothing to tap.
+- The 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} they take come out of the core's set of 6 and are not extra, so they are on that page's parts list rather than this one.
 
 {% include step.html n="1" title="Pick the funnel size for the layer" %}
 
@@ -50,7 +48,7 @@ Decide before printing, since it changes both the funnel and the bin set. The [p
 
 Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, using screws from the chute's set.
 
-Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair, out of the chute's set of 6. Measured from the STLs: the bracket is 8.16 mm thick at the screw and the core's insert pocket is 5.70 mm deep, so a 12 mm screw goes 3.84 mm into the insert. An 8 mm screw would stop short of the insert entirely.
+Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. Why 12 mm and not 8 is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, along with the rest of the split.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -10,9 +10,10 @@ permalink: /hardware/assembly/distribution/chute/
 author: spencer
 ---
 
-1. **[Chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})** — build one per layer.
-2. **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})** — the per-layer door mechanism that releases parts into a bin. Made up of the servo, funnel, PCB, and layer connectors below.
-3. **[MG995 servo]({{ '/hardware/assembly/distribution/chute/mg995-servo/' | relative_url }})** — the servo that drives the door.
-4. **[Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})** — the funnel that guides parts through the door.
-5. **[PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})** — the board that drives the servo.
-6. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** — the connectors that chain layers together.
+The chute is one per layer. Build the core first, since everything else bolts into its heat inserts.
+
+1. **[Chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})**. The printed body everything else mounts to, and the 18 heat inserts that hold it all together.
+2. **[Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**. The funnel that guides parts into the bin, and the two brackets it hangs from. Its size decides that layer's bin set, so pick it before printing.
+3. **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**. The door itself, the bearing assembly it swings on, the servo adapter, and the [MG995 servo]({{ '/hardware/assembly/distribution/chute/mg995-servo/' | relative_url }}) that drives it. Built as a unit, then bolted on.
+4. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})**. The pair that joins this layer's chute to the one below.
+5. **[PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**. The layer adapter board that drives the servo.

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -8,6 +8,11 @@ kicker: Distribution — Chute
 lede: The rotating chute that aims parts at the correct bin.
 permalink: /hardware/assembly/distribution/chute/
 author: spencer
+warning: >-
+  **AI-generated first draft.** The order and the descriptions below come from the machine
+  assembly tree in the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=chute), not from an
+  actual build. Each page carries its own note. Correct them as you build.
 ---
 
 The chute is one per layer. Build the core first, since everything else bolts into its heat inserts.

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -19,8 +19,6 @@ parts_needed:
     qty: 1
   - part: layer-connector-2
     qty: 1
-  - part: scr-m3-8-cs
-    qty: 4
 ---
 
 The layer connectors are a pair of printed parts, Layer connector A and Layer connector B, that join one layer's chute to the next one down so parts pass from chute to chute without a gap.
@@ -30,7 +28,7 @@ The fasteners and quantities are in the parts list above and are called out inli
 {% include fastener-legend.html %}
 
 - **How many:** 1 of each per distribution layer, plus 1 of each for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) and 1 of each for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
-- **Screws:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per connector, 4 for the pair. They come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s set of 8, they are not extra.
+- **Screws:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per connector, 4 for the pair. They come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s set of 8 and are not extra, so they are on that page's parts list rather than this one.
 - Both connectors go into the chute core's M3 heat inserts.
 
 {% include step.html n="1" title="Fit the connectors to the chute core" %}
@@ -39,7 +37,7 @@ Both connectors fasten to the [chute core]({{ '/hardware/assembly/distribution/c
 
 Each connector takes 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flat strap between its two end blocks.
 
-**Why 8 mm and not 12.** Measured off the published STLs. The strap is **3.78 mm** thick at the screw: 1.91 mm of Ø3.40 mm clearance bore, then a 90° countersink opening out to Ø7.15 mm on the outer face. Every M3 pocket in the chute core is a **blind Ø4.20 × 5.70 mm** hole for a {% include fastener.html size="M3" variant="heat-insert" %} and has solid plastic behind it, no relief hole. So an 8 mm screw reaches 4.22 mm into the insert and stops 1.5 mm short of the bottom, while a 12 mm screw would need 8.22 mm of depth and would bottom out before the head ever seated.
+The strap is countersunk 90° on its outer face, so the head sits flush. Why 8 mm and not 12 is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page with the rest of the split.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/mg995-servo/servo-mount.md
@@ -60,7 +60,7 @@ Press the inserts into the housing while it is still bare. See [installing heat 
 
 Drop the MG995 into the housing and fasten it with 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the servo's own mounting ears.
 
-Clock the horn before you commit to a position. The MG995 only rotates 180°, and the door has to reach both fully open and fully closed inside that range, see [how to install]({{ '/hardware/assembly/distribution/chute/mg995-servo/how-to-install/' | relative_url }}).
+Clock the horn before you commit to a position. [How to install]({{ '/hardware/assembly/distribution/chute/mg995-servo/how-to-install/' | relative_url }}) covers why it matters and how far the servo can actually travel.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -16,8 +16,6 @@ warning: >-
 parts_needed:
   - part: layer-adapter-board-basically
     qty: 1
-  - part: hsi-m3
-    qty: 4
   - part: scr-m3-6-bhcs
     qty: 4
 ---
@@ -33,7 +31,7 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 {% include step.html n="1" title="Preparation" %}
 
-Press the chute core's inserts before the chute is assembled, the four PCB inserts among them. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+Nothing to press in here. The four inserts the board sits on are pressed into the chute core along with the rest of its 18, before the chute is assembled. See [Chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) for where they are, and [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
 
 {% include step.html n="2" title="Screw the board onto the chute core" %}
 

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -43,21 +43,22 @@ sections:
                 children:
                   - title: Chute core
                     url: /hardware/assembly/distribution/chute/chute-core/
-                  - title: Door module
-                    url: /hardware/assembly/distribution/chute/door-module/
-                  - title: MG995 servo
-                    url: /hardware/assembly/distribution/chute/mg995-servo/
-                    children:
-                      - title: Servo mount
-                        url: /hardware/assembly/distribution/chute/mg995-servo/servo-mount/
-                      - title: How to install
-                        url: /hardware/assembly/distribution/chute/mg995-servo/how-to-install/
                   - title: Funnel
                     url: /hardware/assembly/distribution/chute/funnel/
-                  - title: PCB
-                    url: /hardware/assembly/distribution/chute/pcb/
+                  - title: Door module
+                    url: /hardware/assembly/distribution/chute/door-module/
+                    children:
+                      - title: MG995 servo
+                        url: /hardware/assembly/distribution/chute/mg995-servo/
+                        children:
+                          - title: Servo mount
+                            url: /hardware/assembly/distribution/chute/mg995-servo/servo-mount/
+                          - title: How to install
+                            url: /hardware/assembly/distribution/chute/mg995-servo/how-to-install/
                   - title: Layer connectors
                     url: /hardware/assembly/distribution/chute/layer-connectors/
+                  - title: PCB
+                    url: /hardware/assembly/distribution/chute/pcb/
           - title: Feeder
             url: /hardware/assembly/feeder/
             children:


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541320334026874921
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541324226118815764
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541326390664765612
preview: /hardware/assembly/distribution/chute/
-->
A review of the whole chute section turned up a contradictory page order, a page that describes the wrong thing, and the same facts written out on two or three pages each. This fixes all of it.

## 1. The order contradicted itself

`chute/index.md` numbered six children while item 2's own description said the door module is "made up of the servo, funnel, PCB, and layer connectors below", so items 3 to 6 appeared twice on one page: as children of item 2, and as its siblings. The landing page also ran door before funnel while `chute-core.md`'s own steps run funnel before door.

Both `chute/index.md` and `nav.yml` now follow the build order, and the servo is nested where it belongs:

1. Chute core
2. Funnel
3. Door module → MG995 servo → Servo mount, How to install
4. Layer connectors
5. PCB

## 2. "Door module" meant two different things

- `chute-core.md`: the door, the bearing assembly, the servo adapter, the servo in its bracket.
- `door-module.md`: the MG995 servo, the funnel, the PCB, the layer connectors.

The catalog settles it. The `flap-module` assembly is `chute-door` + `chute-bearing` + `servo-adapter` + `servo-bracket`, and its `docs` field already points at `/hardware/assembly/distribution/chute/door-module/`. The funnel is counted per `funnel` and the layer connectors also go on both interfaces, so neither is a door part. `door-module.md` was the wrong one and is rewritten.

That page now also carries the **bearing assembly's own 10 heat inserts and 10 M3 × 8 screws** (6 covers to holders, 4 holders to race), which appeared nowhere on the site before, and says plainly that only the servo has build pages so far.

### Still not documented anywhere

`chute-door`, `bearing-race`, `bearing-holder-left`, `bearing-holder-right`, `bearing-cover-covered`, `bearing-cover-servo`, `servo-adapter-servo-side`, `servo-adapter-flap-side`. Eight per-chute parts with no assembly steps. This PR names them and their fasteners rather than inventing procedures for them.

## 3. Repetition removed

- **The screw-length reasoning was written three times** with the same measurements: all four rows on `chute-core.md`, the funnel row again on `funnel.md`, the connector row again on `layer-connectors.md`. Correcting one number meant editing three pages. `chute-core.md` now owns the whole split in one step and the other two point at it.
- **`chute-core.md` steps 2 to 4** restated what `funnel.md`, `servo-mount.md`, `layer-connectors.md` and `pcb.md` each cover in full. They are now one step that gives the screw split and links out for the procedures.
- **The 180° servo travel warning** was on `how-to-install.md` as a callout and again in `servo-mount.md` step 2. Only the callout is left.
- **`chute/index.md` item 2** restated the whole of `door-module.md`.

Left alone deliberately: the fastener legend and the "fasteners and quantities are in the parts list above" line on every page. That is the house pattern from `top-interface.md` and each page needs its own.

## 4. Parts lists cleaned up

Three pages asked for fasteners that are already counted on the chute core, and each one said so in its own prose while its list said otherwise:

- `pcb.md`: 4 × M3 heat inserts, already 4 of the core's 18.
- `funnel.md`: 4 × M3 × 12, already 4 of the core's 6.
- `layer-connectors.md`: 4 × M3 × 8, already 4 of the core's 8.

All three removed; the counts survive in prose on each page, pointing at the core. The catalog was already right in every case, so nothing there changed: `chute-core` is the only chute part with `requires: hsi-m3`, and the screw lines live at the `chute` assembly level.

The convention this settles is site-wide rather than chute-specific: a page's `parts_needed` is a shopping list, so a fastener belongs on the one page that owns it and the pages that merely drive it name it in prose.

## Checks

- `npm run build` in `docs/` on Node 20, clean. All six chute routes prerender and every internal chute link resolves to a built page.
- `docs/scripts/validate_frontmatter.py`: the 5 errors already on `main`, no new ones.
- `docs/scripts/validate_images.py`: 149 assets, passes.
- Test-merged against #406 locally, no conflict, even though both touch `chute-core.md`.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1541303416951804014/1541326390664765612): "Do it. Rewrite the PR title to reflect the overall changes on chute pages. Clean up the needed parts list too." The review it acts on was asked for [here](https://discord.com/channels/1430279849171222682/1541303416951804014/1541324226118815764), and the original duplicate-insert check [here](https://discord.com/channels/1430279849171222682/1541303416951804014/1541320334026874921).
