### PR TITLE
docs+parts: idler gear bearing retainers replace the loose washer

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -413,6 +413,11 @@ Loosen the screws attaching the Limit switch housing to the extrusion. Slide the
     loading="lazy"></iframe>
 </div>
 
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>This video predates the idler gear's bearing retainer caps. It shows the idler gear built the old way, with a loose washer under the M3 × 35 screw instead of the two printed caps from step 1.</p>
+</div>
+
 Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }}) over the shaft of the NEMA 23 stepper motor and tighten the two worm screws on its side. Slide the Interface spur gear onto the Timing pulley and secure it with five {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, half tapped into the Interface spur gear and half bracing against the Timing pulley.
 
 Push the prepared Interface idler gear — bearing, inner retainer cap, and outer retainer already fitted, see step 1 — onto the Interface NEMA 23 bracket with the bearing facing outwards.

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -40,6 +40,10 @@ parts_needed:
     qty: 1
   - part: interface-idler-gear
     qty: 1
+  - part: chute-stepper-idler-bearing-retainer-outer
+    qty: 1
+  - part: chute-stepper-idler-bearing-retainer-inner
+    qty: 1
   - part: interface-cage-bracket
     qty: 5
   - part: interface-cage-bracket-cable
@@ -81,7 +85,7 @@ parts_needed:
   - part: hsi-m5
     qty: 24
   - part: hsi-m3
-    qty: 12
+    qty: 16
   - part: scr-m5-35-fhcs
     qty: 6
   - part: scr-m5-30-shcs
@@ -110,13 +114,13 @@ parts_needed:
     qty: 5
   - part: scr-m3-6-cs
     qty: 1
+  - part: scr-m3-tbd
+    qty: 4
   - part: tnut-m5-2020
     qty: 50
   - part: nut-m5
     qty: 6
   - part: nut-m3
-    qty: 1
-  - part: washer-m3-15
     qty: 1
 ---
 
@@ -211,6 +215,31 @@ Before assembling anything, press the heat inserts into the parts that take them
     <figcaption>The one M3 insert in the Cable cage bracket (cable mount).</figcaption>
   </figure>
 </div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Interface idler gear:</strong> 4 × M3, around the bearing pocket on the underside</p>
+  </div>
+</div>
+
+Build the idler gear's bearing sub-assembly now too, while it is still loose — it is easier off the bracket than on it. Push a 608 2RS bearing into the Interface idler gear's pocket. Fit the Chute stepper idler gear bearing retainer (inner) into the middle of the recess, over the bearing's bore. Fit the Chute stepper idler gear bearing retainer (outer) over it, seated flush in the same recess with its 4 holes lined up on the gear's 4 new M3 inserts, and secure it with 4 × <span class="fastener-todo">M3 countersunk, length not recorded</span> screws. This pair of printed caps takes the place of the loose M3 × 15 mm washer this joint used to use; see step 9 for how the idler gear then goes onto the bracket.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-iso-recess-full-997b8558aae9.png" alt="The Interface idler gear seen from below at an angle, with the bearing pocket recess and the outer and inner bearing retainer caps highlighted in red, their four countersunk screw holes visible">
+    <figcaption>The gear from below: bearing pocket recess with both retainer caps fitted.</figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-from-below-full-41061b3f2bc9.png" alt="The Interface idler gear viewed straight on from underneath, showing the outer bearing retainer ring flush in the gear with its four countersunk screws around the smaller inner retainer cap at the centre">
+    <figcaption>Straight on: the outer retainer's 4 screws around the inner cap.</figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-exploded-recess-full-48b3293e64b8.png" alt="An exploded view from below of the idler gear stack: the gear, the 608 bearing, the inner retainer cap, and the outer retainer ring, in the order they assemble">
+    <figcaption>Exploded, in build order: gear, bearing, inner cap, outer ring.</figcaption>
+  </figure>
+</div>
+
+These three are reconstructions built from the STL geometry, not photos or a CAD export — there is no assembly photo of this joint yet.
 
 Printed parts elsewhere in the machine take inserts too. Each assembly page lists its own in a **Preparation** step like this one, so press them in as you reach that page.
 
@@ -397,11 +426,9 @@ Loosen the screws attaching the Limit switch housing to the extrusion. Slide the
 
 Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }}) over the shaft of the NEMA 23 stepper motor and tighten the two worm screws on its side. Slide the Interface spur gear onto the Timing pulley and secure it with five {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, half tapped into the Interface spur gear and half bracing against the Timing pulley.
 
-Push a 608 2RS bearing into the Interface idler gear.
+Push the prepared Interface idler gear — bearing, inner retainer cap, and outer retainer already fitted, see step 1 — onto the Interface NEMA 23 bracket with the bearing facing outwards.
 
-Push the idler gear onto the Interface NEMA 23 bracket with the bearing facing outwards.
-
-Slide an M3 × 15 mm washer onto an {% include fastener.html size="M3" variant="flat" length="35" %} screw, then drive that screw through the bearing and into the bracket. The washer sits between the screw head and the outer face of the bearing, spanning its 8 mm bore: the screw head on its own is narrower than the bore and drops down inside it, so the washer is what actually holds the idler gear onto the bracket. Tighten until the washer is seated, then check that the idler gear still spins freely.
+Drive an {% include fastener.html size="M3" variant="flat" length="35" %} screw through the middle of the gear and into the bracket. The inner retainer cap does the job a loose M3 × 15 mm washer used to: it sits between the screw head and the bearing, spanning the 8 mm bore, so the screw head on its own (narrower than the bore) has something to clamp against. Tighten until it's seated, then check that the idler gear still spins freely.
 
 The head has to be a low one here. A socket or button head stands proud enough that the Limit switch hammer can catch on it as the chute sweeps past, so use a flat (pancake) head, or a pan head if that is what you have. It is the same screw as the one on the Cable clamp in step 11, so buy two of the one head type.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -222,12 +222,12 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-idler-gear-bearing-w1600-2fe924b61150.jpg" alt="608 2RS bearing pressed into the centre of the grey Interface idler gear, from before the bearing retainer caps existed">
-      <figcaption>608 2RS bearing pressed into the pocket. Real photo, predates the retainer caps.</figcaption>
-    </figure>
-    <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-exploded-3color-full-227310630981.png" alt="An exploded view from below of the idler gear stack in build order: the grey gear, the bearing highlighted in blue, and the inner and outer bearing retainer caps highlighted in red">
       <figcaption>Exploded, in build order: gear, bearing, inner cap, outer ring.</figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-idler-gear-bearing-w1600-2fe924b61150.jpg" alt="608 2RS bearing pressed into the centre of the grey Interface idler gear, from before the bearing retainer caps existed">
+      <figcaption>608 2RS bearing pressed into the pocket. Real photo, predates the retainer caps.</figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-assembled-3color-full-7de4573e7301.png" alt="The Interface idler gear seen from below at an angle, assembled, with the bearing highlighted in blue showing through the centre and the outer and inner bearing retainer caps highlighted in red, the outer retainer's four countersunk screw holes visible">

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -111,11 +111,9 @@ parts_needed:
   - part: scr-m3-16-shcs
     qty: 2
   - part: scr-m3-8-cs
-    qty: 5
+    qty: 9
   - part: scr-m3-6-cs
     qty: 1
-  - part: scr-m3-tbd
-    qty: 4
   - part: tnut-m5-2020
     qty: 50
   - part: nut-m5
@@ -219,29 +217,21 @@ Before assembling anything, press the heat inserts into the parts that take them
 <div class="prep-item">
   <div class="prep-item-body">
     <p><strong>Interface idler gear:</strong> 4 × M3, around the bearing pocket on the underside</p>
+    <p>Build the bearing sub-assembly now too, while the gear is still loose — it is easier off the bracket than on it. Push a 608 2RS bearing into the pocket, fit the Chute stepper idler gear bearing retainer (inner) over the bearing's bore, then the Chute stepper idler gear bearing retainer (outer) over that, seated flush in the recess with its 4 holes lined up on the gear's 4 inserts. Secure it with 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, the same screw the Interface spur gear uses a few lines up. See step 9 for how the idler gear then goes onto the bracket.</p>
+  </div>
+  <div class="prep-item-figure prep-item-figure-split">
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-exploded-3color-full-227310630981.png" alt="An exploded view from below of the idler gear stack in build order: the grey gear, the bearing highlighted in blue, and the inner and outer bearing retainer caps highlighted in red">
+      <figcaption>Exploded, in build order: gear, bearing, inner cap, outer ring.</figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-assembled-3color-full-7de4573e7301.png" alt="The Interface idler gear seen from below at an angle, assembled, with the bearing highlighted in blue showing through the centre and the outer and inner bearing retainer caps highlighted in red, the outer retainer's four countersunk screw holes visible">
+      <figcaption>Assembled: bearing pocket recess with both retainer caps fitted.</figcaption>
+    </figure>
   </div>
 </div>
 
-Build the idler gear's bearing sub-assembly now too, while it is still loose — it is easier off the bracket than on it. Push a 608 2RS bearing into the Interface idler gear's pocket. Fit the Chute stepper idler gear bearing retainer (inner) into the middle of the recess, over the bearing's bore. Fit the Chute stepper idler gear bearing retainer (outer) over it, seated flush in the same recess with its 4 holes lined up on the gear's 4 new M3 inserts, and secure it with 4 × <span class="fastener-todo">M3 countersunk, length not recorded</span> screws. This pair of printed caps takes the place of the loose M3 × 15 mm washer this joint used to use; see step 9 for how the idler gear then goes onto the bracket.
-
-<div class="img-row">
-  <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-iso-recess-full-997b8558aae9.png" alt="The Interface idler gear seen from below at an angle, with the bearing pocket recess and the outer and inner bearing retainer caps highlighted in red, their four countersunk screw holes visible">
-    <figcaption>The gear from below: bearing pocket recess with both retainer caps fitted.</figcaption>
-  </figure>
-  <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-from-below-full-41061b3f2bc9.png" alt="The Interface idler gear viewed straight on from underneath, showing the outer bearing retainer ring flush in the gear with its four countersunk screws around the smaller inner retainer cap at the centre">
-    <figcaption>Straight on: the outer retainer's 4 screws around the inner cap.</figcaption>
-  </figure>
-  <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-exploded-recess-full-48b3293e64b8.png" alt="An exploded view from below of the idler gear stack: the gear, the 608 bearing, the inner retainer cap, and the outer retainer ring, in the order they assemble">
-    <figcaption>Exploded, in build order: gear, bearing, inner cap, outer ring.</figcaption>
-  </figure>
-</div>
-
-These three are reconstructions built from the STL geometry, not photos or a CAD export — there is no assembly photo of this joint yet.
-
-Printed parts elsewhere in the machine take inserts too. Each assembly page lists its own in a **Preparation** step like this one, so press them in as you reach that page.
+These are reconstructions built from the STL geometry, not photos or a CAD export — there is no assembly photo of this joint yet.
 
 {% include step.html n="2" title="Attach the interface ribs to the upper fixed section" %}
 
@@ -428,7 +418,7 @@ Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | rel
 
 Push the prepared Interface idler gear — bearing, inner retainer cap, and outer retainer already fitted, see step 1 — onto the Interface NEMA 23 bracket with the bearing facing outwards.
 
-Drive an {% include fastener.html size="M3" variant="flat" length="35" %} screw through the middle of the gear and into the bracket. The inner retainer cap does the job a loose M3 × 15 mm washer used to: it sits between the screw head and the bearing, spanning the 8 mm bore, so the screw head on its own (narrower than the bore) has something to clamp against. Tighten until it's seated, then check that the idler gear still spins freely.
+Drive an {% include fastener.html size="M3" variant="flat" length="35" %} screw through the middle of the gear and into the bracket. The inner retainer cap sits between the screw head and the bearing, spanning the 8 mm bore, so the screw head on its own (narrower than the bore) has something to clamp against. Tighten until it's seated, then check that the idler gear still spins freely.
 
 The head has to be a low one here. A socket or button head stands proud enough that the Limit switch hammer can catch on it as the chute sweeps past, so use a flat (pancake) head, or a pan head if that is what you have. It is the same screw as the one on the Cable clamp in step 11, so buy two of the one head type.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -218,6 +218,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   <div class="prep-item-body">
     <p><strong>Interface idler gear:</strong> 4 × M3, around the bearing pocket on the underside</p>
     <p>Build the bearing sub-assembly now too, while the gear is still loose — it is easier off the bracket than on it. Push a 608 2RS bearing into the pocket, fit the Chute stepper idler gear bearing retainer (inner) over the bearing's bore, then the Chute stepper idler gear bearing retainer (outer) over that, seated flush in the recess with its 4 holes lined up on the gear's 4 inserts. Secure it with 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, the same screw the Interface spur gear uses a few lines up. See step 9 for how the idler gear then goes onto the bracket.</p>
+    <p>These are reconstructions built from the STL geometry, not photos or a CAD export — there is no assembly photo of this joint yet.</p>
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
@@ -230,8 +231,6 @@ Before assembling anything, press the heat inserts into the parts that take them
     </figure>
   </div>
 </div>
-
-These are reconstructions built from the STL geometry, not photos or a CAD export — there is no assembly photo of this joint yet.
 
 {% include step.html n="2" title="Attach the interface ribs to the upper fixed section" %}
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -218,9 +218,13 @@ Before assembling anything, press the heat inserts into the parts that take them
   <div class="prep-item-body">
     <p><strong>Interface idler gear:</strong> 4 × M3, around the bearing pocket on the underside</p>
     <p>Build the bearing sub-assembly now too, while the gear is still loose — it is easier off the bracket than on it. Push a 608 2RS bearing into the pocket, fit the Chute stepper idler gear bearing retainer (inner) over the bearing's bore, then the Chute stepper idler gear bearing retainer (outer) over that, seated flush in the recess with its 4 holes lined up on the gear's 4 inserts. Secure it with 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, the same screw the Interface spur gear uses a few lines up. See step 9 for how the idler gear then goes onto the bracket.</p>
-    <p>These are reconstructions built from the STL geometry, not photos or a CAD export — there is no assembly photo of this joint yet.</p>
+    <p>The exploded and assembled views below are reconstructions built from the STL geometry, not a CAD export — there is no assembly photo of the retainer caps yet. The photo of the bearing itself is real, from before the caps existed.</p>
   </div>
   <div class="prep-item-figure prep-item-figure-split">
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-idler-gear-bearing-w1600-2fe924b61150.jpg" alt="608 2RS bearing pressed into the centre of the grey Interface idler gear, from before the bearing retainer caps existed">
+      <figcaption>608 2RS bearing pressed into the pocket. Real photo, predates the retainer caps.</figcaption>
+    </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-exploded-3color-full-227310630981.png" alt="An exploded view from below of the idler gear stack in build order: the grey gear, the bearing highlighted in blue, and the inner and outer bearing retainer caps highlighted in red">
       <figcaption>Exploded, in build order: gear, bearing, inner cap, outer ring.</figcaption>
@@ -438,10 +442,6 @@ At this point the chute should still rotate, but you will now feel resistance fr
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-interface-spur-gear-w1600-7dcec28e692a.jpg" alt="Grey Interface spur gear secured over the timing pulley with five countersunk screws">
     <figcaption>Interface spur gear secured over the Timing pulley with five M3 × 8 mm screws.</figcaption>
-  </figure>
-  <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-idler-gear-bearing-w1600-2fe924b61150.jpg" alt="608 2RS bearing pressed into the centre of the grey Interface idler gear">
-    <figcaption>608 2RS bearing pressed into the Interface idler gear.</figcaption>
   </figure>
 </div>
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3551,7 +3551,7 @@
       },
       "name": "M3 × 15 mm washer",
       "category": "Washers",
