### PR TITLE
docs(chute): write down the order the chutes go into the machine

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -8,11 +8,14 @@ kicker: Distribution — Chute
 lede: The rotating chute that aims parts at the correct bin.
 permalink: /hardware/assembly/distribution/chute/
 author: spencer
+contributors: [alex, brickcyclealice]
 warning: >-
-  **AI-generated first draft.** The order and the descriptions below come from the machine
+  **Part AI-generated, part one builder's account.** The list of pages comes from the machine
   assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=chute), not from an
-  actual build. Each page carries its own note. Correct them as you build.
+  actual build. The install order below is how alex built his machine, written down from what
+  he described in Discord; nobody else has said whether they did it the same way. Each page
+  carries its own note. Correct them as you build.
 ---
 
 The chute is one per layer. Build the core first, since everything else bolts into its heat inserts.
@@ -22,3 +25,27 @@ The chute is one per layer. Build the core first, since everything else bolts in
 3. **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**. The door itself, the bearing assembly it swings on, the servo adapter, and the [MG995 servo]({{ '/hardware/assembly/distribution/chute/mg995-servo/' | relative_url }}) that drives it. Built as a unit, then bolted on.
 4. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})**. The pair that joins this layer's chute to the one below.
 5. **[PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**. The layer adapter board that drives the servo.
+
+## Installing the chutes in the machine
+
+**The chutes do not go in as you build the layers.** Build the whole frame first, then put the chutes in one at a time. That is the correction alex gave when the interleaved order was suggested to him: "first build all the frame then add the chutes one by one without funnel."
+
+{% include step.html n="1" title="Build the whole frame first, upside down" %}
+
+Lay the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) on the floor with its top plate down, then stack every [layer]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) onto it. Finish the framing before any chute goes near it.
+
+Building inverted pays for itself here: with the machine upside down, each layer's vertical screws are driven **downwards from above** rather than reached from underneath.
+
+{% include step.html n="2" title="Put the chutes in one at a time" %}
+
+With the frame finished, fit the chutes one after another rather than one per layer as the tower goes up. Each one goes in as a unit, the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) with the parts above already bolted to it, and since the [layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}) join each chute to the one below, they go in in order.
+
+{% include step.html n="3" title="Leave the funnels off" %}
+
+The chutes go in **without their funnels fitted**. When the funnels go on afterwards is not recorded anywhere, so treat that as an open question rather than assuming it happens just before the Lazy Susan.
+
+{% include step.html n="4" title="Bottom Lazy Susan, then the feeder" %}
+
+The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) and its Lazy Susan go on after the chutes. The [feeder]({{ '/hardware/assembly/feeder/' | relative_url }}) is the very last thing on the machine, which is BrickCycleAlice's reading of the order and one alex confirmed for his own build.
+
+If you built yours in a different order, that is worth saying: this is one machine, not a house method.

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -28,24 +28,24 @@ The chute is one per layer. Build the core first, since everything else bolts in
 
 ## Installing the chutes in the machine
 
-**The chutes do not go in as you build the layers.** Build the whole frame first, then put the chutes in one at a time. That is the correction alex gave when the interleaved order was suggested to him: "first build all the frame then add the chutes one by one without funnel."
+**Do not add the chutes while you build the layers.** Build the whole frame first, then add the chutes afterward, one at a time. alex was clear about this: "first build all the frame then add the chutes one by one without funnel."
 
 {% include step.html n="1" title="Build the whole frame first, upside down" %}
 
-Lay the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) on the floor with its top plate down, then stack every [layer]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) onto it. Finish the framing before any chute goes near it.
+Put the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) on the floor with its top plate facing down, then stack every [layer]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) on top of it. Finish the whole frame before you add any chutes.
 
-Building inverted pays for itself here: with the machine upside down, each layer's vertical screws are driven **downwards from above** rather than reached from underneath.
+Building it upside down helps here: each layer's vertical screws can be driven **down from above** instead of reached from underneath.
 
-{% include step.html n="2" title="Put the chutes in one at a time" %}
+{% include step.html n="2" title="Add the chutes one at a time" %}
 
-With the frame finished, fit the chutes one after another rather than one per layer as the tower goes up. Each one goes in as a unit, the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) with the parts above already bolted to it, and since the [layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}) join each chute to the one below, they go in in order.
+Once the frame is finished, add the chutes one after another, not one per layer as you build the frame up. Each chute goes in as a complete unit, the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) with its own parts already attached. The [layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}) join each chute to the one below it, so add the chutes in order rather than skipping around.
 
 {% include step.html n="3" title="Leave the funnels off" %}
 
-The chutes go in **without their funnels fitted**. When the funnels go on afterwards is not recorded anywhere, so treat that as an open question rather than assuming it happens just before the Lazy Susan.
+Add the chutes **without their funnels**. Nobody has said yet when the funnels should go on, so don't assume it happens right before the Lazy Susan step below.
 
 {% include step.html n="4" title="Bottom Lazy Susan, then the feeder" %}
 
