### PR TITLE
docs: orange-pi-mount.md matches the catalog, bracket is no longer missing

### DIFF
--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -12,11 +12,12 @@ contributors: [spencer]
 warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=orange-pi-mount), not
-  from an actual build. The parts and quantities are real, but the printed bracket the Pi stands
-  off is **not in the parts registry**, and no step here has been checked against a machine. The
-  steps below are placeholders with the gaps marked.
+  from an actual build. The parts and quantities are real, but no step here has been checked
+  against a machine. The steps below are placeholders with the gaps marked.
 parts_needed:
   - part: sbc-orange-pi-5
+    qty: 1
+  - part: orange-pi-extrusion-mount
     qty: 1
   - part: standoff-m3-10mm
     qty: 4
@@ -34,21 +35,17 @@ The fasteners and quantities in the parts list come from the parts calculator an
 
 One per machine. Which Orange Pi 5 to buy, how much RAM and storage it needs, the WiFi module, the USB hub and cooling are all on the [Orange Pi 5]({{ '/hardware/orange-pi-5/' | relative_url }}) page. This page is only about bolting it to the machine, and it is the same shape as the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}): 4 inserts, 4 standoffs, 4 M3 screws, 2 M5 into the frame.
 
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>The bracket is missing from the parts registry.</b> The calculator records the Pi, the standoffs, the inserts and the screws, but not the printed part they all attach to. There is no STL and no render for it, so steps 1 and 2 below cannot be followed as written until somebody adds it.</p>
-</div>
-
 {% include step.html n="1" title="Preparation" %}
 
 Before assembling anything, press the heat inserts into the parts that take them, while the parts are still loose. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Orange Pi bracket:</strong> 4 × M3, one per standoff</p>
+    <p><strong>Orange Pi extrusion mount:</strong> 4 × M3, one per standoff</p>
   </div>
   <figure class="prep-item-figure">
-    <div class="img-placeholder">Image coming</div>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-iso-full-5c4a45070801.png" alt="The Orange Pi extrusion mount, an iso view of the flat printed bracket showing its central cutout, the 4 M3 standoff holes along the middle rail, and the 2 larger M5 holes at each end for mounting to the extrusion">
+    <figcaption>The bracket. 4 M3 inserts along the middle rail for the standoffs, 2 larger M5 holes at each end for the frame.</figcaption>
   </figure>
 </div>
 
@@ -64,7 +61,10 @@ Neither the head type nor the length of those screws is recorded: <span class="f
 
 Whether the Pi's heatsink or fan clears the standoffs is not recorded either.
 
-<div class="img-placeholder">Image coming</div>
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-top-full-b540d66f03fa.png" alt="The Orange Pi extrusion mount seen from directly above, showing the standoff face with its 4 M3 holes along the middle rail and the central cutout">
+  <figcaption>The standoff face, straight on. The Pi itself isn't modelled in the catalog, so this shows the bracket only.</figcaption>
+</figure>
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}
 

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -55,18 +55,16 @@ The Pi itself takes no inserts, and neither does anything else on this page.
 
 **Heat inserts first:** the bracket takes 4 × M3 inserts, one per standoff. Press them in before assembling.
 
-Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. Not a direct measurement, same size the control board's own board-to-standoff joint uses. The 10 mm standoff length is the BOM sheet's number, unconfirmed.
-
-Whether the Pi's heatsink or fan clears the standoffs is not recorded either.
+Screw the 4 M3 standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. The 10 mm standoffs are used.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-corners-standoffs-full-840e1699b56c.png" alt="The Orange Pi extrusion mount with 4 standoffs mounted in the corner insert holes and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
-  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders — no standoff or screw STL in the catalog. The Pi itself isn't shown for the same reason.</figcaption>
+  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders.</figcaption>
 </figure>
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}
 
-The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, the same as the [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}). Length is an estimate, not measured.
+The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, the same as the [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}).
 
 Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 
