### PR TITLE
docs(door-module): render the four parts that take heat inserts

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -84,7 +84,7 @@ Every pocket is the same one the rest of the chute uses: Ø4.2 mm, blind, 5.7 mm
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-servo-bracket-housing-full-7545917fe3d9.png" alt="Render of the servo bracket housing at an angle, with its six heat-insert pockets circled in red, two on each of three faces">
-    <figcaption>All six, seen from the corner. They are the only view that catches all three faces at once.</figcaption>
+    <figcaption>All six, seen from the corner. That is the only angle that catches all three faces at once.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -128,7 +128,7 @@ Drop the MG995 into the housing and fasten it with 2 {% include fastener.html si
 
 Clock the horn before you commit to a position. The servo only rotates 180° and the door has to reach both of its positions inside that range; the video at the end of this page shows how it is set.
 
-<div class="img-placeholder">Image coming</div>
+<div class="img-placeholder">Photo of the MG995 seated in the bracket housing, held by its two mounting-ear screws, with the horn already clocked to a known position before the arms go on</div>
 
 {% include step.html n="3" title="Add the bracket arms and the cover" %}
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -53,7 +53,7 @@ parts_needed:
     qty: 12
 ---
 
-The door module is the moving half of the chute. It is built on the bench as one unit and then bolted to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), which is where all of its mounting screws land. One per chute, so one per layer.
+The door module is the moving half of the chute. It is built on the bench as one unit and then bolted to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}). One per chute, so one per layer.
 
 The fasteners and quantities are in the parts list above and are called out inline at each step.
 
@@ -66,35 +66,71 @@ Four things make it up:
 3. **Servo adapter**. Two printed parts, a servo side and a flap side, that couple the servo's output to the door.
 4. **MG995 servo** in its four-part bracket: a housing, a lower arm, a side arm and a cover. Built on the bench, in the steps below.
 
-**Which fasteners belong to what**, since the list above cannot say it:
+**What each fastener is for.** The list above gives totals for the whole module; this is the split:
 
 - **Bearing assembly, its own:** 10 {% include fastener.html size="M3" variant="heat-insert" %} (4 in the race, 3 in each holder) and 10 {% include fastener.html size="M3" variant="countersunk" length="8" %}. Six hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each.
 - **Servo bracket, its own:** 6 {% include fastener.html size="M3" variant="heat-insert" %} in the housing, 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} for the arms, and 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the servo's mounting ears.
-- **Holding the finished module to the chute core:** not in the list above. Those screws come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s own set, and are on that page.
+- **Holding the finished module to the chute core:** not in the list above at all. Those screws come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s own set and are counted on that page.
 
 {% include step.html n="1" title="Preparation" %}
 
-Press the inserts into the servo bracket housing while it is still bare, and into the bearing race and the two holders. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+Four of the module's parts take heat inserts, 16 between them. Press them all in while the parts are still bare, before anything is screwed together. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+
+Every pocket is the same one the rest of the chute uses: Ø4.2 mm, blind, 5.7 mm deep. The two bearing covers, the chute door and the two servo adapter halves take none, so if a part is not below it needs no inserts.
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Servo bracket (housing):</strong> 6 × M3</p>
-    <p><strong>Bearing race:</strong> 4 × M3. <strong>Bearing holder (left)</strong> and <strong>(right)</strong>: 3 × M3 each.</p>
+    <p><strong>Servo bracket (housing):</strong> 6 × M3, on three different faces. 4 of them take the arms and 2 take the servo's own mounting ears.</p>
   </div>
-  <div class="prep-item-figure">
-    <div class="img-placeholder">Image coming</div>
-  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-servo-bracket-housing-full-7545917fe3d9.png" alt="Render of the servo bracket housing at an angle, with its six heat-insert pockets circled in red, two on each of three faces">
+    <figcaption>All six, seen from the corner. They are the only view that catches all three faces at once.</figcaption>
+  </figure>
 </div>
 
-{% include step.html n="2" title="Seat the servo in the housing" %}
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Bearing race:</strong> 4 × M3, two at each end. These are the ones the holders screw down onto.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-race-full-4a30d9cbcc4a.png" alt="Render of the bearing race seen almost straight on, with its four heat-insert pockets circled in red, two at each end">
+    <figcaption>Two at each end of the race.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Bearing holder (left):</strong> 3 × M3, on the outboard face, around the bearing bore. The cover screws onto these three.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-holder-left-full-20b5c1bf8883.png" alt="Render of the left bearing holder at an angle, with its three heat-insert pockets circled in red around the bearing bore">
+    <figcaption>Three around the bore on the outboard face.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Bearing holder (right):</strong> 3 × M3, the mirror of the left one.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-holder-right-full-91e140ed31b4.png" alt="Render of the right bearing holder at an angle, with its three heat-insert pockets circled in red around the bearing bore, mirroring the left holder">
+    <figcaption>The same three, mirrored.</figcaption>
+  </figure>
+</div>
+
+The views are rendered from each part's STL, turned slightly off the face so the pockets shade as holes, and circle only the pockets visible from that angle. The counts match what the [parts calculator](https://parts-calculator.basically.website/assembly?focus=flap-module) asks for: 6 + 4 + 3 + 3.
+
+**Steps 2 and 3 build the servo bracket on the bench.** The bearing assembly, the door and the servo adapter have no steps written yet, so build those from the parts themselves and correct this page as you go.
+
+{% include step.html n="2" title="Seat the servo in its bracket housing" %}
 
 Drop the MG995 into the housing and fasten it with 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the servo's own mounting ears.
 