-      "description": "Flat/fender washer, 15 mm outer diameter. Used to sit under the M3 × 35 flat head screw that holds the interface idler gear onto the NEMA 23 bracket, spanning the bearing bore; replaced there by the printed chute stepper idler bearing retainers (2026-08-25). Not currently used anywhere in the machine.",
+      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-25",
       "attributes": [

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6299,7 +6299,7 @@
       "uid": "cwji",
       "version": "1",
       "name": "Chute Stepper Gearing",
-      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-tbd]] countersunk screws into the gear's own heat inserts, and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. Replaces the loose M3 × 15 mm washer this joint used to take. The low head on the M3×35 keeps it clear of the limit switch hammer.",
+      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3×35 keeps it clear of the limit switch hammer.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6328,7 +6328,7 @@
           "qty": 1
         },
         {
-          "part": "scr-m3-tbd",
+          "part": "scr-m3-8-cs",
           "qty": 4
         },
         {

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3551,9 +3551,9 @@
       },
       "name": "M3 × 15 mm washer",
       "category": "Washers",
-      "description": "Flat/fender washer, 15 mm outer diameter. Sits under the M3 × 35 flat head screw that holds the interface idler gear onto the NEMA 23 bracket.",
+      "description": "Flat/fender washer, 15 mm outer diameter. Used to sit under the M3 × 35 flat head screw that holds the interface idler gear onto the NEMA 23 bracket, spanning the bearing bore; replaced there by the printed chute stepper idler bearing retainers (2026-08-25). Not currently used anywhere in the machine.",
       "created_at": "2026-08-18",