@@ -75,7 +73,5 @@ Which extrusion it goes on, and in which orientation, is not written down. The t
 {% include step.html n="4" title="Plug it in" %}
 
 The Pi is powered by its own 24 V to USB-C adapter off the PSU, not from the control board. That, the USB hub and the cameras are all on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page.
-
-Fan power is open item 1 on that page and is still unresolved, so there is nothing to wire for cooling yet.
 
 The Orange Pi mount is now complete. Flashing and configuring the Pi is [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -45,7 +45,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-ring-near-full-f66229fc5a95.png" alt="The Orange Pi extrusion mount at a slight angle off vertical, with two of the four M3 standoff insert holes circled in red, each showing a real shadowed hole rather than a flat mark">
-    <figcaption>Two of the 4 insert holes, ringed, angled enough for the shadow to actually show a hole. The other 2 mirror these on the far side of the same rail — a straight top-down shot marks the spot but flattens out the shadow that makes it read as a hole at all.</figcaption>
+    <figcaption>2 of the 4 insert holes, ringed. The other 2 mirror these on the far side of the same rail.</figcaption>
   </figure>
 </div>
 
@@ -55,20 +55,18 @@ The Pi itself takes no inserts, and neither does anything else on this page.
 
 **Heat inserts first:** the bracket takes 4 × M3 inserts, one per standoff. Press them in before assembling.
 
-Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws.
-
-Not a direct measurement — neither the standoff nor the Orange Pi 5 has a 3D model in the catalog, so there's no bore depth or board thickness to check it against — but a reasonable call rather than a placeholder: a PCB mounting hole is a plain clearance hole, never countersunk (there's no chamfer machined into the board to seat a countersunk head against), and M3×6 is the standard length for a board-to-standoff screw. It's also what the basically Embedded Control Board uses for the same kind of joint once that one was actually measured, the same size and head type, not just the same reasoning. The 10 mm standoff length is the BOM sheet's number and has not been confirmed against the bracket either.
+Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. Not a direct measurement, same size the control board's own board-to-standoff joint uses. The 10 mm standoff length is the BOM sheet's number, unconfirmed.
 
 Whether the Pi's heatsink or fan clears the standoffs is not recorded either.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-screws-top2-full-9743aaed8c16.png" alt="The Orange Pi extrusion mount seen from directly above with 4 standoffs mounted in the insert holes on the middle rail and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
-  <figcaption>The 4 standoffs mounted, with a board-retention screw on top of each (blue), drawn at the M3 × 6 mm this joint is expected to use. Both are parametric placeholders, not the real parts' geometry — there's no standoff or screw STL in the catalog. The Pi itself isn't shown for the same reason.</figcaption>
+  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders — no standoff or screw STL in the catalog. The Pi itself isn't shown for the same reason.</figcaption>
 </figure>
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}
 
-The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws. The bracket's own holes are 5.5 mm plain clearance, no countersink, through an 8 mm-thick section, measured off the STL; 12 mm is a stack-up estimate (8 mm of bracket plus a typical M5 roll-in T-nut's engagement) rather than a confirmed length, since the T-nut itself isn't dimensioned in the catalog. The [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}) use the same M5 screw for the same job, but their own brackets weren't remeasured here.
+The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, the same as the [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}). Length is an estimate, not measured.
 
 Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -25,7 +25,7 @@ parts_needed:
     qty: 4
   - part: scr-m3-tbd
     qty: 4
-  - part: scr-m5-shcs-tbd
+  - part: scr-m5-12-shcs
     qty: 2
 ---
 
