### PR TITLE
parts-calculator: add a 3D-printed option for the cable cage

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1387,6 +1387,42 @@
       ]
     },
     {
+      "id": "cage-top-hex-corner",
+      "uid": "o732",
+      "name": "Cable cage hex corner (printed)",
+      "description": "One corner segment of the 3D-printed cable cage hexagon. 6 build the bottom plate; 4 plus one cage motor piece build the top plate.",
+      "internal_notes": "Community 3D-printed alternative to the laser-cut cable-cage-top/-bottom hexagon plates, from Alec's own OnShape design (shared 2026-07-16 in the general build thread, see cable cage 3d-print status). Assembly: bolt segments together with M3 nuts and bolts as a temporary clamp, glue the joints, then remove the M3 hardware once the glue is dry. Not wired into quantities -- this is an alternative fabrication route for cable-cage-top/-bottom, not an extra part on the machine; the laser-cut plates stay the counted default. 6x builds cable-cage-bottom; 4x (with 1x cage-top-motor-piece) builds cable-cage-top.",
+      "version": "1",
+      "created_at": "2026-08-24",
+      "updated_at": "2026-08-24",
+      "quantities": {},
+      "assembly": "cable-cage",
+      "stl_hash": "92c8342eaa282d1c6b25d83f73d179f545426072198f544d1035306c8380dabc",
+      "color": {
+        "role": "frame"
+      },
+      "optional": true,
+      "support": false
+    },
+    {
+      "id": "cage-top-motor-piece",
+      "uid": "64tz",
+      "name": "Cable cage motor piece (printed)",
+      "description": "The chute-motor segment of the 3D-printed cable cage top plate. 1 needed, alongside 4 hex corner pieces.",
+      "internal_notes": "Community 3D-printed alternative to the laser-cut cable-cage-top/-bottom hexagon plates, from Alec's own OnShape design (shared 2026-07-16 in the general build thread, see cable cage 3d-print status). Assembly: bolt segments together with M3 nuts and bolts as a temporary clamp, glue the joints, then remove the M3 hardware once the glue is dry. Not wired into quantities -- this is an alternative fabrication route for cable-cage-top/-bottom, not an extra part on the machine; the laser-cut plates stay the counted default. Used only in the top plate build: 4x cage-top-hex-corner + 1x this piece.",
+      "version": "1",
+      "created_at": "2026-08-24",
+      "updated_at": "2026-08-24",
+      "quantities": {},
+      "assembly": "cable-cage",
+      "stl_hash": "c4d97fa88f75337acfb5fd9e1ae88b761b87a19be409d3ef0213d432187b77ec",
+      "color": {
+        "role": "frame"
+      },
+      "optional": true,
+      "support": false
+    },
+    {
       "id": "ribbon-cable-clamp",
       "uid": "nf0n",
       "name": "Ribbon cable clamp",
@@ -5365,6 +5401,19 @@
         "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big Ø177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
         "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
         "tools": "jigsaw · drill · tape measure"
+      },
+      "printed": {
+        "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
+        "components": [
+          {
+            "part": "cage-top-hex-corner",
+            "qty": 4
+          },
+          {
+            "part": "cage-top-motor-piece",
+            "qty": 1
+          }
+        ]
       }
     },
     {
@@ -5389,6 +5438,15 @@
         "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big Ø177 mm centre hole and six Ø5.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
         "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
         "tools": "jigsaw · drill · tape measure"
+      },
+      "printed": {
+        "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
+        "components": [
+          {
+            "part": "cage-top-hex-corner",
+            "qty": 6
+          }
+        ]
       }
     },
     {

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -14120,6 +14120,263 @@
 					"note": "smaller text"
 				}
 			]
