### PR TITLE
parts-calculator: sort hardware page screws/nuts/heat inserts by size then length

### DIFF
--- a/parts-calculator/src/routes/hardware/+page.svelte
+++ b/parts-calculator/src/routes/hardware/+page.svelte
@@ -80,6 +80,14 @@
 		filtering ? search(filter, HARDWARE, hardwareSearchable).map((r) => r.item) : HARDWARE
 	);
 
+	// Screws, nuts and heat inserts read as a size chart, so within these
+	// categories rows go by thread size then length ascending (M2x8 before
+	// M3x6 before M3x12) instead of manifest order.
+	const SIZE_SORTED_CATEGORIES = new Set(['Screws', 'Nuts', 'Heat inserts']);
+	const sizeNum = (h: Hardware) => parseInt(h.cots?.size?.replace(/\D/g, '') ?? '', 10) || 0;
+	const bySizeThenLength = (a: Hardware, b: Hardware) =>
+		sizeNum(a) - sizeNum(b) || (a.cots?.length_mm ?? 0) - (b.cots?.length_mm ?? 0);
+
 	// categories in manifest order, preserving first-seen order
 	const groups = $derived.by(() => {
 		const by = new Map<string, Hardware[]>();
@@ -87,6 +95,9 @@
 			const cat = h.category ?? 'Other';
 			if (!by.has(cat)) by.set(cat, []);
 			by.get(cat)!.push(h);
+		}
+		for (const [cat, items] of by) {
+			if (SIZE_SORTED_CATEGORIES.has(cat)) items.sort(bySizeThenLength);
 		}
 		return [...by.entries()];
 	});


### PR DESCRIPTION
Sorts the `/hardware` page's Screws, Nuts and Heat inserts categories by thread size, then by length ascending (an item with no length, e.g. a TBD placeholder, sorts first within its size). Ties keep their existing order.

Requested by uwe_barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1541858414504837171): "In the part calculator on the hardware page, please sort all screws, nuts, and heat inserts within their respective categories by size and then by length in ascending order, so that M2x8mm appears before M3x6mm, which appears before M3x12mm."

Verified with `npm run check` (0 errors) and `npm run build`, then checked the prerendered `/hardware` page's row order directly.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1541858414504837171
preview: /hardware
-->