@@ -44,8 +44,8 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Orange Pi extrusion mount:</strong> 4 × M3, one per standoff</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-iso-full-5c4a45070801.png" alt="The Orange Pi extrusion mount, an iso view of the flat printed bracket showing its central cutout, the 4 M3 standoff holes along the middle rail, and the 2 larger M5 holes at each end for mounting to the extrusion">
-    <figcaption>The bracket. 4 M3 inserts along the middle rail for the standoffs, 2 larger M5 holes at each end for the frame.</figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-top-final-ringed-full-f6c52bec2a4a.png" alt="The Orange Pi extrusion mount from directly above, with the 4 M3 standoff insert holes on the middle rail circled in red, and the 2 larger M5 frame holes visible at each end">
+    <figcaption>The bracket, insert locations ringed. 4 M3 along the middle rail for the standoffs, 2 larger M5 holes at each end for the frame (no insert, plain clearance).</figcaption>
   </figure>
 </div>
 
@@ -57,18 +57,18 @@ The Pi itself takes no inserts, and neither does anything else on this page.
 
 Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the Pi on them and fasten it down with 4 M3 screws.
 
-Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. The 10 mm standoff length is the BOM sheet's number and has not been confirmed against the bracket either.
+Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. Unlike the frame screws in step 3, this one can't be worked out from the bracket's own geometry either — neither the standoff nor the Orange Pi 5 has a 3D model in the catalog, so there's no bore depth or board thickness to measure. The 10 mm standoff length is the BOM sheet's number and has not been confirmed against the bracket either.
 
 Whether the Pi's heatsink or fan clears the standoffs is not recorded either.
 
 <figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-top-full-b540d66f03fa.png" alt="The Orange Pi extrusion mount seen from directly above, showing the standoff face with its 4 M3 holes along the middle rail and the central cutout">
-  <figcaption>The standoff face, straight on. The Pi itself isn't modelled in the catalog, so this shows the bracket only.</figcaption>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-standoffs-top-full-6a41479303b6.png" alt="The Orange Pi extrusion mount seen from directly above with 4 standoffs mounted in the insert holes on the middle rail, shown as plain hex placeholders since the standoff isn't modelled in the catalog">
+  <figcaption>The 4 standoffs mounted, seen from above. The standoffs are a plain parametric placeholder (M3, ~10 mm), not the real part's geometry — there's no standoff STL in the catalog. The Pi itself isn't shown for the same reason.</figcaption>
 </figure>
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}
 
-The mount hangs off the 2020 frame on 2 <span class="fastener-todo">M5, length not recorded</span> screws, the same as the [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}).
+The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws. The bracket's own holes are 5.5 mm plain clearance, no countersink, through an 8 mm-thick section, measured off the STL; 12 mm is a stack-up estimate (8 mm of bracket plus a typical M5 roll-in T-nut's engagement) rather than a confirmed length, since the T-nut itself isn't dimensioned in the catalog. The [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}) use the same M5 screw for the same job, but their own brackets weren't remeasured here.
 
 Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -62,8 +62,8 @@ Neither the head type nor the length of those screws is recorded: <span class="f
 Whether the Pi's heatsink or fan clears the standoffs is not recorded either.
 
 <figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-standoffs-top-full-6a41479303b6.png" alt="The Orange Pi extrusion mount seen from directly above with 4 standoffs mounted in the insert holes on the middle rail, shown as plain hex placeholders since the standoff isn't modelled in the catalog">
-  <figcaption>The 4 standoffs mounted, seen from above. The standoffs are a plain parametric placeholder (M3, ~10 mm), not the real part's geometry — there's no standoff STL in the catalog. The Pi itself isn't shown for the same reason.</figcaption>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-screws-top2-full-9743aaed8c16.png" alt="The Orange Pi extrusion mount seen from directly above with 4 standoffs mounted in the insert holes on the middle rail and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
+  <figcaption>The 4 standoffs mounted, with a board-retention screw on top of each (blue). Both are parametric placeholders, not the real parts' geometry — there's no standoff or screw STL in the catalog, and the screw's length here is illustrative, not the confirmed dimension the text above says is still missing. The Pi itself isn't shown for the same reason.</figcaption>
 </figure>
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -44,7 +44,7 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Orange Pi extrusion mount:</strong> 4 × M3, one per standoff</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-corners-test-full-84d5deb7769f.png" alt="The Orange Pi extrusion mount at a slight angle off vertical, with all four M3 standoff insert holes circled in red near the four corners of the frame, each showing a real shadowed hole">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-landscape-ringed-full-aa8aaac704ff.png" alt="The Orange Pi extrusion mount lying on its long edge, with all four M3 standoff insert holes circled in red near the four corners of the frame, each showing a real shadowed hole">
     <figcaption>The 4 insert holes, ringed, near the four corners of the frame.</figcaption>
   </figure>
 </div>
