### PR TITLE
docs: servo adapter screws and the MG995 Servo Horn

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -50,7 +50,7 @@ parts_needed:
   - part: scr-m3-12-cs
     qty: 4
   - part: scr-m3-8-cs
-    qty: 12
+    qty: 16
 ---
 
 The door module is the moving half of the chute. It is built on the bench as one unit and then bolted to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}). One per chute, so one per layer.
@@ -63,12 +63,13 @@ Four things make it up:
 
 1. **Chute door**. The flap itself, one printed part.
 2. **Bearing assembly**. What the door swings on: the Bearing race, a Bearing holder (left) and a Bearing holder (right), a Bearing cover (covered side) and a Bearing cover (servo side), and two 6704-2RS bearings.
-3. **Servo adapter**. Two printed parts, a servo side and a flap side, that couple the servo's output to the door.
+3. **Servo adapter**. Two printed parts, a servo side and a flap side, that couple the servo's output to the door. The MG995 Servo Horn that comes with the servo is clasped between the two halves, then the halves are screwed together around it: 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, driven through the flap side (it's the half with the visible screw holes) into the servo side. No heat inserts, the screws thread directly into the printed plastic.
 4. **MG995 servo** in its four-part bracket: a housing, a lower arm, a side arm and a cover. Built on the bench, in the steps below.
 
 **What each fastener is for.** The list above gives totals for the whole module; this is the split:
 
 - **Bearing assembly, its own:** 10 {% include fastener.html size="M3" variant="heat-insert" %} (4 in the race, 3 in each holder) and 10 {% include fastener.html size="M3" variant="countersunk" length="8" %}. Six hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each.
+- **Servo adapter, its own:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %}, no heat inserts. They hold the servo-side and flap-side halves together with the MG995 Servo Horn clasped between them.
 - **Servo bracket, its own:** 6 {% include fastener.html size="M3" variant="heat-insert" %} in the housing, 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} for the arms, and 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the servo's mounting ears.
 - **Holding the finished module to the chute core:** not in the list above at all. Those screws come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s own set and are counted on that page.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -83,21 +83,24 @@ Every pocket is the same one the rest of the chute uses: Ø4.2 mm, blind, 5.7 mm
 
 The servo adapter takes no inserts, but assemble it here anyway, before the bracket steps:
 
-<p><strong>Servo adapter:</strong> the servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Lay it against the servo-side half, bring the flap-side half down over it, and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. No heat inserts, the screws cut their own thread in the printed plastic.</p>
-
-<div class="img-row">
-  <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-square-full-150991b8cde4.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the MG995 servo">
-    <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together.</figcaption>
-  </figure>
-  <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-servo-side-recess-white-full-32262f257d09.png" alt="The servo-side adapter half, rotated to show the recess that the MG995 Servo Horn seats into, with the four screw pilot holes around it">
-    <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into.</figcaption>
-  </figure>
-  <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-door-face-full-ec3b4136d249.png" alt="The flap-side adapter half, rotated 180 degrees from the screw side to show the hexagonal boss and keyed bore that the chute door's shaft inserts into">
-    <figcaption>Flap-side half, other face. The hex boss the chute door's shaft inserts into.</figcaption>
-  </figure>
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Servo adapter:</strong> the servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Lay it against the servo-side half, bring the flap-side half down over it, and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. No heat inserts, the screws cut their own thread in the printed plastic.</p>
+  </div>
+  <div class="prep-item-figure prep-item-figure-split">
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-square-full-150991b8cde4.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the MG995 servo">
+      <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together.</figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-servo-side-recess-white-full-32262f257d09.png" alt="The servo-side adapter half, rotated to show the recess that the MG995 Servo Horn seats into, with the four screw pilot holes around it">
+      <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into.</figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-door-face-full-ec3b4136d249.png" alt="The flap-side adapter half, rotated 180 degrees from the screw side to show the hexagonal boss and keyed bore that the chute door's shaft inserts into">
+      <figcaption>Flap-side half, other face. The hex boss the chute door's shaft inserts into.</figcaption>
+    </figure>
+  </div>
 </div>
 
 <div class="prep-item">

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -95,8 +95,8 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
     <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into.</figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-holes-white-full-5a4ace682ea3.png" alt="The flap-side adapter half, showing its four countersunk screw holes and the keyed centre hole">