-Clock the horn before you commit to a position. The servo only rotates 180°, and the door has to reach both of its positions inside that range, which is what the video further down is about.
+Clock the horn before you commit to a position. The servo only rotates 180° and the door has to reach both of its positions inside that range; the video at the end of this page shows how it is set.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="3" title="Add the arms and the cover" %}
+{% include step.html n="3" title="Add the bracket arms and the cover" %}
 
 Fit the lower arm and the side arm to the housing and fasten them with the 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws into the housing's inserts. Clip the cover on last; it takes no screws.
 


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541303416951804014/1541409445416927352
request: https://discord.com/channels/1430279849171222682/1541411632448536697/1541441364997316710
request: https://discord.com/channels/1430279849171222682/1541411632448536697/1541444656645279876
preview: /hardware/assembly/distribution/chute/door-module/
-->
> [!NOTE]
> #409 and #413 have both merged, so this branch was rebuilt onto current `main` (just this page's own commits, cherry-picked clean) and no longer carries their content itself.

## The renders

Four parts on the door module page take heat inserts. Each now has its own prep item with its own render, the same treatment the chute core got in #406: pockets found from the part's STL, the view turned about 18° off the face so they shade as holes rather than disappearing into the plate, and a thin circle on each one.

- **Servo bracket (housing)**, 6
- **Bearing race**, 4
- **Bearing holder (left)**, 3
- **Bearing holder (right)**, 3

That is 16, which is what the page already claimed and what `catalog/parts.json` asks for, so **the geometry confirms the count independently** rather than repeating it.

The housing needed a corner view rather than a face-on one: its six pockets sit on **three different faces**, two per face, so no face-on angle shows more than two. The view picker now scores a candidate direction by how face-on it puts each unoccluded pocket rather than by how many are merely visible, which is what surfaced that.

## Are the steps accurate?

Yes, as far as they go. Checked against `catalog/parts.json` and the STLs:

- Step 1's insert counts: 6 / 4 / 3 / 3, confirmed off the geometry.
- Step 2's 2 × M3 × 8 through the servo's ears and step 3's 4 × M3 × 12 for the arms: that is the `servo-bracket` assembly's whole screw list, and 2 + 4 accounts for all 6 of the housing's inserts.
- Step 4's 4 × M3 × 8 for the bearing covers and 2 × M3 × 12 for the arms: matches the chute core's split.

## What is missing, and it is not small

**Steps 1 to 4 do not build the door module.** They press the inserts, build the servo bracket, and bolt the finished module to the core. Between those, three things never get assembled by any step on the page:

- **The bearing assembly.** The page says where its 10 M3 × 8 go (6 covers to holders, 3 each; 4 holders to race, 2 each) but no step puts the two 6704-2RS bearings in, sandwiches the race, or screws the covers on.
- **The chute door.** Never appears in a step.
- **The servo adapter.** Step 4 says it couples the servo's output to the door, but not how either half attaches.

The page's warning banner already says these have no steps, so it is disclosed rather than hidden, and I have not invented an order for them. Writing those steps properly needs somebody who has built one: the screw counts are in the catalog but the sequence is not.

Two smaller gaps this PR does close: the page now says up front which parts take **no** inserts (both bearing covers, the door, both servo adapter halves), and it says plainly that steps 2 and 3 only build the servo bracket, because reading 1 through 4 straight through otherwise looks like it assembles the whole module.

## Wording

- **"which is where all of its mounting screws land"** in the intro was wrong. The module's internal screws do not land in the core, only the six that hold it on. Cut.
- **"Which fasteners belong to what, since the list above cannot say it"** read as an apology for the format. Now "What each fastener is for."
- **"which is what the video further down is about"** was vague about what the video shows. Now "the video at the end of this page shows how it is set."
- Steps 2 and 3 retitled to name the bracket, so their scope is visible from the step list alone.

## Checks

- `npm run build` in `docs/` on Node 20, clean.
- `docs/scripts/validate_frontmatter.py`: the 5 errors already on `main`, no new ones.
- `docs/scripts/validate_images.py`: 156 assets, passes, including the four new renders.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1541303416951804014/1541409445416927352): "Create renderings of the parts on this page that need to be fitted with heat inserts. Use the renderings in Chute Core as a guide for your renderings. Add these renderings to the preparation step. Are the steps on this page accurate, or is anything missing? Should anything be worded better or more clearly?"