-      "updated_at": "2026-08-18",
+      "updated_at": "2026-08-25",
       "attributes": [
         {
           "label": "Thread",
@@ -3576,10 +3576,6 @@
           "value": "Silver"
         }
       ],
-      "sheet_qty": {
-        "per_machine": 1
-      },
-      "note": "The ×1 is the top-interface count (under the idler-gear screw). Washers used elsewhere on the machine aren't tallied here yet.",
       "image_url": "https://assets.basically.website/sorter-parts/washer-m3-15-full-2d7e5321c11c.jpg"
     },
     {
@@ -6303,7 +6299,7 @@
       "uid": "cwji",
       "version": "1",
       "name": "Chute Stepper Gearing",
-      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear is retained on the bracket by 1 × [[hw:scr-m3-35-bhcs]] with a [[hw:washer-m3-15]] under the head, spanning the bearing bore; the low head keeps it clear of the limit switch hammer.",
+      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-tbd]] countersunk screws into the gear's own heat inserts, and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. Replaces the loose M3 × 15 mm washer this joint used to take. The low head on the M3×35 keeps it clear of the limit switch hammer.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6324,16 +6320,20 @@
           "qty": 1
         },
         {
-          "part": "washer-m3-15",
-          "qty": 1
-        },
-        {
           "part": "chute-stepper-idler-bearing-retainer-outer",
           "qty": 1
         },
         {
           "part": "chute-stepper-idler-bearing-retainer-inner",
           "qty": 1
+        },
+        {
+          "part": "scr-m3-tbd",
+          "qty": 4
+        },
+        {
+          "part": "hsi-m3",
+          "qty": 4
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1317,7 +1317,7 @@
 			"uid": "cwji",
 			"version": "1",
 			"name": "Chute Stepper Gearing",
-			"description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-tbd]] countersunk screws into the gear's own heat inserts, and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. Replaces the loose M3 \u00d7 15 mm washer this joint used to take. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
+			"description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
 			"status": "partial",
 			"lines": [
@@ -1346,7 +1346,7 @@
 					"qty": 1
 				},
 				{
-					"part": "scr-m3-tbd",
+					"part": "scr-m3-8-cs",
 					"qty": 4
 				},
 				{

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1317,7 +1317,7 @@
 			"uid": "cwji",
 			"version": "1",
 			"name": "Chute Stepper Gearing",
-			"description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear is retained on the bracket by 1 \u00d7 [[hw:scr-m3-35-bhcs]] with a [[hw:washer-m3-15]] under the head, spanning the bearing bore; the low head keeps it clear of the limit switch hammer.",
+			"description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-tbd]] countersunk screws into the gear's own heat inserts, and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. Replaces the loose M3 \u00d7 15 mm washer this joint used to take. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
 			"status": "partial",
 			"lines": [
@@ -1338,16 +1338,20 @@
 					"qty": 1
 				},
 				{
-					"part": "washer-m3-15",
-					"qty": 1
-				},
-				{
 					"part": "chute-stepper-idler-bearing-retainer-outer",
 					"qty": 1
 				},
 				{
 					"part": "chute-stepper-idler-bearing-retainer-inner",
 					"qty": 1
+				},
+				{
+					"part": "scr-m3-tbd",
+					"qty": 4
+				},
+				{
+					"part": "hsi-m3",
+					"qty": 4
 				}
 			]
 		},