+		},
+		{
+			"id": "cage-top-hex-corner",
+			"uid": "o732",
+			"name": "Cable cage hex corner (printed)",
+			"quantities": {},
+			"assembly": "cable-cage",
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "One corner segment of the 3D-printed cable cage hexagon. 6 build the bottom plate; 4 plus one cage motor piece build the top plate.",
+			"version": "1",
+			"created_at": "2026-08-24",
+			"updated_at": "2026-08-24",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "o732",
+					"date": "2026-08-24",
+					"message": "Initial version.",
+					"commit": null
+				}
+			],
+			"attributes": [],
+			"grams": 29.01,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 2334,
+			"color": {
+				"role": "frame"
+			},
+			"optional": true,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-92c8342e.stl",
+			"render": "https://img.basically.website/parts/render/cage-top-hex-corner-3a346d2e.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-stamped-bottom-fcb66f29.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						100.41,
+						68.36,
+						237.0
+					],
+					"size": [
+						12.33,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-stamped-top-84208af2.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						154.96,
+						10.19,
+						240.0
+					],
+					"size": [
+						12.33,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top 2",
+					"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-stamped-top-2-d39f1122.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						95.8,
+						-3.81,
+						238.5
+					],
+					"size": [
+						12.33,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				},
+				{
+					"face": "top 3",
+					"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-stamped-top-3-5ef81bc5.stl",
+					"normal": [
+						0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						48.51,
+						82.57,
+						238.5
+					],
+					"size": [
+						3.63,
+						12.33
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				}
+			]
+		},
+		{
+			"id": "cage-top-motor-piece",
+			"uid": "64tz",
+			"name": "Cable cage motor piece (printed)",
+			"quantities": {},
+			"assembly": "cable-cage",
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "The chute-motor segment of the 3D-printed cable cage top plate. 1 needed, alongside 4 hex corner pieces.",
+			"version": "1",
+			"created_at": "2026-08-24",
+			"updated_at": "2026-08-24",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "64tz",
+					"date": "2026-08-24",
+					"message": "Initial version.",
+					"commit": null
+				}
+			],
+			"attributes": [],
+			"grams": 52.99,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3798,
+			"color": {
+				"role": "frame"
+			},
+			"optional": true,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-c4d97fa8.stl",
+			"render": "https://img.basically.website/parts/render/cage-top-motor-piece-fe7fc28a.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-stamped-bottom-aff68d79.stl",
+					"normal": [
+						0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						-78.84,
+						-135.07,
+						237.0
+					],
+					"size": [
+						12.28,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				},
+				{
+					"face": "top",
+					"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-stamped-top-0f01b6da.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						-90.99,
+						-128.07,
+						240.0
+					],
+					"size": [
+						12.28,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top 2",
+					"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-stamped-top-2-468a76f6.stl",
+					"normal": [
+						0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						-68.65,
+						-120.71,
+						238.5
+					],
+					"size": [
+						3.56,
+						12.28
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				},
+				{
+					"face": "bottom 2",
+					"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-stamped-bottom-2-a4896b9d.stl",
+					"normal": [
+						0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						-48.48,
+						82.54,
+						238.5
+					],
+					"size": [
+						3.56,
+						12.28
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				}
+			]
 		}
 	],
 	"plates": [
@@ -17396,6 +17653,19 @@
 				"blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big \u00d8177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
 				"stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
 				"tools": "jigsaw \u00b7 drill \u00b7 tape measure"
+			},
+			"printed": {
+				"blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
+				"components": [
+					{
+						"part": "cage-top-hex-corner",
+						"qty": 4
+					},
+					{
+						"part": "cage-top-motor-piece",
+						"qty": 1
+					}
+				]
 			}
 		},
 		{
@@ -17419,6 +17689,15 @@
 				"blurb": "The same regular-hexagon outline as the top cage, but simpler: one big \u00d8177 mm centre hole and six \u00d85.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
 				"stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
 				"tools": "jigsaw \u00b7 drill \u00b7 tape measure"
+			},
+			"printed": {
+				"blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
+				"components": [
+					{
+						"part": "cage-top-hex-corner",
+						"qty": 6
+					}
+				]
 			}
 		},
 		{

--- a/parts-calculator/src/lib/lasercut.ts
+++ b/parts-calculator/src/lib/lasercut.ts
@@ -36,6 +36,12 @@ export type LaserCutPart = {
 		stock: string; // stock size, shown on the tab
 		tools: string; // tools line, shown on the tab
 	};
+	// optional 3D-printed route: this sheet part built instead from printed
+	// pieces (ids into PARTS) rather than cut from stock
+	printed?: {
+		blurb: string; // the "3D Printed" tab paragraph
+		components: { part: string; qty: number }[]; // printed part id + count needed
+	};
 };
 
 export const LASER_CUT_PARTS = ((raw as Record<string, unknown>).lasercut ??

--- a/parts-calculator/src/routes/lasercut/+page.svelte
+++ b/parts-calculator/src/routes/lasercut/+page.svelte
@@ -7,7 +7,7 @@
 	import HandCutCageGuide from '$lib/components/HandCutCageGuide.svelte';
 	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
 	import { LASER_CUT_PARTS, type LaserCutPart } from '$lib/lasercut';
-	import { fmtDate } from '$lib/filament';
+	import { fmtDate, PARTS } from '$lib/filament';
 	import { type Units } from '$lib/handcut';
 	import { page } from '$app/state';
 	import { replaceState } from '$app/navigation';
@@ -23,10 +23,12 @@
 	}
 
 	// each card offers a second view besides the laser-cut files: parts with a