-The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) and its Lazy Susan go on after the chutes. The [feeder]({{ '/hardware/assembly/feeder/' | relative_url }}) is the very last thing on the machine, which is BrickCycleAlice's reading of the order and one alex confirmed for his own build.
+The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) and its Lazy Susan go on after the chutes. The [feeder]({{ '/hardware/assembly/feeder/' | relative_url }}) goes on last. This last part is based on how BrickCycleAlice and alex both built their machines.
 
-If you built yours in a different order, that is worth saying: this is one machine, not a house method.
+If you built yours in a different order, let us know. This is how one person built their machine, not an official method everyone has to follow.

--- a/docs/src/liquid/_data/authors.yml
+++ b/docs/src/liquid/_data/authors.yml
@@ -30,3 +30,6 @@ effreek:
 jgadling:
   name: Jessica Gadling
   url: https://github.com/jgadling
+
+alex:
+  name: alex


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541394845837430894
preview: /hardware/assembly/distribution/chute/
-->
Adds an **Installing the chutes in the machine** section to the Chute page. The docs said nothing about it, and the obvious guess is wrong.

## Where it comes from

`#machine-setup-help`, 2026-08-22. BrickCycleAlice asked twice how the chute goes in, and **alex**, who has built one, answered:

- ["I assembled my machine upside down. First, I placed the top interface on the floor, then added all the layers and finally put in one chute after another. And then I added the bottom lazy Susan."](https://discord.com/channels/1430279849171222682/1503528472818094220/1540631359515664424)
- ["Here's a picture showing how I have it upside down. Also, like this, it's very easy to stack the layers since the screw can be fastened from above."](https://discord.com/channels/1430279849171222682/1503528472818094220/1540635446692941944)
- ["One by one"](https://discord.com/channels/1430279849171222682/1503528472818094220/1540666668278091847) / ["But after all layers where constucted"](https://discord.com/channels/1430279849171222682/1503528472818094220/1540666774524002305)
- and the one that matters most, when the interleaved order was put to him: ["No, first build all the frame then add the chutes one by one without funnel."](https://discord.com/channels/1430279849171222682/1503528472818094220/1540671099950338081)

That last message is a **correction**, not a restatement. BrickCycleAlice had proposed mounting one chute section into the top interface and then building the next layer onto it. Somebody reading only the earlier messages would land on exactly that, so the page leads with the corrected version.

barthel said at the time that it "would definitely be an important note to include in the assembly documentation". This is that note.

## What the section says

Four steps, in the [Top interface](https://github.com/basicallysource/sorter-v2/blob/main/docs/src/content/hardware/assembly/distribution/top-interface.md) page's style:

1. Build the whole frame first, upside down. Top interface plate down on the floor, every layer stacked onto it. Inverted also means each layer's vertical screws are driven downwards from above rather than reached from underneath.
2. Put the chutes in one at a time, once the frame is finished, not one per layer as the tower goes up.
3. Leave the funnels off.
4. Bottom interface and its Lazy Susan after the chutes, feeder very last.

## What it deliberately does not say

- **When the funnels go on.** Nobody has said. The page says that rather than guessing, which is the one thing a reader will want next.
- **That this is the house method.** One builder, one machine. barthel asked "did the others do it that way, too?" in the thread and nobody answered. The page banner says so.

## Style notes

- Caveats live in the page's `warning:` banner rather than in stacked callout boxes. The page already had one and a second and third yellow box on a short page reads as noise. Top interface reserves `callout-warning` for real build cautions ("the screw head must sit completely flush"), and there is no such caution here.
- **No Discord links on the page.** No docs page links Discord anywhere on the site, so alex is credited by name in prose and in `contributors:`, and the permalinks live in this PR body instead.
- `alex` is new to `docs/src/liquid/_data/authors.yml`. No GitHub URL, since none is known.

## Not included: alex's photo

He posted a photo of his machine inverted, which shows the method better than the prose does. It is not in this PR, because publishing somebody's build photo on the public docs site is his call and not mine. If he is happy with it, it is one upload and a one-line diff. The file is in the Discord thread.

## Checks

- `npm run build` in `docs/` on Node 20, clean.
- `docs/scripts/validate_frontmatter.py`: the 5 errors already on `main`, no new ones.
- `docs/scripts/validate_images.py`: 152 assets, passes.
- Every internal link in the new section resolves to a page that exists: top interface, regular layers, chute core, layer connectors, bottom interface, feeder.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1541303416951804014/1541394845837430894): "Create a new PR and Add a description to the Chute page explaining the best way to install it in the machine. Look for descriptions on Discord (I think I saw one from Alex). Use the Top Interface as a style and layout template here as well."