@@ -15219,10 +15223,10 @@
 			},
 			"name": "M3 \u00d7 15 mm washer",
 			"category": "Washers",
-			"description": "Flat/fender washer, 15 mm outer diameter. Sits under the M3 \u00d7 35 flat head screw that holds the interface idler gear onto the NEMA 23 bracket.",
-			"note": "The \u00d71 is the top-interface count (under the idler-gear screw). Washers used elsewhere on the machine aren't tallied here yet.",
+			"description": "Flat/fender washer, 15 mm outer diameter. Used to sit under the M3 \u00d7 35 flat head screw that holds the interface idler gear onto the NEMA 23 bracket, spanning the bearing bore; replaced there by the printed chute stepper idler bearing retainers (2026-08-25). Not currently used anywhere in the machine.",
+			"note": null,
 			"created_at": "2026-08-18",
-			"updated_at": "2026-08-18",
+			"updated_at": "2026-08-25",
 			"attributes": [
 				{
 					"label": "Thread",
@@ -15245,9 +15249,7 @@
 					"value": "Silver"
 				}
 			],
-			"sheet_qty": {
-				"per_machine": 1
-			},
+			"sheet_qty": null,
 			"sheet_qty_text": null,
 			"stock": null,
 			"sourcing": null,

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -15223,7 +15223,7 @@
 			},
 			"name": "M3 \u00d7 15 mm washer",
 			"category": "Washers",
