### PR TITLE
docs: rename Pico headers to Soldering Pico headers, move to Parts nav

### DIFF
--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -11,7 +11,7 @@ author: barthel
 contributors: [spencer]
 warning: >-
   **Mixed.** The two control board pages come from a real build. The PSU box, Orange Pi mount
-  and Pico headers pages are AI-generated first drafts written from the [parts
+  and Soldering Pico headers pages are AI-generated first drafts written from the [parts
   calculator](https://parts-calculator.basically.website/assembly), not from a build: the parts
   are real, the steps are not checked. Gaps are marked in place. Correct them as you build.
 ---
@@ -25,7 +25,7 @@ The PSU, the control board and the Orange Pi each live in their own mount, and a
   <figcaption>Where everything sits, top-down. This photo is currently the only record of the placement.</figcaption>
 </figure>
 
-1. **[Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**: soldering the header pins so the Pico can seat in the control board. First, while the board is still loose.
+1. **[Soldering Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**: soldering the header pins so the Pico can seat in the control board. First, while the board is still loose.
 2. **[PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }})**: the printed enclosure around the Mean Well LRS-350-24.
 3. **[Preparing the control board]({{ '/hardware/electronics/installation/control-board-prep/' | relative_url }})**: the five stepper drivers, the Pico, and the jumpers that address the drivers.
 4. **[Control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }})**: the printed housing the board closes into, with its fan.

--- a/docs/src/content/hardware/electronics/installation/pico-headers.md
+++ b/docs/src/content/hardware/electronics/installation/pico-headers.md
@@ -4,7 +4,7 @@ title: Soldering Pico headers
 type: how-to
 section: hardware
 slug: electronics-pico-headers
-kicker: Parts — Soldering Pico headers
+kicker: Helpers — Soldering Pico headers
 lede: Soldering 2.54 mm header pins to the Raspberry Pi Pico so it can seat in the control board.
 permalink: /hardware/electronics/installation/pico-headers/
 author: barthel

--- a/docs/src/content/hardware/electronics/installation/pico-headers.md
+++ b/docs/src/content/hardware/electronics/installation/pico-headers.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Pico headers
+title: Soldering Pico headers
 type: how-to
 section: hardware
 slug: electronics-pico-headers
-kicker: Electronics — Pico headers
+kicker: Parts — Soldering Pico headers
 lede: Soldering 2.54 mm header pins to the Raspberry Pi Pico so it can seat in the control board.
 permalink: /hardware/electronics/installation/pico-headers/
 author: barthel

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -82,8 +82,6 @@ sections:
                 url: /hardware/electronics/installation/control-board-housing/
               - title: Orange Pi mount
                 url: /hardware/electronics/installation/orange-pi-mount/
-              - title: Pico headers
-                url: /hardware/electronics/installation/pico-headers/
           - title: Stepper connectors
             url: /hardware/electronics/steppers/
           - title: Order spec
@@ -110,6 +108,8 @@ sections:
             url: /hardware/parts/external-bracket/
           - title: Orange Pi 5
             url: /hardware/orange-pi-5/
+          - title: Soldering Pico headers
+            url: /hardware/electronics/installation/pico-headers/
 
   - id: sorter
     title: Sorter

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -99,6 +99,8 @@ sections:
             url: /hardware/helpers/pulley-gear-mod/
           - title: Installing heat inserts
             url: /hardware/helpers/heat-inserts/
+          - title: Soldering Pico headers
+            url: /hardware/electronics/installation/pico-headers/
       - title: Parts
         url: /hardware/parts/
         children:
@@ -108,8 +110,6 @@ sections:
             url: /hardware/parts/external-bracket/
           - title: Orange Pi 5
             url: /hardware/orange-pi-5/
-          - title: Soldering Pico headers
-            url: /hardware/electronics/installation/pico-headers/
 
   - id: sorter
     title: Sorter


### PR DESCRIPTION
Renamed and moved per the request: title/kicker now "Soldering Pico headers", moved out of Electronics > Installing the electronics into Helpers (URL unchanged). Updated the two other places that named the page: the installation index's warning callout and its numbered walkthrough list.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541896259521220658
request: https://discord.com/channels/1430279849171222682/1541788743021891694/1541896583199727789
preview: /hardware/helpers/
-->