### PR TITLE
docs: light-post fastener details measured off the STLs

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -11,8 +11,8 @@ author: barthel
 warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=camera-mount), not from an
-  actual build. The parts are recorded; the assembly order, every screw's position, the camera fixing
-  and all photographs are missing. Fill it in as you build.
+  actual build. The A/B connector's joint is now measured off the STLs. The rod mounts, the camera
+  fixing and every photograph are still missing. Fill it in as you build.
 parts_needed:
   - part: camera-mount-part-6
     qty: 1
@@ -78,13 +78,16 @@ Slide a cut rod into each mount.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="4" title="Join the two arm halves" %}
+{% include step.html n="4" title="Join arm A to the connector" %}
 
-Overhead camera mount A (part 37) and B (part 37b) join through the A/B connector (part 6), using the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws and 3 M3 nuts in the list above.
+Overhead camera mount A (part 37) bolts to the A/B connector (part 6) with the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws and 3 M3 nuts in the list above — measured off the two STLs, both parts carry the same bolt circle: 12 holes, 3.3 mm across, evenly spaced 30° apart on a 27 mm radius. Only 3 of the 12 are used at once, so the joint sets the arm's **angle**, not its reach — pick which 3 (every 4th hole, 120° apart, matching the 3-screw pattern) to fix the rotation you want, in 30° steps.
 
-**Not recorded:** which joint takes which screw, and whether the connector is what sets the arm's reach over the channel. <span class="fastener-todo">fastener not recorded</span>
+**Not recorded:** which 3 of the 12 holes are the intended ones, and how part B (part 37b) joins in — it doesn't share this bolt circle, so it connects some other way. <span class="fastener-todo">fastener not recorded</span>
 
-<div class="img-placeholder">Image coming</div>
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/connector-holes-full-24e039791962.png" alt="The A/B connector's bolt face, showing 12 evenly-spaced holes on a circle with one example set of 3, 120 degrees apart, marked in red dashes">
+  <figcaption>The connector's bolt circle: 12 holes, 30° apart. One example set of 3 (120° apart) marked — any of the 4 such sets fixes a different 30°-step rotation. Drawn from the part geometry, not from a build.</figcaption>
+</figure>
 
 {% include step.html n="5" title="Fit the camera and set the height" %}
 

--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -85,8 +85,8 @@ Overhead camera mount A (part 37) bolts to the A/B connector (part 6) with the 3
 **Not recorded:** which 3 of the 12 holes are the intended ones, and how part B (part 37b) joins in — it doesn't share this bolt circle, so it connects some other way. <span class="fastener-todo">fastener not recorded</span>
 
 <figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/connector-holes-full-24e039791962.png" alt="The A/B connector's bolt face, showing 12 evenly-spaced holes on a circle with one example set of 3, 120 degrees apart, marked in red dashes">