-    <figcaption>Flap-side half. The 4 countersunk holes the screws pass through, into the servo side.</figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-door-face-full-ec3b4136d249.png" alt="The flap-side adapter half, rotated 180 degrees from the screw side to show the hexagonal boss and keyed bore that the chute door's shaft inserts into">
+    <figcaption>Flap-side half, other face. The hex boss the chute door's shaft inserts into.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -83,13 +83,20 @@ Every pocket is the same one the rest of the chute uses: Ø4.2 mm, blind, 5.7 mm
 
 The servo adapter takes no inserts, but assemble it here anyway, before the bracket steps:
 
-<div class="prep-item">
-  <div class="prep-item-body">
-    <p><strong>Servo adapter:</strong> the servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Lay it against the servo-side half, bring the flap-side half down over it, and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. No heat inserts, the screws cut their own thread in the printed plastic.</p>
-  </div>
-  <figure class="prep-item-figure">
+<p><strong>Servo adapter:</strong> the servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Lay it against the servo-side half, bring the flap-side half down over it, and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. No heat inserts, the screws cut their own thread in the printed plastic.</p>
+
+<div class="img-row">
+  <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-full-e3eb30ad4de0.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the MG995 servo">
     <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together.</figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-servo-side-recess-full-b4266d52934f.png" alt="The servo-side adapter half, rotated to show the recess that the MG995 Servo Horn seats into, with the four screw pilot holes around it">
+    <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into.</figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-holes-full-d9bfc444c1c4.png" alt="The flap-side adapter half, showing its four countersunk screw holes and the keyed centre hole">
+    <figcaption>Flap-side half. The 4 countersunk holes the screws pass through, into the servo side.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -87,15 +87,15 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
 
 <div class="img-row">
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-full-e3eb30ad4de0.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the MG995 servo">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-square-full-150991b8cde4.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the MG995 servo">
     <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together.</figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-servo-side-recess-full-b4266d52934f.png" alt="The servo-side adapter half, rotated to show the recess that the MG995 Servo Horn seats into, with the four screw pilot holes around it">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-servo-side-recess-white-full-32262f257d09.png" alt="The servo-side adapter half, rotated to show the recess that the MG995 Servo Horn seats into, with the four screw pilot holes around it">
     <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into.</figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-holes-full-d9bfc444c1c4.png" alt="The flap-side adapter half, showing its four countersunk screw holes and the keyed centre hole">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-holes-white-full-5a4ace682ea3.png" alt="The flap-side adapter half, showing its four countersunk screw holes and the keyed centre hole">
     <figcaption>Flap-side half. The 4 countersunk holes the screws pass through, into the servo side.</figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -33,6 +33,8 @@ parts_needed:
     qty: 1
   - part: servo-adapter-flap-side
     qty: 1
+  - part: mg995-servo-horn
+    qty: 1
   - part: servo-bracket-housing
     qty: 1
   - part: servo-bracket-lower-arm
@@ -78,6 +80,18 @@ Four things make it up:
 Four of the module's parts take heat inserts, 16 between them. Press them all in while the parts are still bare, before anything is screwed together. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
 
 Every pocket is the same one the rest of the chute uses: Ø4.2 mm, blind, 5.7 mm deep. The two bearing covers, the chute door and the two servo adapter halves take none, so if a part is not below it needs no inserts.
+
+The servo adapter takes no inserts, but assemble it here anyway, before the bracket steps:
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Servo adapter:</strong> the servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Lay it against the servo-side half, bring the flap-side half down over it, and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. No heat inserts, the screws cut their own thread in the printed plastic.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-full-e3eb30ad4de0.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the MG995 servo">
+    <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together.</figcaption>
+  </figure>
+</div>
 
 <div class="prep-item">
   <div class="prep-item-body">

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -4321,7 +4321,7 @@
       "created_at": "2026-08-24",
       "updated_at": "2026-08-24",
       "note": "Ships in the box with the MG995 servo. Not sold separately, so it has no sourcing of its own here.",