@@ -58,7 +58,7 @@ The Pi itself takes no inserts, and neither does anything else on this page.
 Screw the 4 M3 standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. The 10 mm standoffs are used.
 
 <figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-corners-standoffs-full-840e1699b56c.png" alt="The Orange Pi extrusion mount with 4 standoffs mounted in the corner insert holes and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-landscape-standoffs-full-cefb56a912b0.png" alt="The Orange Pi extrusion mount lying on its long edge with 4 standoffs mounted in the corner insert holes and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
   <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders.</figcaption>
 </figure>
 

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -23,7 +23,7 @@ parts_needed:
     qty: 4
   - part: hsi-m3
     qty: 4
-  - part: scr-m3-tbd
+  - part: scr-m3-6-bhcs
     qty: 4
   - part: scr-m5-12-shcs
     qty: 2
@@ -55,15 +55,15 @@ The Pi itself takes no inserts, and neither does anything else on this page.
 
 **Heat inserts first:** the bracket takes 4 × M3 inserts, one per standoff. Press them in before assembling.
 
-Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the Pi on them and fasten it down with 4 M3 screws.
+Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws.
 
-Neither the head type nor the length of those screws is recorded: <span class="fastener-todo">M3, type and length not recorded</span>. Unlike the frame screws in step 3, this one can't be worked out from the bracket's own geometry either — neither the standoff nor the Orange Pi 5 has a 3D model in the catalog, so there's no bore depth or board thickness to measure. The 10 mm standoff length is the BOM sheet's number and has not been confirmed against the bracket either.
+Not a direct measurement — neither the standoff nor the Orange Pi 5 has a 3D model in the catalog, so there's no bore depth or board thickness to check it against — but a reasonable call rather than a placeholder: a PCB mounting hole is a plain clearance hole, never countersunk (there's no chamfer machined into the board to seat a countersunk head against), and M3×6 is the standard length for a board-to-standoff screw. It's also what the basically Embedded Control Board uses for the same kind of joint once that one was actually measured, the same size and head type, not just the same reasoning. The 10 mm standoff length is the BOM sheet's number and has not been confirmed against the bracket either.
 
 Whether the Pi's heatsink or fan clears the standoffs is not recorded either.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-screws-top2-full-9743aaed8c16.png" alt="The Orange Pi extrusion mount seen from directly above with 4 standoffs mounted in the insert holes on the middle rail and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
-  <figcaption>The 4 standoffs mounted, with a board-retention screw on top of each (blue). Both are parametric placeholders, not the real parts' geometry — there's no standoff or screw STL in the catalog, and the screw's length here is illustrative, not the confirmed dimension the text above says is still missing. The Pi itself isn't shown for the same reason.</figcaption>
+  <figcaption>The 4 standoffs mounted, with a board-retention screw on top of each (blue), drawn at the M3 × 6 mm this joint is expected to use. Both are parametric placeholders, not the real parts' geometry — there's no standoff or screw STL in the catalog. The Pi itself isn't shown for the same reason.</figcaption>
 </figure>
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -53,14 +53,16 @@ The Pi itself takes no inserts, and neither does anything else on this page.
 
 {% include step.html n="2" title="Stand the Pi off the bracket" %}
 
+<figure class="figure-float-right">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-landscape-standoffs-full-cefb56a912b0.png" alt="The Orange Pi extrusion mount lying on its long edge with 4 standoffs mounted in the corner insert holes and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
+  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders.</figcaption>
+</figure>
+
 **Heat inserts first:** the bracket takes 4 × M3 inserts, one per standoff. Press them in before assembling.
 
 Screw the 4 M3 standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. The 10 mm standoffs are used.
 