-  <figcaption>The connector's bolt circle: 12 holes, 30° apart. One example set of 3 (120° apart) marked — any of the 4 such sets fixes a different 30°-step rotation. Drawn from the part geometry, not from a build.</figcaption>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/connector-iso-full-9426650a084d.png" alt="Angled render of the A/B connector, showing all 12 holes of its bolt circle">
+  <figcaption>The connector's bolt circle: 12 holes, 30° apart. Any 3 spaced 120° apart (every 4th hole) fix one of 4 possible rotations. Rendered from the part geometry, not from a build.</figcaption>
 </figure>
 
 {% include step.html n="5" title="Fit the camera and set the height" %}

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -49,14 +49,26 @@ Build the classification channel as a normal [C-channel]({{ '/hardware/assembly/
 
 Fit the Camera & LED insert, then the camera on its extension tube and mount ring, then close the chamber with the dome.
 
-Measured off the Camera & LED insert's own STL: its top face carries two separate hole patterns, both visible in the render below. Four countersunk M3 holes (3.4 mm clearance) sit in a 46 mm square around the central opening — most likely the camera board's own mounting holes. A second, outer ring of 10 larger holes (10 mm, no thread, 65 mm radius, 36° apart) runs around the rim — almost certainly what fastens the insert to the rest of the chamber, but nothing records what goes through them or what they thread into. The Classification dome itself has no screw holes anywhere in its own geometry — how it closes onto the rest of the chamber (screwed, clipped, or just resting in place) isn't recorded either.
+Measured off the STLs. The Camera & LED insert's top face carries two hole patterns, both visible in the first render below: 4 countersunk M3 holes (3.4 mm clearance) in a 46 mm square around the central opening, and an outer ring of 10 larger holes (10 mm, no thread, 65 mm radius, 36° apart). The inner 46 mm square repeats on the camera extension's mount ring at the same 3.4-3.5 mm size — that's the real match, so the insert's 4 holes are the mount-ring joint, M3 like everything else on this page, not the camera board.
 
-<figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-iso-full-e4b396fc8c88.png" alt="Angled render of the camera and LED insert's top face, showing a ring of 10 large holes around the rim and 4 smaller countersunk holes around a central square opening">
-  <figcaption>The insert's top face: 10 larger holes around the rim (what it mounts to the chamber with), 4 smaller countersunk ones around the central opening (likely the camera board). Rendered from the part geometry, not from a build.</figcaption>
-</figure>
+The camera board itself mounts to the **camera extension**, not the insert. It's a bracket with two posts, each carrying a hole near the top and near the bottom — 4 holes total, 2.6 mm, sized for the **M2** the IMX415 module's own datasheet calls for (barthel confirmed 2.6 mm is right and gave the module's board thickness, 1.57 mm). The board sits on the top pair. Working from those two numbers: 1.57 mm of board, plus reaching into an 8 mm-deep post with nothing narrower or countersunk in the way — a straight 2.6 mm clearance bore the whole depth, so whatever it threads into (nut or insert) isn't visible in the geometry. {% include fastener.html size="M2" variant="socket-button" length="8" %} clears the board and reaches well into the post without bottoming out before the head seats. Confirm against the physical board which of nut/insert/self-tap it actually is; that's the one thing the STL can't show.
 
-**Not recorded:** what fastens through the outer ring and what it threads into, what screw the inner 4 holes take, how the extension tube and mount ring join, and how the dome closes the chamber. <span class="fastener-todo">fastener not recorded</span>
+**M2 is new to this catalog.** Every other screw on the site is M3, M4, M5 or M6 — there's no M2 part id yet, so this one isn't in the parts list above and doesn't have a legend colour (it renders grey). Add `scr-m2-8-shcs` (or whichever head style is correct) when this is confirmed.
+
+The Classification dome itself has no screw holes anywhere in its own geometry — how it closes onto the rest of the chamber (screwed, clipped, or just resting in place) isn't recorded either.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-iso-full-e4b396fc8c88.png" alt="Angled render of the camera and LED insert's top face, showing a ring of 10 large holes around the rim and 4 smaller countersunk holes around a central square opening">
+    <figcaption>The insert's top face: 10 holes around the rim (mounts to the chamber), 4 smaller ones around the central opening (matches the extension mount, M3). Rendered from the part geometry, not from a build.</figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/extension-iso-full-8d1f0c51606f.png" alt="Angled render of the camera extension bracket, showing two posts each with a mounting hole">
+    <figcaption>The camera extension: two posts, a hole near the top and bottom of each. The top pair takes the M2 camera-board screws. Rendered from the part geometry, not from a build.</figcaption>
+  </figure>
+</div>
+
+**Not recorded:** what fastens through the insert's outer ring and what it threads into, whether the extension's M2 holes are a nut, an insert, or self-tap, how the extension's bottom pair joins the mount ring, and how the dome closes the chamber. <span class="fastener-todo">fastener not recorded</span>
 
 {% include step.html n="3" title="Light the chamber" %}
 

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -12,8 +12,9 @@ contributors: [barthel]
 warning: >-
   **AI-generated first draft.** Written from the parts registry in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=classification-chamber),
-  not from an actual build. The assembly order is not recorded anywhere yet, so this page
-  lists what the chamber is made of rather than how it goes together. Correct it as you build.
+  not from an actual build. The assembly order is still not recorded, so this page mostly lists
+  what the chamber is made of rather than how it goes together — one fastener is now measured
+  off the STLs, everything else about how the pieces join is still open. Correct it as you build.
 parts_needed:
   - part: classification-dome
     qty: 1
@@ -31,7 +32,7 @@ parts_needed:
 
 The classification chamber is where a part is lit and photographed on its way through. It sits on the fourth [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), the classification-channel one.
 
-The parts are in the list above. No fasteners are recorded for this stage yet.
+The parts are in the list above. Most fasteners for this stage still aren't recorded; what is, is called out in Step 2.
 
 {% include fastener-legend.html %}
 
@@ -48,9 +49,19 @@ Build the classification channel as a normal [C-channel]({{ '/hardware/assembly/
 
 Fit the Camera & LED insert, then the camera on its extension tube and mount ring, then close the chamber with the dome.
 
-The fasteners for this stage are not recorded yet: <span class="fastener-todo">fastener not recorded</span>.
+Measured off the Camera & LED insert's own STL: its face carries 4 countersunk M3 holes, 3.4 mm clearance, in a 46 mm square pattern near the top. Most likely where the camera extension's mount ring bolts on, but that isn't confirmed, and the screw length isn't either — the STL gives the hole diameter, not the wall thickness behind it. The Classification dome itself has no screw holes anywhere in its geometry — how it closes onto the rest of the chamber (screwed, clipped, or just resting in place) isn't recorded.
 
-<div class="img-placeholder">Image coming</div>
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-top-render-full-67381d1cb15a.png" alt="Top-down outline of the camera and LED insert's face, showing four countersunk screw holes in a square pattern">
+    <figcaption>The insert's face: 4 countersunk holes, 46 mm square. Drawn from the part geometry, not from a build.</figcaption>
+  </figure>
+  <figure>
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
+
+**Not recorded:** what those 4 holes actually bolt to, what screw length they take, how the extension tube and mount ring join, and how the dome closes the chamber. <span class="fastener-todo">fastener not recorded</span>
 
 {% include step.html n="3" title="Light the chamber" %}
 

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -49,19 +49,14 @@ Build the classification channel as a normal [C-channel]({{ '/hardware/assembly/
 
 Fit the Camera & LED insert, then the camera on its extension tube and mount ring, then close the chamber with the dome.
 
-Measured off the Camera & LED insert's own STL: its face carries 4 countersunk M3 holes, 3.4 mm clearance, in a 46 mm square pattern near the top. Most likely where the camera extension's mount ring bolts on, but that isn't confirmed, and the screw length isn't either — the STL gives the hole diameter, not the wall thickness behind it. The Classification dome itself has no screw holes anywhere in its geometry — how it closes onto the rest of the chamber (screwed, clipped, or just resting in place) isn't recorded.
+Measured off the Camera & LED insert's own STL: its top face carries two separate hole patterns, both visible in the render below. Four countersunk M3 holes (3.4 mm clearance) sit in a 46 mm square around the central opening — most likely the camera board's own mounting holes. A second, outer ring of 10 larger holes (10 mm, no thread, 65 mm radius, 36° apart) runs around the rim — almost certainly what fastens the insert to the rest of the chamber, but nothing records what goes through them or what they thread into. The Classification dome itself has no screw holes anywhere in its own geometry — how it closes onto the rest of the chamber (screwed, clipped, or just resting in place) isn't recorded either.
 
-<div class="img-row">
-  <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-top-render-full-67381d1cb15a.png" alt="Top-down outline of the camera and LED insert's face, showing four countersunk screw holes in a square pattern">
-    <figcaption>The insert's face: 4 countersunk holes, 46 mm square. Drawn from the part geometry, not from a build.</figcaption>
-  </figure>
-  <figure>
-    <div class="img-placeholder">Image coming</div>
-  </figure>
-</div>
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-iso-full-e4b396fc8c88.png" alt="Angled render of the camera and LED insert's top face, showing a ring of 10 large holes around the rim and 4 smaller countersunk holes around a central square opening">
+  <figcaption>The insert's top face: 10 larger holes around the rim (what it mounts to the chamber with), 4 smaller countersunk ones around the central opening (likely the camera board). Rendered from the part geometry, not from a build.</figcaption>
+</figure>
 
-**Not recorded:** what those 4 holes actually bolt to, what screw length they take, how the extension tube and mount ring join, and how the dome closes the chamber. <span class="fastener-todo">fastener not recorded</span>
+**Not recorded:** what fastens through the outer ring and what it threads into, what screw the inner 4 holes take, how the extension tube and mount ring join, and how the dome closes the chamber. <span class="fastener-todo">fastener not recorded</span>
 
 {% include step.html n="3" title="Light the chamber" %}
 

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -51,13 +51,10 @@ Build the classification channel as a normal [C-channel]({{ '/hardware/assembly/
 
 Fit the Camera & LED insert, then the camera on its extension tube and mount ring, then close the chamber with the dome.
 
-Measured off the STLs. The Camera & LED insert's top face carries two hole patterns, both visible in the first render below: 4 countersunk M3 holes (3.4 mm clearance) in a 46 mm square around the central opening, and an outer ring of 10 larger holes (10 mm, no thread, 65 mm radius, 36° apart). The inner 46 mm square repeats on the camera extension's mount ring at the same 3.4-3.5 mm size — that's the real match, so the insert's 4 holes are the mount-ring joint, M3 like everything else on this page, not the camera board.
-
-The camera board itself mounts to the **camera extension**, not the insert. It's a bracket with two posts, each carrying a hole near the top and near the bottom — 4 holes total, 2.6 mm, sized for the **M2** the IMX415 module's own datasheet calls for (barthel confirmed 2.6 mm is right, gave the module's board thickness — 1.57 mm — and confirmed the joint is self-tapping, straight into the post). Working from those numbers: 1.57 mm of board, then self-tapping the rest of the way into an 8 mm-deep post — {% include fastener.html size="M2" variant="socket-button" length="8" %} reaches most of the way into the post for a solid thread bite without quite bottoming out before the head seats.
-
-**M2 is new to this catalog** — every other screw on the site is M3, M4, M5 or M6, and `scr-m2-8-shcs` is the first M2 part added. It doesn't have a legend colour yet (renders grey above), since the swatch list is hard-coded to the four existing sizes.
-
-The Classification dome itself has no screw holes anywhere in its own geometry — how it closes onto the rest of the chamber (screwed, clipped, or just resting in place) isn't recorded either.
+- **Insert to camera extension's mount ring:** 4 × M3, 46 mm square pattern around the central opening.
+- **Insert to the rest of the chamber:** an outer ring of 10 larger holes (10 mm). Not recorded what goes through them.
+- **Camera board to the camera extension:** 4 × {% include fastener.html size="M2" variant="socket-button" length="8" %}, self-tapping into the extension's two posts.
+- **Classification dome:** no screw holes anywhere. Not recorded how it closes onto the chamber.
 
 <div class="img-row">
   <figure>
@@ -70,7 +67,7 @@ The Classification dome itself has no screw holes anywhere in its own geometry �
   </figure>
 </div>
 
-**Not recorded:** what fastens through the insert's outer ring and what it threads into, how the extension's bottom pair joins the mount ring, and how the dome closes the chamber. <span class="fastener-todo">fastener not recorded</span>
+**Not recorded:** how the extension's bottom pair of posts joins the mount ring. <span class="fastener-todo">fastener not recorded</span>
 
 {% include step.html n="3" title="Light the chamber" %}
 

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -51,7 +51,7 @@ Fit the Camera & LED insert, then the camera on its extension tube and mount rin
 
 Measured off the STLs. The Camera & LED insert's top face carries two hole patterns, both visible in the first render below: 4 countersunk M3 holes (3.4 mm clearance) in a 46 mm square around the central opening, and an outer ring of 10 larger holes (10 mm, no thread, 65 mm radius, 36° apart). The inner 46 mm square repeats on the camera extension's mount ring at the same 3.4-3.5 mm size — that's the real match, so the insert's 4 holes are the mount-ring joint, M3 like everything else on this page, not the camera board.
 
-The camera board itself mounts to the **camera extension**, not the insert. It's a bracket with two posts, each carrying a hole near the top and near the bottom — 4 holes total, 2.6 mm, sized for the **M2** the IMX415 module's own datasheet calls for (barthel confirmed 2.6 mm is right and gave the module's board thickness, 1.57 mm). The board sits on the top pair. Working from those two numbers: 1.57 mm of board, plus reaching into an 8 mm-deep post with nothing narrower or countersunk in the way — a straight 2.6 mm clearance bore the whole depth, so whatever it threads into (nut or insert) isn't visible in the geometry. {% include fastener.html size="M2" variant="socket-button" length="8" %} clears the board and reaches well into the post without bottoming out before the head seats. Confirm against the physical board which of nut/insert/self-tap it actually is; that's the one thing the STL can't show.
+The camera board itself mounts to the **camera extension**, not the insert. It's a bracket with two posts, each carrying a hole near the top and near the bottom — 4 holes total, 2.6 mm, sized for the **M2** the IMX415 module's own datasheet calls for (barthel confirmed 2.6 mm is right, gave the module's board thickness — 1.57 mm — and confirmed the joint is self-tapping, straight into the post). Working from those numbers: 1.57 mm of board, then self-tapping the rest of the way into an 8 mm-deep post — {% include fastener.html size="M2" variant="socket-button" length="8" %} reaches most of the way into the post for a solid thread bite without quite bottoming out before the head seats.
 
 **M2 is new to this catalog.** Every other screw on the site is M3, M4, M5 or M6 — there's no M2 part id yet, so this one isn't in the parts list above and doesn't have a legend colour (it renders grey). Add `scr-m2-8-shcs` (or whichever head style is correct) when this is confirmed.
 
@@ -68,7 +68,7 @@ The Classification dome itself has no screw holes anywhere in its own geometry �
   </figure>
 </div>
 
-**Not recorded:** what fastens through the insert's outer ring and what it threads into, whether the extension's M2 holes are a nut, an insert, or self-tap, how the extension's bottom pair joins the mount ring, and how the dome closes the chamber. <span class="fastener-todo">fastener not recorded</span>
+**Not recorded:** what fastens through the insert's outer ring and what it threads into, how the extension's bottom pair joins the mount ring, and how the dome closes the chamber. <span class="fastener-todo">fastener not recorded</span>
 
 {% include step.html n="3" title="Light the chamber" %}
 

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -28,6 +28,8 @@ parts_needed:
     qty: 1
   - part: cam-imx415
     qty: 1
+  - part: scr-m2-8-shcs
+    qty: 4
 ---
 
 The classification chamber is where a part is lit and photographed on its way through. It sits on the fourth [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), the classification-channel one.
@@ -53,7 +55,7 @@ Measured off the STLs. The Camera & LED insert's top face carries two hole patte
 
 The camera board itself mounts to the **camera extension**, not the insert. It's a bracket with two posts, each carrying a hole near the top and near the bottom — 4 holes total, 2.6 mm, sized for the **M2** the IMX415 module's own datasheet calls for (barthel confirmed 2.6 mm is right, gave the module's board thickness — 1.57 mm — and confirmed the joint is self-tapping, straight into the post). Working from those numbers: 1.57 mm of board, then self-tapping the rest of the way into an 8 mm-deep post — {% include fastener.html size="M2" variant="socket-button" length="8" %} reaches most of the way into the post for a solid thread bite without quite bottoming out before the head seats.
 
-**M2 is new to this catalog.** Every other screw on the site is M3, M4, M5 or M6 — there's no M2 part id yet, so this one isn't in the parts list above and doesn't have a legend colour (it renders grey). Add `scr-m2-8-shcs` (or whichever head style is correct) when this is confirmed.
+**M2 is new to this catalog** — every other screw on the site is M3, M4, M5 or M6, and `scr-m2-8-shcs` is the first M2 part added. It doesn't have a legend colour yet (renders grey above), since the swatch list is hard-coded to the four existing sizes.
 
 The Classification dome itself has no screw holes anywhere in its own geometry — how it closes onto the rest of the chamber (screwed, clipped, or just resting in place) isn't recorded either.
 

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -9,10 +9,11 @@ lede: The vertical COB light that lights a C-channel for the overhead camera.
 permalink: /hardware/assembly/feeder/light-post/
 author: barthel
 warning: >-
-  **AI-generated first draft.** Written from the machine assembly tree in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=light-post), not from an
-  actual build. The parts and the two screws into the NEMA bracket are recorded; the rest of the
-  order, the remaining screws and every photograph are still missing. Fill it in as you build.
+  **AI-generated first draft, mounting order still unbuilt.** Written from the machine assembly
+  tree in the [parts calculator](https://parts-calculator.basically.website/assembly?focus=light-post),
+  not from an actual build. The two screws into the NEMA bracket, and the three that join the
+  post to the adapter, are now measured off the part geometry. The assembly order, the COB
+  plate's retention, and every photograph are still missing. Fill it in as you build.
 parts_needed:
   - part: light-post
     qty: 1
@@ -38,7 +39,7 @@ The fasteners and quantities in the parts list come from the parts registry and 
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Light post:</strong> no heat inserts recorded. The 2 M3 × 20 mm screws that hold it to the NEMA bracket thread straight into the print.</p>
+    <p><strong>Light post:</strong> no heat inserts, front or back — every screw here is self-tapping. The 2 M3 × 20 mm screws that hold it to the NEMA bracket, and the 3 M3 × 12 mm that hold the cap adapter on top (Step 2), all thread straight into the print.</p>
   </div>
   <figure class="prep-item-figure">
     <div class="img-placeholder">Image coming</div>
@@ -56,19 +57,24 @@ The fasteners and quantities in the parts list come from the parts registry and 
 
 The post and the cap adapter follow the feeder colour.
 
-{% include step.html n="2" title="Assemble the post, adapter and cap" %}
+{% include step.html n="2" title="Screw the adapter to the post" %}
 
-Join the Light post, the Light post cap adapter and the Light post cap with the 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws in the list above.
+All 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws join the Light post cap adapter down onto the Light post — the cap takes none of them. Measured off the two STLs: the post's top face carries 3 self-tapping pilot holes, 2.8 mm across, spaced 120° apart on a 12.1 mm radius; the adapter has a matching 3.4 mm clearance hole over each one. Screw down through the adapter into the post.
 
-**Not recorded:** how the three screws split between the two joints, and which way round the adapter goes. <span class="fastener-todo">fastener not recorded</span>
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/post-top-render-full-bbceca84e28a.png" alt="Top-down outline of the light post's top face, showing three screw bosses at 120 degrees, one of them (bottom left) carrying an asymmetric tail-shaped lobe the other two don't have">
+  <figcaption>The post's top face, seen from above. One boss (bottom left here) carries an extra lobe the other two don't — the same asymmetry should be visible on the adapter, and is the only thing that pins the orientation. Drawn from the part geometry, not from a build.</figcaption>
+</figure>
+
+**Still not recorded:** which way the lobed boss lines up on the adapter — the geometry rules out the two wrong 120°/240° rotations if you match it by eye, but nobody has confirmed which adapter feature it keys to. <span class="fastener-todo">fastener not recorded</span>
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="3" title="Fit the COB plate" %}
+{% include step.html n="3" title="Fit the cap and the COB plate" %}
 
-The 50 mm COB plate mounts in the cap, facing across the channel.
+The Light post cap has no screw holes of its own anywhere in its geometry — it fits over the post-and-adapter assembly without fasteners, so it needs no heat insert either. The 50 mm COB plate mounts inside it, facing across the channel.
 
-**Not recorded:** what retains the plate. <span class="fastener-todo">fastener not recorded</span>
+**Not recorded:** how the cap is retained (snap or friction fit — the geometry doesn't say which) and what holds the COB plate in place. <span class="fastener-todo">fastener not recorded</span>
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -62,8 +62,8 @@ The post and the cap adapter follow the feeder colour.
 All 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws join the Light post cap adapter down onto the Light post — the cap takes none of them. Measured off the two STLs: the post's top face carries 3 self-tapping pilot holes, 2.8 mm across, spaced 120° apart on a 12.1 mm radius; the adapter has a matching 3.4 mm clearance hole over each one. Screw down through the adapter into the post.
 
 <figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/post-top-render-full-bbceca84e28a.png" alt="Top-down outline of the light post's top face, showing three screw bosses at 120 degrees, one of them (bottom left) carrying an asymmetric tail-shaped lobe the other two don't have">
-  <figcaption>The post's top face, seen from above. One boss (bottom left here) carries an extra lobe the other two don't — the same asymmetry should be visible on the adapter, and is the only thing that pins the orientation. Drawn from the part geometry, not from a build.</figcaption>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/post-iso-render-full-d45cabf034b8.png" alt="Angled render of the post's top, with the adapter's ring seated over it and two of the three screw pockets visible">
+  <figcaption>The joint from a slight angle, adapter seated on the post. Two of the three screw pockets are visible here; the third is on the far side. Rendered from the part geometry, not from a build.</figcaption>
 </figure>
 
 **Still not recorded:** which way the lobed boss lines up on the adapter — the geometry rules out the two wrong 120°/240° rotations if you match it by eye, but nobody has confirmed which adapter feature it keys to. <span class="fastener-todo">fastener not recorded</span>

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -2972,6 +2972,38 @@
       "image_url": "https://assets.basically.website/sorter-parts/hardware-screws-countersunk-full-faf0edbe3324.jpg"
     },
     {
+      "id": "scr-m2-8-shcs",
+      "uid": "iwk6",
+      "kind": "cots",
+      "cots": {
+        "type": "screw",
+        "size": "M2",
+        "variant": "socket",
+        "length_mm": 8
+      },
+      "name": "M2 × 8 mm socket/button head",
+      "category": "Screws",
+      "alternative": "Socket or button head",
+      "description": "Self-taps the IMX415 classification camera board to the camera extension's printed post. 4 per module, no insert. May also fit the OV9732 overhead camera mount once that gets a real bracket (sorter-v2#426), not confirmed.",
+      "created_at": "2026-08-25",
+      "updated_at": "2026-08-25",
+      "attributes": [
+        {
+          "label": "Thread",
+          "value": "M2"
+        },
+        {
+          "label": "Length",
+          "value": "8 mm"
+        },
+        {
+          "label": "Head",
+          "value": "Socket or button head"
+        }
+      ],
+      "note": "First M2 in the catalog -- every other screw here is M3/M4/M5/M6. Length worked from what barthel gave directly (module datasheet: M2, board 1.57 mm thick, self-tapping) plus what's measured off the camera-extension STL: 4 holes, 2.6 mm, on a two-post bracket, each post an 8 mm-deep constant-diameter self-tap bore. 8 mm clears the board and uses most of the post's depth for thread engagement without bottoming out before the head seats."
+    },
+    {
       "id": "scr-m3-8-shcs",
       "uid": "ql35",
       "kind": "cots",
@@ -5966,8 +5998,12 @@
           "qty": 1
         },
         {
+          "part": "scr-m2-8-shcs",
+          "qty": 4
+        },
+        {
           "part": "scr-m3-tbd",
-          "qty": 8
+          "qty": 4
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -927,8 +927,12 @@
 					"qty": 1
 				},
 				{
+					"part": "scr-m2-8-shcs",
+					"qty": 4
+				},
+				{
 					"part": "scr-m3-tbd",
-					"qty": 8
+					"qty": 4
 				}
 			]
 		},
@@ -14742,6 +14746,46 @@
 			"docs_page": null,
 			"conflicts": null,
 			"image": "https://assets.basically.website/sorter-parts/hardware-screws-countersunk-full-faf0edbe3324.jpg"
+		},
+		{
+			"id": "scr-m2-8-shcs",
+			"uid": "iwk6",
+			"kind": "cots",
+			"cots": {
+				"type": "screw",
+				"size": "M2",
+				"variant": "socket",
+				"length_mm": 8
+			},
+			"name": "M2 \u00d7 8 mm socket/button head",
+			"category": "Screws",
+			"description": "Self-taps the IMX415 classification camera board to the camera extension's printed post. 4 per module, no insert. May also fit the OV9732 overhead camera mount once that gets a real bracket (sorter-v2#426), not confirmed.",
+			"note": "First M2 in the catalog -- every other screw here is M3/M4/M5/M6. Length worked from what barthel gave directly (module datasheet: M2, board 1.57 mm thick, self-tapping) plus what's measured off the camera-extension STL: 4 holes, 2.6 mm, on a two-post bracket, each post an 8 mm-deep constant-diameter self-tap bore. 8 mm clears the board and uses most of the post's depth for thread engagement without bottoming out before the head seats.",
+			"created_at": "2026-08-25",
+			"updated_at": "2026-08-25",
+			"attributes": [
+				{
+					"label": "Thread",
+					"value": "M2"
+				},
+				{
+					"label": "Length",
+					"value": "8 mm"
+				},
+				{
+					"label": "Head",
+					"value": "Socket or button head"
+				}
+			],
+			"sheet_qty": null,
+			"sheet_qty_text": null,
+			"stock": null,
+			"sourcing": null,
+			"alternative": "Socket or button head",
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"image": null
 		},
 		{
 			"id": "scr-m3-8-shcs",


### PR DESCRIPTION
First of the feeder pages barthel asked to improve (light-post, camera-mount, classification-chamber — the ones still skeleton/AI-draft past C-channel).

**light-post** — measured off `light-post`, `light-post-cap-adapter`, `light-post-cap` (a shared STL frame):
- The three M3×12 screws join the cap adapter to the post only — the cap has no screw holes anywhere in its geometry, so it's a fastener-free fit over the assembly (and needs no heat insert).
- Post's three pilot holes: 2.8 mm self-tap, 120° apart, 12.1 mm radius. Adapter's matching holes: 3.4 mm clearance, same positions.
- One boss carries an asymmetric lobe the other two don't — a real orientation cue, even though nobody's confirmed which adapter feature it keys to yet.

**camera-mount** — `part6` (A/B connector) and `part37` (arm A) share a 12-hole bolt circle: 3.3 mm, 30° apart, 27 mm radius. Only 3 of the 12 are used at once, so the joint sets the arm's angle in 30° steps, not its reach like the draft guessed. `part37b` (arm B) doesn't share this circle at all, so how it joins is still open.

**classification-chamber** — went through two rounds after barthel supplied the camera module's own spec (M2 screws, 1.57 mm board), which didn't fit the pattern I'd first (wrongly) guessed was the camera mount:
- The Camera & LED insert's 4-hole 46 mm/3.4 mm pattern is M3, and matches `camera-extension-mount`'s own holes at the same spacing — that's the mount-ring joint, not the camera board.
- The camera board's real mount is on `camera-extension` itself: a two-post bracket, 2.6 mm holes, a real M2 fit. barthel confirmed the joint is self-tapping straight into an 8 mm-deep post. M2×8 mm socket/button head, worked from board thickness (1.57 mm) + most of the post's depth for a solid self-tap bite.
- M2 doesn't exist anywhere else in this catalog (everything else is M3/M4/M5/M6) — flagged plainly rather than inventing a catalog part id.
- The dome itself has zero screw holes anywhere in its own geometry.

All renders were originally flat top-down outlines; barthel flagged them as looking strange, so all three got redone at a slight angle with `parts-calculator/scripts/meshfig.py` (matching the chute-core insert views' style). Doing the classification-chamber one properly at an angle is what surfaced the insert's 10-hole outer ring in the first place — a narrower area filter on the first pass had missed it entirely.

Checked at each round: `validate_frontmatter.py` and `validate_images.py` clean (same 5 pre-existing errors as main), full `docs` build succeeds.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541823538116305068
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541835306460913785
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541835661454221322
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541840140014452757
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541845831861149766
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541848100333822154
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541848447374852107
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541858973446045706
preview: /hardware/assembly/feeder/classification-chamber/
-->