-      "image_url": "https://assets.basically.website/sorter-parts/mg995-servo-horn-full-e3eb30ad4de0.png"
+      "image_url": "https://assets.basically.website/sorter-parts/mg995-servo-horn-square-full-150991b8cde4.png"
     },
     {
       "id": "brg-6806-2rs",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -4309,6 +4309,21 @@
       }
     },
     {
+      "id": "mg995-servo-horn",
+      "uid": "s8dv",
+      "kind": "cots",
+      "cots": {
+        "type": "servo-horn"
+      },
+      "name": "MG995 Servo Horn",
+      "category": "Motors",
+      "description": "Two-arm splined servo horn. Clasped between the servo-adapter's two halves once they're screwed together.",
+      "created_at": "2026-08-24",
+      "updated_at": "2026-08-24",
+      "note": "Ships in the box with the MG995 servo. Not sold separately, so it has no sourcing of its own here.",
+      "image_url": "https://assets.basically.website/sorter-parts/mg995-servo-horn-full-e3eb30ad4de0.png"
+    },
+    {
       "id": "brg-6806-2rs",
       "uid": "elxe",
       "kind": "cots",
@@ -5616,6 +5631,10 @@
         },
         {
           "part": "servo-adapter-flap-side",
+          "qty": 1
+        },
+        {
+          "part": "mg995-servo-horn",
           "qty": 1
         },
         {

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5606,7 +5606,7 @@
       "uid": "irue",
       "version": "1",
       "name": "Servo adapter (MG995)",
-      "description": "MG995 servo adapter: servo side + flap side.",
+      "description": "MG995 servo adapter: servo side + flap side, clamping the MG995 Servo Horn (comes with the servo) between them. 4 M3 x 8 countersunk hold the two halves together, no heat inserts.",
       "docs": "/hardware/assembly/distribution/chute/door-module/",
       "status": "partial",
       "lines": [
@@ -5617,6 +5617,10 @@
         {
           "part": "servo-adapter-flap-side",
           "qty": 1
+        },
+        {
+          "part": "scr-m3-8-cs",
+          "qty": 4
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -648,6 +648,10 @@
 					"qty": 1
 				},
 				{
+					"part": "mg995-servo-horn",
+					"qty": 1
+				},
+				{
 					"part": "scr-m3-8-cs",
 					"qty": 4
 				}
@@ -16107,6 +16111,30 @@
 			"docs_page": null,
 			"conflicts": null,
 			"image": "https://img.basically.website/parts/img/servo-mg995-8a8b0ae4.jpg"
+		},
+		{
+			"id": "mg995-servo-horn",
+			"uid": "s8dv",
+			"kind": "cots",
+			"cots": {
+				"type": "servo-horn"
+			},
+			"name": "MG995 Servo Horn",
+			"category": "Motors",
+			"description": "Two-arm splined servo horn. Clasped between the servo-adapter's two halves once they're screwed together.",
+			"note": "Ships in the box with the MG995 servo. Not sold separately, so it has no sourcing of its own here.",
+			"created_at": "2026-08-24",
+			"updated_at": "2026-08-24",
+			"attributes": [],
+			"sheet_qty": null,
+			"sheet_qty_text": null,
+			"stock": null,
+			"sourcing": null,
+			"alternative": null,
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"image": "https://assets.basically.website/sorter-parts/mg995-servo-horn-full-e3eb30ad4de0.png"
 		},
 		{
 			"id": "brg-6806-2rs",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -635,7 +635,7 @@
 			"uid": "irue",
 			"version": "1",
 			"name": "Servo adapter (MG995)",
-			"description": "MG995 servo adapter: servo side + flap side.",
+			"description": "MG995 servo adapter: servo side + flap side, clamping the MG995 Servo Horn (comes with the servo) between them. 4 M3 x 8 countersunk hold the two halves together, no heat inserts.",
 			"docs": "/hardware/assembly/distribution/chute/door-module/",
 			"status": "partial",
 			"lines": [
@@ -646,6 +646,10 @@
 				{
 					"part": "servo-adapter-flap-side",
 					"qty": 1
+				},
+				{
+					"part": "scr-m3-8-cs",
+					"qty": 4
 				}
 			]
 		},

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -16134,7 +16134,7 @@
 			"caption": null,
 			"docs_page": null,
 			"conflicts": null,
-			"image": "https://assets.basically.website/sorter-parts/mg995-servo-horn-full-e3eb30ad4de0.png"
+			"image": "https://assets.basically.website/sorter-parts/mg995-servo-horn-square-full-150991b8cde4.png"
 		},
 		{
 			"id": "brg-6806-2rs",


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1541540128214880297
request: https://discord.com/channels/1430279849171222682/1540455365521440778/1540460257745309727
request: https://discord.com/channels/1430279849171222682/1541540128214880297/1541548023681650858
request: https://discord.com/channels/1430279849171222682/1541540128214880297/1541655676495986748
request: https://discord.com/channels/1430279849171222682/1541540128214880297/1541658043996049429
request: https://discord.com/channels/1430279849171222682/1541540128214880297/1541660850639601795
preview: /hardware/assembly/distribution/chute/door-module/
-->

Requested by uwe_barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1541540128214880297): "Could you please add this to the assembly instructions for the servo motor for the chute door?", pointing at [Spencer](@spencerhubert)'s note in #balloon-does-docs: "these need 4x of the m3 counter sunks. 8mm. that's what holds them together... this is the MG995 Servo Horn. it comes with each of the servos when you buy them. it is clasped between the two adapter pieces once they're screwed together. 'flap side' looks like the side with the thru holes."