-<figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-landscape-standoffs-full-cefb56a912b0.png" alt="The Orange Pi extrusion mount lying on its long edge with 4 standoffs mounted in the corner insert holes and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
-  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders.</figcaption>
-</figure>
+<div class="clear-float"></div>
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}
 

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -44,8 +44,8 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Orange Pi extrusion mount:</strong> 4 × M3, one per standoff</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-top-final-ringed-full-f6c52bec2a4a.png" alt="The Orange Pi extrusion mount from directly above, with the 4 M3 standoff insert holes on the middle rail circled in red, and the 2 larger M5 frame holes visible at each end">
-    <figcaption>The bracket, insert locations ringed. 4 M3 along the middle rail for the standoffs, 2 larger M5 holes at each end for the frame (no insert, plain clearance).</figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-ring-near-full-f66229fc5a95.png" alt="The Orange Pi extrusion mount at a slight angle off vertical, with two of the four M3 standoff insert holes circled in red, each showing a real shadowed hole rather than a flat mark">
+    <figcaption>Two of the 4 insert holes, ringed, angled enough for the shadow to actually show a hole. The other 2 mirror these on the far side of the same rail — a straight top-down shot marks the spot but flattens out the shadow that makes it read as a hole at all.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -44,8 +44,8 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Orange Pi extrusion mount:</strong> 4 × M3, one per standoff</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-ring-near-full-f66229fc5a95.png" alt="The Orange Pi extrusion mount at a slight angle off vertical, with two of the four M3 standoff insert holes circled in red, each showing a real shadowed hole rather than a flat mark">
-    <figcaption>2 of the 4 insert holes, ringed. The other 2 mirror these on the far side of the same rail.</figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-corners-test-full-84d5deb7769f.png" alt="The Orange Pi extrusion mount at a slight angle off vertical, with all four M3 standoff insert holes circled in red near the four corners of the frame, each showing a real shadowed hole">
+    <figcaption>The 4 insert holes, ringed, near the four corners of the frame.</figcaption>
   </figure>
 </div>
 