-	// `handcut` config can be cut by hand (jigsaw + drill); parts without one
-	// show a disabled "3D Printed" tab as a placeholder.
-	type Mode = 'laser' | 'hand';
+	// `handcut` config can be cut by hand (jigsaw + drill), and parts with a
+	// `printed` config can be built from printed pieces instead. A part with
+	// neither shows a disabled "3D Printed" tab as a placeholder.
+	type Mode = 'laser' | 'hand' | 'printed';
 	const handCutReady = (p: LaserCutPart) => !!p.handcut;
+	const printedReady = (p: LaserCutPart) => !!p.printed;
 	let mode = $state<Record<string, Mode>>(
 		Object.fromEntries(LASER_CUT_PARTS.map((p) => [p.id, 'laser' as Mode]))
 	);
@@ -88,8 +90,8 @@
 			<p class="mt-1 text-sm text-text-muted">
 				Flat plywood parts, cut from the DXFs below. Thicknesses are quoted in the imperial size the
 				sheet is sold as, with the nearest full-mm equivalent the CAD expects. No laser? The top
-				plate and both cable cage plates have a “by hand” view; 3D-printable cage options are still
-				to come.
+				plate and both cable cage plates have a “by hand” view, and both cable cage plates also
+				have a 3D-printed option.
 			</p>
 		</div>
 		<a href="https://bin-gen.basically.website/" target="_blank" rel="noopener" class="inline-flex shrink-0 items-center justify-center gap-1.5 border border-border bg-surface px-3 py-2 text-sm font-semibold text-text-muted transition-colors hover:border-primary hover:text-primary">
@@ -129,6 +131,16 @@
 								>
 									<Hammer size={12} /> By hand
 								</button>
+							{/if}
+							{#if printedReady(p)}
+								<button
+									class="inline-flex items-center gap-1 border-b-2 px-2.5 py-1.5 text-xs font-semibold {mode[p.id] === 'printed'
+										? 'border-text text-text'
+										: 'border-transparent text-text-muted hover:text-text'}"
+									onclick={() => (mode[p.id] = 'printed')}
+								>
+									<Box size={12} /> 3D Printed
+								</button>
 							{:else}
 								<span
 									class="inline-flex cursor-not-allowed items-center gap-1 border-b-2 border-transparent px-2.5 py-1.5 text-xs font-semibold text-text-muted opacity-40"
@@ -165,7 +177,7 @@
 										OnShape <ExternalLink size={11} />
 									</a>
 								</div>
-							{:else}
+							{:else if mode[p.id] === 'hand'}
 								<p class="text-sm text-text-muted">{p.handcut?.blurb}</p>
 								<dl class="grid max-w-sm grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs text-text-muted">
 									<dt>Thickness</dt>
@@ -183,6 +195,22 @@
 										<Hammer size={14} /> Open the step-by-step guide
 									</button>
 								</div>