Follow-ups, also from uwe_barthel:
1. [from Discord](https://discord.com/channels/1430279849171222682/1541540128214880297/1541548023681650858): "Could you please include the picture of the component and describe how to assemble it with the two plates in the preparation step?"
2. [from Discord](https://discord.com/channels/1430279849171222682/1541540128214880297/1541655676495986748): "Insert the two servo adapters next to the servo horn in the preparation step, as shown in the image. Rotate and render the 'servo adapter - servo side' so that the recess for the servo horn is visible."
3. [from Discord](https://discord.com/channels/1430279849171222682/1541540128214880297/1541658043996049429): "Make These 3 Images the Same size"
4. [from Discord](https://discord.com/channels/1430279849171222682/1541540128214880297/1541660850639601795): "Please rotate the servo adapter—flap side—about 180 degrees so that you can see the part where the chute door will be inserted later."

- `door-module.md`: item 3 (Servo adapter) and the fastener-split section cover the 4x M3x8 CS screws and the horn; `parts_needed`'s `scr-m3-8-cs` goes 12 → 16. The Preparation step has the assembly text plus an `img-row` of three matched 900x900 white-background images: the horn photo, the servo-side half rotated to show the horn's recess, and the flap-side half rotated to its door-coupling face (hex boss + keyed bore the door's shaft seats into, not the screw face).
- `catalog/parts.json`: the `servo-adapter` assembly gets its missing `scr-m3-8-cs` x4 line. The MG995 Servo Horn is its own catalog part now (ships with the servo, no separate sourcing), so it's in the needed-parts list, using the same squared photo as the docs page.
- The renders are `meshfig.py` (already in the repo, no GL/matplotlib needed) shots of the actual STLs, camera on whichever face was asked for — the two adapter halves share assembly coordinates so there's no guessing at orientation between them.
- Regenerated with `generate.py --metadata-only`; `check_generated_pins.py` and `check_bucket_urls.py` both pass locally.

Checked against the STLs: the flap-side half has 4 countersunk clearance holes at its mating face, no matching heat-insert pockets on either half, and the servo-side half has 4 blind ~2.8 mm pilot holes at the same positions — consistent with self-tapping, not inserts, matching what's written. The horn photo is Spencer's own reference/identification image (a stock photo, not our render — it's a bought part with no STL).