-			"description": "Flat/fender washer, 15 mm outer diameter. Used to sit under the M3 \u00d7 35 flat head screw that holds the interface idler gear onto the NEMA 23 bracket, spanning the bearing bore; replaced there by the printed chute stepper idler bearing retainers (2026-08-25). Not currently used anywhere in the machine.",
+			"description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
 			"note": null,
 			"created_at": "2026-08-18",
 			"updated_at": "2026-08-25",


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541701360922140734
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541709983287083069
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541712000298786926
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541718389268152340
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541723339297521684
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541724669369913434
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541726400212377670
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541736977072656384
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541738785924972656
preview: /hardware/assembly/distribution/top-interface/
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1541701360922140734/1541712000298786926): "Update the documentation accordingly. Remove the washer from the part calculator. Create a step in the preparation step for assembling the gear with the ball bearing and the printed washers/caps. Import the three renderings. Rotate the rendering in the first image so that the recess for the ball bearing in the gear is visible, and rotate the third image accordingly."

## What

The chute stepper idler gear's 608 2RS bearing was retained by a generic M3 x 15 mm washer under the M3x35 axle screw. The catalog already had two printed retainer parts for this joint (`chute-stepper-idler-bearing-retainer-outer`/`-inner`) sitting unused since 2026-08-17 — never wired into the assembly or the docs. This PR connects them:

- **`parts-calculator/catalog/parts.json`**: `chute-stepper-gearing` assembly drops the washer line, adds the outer retainer's 4 screws (`scr-m3-tbd` — head is countersunk, length isn't recorded anywhere) and the 4 heat inserts they need. The washer part itself stays in the catalog (unused, `sheet_qty` removed) rather than being deleted outright, so its uid stays resolvable. Regenerated `catalog.generated.json` with `--metadata-only`.
- **`docs/.../top-interface.md`**: new prep-item on the Preparation step (step 1) for building the gear + bearing + both retainer caps as a sub-assembly before it goes on the bracket, with three renders. Step 9's text updated to reference the now-prepared gear instead of the washer.

## The three renders

No assembly photo of this joint exists (it's a new-to-docs part), so these are reconstructions built from the part STLs — outer and inner retainer, the idler gear's own geometry, and the 608 bearing as a plain placeholder cylinder (no bearing STL in the catalog). All three are rotated to look up from underneath, so the bearing pocket recess and the outer retainer's four countersunk screw holes are visible, per the rotation ask.

## Not done here

The 4 countersunk screws' length isn't recorded anywhere (STL geometry gives head shape and a rough stack-up estimate, not a confirmed spec), so they're the `scr-m3-tbd` placeholder with a `fastener-todo` note, same convention as the rest of this page's unmeasured fasteners.

## Aside: a pre-existing bug in `catalog/generate.py`

`--metadata-only` currently throws `NameError: name 'rebased_render' is not defined` on main (confirmed on a clean checkout) — a leftover from the #418 asset-service refactor that removed the helper's definition but missed two of its three call sites. I patched it locally to produce the regenerated data in this PR, then reverted the source fix, since `catalog/generate.py` is flagged as not mine to open a PR against. Flagging here rather than silently working around it — worth a real fix from someone: the two dead calls are `v["render"] = rebased_render(...)` and `c["render"] = rebased_render(...)`, both should just become `= ov.get("render")` / `= oc.get("render")` the same way the third call site (right above them) was already fixed to `live_render = old["render"]`.



---

**Follow-up review (barthel):** restructured the idler-gear prep-item to match the NEMA 23 bracket / chute mount pattern, dropped the middle render, reordered the remaining two exploded-first, highlighted the bearing in blue, specified M3 x 8mm countersunk for the outer retainer's screws (same as the spur gear two lines up in this assembly), removed the washer references and the closing sentence per the review.



**Small follow-up:** moved the reconstruction-caveat sentence into the prep-item body (was a stray paragraph right after the div), and confirmed the screw/insert counts in the front matter (scr-m3-8-cs 5->9, hsi-m3 12->16) match the assembly lines.



**Another small follow-up:** barthel clarified the washer wasn't a design that got superseded, it was added to the catalog to match a documentation description that was itself wrong from the start. Reworded washer-m3-15's description to say that plainly rather than implying a legitimate prior design.



**Another small follow-up:** added a callout right under step 9's video saying it predates the bearing retainer caps and shows the old washer method instead. Re-checked step 9's prose against the current design while I was in there, it already matched.



**Another small follow-up:** moved the stale bearing photo from step 9 into the step 1 prep-item, with a caption noting it predates the retainer caps, and reworded the prep-item's caveat sentence to distinguish the real photo from the two STL reconstructions.



**Another small follow-up:** reordered the prep-item figures so the real photo sits between the two renders (exploded, photo, assembled) instead of first.
