### PR TITLE
docs(chute): list each part on the page that describes it

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -16,16 +16,6 @@ warning: >-
 parts_needed:
   - part: chute-core
     qty: 1
-  - part: funnel-bracket-left
-    qty: 1
-  - part: funnel-bracket-right
-    qty: 1
-  - part: layer-connector-1
-    qty: 1
-  - part: layer-connector-2
-    qty: 1
-  - part: layer-adapter-board-basically
-    qty: 1
   - part: hsi-m3
     qty: 18
   - part: scr-m3-12-cs

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -14,6 +14,29 @@ warning: >-
   an actual build. Nothing here has been checked against a machine, and only the servo has
   build pages: the door, the bearing assembly and the servo adapter have no assembly steps
   written yet. Correct it as you build.
+parts_needed:
+  - part: chute-door
+    qty: 1
+  - part: bearing-race
+    qty: 1
+  - part: bearing-holder-left
+    qty: 1
+  - part: bearing-holder-right
+    qty: 1
+  - part: bearing-cover-covered
+    qty: 1
+  - part: bearing-cover-servo
+    qty: 1
+  - part: servo-adapter-servo-side
+    qty: 1
+  - part: servo-adapter-flap-side
+    qty: 1
+  - part: brg-6704-2rs
+    qty: 2
+  - part: hsi-m3
+    qty: 10
+  - part: scr-m3-8-cs
+    qty: 10
 ---
 
 The door module is the moving half of the chute. It is built on the bench as one unit and then bolted to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), which is where all of its mounting screws land. One per chute, so one per layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -16,9 +16,7 @@ warning: >-
   build.
 parts_needed:
   - part: funnel-half
-    qty: 1
   - part: funnel-third
-    qty: 1
   - part: funnel-bracket-left
     qty: 1
   - part: funnel-bracket-right


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541390546860511262
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541391616672276580
preview: /hardware/assembly/distribution/chute/door-module/
-->
Follow-up to #407, which sorted out the chute pages' fasteners but left the printed parts alone. Asked whether each part is listed only where it is actually used or described: it was not, in both directions.

## 1. Listed where they are not described

`chute-core.md` had nine `parts_needed` entries and five belonged to other pages, each already listed on the page that describes it:

- `funnel-bracket-left`, `funnel-bracket-right` → `funnel.md`
- `layer-connector-1`, `layer-connector-2` → `layer-connectors.md`
- `layer-adapter-board-basically` → `pcb.md`

The chute core page never describes any of them. It names them once each in the screw-split step and links out. Removed, so what is left is the part that page is about: the **Chute core**, its **18 M3 heat inserts**, and the **6 M3 × 12 and 8 M3 × 8** that thread into them.

## 2. Described but listed nowhere

The **door module** had no parts list, and none of its parts appeared in any `parts_needed` on the whole site. Checked id by id with `grep -rl "part: <id>$" docs/src/content`:

`chute-door`, `bearing-race`, `bearing-holder-left`, `bearing-holder-right`, `bearing-cover-covered`, `bearing-cover-servo`, `servo-adapter-servo-side`, `servo-adapter-flap-side`, `brg-6704-2rs`. It now has all nine, plus the bearing assembly's own **10 M3 heat inserts** and **10 M3 × 8** screws.

A duplicate makes somebody over-order; this one silently missed a whole sub-assembly, which is the worse failure.

Deliberately not on that list, because they are described elsewhere: the four servo bracket parts and the MG995 (on `mg995-servo/servo-mount.md`), and the 4 + 2 screws that hold the finished module to the core (on `chute-core.md`, which owns the core's set). No number on this page overlaps another page's.

`parts_needed` renders on a `type: landing` page, confirmed in the built output.

## 3. A list that contradicted its own page

`funnel.md` asked for one **Funnel (half size)** and one **Funnel (third size)**, while step 1 of that same page says the size is chosen per layer and sets that layer's bin set with it. The list said buy both.

The counts are dropped from those two entries, so the list shows the two options without claiming you need one of each. The catalog's own captions do the rest: the cards read "For a layer of 12 half bins" and "For a layer of 18 third bins".

**Correcting something I said in Discord:** I suggested the catalog's `conflicts` field could mark this as a "pick one". It cannot. `conflicts` is the catalog-merge marker ("the docs and the parts calculator disagreed about this part when their catalogs were merged"), and `alternative` means an interchangeable substitute. The site has no "choose one of these variants" mechanism, so this is handled by not asserting a count rather than by a new flag.

## Not changed

`layer-connectors.md`, `pcb.md` and `mg995-servo/servo-mount.md` were already right. The servo mount's 6 inserts and its 4 M3 × 12 and 2 M3 × 8 are the bracket housing's own and are driven in its own steps.

Nothing in `parts-calculator/catalog/parts.json` needed changing: it already had every one of these parts under the right assembly, with `chute-bearing` carrying its own 10 screws separately from the `chute` assembly's 8. The drift was only in the pages' hand-written front matter.

## Checks

- `npm run build` in `docs/` on Node 20, clean.
- `docs/scripts/validate_frontmatter.py`: the 5 errors already on `main`, no new ones.
- `docs/scripts/validate_images.py`: 152 assets, passes.
- Read the three rendered parts blocks out of the prerendered HTML to confirm each one lists what it should and nothing else.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1541303416951804014/1541391616672276580): "Create a new PR and show me a link for preview". The audit it acts on was asked for [here](https://discord.com/channels/1430279849171222682/1541303416951804014/1541390546860511262): "Check the “needed parts” in the chute pages. Are the “needed parts” listed only where they are actually used or described?"