@@ -60,7 +60,7 @@ Screw the 4 M3 × 10 mm standoffs into the inserts. Sit the Pi on them and faste
 Whether the Pi's heatsink or fan clears the standoffs is not recorded either.
 
 <figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-screws-top2-full-9743aaed8c16.png" alt="The Orange Pi extrusion mount seen from directly above with 4 standoffs mounted in the insert holes on the middle rail and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-corners-standoffs-full-840e1699b56c.png" alt="The Orange Pi extrusion mount with 4 standoffs mounted in the corner insert holes and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
   <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders — no standoff or screw STL in the catalog. The Pi itself isn't shown for the same reason.</figcaption>
 </figure>
 


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541753223918911498
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541754683230781481
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541759297753710632
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541765272703336558
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541766626570149948
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541768560882491463
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541769463630659615
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541772771573501982
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541774359641858060
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541777970186817688
request: https://discord.com/channels/1430279849171222682/1541701360922140734/1541780280778686524
preview: /hardware/electronics/installation/orange-pi-mount/
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1541701360922140734/1541754683230781481): "Yes. Use the style and layout from top interface." (following [this message](https://discord.com/channels/1430279849171222682/1541701360922140734/1541753223918911498) asking what changes I'd suggest, after I'd flagged the page as stale in [this thread](https://discord.com/channels/1430279849171222682/1541701360922140734/1541749689232269393)).

## What

`orange-pi-mount.md` still described the printed bracket (`orange-pi-extrusion-mount`) as missing from the parts registry. It hasn't been since 2026-08-22: it has a real STL, it's wired into the `orange-pi-mount` assembly, and it's counted in the electronics totals. The page just never caught up.

- **Front-matter `warning:`** — dropped the false "not in the parts registry" claim, kept the rest (AI-generated first draft, unchecked against a machine).
- **`parts_needed`** — added `orange-pi-extrusion-mount`, it wasn't listed at all even though it's required.
- **Removed the callout** right under the intro paragraph describing the (now resolved) blocker.
- **Replaced both "Image coming" placeholders** with real renders built from the STL, same technique as the idler gear bearing retainers in #420: an iso view for the step 1 prep-item, a straight-on view of the standoff face for step 2. Neither shows the Orange Pi 5 itself since it isn't a 3D part in the catalog, bracket only.

A third "Image coming" placeholder in step 3 (extrusion orientation) is untouched — that needs the frame context, not just this part's own geometry, and wasn't part of what was asked.

Style and layout match top-interface.md per the request: `prep-item`/`prep-item-body`/`prep-item-figure`, `fastener-todo` spans for the still-unmeasured screws, plain STL-reconstruction renders with a caption noting what they show.



---

**Follow-up review:** three more asks on the same page —
- Insert-hole rings were missing from the prep-step render, added (4, all visible from a straight top-down framing).
- Measured the M5 frame screw off the STL (5.5mm clearance, no countersink, 8mm-thick section) and swapped the placeholder for scr-m5-12-shcs (a stack-up estimate, labeled as such). The M3 board-retention screw genuinely can't be measured the same way, explained why in the text.
- Added a render of the bracket with 4 standoffs mounted, drawn as a parametric placeholder since neither the standoff nor the Orange Pi 5 has a 3D model in the catalog.



**One more small addition:** added the 4 board-retention screws (blue) on top of the standoffs in the render, same parametric-placeholder treatment, length illustrative only.



**Committed to a real spec for the last placeholder:** M3x6 socket/button head for the Pi retention screws, not measured but a well-evidenced call, PCB mounts are never countersunk and the control board's own board-to-standoff joint measured out to the same size for the same kind of connection.



**Rendering fix:** the prep-item render marked the insert holes with rings but the holes themselves were invisible under straight top-down orthographic lighting, no shadow, no depth cue. Retried at several camera tilts, picked one where the pocket wall actually catches shadow. Only 2 of 4 holes read cleanly from any single angle (the other 2 open away from whichever camera is used), so the image shows those 2 clearly and the caption says the other 2 mirror them.



**Text compacted:** removed the paragraph-length justification behind each inferred screw spec (M3x6, M5x12) and the render captions, the page banner already says nothing here is validated against a build, so the reasoning was redundant. States the spec and that it is not measured, nothing more.



---

**Correction, this one mattered:** the insert holes I'd been ringing (and mounting standoffs on) were the wrong holes entirely — a feature on the bracket's middle rail, not the actual M3 insert holes. Re-surveyed the STL from scratch and found the real 4 insert holes near the four corners of the frame, 95mm x 56mm apart, matching a normal SBC standoff footprint. Rebuilt both renders at the correct positions; all 4 are visible with real shadow in one shot now, since the corner positions aren't tucked behind the raised wall the old (wrong) positions were.



**More trimming:** removed six specific sentences/clauses (the control-board-precedent aside, the standoff-length caveat, the heatsink-clearance note, the parametric-placeholder trailing clause on the standoff caption, the M5 length-estimate caveat, and the fan-power aside in step 4), replacing one with a short factual line as asked. Nothing left but the steps and the facts.



**Rendering polish:** rotated both renders so the bracket lies on its long edge (landscape, not portrait), and dropped meshfig's built-in caption bar (the black box) by compositing the panel directly instead of calling Panel.finish(label) — the HTML figcaption already carries the text, the burned-in one was redundant and, per this comment, in the way.



**Layout:** floated the standoff render to the right margin with figure-float-right, step 2's text now wraps around it on the left instead of sitting as a full-width block below the paragraphs. Same pattern top-interface.md already uses for its corner-section drawing.
