### PR TITLE
parts-calculator: P2 warning for the NEMA 23 chute motor's mounting screws

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -307,6 +307,23 @@
           "cable-cage"
         ]
       }
+    },
+    {
+      "id": "retain-nema23-motor-mounting-screws",
+      "name": "NEMA 23 chute motor screws have no retention against vibration",
+      "priority": "P2",
+      "description": "The four M5 x 12 screws holding the NEMA 23 chute stepper onto its bracket are driven upward from below, since the bracket is already mounted to the underside of the Top plate by the time the motor goes on. Nothing but the screws' own friction holds that joint, so machine vibration backs them out over time and they can drop out completely. The fix needs some form of positive retention at the joint (captive nut/washer, a retaining boss or clip, or reworked bracket/motor mount geometry) rather than relying on threadlocker. Reported by Nafets from a machine with 280k+ pieces sorted, diagnosed by barthel. Tracked as sorter-v2 issue #411.",
+      "targets": {
+        "parts": [
+          "interface-nema23-bracket"
+        ],
+        "assemblies": [
+          "interface-nema23-mount"
+        ],
+        "hardware": [
+          "scr-m5-12-shcs"
+        ]
+      }
     }
   ],
   "folders": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -321,6 +321,23 @@
 					"cable-cage"
 				]
 			}
+		},
+		{
+			"id": "retain-nema23-motor-mounting-screws",
+			"name": "NEMA 23 chute motor screws have no retention against vibration",
+			"priority": "P2",
+			"description": "The four M5 x 12 screws holding the NEMA 23 chute stepper onto its bracket are driven upward from below, since the bracket is already mounted to the underside of the Top plate by the time the motor goes on. Nothing but the screws' own friction holds that joint, so machine vibration backs them out over time and they can drop out completely. The fix needs some form of positive retention at the joint (captive nut/washer, a retaining boss or clip, or reworked bracket/motor mount geometry) rather than relying on threadlocker. Reported by Nafets from a machine with 280k+ pieces sorted, diagnosed by barthel. Tracked as sorter-v2 issue #411.",
+			"targets": {
+				"parts": [
+					"interface-nema23-bracket"
+				],
+				"assemblies": [
+					"interface-nema23-mount"
+				],
+				"hardware": [
+					"scr-m5-12-shcs"
+				]
+			}
 		}
 	],
 	"folders": [


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1503528472818094220/1541404609489145927
preview: /part/interface-nema23-bracket
-->

Adds a P2 changes entry for the NEMA 23 chute motor's mounting screws: they're driven up into the bracket from below with nothing but friction holding them, and vibration backs them out over time. Full writeup and the CAD fix are in basicallysource/sorter-v2#411.

`retain-nema23-motor-mounting-screws`, targets `interface-nema23-bracket`, the `interface-nema23-mount` assembly, and `scr-m5-12-shcs`, so the warning shows up on the bracket's part page, the hardware row, and the assembly tree. Regenerated with `catalog/generate.py --metadata-only`; diff is just the one entry in both files.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1503528472818094220/1541404609489145927): "Also, create a PR in which the affected element receives a P2 warning in the part calculator."
