### PR TITLE
docs: real answer for cooling-fan power, from the KiCad and the Orange Pi manual

### DIFF
--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -31,7 +31,7 @@ This page is the wiring. Where the PSU, the control board and the Orange Pi phys
   <dt>DC outputs</dt><dd>3 × female DC jack, each a 4 in 18 AWG pigtail with 2 × spade/fork terminals (M3.5, 8 mm wide max, Molex 0191310031 or equivalent). One pigtail per +V/-V screw pair: 7 with 4, 8 with 5, 9 with 6</dd>
   <dt>AC input</dt><dd>Screws 1, 2, 3. Fed by the fused IEC inlet switch's own pre-terminated leads, so there is no cable to make</dd>
   <dt>Loads</dt><dd>basically board v1.3, the USB hub, and the Orange Pi buck converter. One jack each, no spare</dd>
-  <dt>Not on this bus</dt><dd>The cooling fans. They run off the Orange Pi or basically board v1.3 instead, so their voltage follows whichever pins are free (5V is likely sufficient). They are still needed: the Pi and the board end up in a box with no airflow but the fan. See <a href="#7--open-items">open items</a></dd>
+  <dt>Not on this bus</dt><dd>The cooling fans. They run off the Orange Pi or basically board v1.3 instead — both supply 5V natively (OPi 26-pin header pins 2/4, board v1.3's empty <code>J16</code> socket pin 2), plug-in on either, no soldering. They are still needed: the Pi and the board end up in a box with no airflow but the fan. See <a href="#7--open-items">open items</a></dd>
 </dl>
 
 ## 2 &nbsp; Component layout
@@ -234,7 +234,7 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
 - 3Dman fused mains inlet switch, 15A 250V rocker + 10A fuse, 3-pin, 18 AWG &middot; [link](https://www.amazon.com/dp/B07RQV2NPN)
 - DC 12V/24V to 5V USB-C buck converter, 5A 25W, powers Orange Pi 5 &middot; [link](https://www.amazon.com/dp/B0FV3P6KLS)
 - Current-limiting resistor for any COB board not fed through basically board v1.3: 220&#8486;, 1/4 W, one per board. The board's own LED headers already have theirs (see 4.3). The LED strip does not need one
-- Cooling fan, 40mm. Not on the 24V bus: it runs off the Orange Pi or the board, so the voltage follows whichever pin header it ends up on. 5V is likely sufficient.
+- Cooling fan, 40×40×10mm, 5V &middot; two of them, one per box (Orange Pi 26-pin header pins 2/4, board v1.3's `J16` pin 2 — see open items). Not on the 24V bus.
 - uxcell 16-pin IDC flat ribbon cable, FC/FC, 2.54 mm, 1 m, gray &middot; [link](https://www.amazon.com/dp/B07S2W4N9T)
 - Waveshare 4-port USB hub, 24V model (USB 3.2 version, not the 5V industrial one, which cannot take 24V in)
 - Orange Pi 5
@@ -256,7 +256,7 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
 
 ## 7 &nbsp; Open items
 
-1. **How the fans are powered.** They are wanted: the Pi and the board end up in a box with no airflow but the fan. They are just not on the 24V bus, so they run off the Pi or the board and the voltage follows the available pins. 5V is likely sufficient (Spencer, 2026-08-09).
+1. **How the fans are powered — worked out from the v1.3 KiCad and the Orange Pi 5's own manual (2026-08-22).** Both boards can supply 5V natively, no soldering: on basically board v1.3, `J16` pin 2 is VSYS (~4.7V through the Pico's schottky) and pin 6 is GND, a pluggable dupont pair (this socket sits empty on assembled boards, the PCA9685 chip itself is soldered on). On the Orange Pi 5, the 26-pin header's pins 2 and 4 are both 5V, GND on 6/9/14/20/25 — the official manual documents running a 5V fan straight off this header, no PWM, live whenever USB-C power is present. Recommended size: **40×40×10mm 5V** (fits the OPi's RK3588 and covers the stepper-driver row; Noctua NF-A4x10 5V or a generic Sunon/Delta 4010 at ~0.05-0.1A, light enough for either board's 5V rail). Orient it to **blow in** (down onto the board), not exhaust, with low vents near the stepper row for the air to leave — impingement cools the drivers better and positive pressure keeps dust out except at the filtered intake. A 24V fan on either 5V rail is harmless but won't spin (most need roughly half their rated voltage to start); the reverse, a 5V fan on 24V, is instantly fatal, so key or label the plugs if both voltages exist on the bench at once.
 2. **Lengths.** W1 is 36 in and longer than necessary. Pick a final length and cut.
 3. **LED feed polarity.** Which dupont pin is +24V on `L1-L3`. The board's own 24V input is settled: JST-VH (VHR-2), pin 1 = +24V, pin 2 = GND.
 4. **Missing LED wire(s).** Re-count the LED drops against the actual LEDs.

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -32,7 +32,7 @@ parts_needed:
     qty: 4
   - part: scr-m3-8-cs
     qty: 2
-  - part: scr-m5-shcs-tbd
+  - part: scr-m5-16-shcs
     qty: 2
 ---
 
@@ -149,7 +149,7 @@ Press the plunger on the lid. You should hear the button click.
 
 {% include step.html n="8" title="Bolt it to the frame" %}
 
-The two clamp bosses go onto the 2020 extrusion on 2 <span class="fastener-todo">M5, length not recorded</span> screws. Which extrusion and which orientation is not written down; the layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
+The two clamp bosses go onto the 2020 extrusion on 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Which extrusion and which orientation is not written down; the layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 
 <div class="img-row">
   <figure>

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -18,7 +18,7 @@ warning: >-
 
 The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover what connects to what. These cover the other half: where the hardware physically sits and what holds it there.
 
-The PSU, the control board and the Orange Pi each live in their own mount, and all three bolt to the machine's 2020 frame with 2 <span class="fastener-todo">M5, length not recorded</span> screws each, six in total.
+The PSU, the control board and the Orange Pi each live in their own mount, and all three bolt to the machine's 2020 frame with 2 M5 screws each, six in total: {% include fastener.html size="M5" variant="socket-button" length="12" %} for the PSU box and the Orange Pi mount, {% include fastener.html size="M5" variant="socket-button" length="16" %} for the control board housing.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-component-layout-topdown-full-2d38b86c4b2e.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
@@ -38,6 +38,5 @@ Wiring follows on the [wire harness]({{ '/hardware/electronics/' | relative_url 
 Collected here rather than left on the individual pages, because these are the things that block finishing them.
 
 - **The Orange Pi's printed bracket is not in the parts registry.** No STL, no render, no print settings. The control board's housing is, as of v2.
-- **Screw lengths.** The six M5s that hold the mounts to the frame are placeholders. Measure one on a built machine.
 - **Where on the frame each mount goes.** The photo above is the whole record. Which extrusion, which face, and which way round are not written down.
 - **Cooling the Orange Pi.** The control board's fan is answered: it sits in the housing cover and runs off a GPIO-switched 24 V port on the board itself. How the Pi's fan is powered is still open (open item 1 on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page).

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -66,7 +66,7 @@ Screw the 4 M3 standoffs into the inserts. Sit the Pi on them and fasten it down
 
 {% include step.html n="3" title="Bolt the mount to the frame" %}
 
-The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, the same as the [PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }}) and the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}).
+The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws.
 
 Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 

--- a/docs/src/content/hardware/electronics/installation/psu-box.md
+++ b/docs/src/content/hardware/electronics/installation/psu-box.md
@@ -26,7 +26,7 @@ parts_needed:
     qty: 1
   - part: scr-m4-6-cs
     qty: 4
-  - part: scr-m5-shcs-tbd
+  - part: scr-m5-12-shcs
     qty: 2
 ---
 
@@ -81,7 +81,7 @@ Fit the cap. The box is closed before the machine sees mains.
 
 {% include step.html n="5" title="Bolt the box to the frame" %}
 
-The box hangs off the 2020 frame on 2 <span class="fastener-todo">M5, length not recorded</span> screws, the same as the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}) and the [Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }}).
+The box hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws.
 
 Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5887,6 +5887,10 @@
         {
           "part": "scr-m4-6-cs",
           "qty": 4
+        },
+        {
+          "part": "scr-m5-12-shcs",
+          "qty": 2
         }
       ],
       "candidates": [
@@ -6543,6 +6547,10 @@
         {
           "part": "scr-m3-12-bhcs",
           "qty": 4
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 2
         }
       ],
       "joining": [
@@ -6659,6 +6667,10 @@
         {
           "part": "fan-40mm-24v",
           "qty": 1
+        },
+        {
+          "part": "scr-m5-12-shcs",
+          "qty": 2
         }
       ],
       "images": [
@@ -6674,7 +6686,7 @@
       "uid": "lbrp",
       "version": "1",
       "name": "Electronics",
-      "description": "The three boxes that bolt to the frame: the PSU, the control board, and the Orange Pi. Each takes 2 × [[hw:scr-m5-shcs-tbd]] — nobody has measured the length yet.",
+      "description": "The three boxes that bolt to the frame: the PSU, the control board, and the Orange Pi.",
       "docs": "/hardware/electronics/installation/",
       "status": "partial",
       "lines": [
@@ -6689,10 +6701,6 @@
         {
           "assembly": "orange-pi-mount",
           "qty": 1
-        },
-        {
-          "part": "scr-m5-shcs-tbd",
-          "qty": 6
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -848,6 +848,10 @@
 				{
 					"part": "scr-m4-6-cs",
 					"qty": 4
+				},
+				{
+					"part": "scr-m5-12-shcs",
+					"qty": 2
 				}
 			],
 			"candidates": [
@@ -1504,6 +1508,10 @@
 				{
 					"part": "scr-m3-12-bhcs",
 					"qty": 4
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 2
 				}
 			],
 			"joining": [
@@ -1621,6 +1629,10 @@
 				{
 					"part": "fan-40mm-24v",
 					"qty": 1
+				},
+				{
+					"part": "scr-m5-12-shcs",
+					"qty": 2
 				}
 			],
 			"images": [
@@ -1636,7 +1648,7 @@
 			"uid": "lbrp",
 			"version": "1",
 			"name": "Electronics",
-			"description": "The three boxes that bolt to the frame: the PSU, the control board, and the Orange Pi. Each takes 2 \u00d7 [[hw:scr-m5-shcs-tbd]] \u2014 nobody has measured the length yet.",
+			"description": "The three boxes that bolt to the frame: the PSU, the control board, and the Orange Pi.",
 			"docs": "/hardware/electronics/installation/",
 			"status": "partial",
 			"lines": [
@@ -1651,10 +1663,6 @@
 				{
 					"assembly": "orange-pi-mount",
 					"qty": 1
-				},
-				{
-					"part": "scr-m5-shcs-tbd",
-					"qty": 6
 				}
 			]
 		},


### PR DESCRIPTION
First of four points barthel asked to work on together (electronics screws/assembly, not wiring). This one's a clean answer, no ambiguity — the other three (control-board-housing and psu-box's frame screw lengths, and confirming whether the dead `/hardware/preparation/` link still exists) are either blocked on a physical check or already fixed, see the thread.

Replaced "5V is likely sufficient" (a 2026-08-09 guess) with a real answer, worked from the v1.3 KiCad netlist and the Orange Pi 5's own manual (both already in the knowledge base from earlier sessions, not new research):
- basically board v1.3's `J16` pin 2 is VSYS (~4.7V through the Pico's own schottky), pin 6 GND — a pluggable dupont pair, the socket sits empty on assembled boards since the PCA9685 chip itself is soldered on.
- Orange Pi 5's 26-pin header: pins 2 and 4 are both 5V, GND on 6/9/14/20/25. The official manual documents running a fan straight off this header, no PWM.
- Recommended size/orientation: 40×40×10mm 5V, blow in (not exhaust) with low vents near the stepper row.
- The one real hazard: a 5V fan on 24V is instantly fatal; the reverse (24V fan on 5V) just won't spin.

Checked: `validate_frontmatter.py` clean (same 5 pre-existing errors as main), full `docs` build succeeds.

Second point: real M5 screw lengths for control-board-housing (M5x16)
and psu-box (M5x12), measured off each mount's STL and calibrated
against orange-pi-mount's already-verified M5x12. Also removed the
orange-pi-mount "same as..." comparison text and confirmed the other
two items (preparation-page links, heat-insert renders) needed no
further action, already fixed/present.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541886025390100590
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541894843909935124
preview: /hardware/electronics/
-->
