### PR TITLE
fix: chute count is N, not N+2 -- bottom interface doesn't have its own chutes

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -24,7 +24,7 @@ parts_needed:
     qty: 8
 ---
 
-The chute is what steers a part into the right bin. Build one per layer, plus two for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
+The chute is what steers a part into the right bin. Build one per layer, N for an N-layer machine. The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) doesn't add any extra chutes of its own, it's a mounting stage the bottommost chute sits on, bridged to it by a [layer connector]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
 
 The fasteners and quantities are in the parts list above and are called out inline at each step.
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6205,7 +6205,7 @@
       "uid": "67uq",
       "version": "1",
       "name": "Bottom interface",
-      "description": "The bottom interface / lazy Susan level. Carries two chutes.",
+      "description": "The bottom interface / lazy Susan level. The chute above it is one of the machine's N regular chutes, already counted there; this assembly only adds the layer connector that bridges down to it.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
       "status": "partial",
       "lines": [
@@ -6218,8 +6218,8 @@
           "qty": 1
         },
         {
-          "assembly": "chute",
-          "qty": 2
+          "assembly": "layer-connector",
+          "qty": 1
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1166,7 +1166,7 @@
 			"uid": "67uq",
 			"version": "1",
 			"name": "Bottom interface",
-			"description": "The bottom interface / lazy Susan level. Carries two chutes.",
+			"description": "The bottom interface / lazy Susan level. The chute above it is one of the machine's N regular chutes, already counted there; this assembly only adds the layer connector that bridges down to it.",
 			"docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
 			"status": "partial",
 			"lines": [
@@ -1179,8 +1179,8 @@
 					"qty": 1
 				},
 				{
-					"assembly": "chute",
-					"qty": 2
+					"assembly": "layer-connector",
+					"qty": 1
 				}
 			]
 		},


### PR DESCRIPTION
`chute-core.md` said "one per layer, plus two for the bottom interface" — contradicting `funnel.md` / `pcb.md` / `door-module.md`, which all say one per layer with no extra.

Root cause was in the catalog, not just docs wording: the `bottom-interface` assembly had `{"assembly": "chute", "qty": 2}` in its `lines`, pulling in two complete extra chutes (each with its own door, servo, PCB and funnel brackets) that nothing else corroborates. `bottom-interface.md`'s own build guide (real photos, credited to Adrianbaker and BrickCycleAlice) never mentions a chute at all — just the lazy Susan stack and the extrusion mounts. The `layer` assembly's own `{"assembly": "chute", "qty": 1}` per regular layer already accounts for all N chutes.

Alice flagged this exact contradiction in a docs-map session on 2026-08-22 ("if I have a 5 layer machine I need 5 chutes, all with doors and the associated bits"), but nobody had traced it back to the catalog assembly actually producing the wrong count, so `chute-core.md`'s wording never got corrected either, and the catalog's real BOM bug (2 extra chutes' worth of parts) survived.

**Fixed:**
- `bottom-interface` assembly's `lines`: `chute × 2` → `layer-connector × 1`, matching both its own real build guide and `layer-connectors.md`'s existing "1 of each for the bottom interface" (that page needed no change — its N+2 was always about connectors bridging to both interfaces, never about full chutes).
- `chute-core.md`: dropped the "plus two for the bottom interface" line.
- Regenerated `catalog.generated.json` (6-line diff).

Checked: `python3 docs/scripts/validate_frontmatter.py` clean (same 5 pre-existing errors as main), full `docs` build succeeds with no new broken links, `parts-calculator` `npm run check` is 0 errors, `scripts/check_generated_pins.py` agrees.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541819648327032862
preview: /hardware/assembly/distribution/chute/chute-core/
-->