+							{:else}
+								<p class="text-sm text-text-muted">{p.printed?.blurb}</p>
+								<ul class="flex flex-col gap-1.5">
+									{#each p.printed?.components ?? [] as c (c.part)}
+										{@const printedPart = PARTS.find((x) => x.id === c.part)}
+										<li class="flex items-center justify-between gap-2 text-xs">
+											<a
+												href="/part/{c.part}"
+												class="text-text hover:text-primary hover:underline"
+											>
+												{printedPart?.name ?? c.part}
+											</a>
+											<span class="shrink-0 text-text-muted">× {c.qty}</span>
+										</li>
+									{/each}
+								</ul>
 							{/if}
 						</div>
 					</div>

--- a/parts-calculator/src/routes/lasercut/+page.svelte
+++ b/parts-calculator/src/routes/lasercut/+page.svelte
@@ -6,8 +6,10 @@
 	import HandCutTopPlateGuide from '$lib/components/HandCutTopPlateGuide.svelte';
 	import HandCutCageGuide from '$lib/components/HandCutCageGuide.svelte';
 	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
+	import PartDetailModal from '$lib/components/PartDetailModal.svelte';
 	import { LASER_CUT_PARTS, type LaserCutPart } from '$lib/lasercut';
-	import { fmtDate, PARTS } from '$lib/filament';
+	import { fmtDate, PARTS, primaryColorId, type Part, type PartVersion } from '$lib/filament';
+	import { colorStore } from '$lib/colors.svelte';
 	import { type Units } from '$lib/handcut';
 	import { page } from '$app/state';
 	import { replaceState } from '$app/navigation';
@@ -37,6 +39,19 @@
 	function openGuide(p: LaserCutPart) {
 		guidePart = p;
 		guideOpen = true;
+	}
+
+	// Clicking a printed component opens the same detail view the parts
+	// dashboard and assembly tree use, rather than navigating to /part/<id>.
+	let partOpen = $state(false);
+	let partModal = $state<Part | null>(null);
+	let partColor = $state('ash-gray');
+	let partVersion = $state<PartVersion | null>(null);
+	function openPart(p: Part) {
+		partModal = p;
+		partColor = primaryColorId(p, colorStore.roles) ?? 'ash-gray';
+		partVersion = p.versions?.[p.versions.length - 1] ?? null;
+		partOpen = true;
 	}
 
 	// Deep-link the hand-cut guide: `?guide=top-plate` opens the modal and
@@ -201,12 +216,17 @@
 									{#each p.printed?.components ?? [] as c (c.part)}
 										{@const printedPart = PARTS.find((x) => x.id === c.part)}
 										<li class="flex items-center justify-between gap-2 text-xs">
-											<a
-												href="/part/{c.part}"
-												class="text-text hover:text-primary hover:underline"
-											>
-												{printedPart?.name ?? c.part}
-											</a>
+											{#if printedPart}
+												<button
+													type="button"
+													class="text-text hover:text-primary hover:underline"
+													onclick={() => openPart(printedPart)}
+												>
+													{printedPart.name}
+												</button>
+											{:else}
+												<span class="text-text">{c.part}</span>
+											{/if}
 											<span class="shrink-0 text-text-muted">× {c.qty}</span>
 										</li>
 									{/each}
@@ -243,3 +263,5 @@
 		<HandCutCageGuide variant="bottom" bind:units />
 	{/if}
 </Modal>
+
+<PartDetailModal bind:open={partOpen} part={partModal} bind:colorId={partColor} bind:version={partVersion} />


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1541539313370800249
request: https://discord.com/channels/1430279849171222682/1541539313370800249/1541556170844545224
request: https://discord.com/channels/1430279849171222682/1541539313370800249/1541719076756520971
preview: /lasercut
-->
Adds a 3D-printed option for both cable cage plates, alongside the existing laser-cut and by-hand routes.

New printed parts (`catalog/parts.json`):
- `cage-top-hex-corner` — one hexagon corner segment. 6 build the bottom plate; 4 (+ 1 motor piece) build the top plate.
- `cage-top-motor-piece` — the top plate's chute-motor segment, used once alongside 4 hex corners.

Both are an alternative fabrication route for `cable-cage-top`/`cable-cage-bottom`, not new parts on the machine, so they carry empty `quantities` and don't add to the standard totals — same treatment as other unadopted alternatives in the catalog.

`src/lib/lasercut.ts` gets a `printed` field on `LaserCutPart` (parallel to the existing `handcut` one), and `/lasercut` now shows a working "3D Printed" tab on both cage cards listing the pieces to print and the assembly note, instead of the disabled placeholder.

Assembly, per Alec's own design: bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue cures.

Requested by zed0 (@zed0) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1541539313370800249): "can you add a 3d printed option to the cable cage in the parts calculator. The bottom part requires 6 of the attached `cage_top-hex_corner.stl` and the top part requires 4 of the attached `cage_top-hex_corner.stl` and 1 of the attached `cage_top-motor-piece.stl`. The assembly method is to attach the pieces with m3 nuts and bolts, glue them together, and then remove the m3 nuts and bolts once the glue is dry. Add credit to Alec"

Design credit: Alec (@flewber), who shared this cage design 2026-07-16.


---

Update: clicking a printed piece now opens the same part-detail modal the dashboard uses, instead of navigating to its own page.
