### PR TITLE
docs: caption every photo and video with its credit

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -52,11 +52,11 @@ The bottom interface stacks the chute mount, the Lazy Susan washer, the Lazy Sus
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-exploded-view-cropped-full-b7caae0e6e6f.png" alt="Exploded view of the bottom interface: chute mount on top, Lazy Susan washer, Lazy Susan bearing, and the corner mounting brackets below">
-    <figcaption>Exploded view. Render: Adrianbaker.</figcaption>
+    <figcaption>Exploded view. <cite>Render: Adrianbaker.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-exploded-view-detail-full-43115f353ffc.png" alt="Close-up exploded view of the bottom interface parts separating from the mounting brackets">
-    <figcaption>Detail of the same exploded view. Render: Adrianbaker.</figcaption>
+    <figcaption>Detail of the same exploded view. <cite>Render: Adrianbaker.</cite></figcaption>
   </figure>
 </div>
 
@@ -65,7 +65,7 @@ Once assembled, it mounts into the machine frame:
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-mounted-in-frame-full-476d171d148e.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
-    <figcaption>Diagram pictures courtesy of Adrianbaker in the basically Discord.</figcaption>
+    <figcaption><cite>Diagram pictures courtesy of Adrianbaker in the basically Discord.</cite></figcaption>
   </figure>
 </div>
 
@@ -88,7 +88,7 @@ Press the heat inserts into both printed parts while they are still loose. Once 
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-prep-bottom-static-inserts-full-55b0a52a2cd1.png" alt="Close-up of the black Lazy Susan bottom static ring with three of its four brass M4 heat inserts clearly visible, pressed flush into the top face">
-    <figcaption>Three of the four M4 inserts in the bottom static part. The fourth sits under the chute mount coming down on the right. Photo: Spencer.</figcaption>
+    <figcaption>Three of the four M4 inserts in the bottom static part. The fourth sits under the chute mount coming down on the right. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -103,11 +103,11 @@ Remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardw
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-insert-through-hole-full-a67b71f5c4a7.png" alt="Close-up down an aligned hole in the Lazy Susan, with the brass M4 heat insert in the chute mount visible at the bottom of it">
-    <figcaption>Lined up: the brass insert sits at the bottom of the hole. Photo: Spencer.</figcaption>
+    <figcaption>Lined up: the brass insert sits at the bottom of the hole. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step1-drive-screw-full-622f05a7a4fe.jpg" alt="Driving a countersunk screw through the Lazy Susan into the chute mount">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -116,9 +116,9 @@ Remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardw
   <p>The {% include fastener.html size="M4" variant="countersunk" length="12" %} screws must be very tight. A drill or electric screwdriver will not get them there, so finish them with a hex key by hand. Machine vibration works a loose one out of a spot that is a hassle to reach later.</p>
 </div>
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-lazy-susan-on-chute-mount-full-d478621b1f81.jpg" alt="Lazy Susan bearing mounted on the chute mount with the washer between them">
-  <figcaption>Photo: Spencer.</figcaption>
+  <figcaption><cite>Photo: Spencer.</cite></figcaption>
 </figure>
 
 {% include step.html n="3" title="Mount the Lazy Susan to the bottom static part" %}
@@ -128,11 +128,11 @@ The bearing's other disc screws down into the bottom static part. All four of th
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-holes-aligned-full-ebf0c303cdb4.jpg" alt="Lazy Susan hole aligned with the pass-through hole, seen from the top">
-    <figcaption>Seen from the top, with the bearing hole over the pass-through. Photo: Spencer.</figcaption>
+    <figcaption>Seen from the top, with the bearing hole over the pass-through. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-pass-through-full-0522b2c6e677.jpg" alt="Pass-through hole in the chute mount with the screw reachable underneath">
-    <figcaption>The pass-through hole in the chute mount. Photo: Spencer.</figcaption>
+    <figcaption>The pass-through hole in the chute mount. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -141,19 +141,19 @@ Set the chute mount and Lazy Susan assembly onto the bottom static part, then li
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-place-chute-adapter-full-5d3dfd2a5794.jpg" alt="Placing the chute mount and Lazy Susan assembly onto the bottom static part">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-hole-red-square-full-fd314fd2c0a2.jpg" alt="Pass-through hole lined up over the heat insert, marked with a red square">
-    <figcaption>Lined up over the marked insert. Photo: Spencer.</figcaption>
+    <figcaption>Lined up over the marked insert. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
 Drive the first {% include fastener.html size="M4" variant="countersunk" length="12" %} screw through the pass-through hole.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-screwed-in-full-92f81fc1417a.jpg" alt="First screw driven through the pass-through hole">
-  <figcaption>Photo: Spencer.</figcaption>
+  <figcaption><cite>Photo: Spencer.</cite></figcaption>
 </figure>
 
 Rotate the chute on the Lazy Susan, the way it turns in normal operation rather than forcing the whole assembly, to bring the pass-through hole over the next insert. Repeat for all four screws.
@@ -161,19 +161,19 @@ Rotate the chute on the Lazy Susan, the way it turns in normal operation rather 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-rotate-90-full-7139a08a65e9.jpg" alt="Rotating the chute with the Lazy Susan to the next screw position">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-after-rotate-full-cdec5eba44af.jpg" alt="Pass-through hole lined up over the next heat insert after rotating">
-    <figcaption>Pass-through hole now over the next insert. Photo: Spencer.</figcaption>
+    <figcaption>Pass-through hole now over the next insert. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
 The bearing stack is now complete:
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-complete-full-8aa4adc4ac4c.jpg" alt="The completed bottom interface with chute mount, Lazy Susan bearing, and bottom static part assembled">
-  <figcaption>Photo: Spencer.</figcaption>
+  <figcaption><cite>Photo: Spencer.</cite></figcaption>
 </figure>
 
 {% include step.html n="4" title="Mount it into the frame" %}
@@ -183,11 +183,11 @@ Three Lazy Susan extrusion mounts fix the assembly to the external extrusion of 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-w1600-06391df95795.jpg" alt="A Lazy Susan extrusion mount and a Lazy Susan hold in place bolted together, forming a grey wedge with a triangular window through its web and two counterbored holes along its bottom face">
-    <figcaption>The extrusion mount and the hold in place, bolted together. Photo: BrickCycleAlice.</figcaption>
+    <figcaption>The extrusion mount and the hold in place, bolted together. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-on-2020-w1600-36f5200925fd.jpg" alt="The same pair with a length of 2020 aluminum extrusion seated in the channel along its sloped edge">
-    <figcaption>With a length of 2020 in its channel. Photos by BrickCycleAlice.</figcaption>
+    <figcaption>With a length of 2020 in its channel. <cite>Photos by BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -45,14 +45,18 @@ The fasteners and quantities in the parts list are called out inline at each ste
     loading="lazy"></iframe>
 </div>
 
+_Video: Basically's own YouTube channel. Who filmed it isn't recorded._
+
 The bottom interface stacks the chute mount, the Lazy Susan washer, the Lazy Susan bearing, and the bottom static part. Here it is exploded into its components:
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-exploded-view-cropped-full-b7caae0e6e6f.png" alt="Exploded view of the bottom interface: chute mount on top, Lazy Susan washer, Lazy Susan bearing, and the corner mounting brackets below">
+    <figcaption>Exploded view. Render: Adrianbaker.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-exploded-view-detail-full-43115f353ffc.png" alt="Close-up exploded view of the bottom interface parts separating from the mounting brackets">
+    <figcaption>Detail of the same exploded view. Render: Adrianbaker.</figcaption>
   </figure>
 </div>
 
@@ -84,7 +88,7 @@ Press the heat inserts into both printed parts while they are still loose. Once 
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-prep-bottom-static-inserts-full-55b0a52a2cd1.png" alt="Close-up of the black Lazy Susan bottom static ring with three of its four brass M4 heat inserts clearly visible, pressed flush into the top face">
-    <figcaption>Three of the four M4 inserts in the bottom static part. The fourth sits under the chute mount coming down on the right.</figcaption>
+    <figcaption>Three of the four M4 inserts in the bottom static part. The fourth sits under the chute mount coming down on the right. Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -99,10 +103,11 @@ Remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardw
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-insert-through-hole-full-a67b71f5c4a7.png" alt="Close-up down an aligned hole in the Lazy Susan, with the brass M4 heat insert in the chute mount visible at the bottom of it">
-    <figcaption>Lined up: the brass insert sits at the bottom of the hole.</figcaption>
+    <figcaption>Lined up: the brass insert sits at the bottom of the hole. Photo: Spencer.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step1-drive-screw-full-622f05a7a4fe.jpg" alt="Driving a countersunk screw through the Lazy Susan into the chute mount">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -111,7 +116,10 @@ Remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardw
   <p>The {% include fastener.html size="M4" variant="countersunk" length="12" %} screws must be very tight. A drill or electric screwdriver will not get them there, so finish them with a hex key by hand. Machine vibration works a loose one out of a spot that is a hassle to reach later.</p>
 </div>
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-lazy-susan-on-chute-mount-full-d478621b1f81.jpg" alt="Lazy Susan bearing mounted on the chute mount with the washer between them">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-lazy-susan-on-chute-mount-full-d478621b1f81.jpg" alt="Lazy Susan bearing mounted on the chute mount with the washer between them">
+  <figcaption>Photo: Spencer.</figcaption>
+</figure>
 
 {% include step.html n="3" title="Mount the Lazy Susan to the bottom static part" %}
 
@@ -120,11 +128,11 @@ The bearing's other disc screws down into the bottom static part. All four of th
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-holes-aligned-full-ebf0c303cdb4.jpg" alt="Lazy Susan hole aligned with the pass-through hole, seen from the top">
-    <figcaption>Seen from the top, with the bearing hole over the pass-through.</figcaption>
+    <figcaption>Seen from the top, with the bearing hole over the pass-through. Photo: Spencer.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-pass-through-full-0522b2c6e677.jpg" alt="Pass-through hole in the chute mount with the screw reachable underneath">
-    <figcaption>The pass-through hole in the chute mount.</figcaption>
+    <figcaption>The pass-through hole in the chute mount. Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -133,32 +141,40 @@ Set the chute mount and Lazy Susan assembly onto the bottom static part, then li
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-place-chute-adapter-full-5d3dfd2a5794.jpg" alt="Placing the chute mount and Lazy Susan assembly onto the bottom static part">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-hole-red-square-full-fd314fd2c0a2.jpg" alt="Pass-through hole lined up over the heat insert, marked with a red square">
-    <figcaption>Lined up over the marked insert.</figcaption>
+    <figcaption>Lined up over the marked insert. Photo: Spencer.</figcaption>
   </figure>
 </div>
 
 Drive the first {% include fastener.html size="M4" variant="countersunk" length="12" %} screw through the pass-through hole.
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-screwed-in-full-92f81fc1417a.jpg" alt="First screw driven through the pass-through hole">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-screwed-in-full-92f81fc1417a.jpg" alt="First screw driven through the pass-through hole">
+  <figcaption>Photo: Spencer.</figcaption>
+</figure>
 
 Rotate the chute on the Lazy Susan, the way it turns in normal operation rather than forcing the whole assembly, to bring the pass-through hole over the next insert. Repeat for all four screws.
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-rotate-90-full-7139a08a65e9.jpg" alt="Rotating the chute with the Lazy Susan to the next screw position">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step2-after-rotate-full-cdec5eba44af.jpg" alt="Pass-through hole lined up over the next heat insert after rotating">
-    <figcaption>Pass-through hole now over the next insert.</figcaption>
+    <figcaption>Pass-through hole now over the next insert. Photo: Spencer.</figcaption>
   </figure>
 </div>
 
 The bearing stack is now complete:
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-complete-full-8aa4adc4ac4c.jpg" alt="The completed bottom interface with chute mount, Lazy Susan bearing, and bottom static part assembled">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-complete-full-8aa4adc4ac4c.jpg" alt="The completed bottom interface with chute mount, Lazy Susan bearing, and bottom static part assembled">
+  <figcaption>Photo: Spencer.</figcaption>
+</figure>
 
 {% include step.html n="4" title="Mount it into the frame" %}
 
@@ -167,7 +183,7 @@ Three Lazy Susan extrusion mounts fix the assembly to the external extrusion of 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-w1600-06391df95795.jpg" alt="A Lazy Susan extrusion mount and a Lazy Susan hold in place bolted together, forming a grey wedge with a triangular window through its web and two counterbored holes along its bottom face">
-    <figcaption>The extrusion mount and the hold in place, bolted together.</figcaption>
+    <figcaption>The extrusion mount and the hold in place, bolted together. Photo: BrickCycleAlice.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-on-2020-w1600-36f5200925fd.jpg" alt="The same pair with a length of 2020 aluminum extrusion seated in the channel along its sloped edge">

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -36,16 +36,17 @@ The fasteners and quantities in the parts list are called out inline at each ste
 
 {% include fastener-legend.html %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/XsVXOLvNsMA"
-    title="Bottom interface assembly"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
-
-_Video: Basically's own YouTube channel. Who filmed it isn't recorded._
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/XsVXOLvNsMA"
+      title="Bottom interface assembly"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: Basically's own YouTube channel. Who filmed it isn't recorded.</cite></figcaption>
+</figure>
 
 The bottom interface stacks the chute mount, the Lazy Susan washer, the Lazy Susan bearing, and the bottom static part. Here it is exploded into its components:
 
@@ -187,7 +188,7 @@ Three Lazy Susan extrusion mounts fix the assembly to the external extrusion of 
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-on-2020-w1600-36f5200925fd.jpg" alt="The same pair with a length of 2020 aluminum extrusion seated in the channel along its sloped edge">
-    <figcaption>With a length of 2020 in its channel. <cite>Photos by BrickCycleAlice.</cite></figcaption>
+    <figcaption>With a length of 2020 in its channel. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -67,16 +67,17 @@ Slide piece A/G (Outer horizontal / Horizontal interface frame) of aluminum extr
 
 If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2 into the innermost section of the extrusion and 4 into the outermost section before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/LWruBv-fMz4"
-    title="Assembling the frame brackets"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
-
-_Video: zed0._
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/LWruBv-fMz4"
+      title="Assembling the frame brackets"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 <div class="img-row">
   <figure>
@@ -111,16 +112,17 @@ Repeat these steps to make two semi-circles of three sections of extrusion and t
 
 Prepare 12 Frame 90° brackets by drilling out the holes on the long side to allow an M5 screw to rotate freely. If you do not have a drill of the correct diameter, this can also be done using an electric screwdriver to overtighten an M5 screw, thus breaking the threads.
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/ULeByfqfVZs"
-    title="Preparing the Frame 90° brackets and attaching the spokes"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
-
-_Video: zed0._
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/ULeByfqfVZs"
+      title="Preparing the Frame 90° brackets and attaching the spokes"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-brackets-attached-w1600-47b3c12e2344.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -55,9 +55,11 @@ See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | rel
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-w1600-a47ad55fb797.png" alt="Two A/G aluminum extrusions meeting at an External bracket — side, forming one corner of the hexagon">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-angled-w1600-6265c41bbf5f.png" alt="Angled view of the same corner joint, showing the fasteners along the extrusion">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
 </div>
 
@@ -74,25 +76,34 @@ If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2
     loading="lazy"></iframe>
 </div>
 
+_Video: zed0._
+
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-tnut-holes-w1600-b5863688aeea.png" alt="Side view of an A/G extrusion showing the row of holes where T-nuts sit and the screws pass through">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-into-bracket-w1600-1cd20074b56c.png" alt="An A/G extrusion sliding into an External bracket — side">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
 </div>
 
 Repeat these steps to make two semi-circles of three sections of extrusion and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-two-half-hexagons-full-5e7c0f80f57f.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-two-half-hexagons-full-5e7c0f80f57f.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
+  <figcaption>Photo: zed0.</figcaption>
+</figure>
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-hexagon-assembled-full-a1fb3a1b6fb4.png" alt="The completed hexagon frame of six A/G extrusions and six corner brackets">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-hexagon-assembled-top-w1600-5a469702622a.png" alt="Top-down view of the completed hexagon frame">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
 </div>
 
@@ -109,7 +120,12 @@ Prepare 12 Frame 90° brackets by drilling out the holes on the long side to all
     loading="lazy"></iframe>
 </div>
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-brackets-attached-w1600-47b3c12e2344.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">
+_Video: zed0._
+
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-brackets-attached-w1600-47b3c12e2344.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">
+  <figcaption>Photo: zed0.</figcaption>
+</figure>
 
 Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
 
@@ -118,9 +134,11 @@ Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-installed-w1600-536d49087ec4.png" alt="A B/H spoke extrusion standing up in the two Frame 90° brackets">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-crossbeams-first-full-dca5e96ee46d.png" alt="A spoke with a Frame crossbeam slid into place on each side">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
 </div>
 
@@ -128,14 +146,19 @@ On each side of this B/H (Spoke / Interface spoke (short)) slide a Frame crossbe
 
 Perform these steps 2 more times, on every 2nd side of the hexagon.
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-crossbeams-top-full-d16c233ea6e1.png" alt="Top-down view of three spokes with crossbeams, forming a partial inner ring">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-crossbeams-top-full-d16c233ea6e1.png" alt="Top-down view of three spokes with crossbeams, forming a partial inner ring">
+  <figcaption>Photo: zed0.</figcaption>
+</figure>
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-1-w1600-bfbe2a608499.png" alt="The hexagon partway through spoke installation, some sides done">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-2-w1600-5a478c564363.png" alt="More spokes and crossbeams filled in around the hexagon">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
 </div>
 
@@ -144,13 +167,18 @@ On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-3-w1600-e63cf43ad122.png" alt="Nearly all spokes and crossbeams installed">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-nearly-complete-w1600-8911fb6fef42.png" alt="The spoke ring almost complete, seen at an angle">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
 </div>
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-complete-top-full-f9b0a154d84b.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-complete-top-full-f9b0a154d84b.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
+  <figcaption>Photo: zed0.</figcaption>
+</figure>
 
 Secure them in place with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket-button" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="socket-button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
 
@@ -163,9 +191,11 @@ Secure them in place with 2 {% include fastener.html size="M5" variant="socket-b
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-vertical-corner-detail-w1600-81d31a256733.png" alt="A corner with piece C vertical extrusion held between the External bracket — cover and the External bracket — side, seen from below">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-verticals-installed-full-b1393c02452b.png" alt="The hexagon with vertical supports standing up at each corner">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
 </div>
 
@@ -174,9 +204,11 @@ On each corner of your hexagon, slot an External bracket — cover onto the Exte
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-vertical-bottom-bracket-w1600-a45e5b572247.png" alt="Close-up of an External bracket — bottom vertical at the base of a corner vertical extrusion">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-verticals-top-w1600-400576ddb1b6.png" alt="Top view of the layer with vertical supports and bottom brackets at every corner">
+    <figcaption>Photo: zed0.</figcaption>
   </figure>
 </div>
 
@@ -186,7 +218,10 @@ Matching parts from the same print run are embossed with a shared set code (e.g.
 
 {% include step.html n="4" title="Add the bin retainers" %}
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-bin-retainers-installed-w1600-31bf32089e71.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-bin-retainers-installed-w1600-31bf32089e71.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
+  <figcaption>Photo: zed0.</figcaption>
+</figure>
 
 On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
 
@@ -198,7 +233,7 @@ A regular layer is now complete. You will also need to construct a [Chute core](
   <a href="https://assets.basically.website/sorter-docs/assembly-regular-layers-layer-joint-section-full-71e3c366f4e7.png" target="_blank" rel="noopener">
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-layer-joint-section-w1600-b40f8b102c10.jpg" alt="Vertical cross-section through one corner of two stacked layers, with the lower layer's extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, the two screw pairs dashed in red, and six numbered callouts">
   </a>
-  <figcaption>One corner where any two layers meet, cut through the centre of the profile. Blue is the lower layer, purple the layer above. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build.</figcaption>
+  <figcaption>One corner where any two layers meet, cut through the centre of the profile. Blue is the lower layer, purple the layer above. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build, by Balloon.</figcaption>
 </figure>
 
 A finished layer already carries everything that spans up to the next one: piece C standing out of its External bracket — side, and the External bracket — bottom vertical capping that extrusion. Joining two layers is therefore only the flange joint at each of the six corners.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -55,11 +55,11 @@ See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | rel
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-w1600-a47ad55fb797.png" alt="Two A/G aluminum extrusions meeting at an External bracket — side, forming one corner of the hexagon">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-angled-w1600-6265c41bbf5f.png" alt="Angled view of the same corner joint, showing the fasteners along the extrusion">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -81,29 +81,29 @@ _Video: zed0._
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-tnut-holes-w1600-b5863688aeea.png" alt="Side view of an A/G extrusion showing the row of holes where T-nuts sit and the screws pass through">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-into-bracket-w1600-1cd20074b56c.png" alt="An A/G extrusion sliding into an External bracket — side">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
 Repeat these steps to make two semi-circles of three sections of extrusion and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-two-half-hexagons-full-5e7c0f80f57f.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
-  <figcaption>Photo: zed0.</figcaption>
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-hexagon-assembled-full-a1fb3a1b6fb4.png" alt="The completed hexagon frame of six A/G extrusions and six corner brackets">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-hexagon-assembled-top-w1600-5a469702622a.png" alt="Top-down view of the completed hexagon frame">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -122,9 +122,9 @@ Prepare 12 Frame 90° brackets by drilling out the holes on the long side to all
 
 _Video: zed0._
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-brackets-attached-w1600-47b3c12e2344.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">
-  <figcaption>Photo: zed0.</figcaption>
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
@@ -134,11 +134,11 @@ Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-installed-w1600-536d49087ec4.png" alt="A B/H spoke extrusion standing up in the two Frame 90° brackets">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-crossbeams-first-full-dca5e96ee46d.png" alt="A spoke with a Frame crossbeam slid into place on each side">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -146,19 +146,19 @@ On each side of this B/H (Spoke / Interface spoke (short)) slide a Frame crossbe
 
 Perform these steps 2 more times, on every 2nd side of the hexagon.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-crossbeams-top-full-d16c233ea6e1.png" alt="Top-down view of three spokes with crossbeams, forming a partial inner ring">
-  <figcaption>Photo: zed0.</figcaption>
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-1-w1600-bfbe2a608499.png" alt="The hexagon partway through spoke installation, some sides done">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-2-w1600-5a478c564363.png" alt="More spokes and crossbeams filled in around the hexagon">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -167,17 +167,17 @@ On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-3-w1600-e63cf43ad122.png" alt="Nearly all spokes and crossbeams installed">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-nearly-complete-w1600-8911fb6fef42.png" alt="The spoke ring almost complete, seen at an angle">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-complete-top-full-f9b0a154d84b.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
-  <figcaption>Photo: zed0.</figcaption>
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 Secure them in place with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket-button" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="socket-button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
@@ -191,11 +191,11 @@ Secure them in place with 2 {% include fastener.html size="M5" variant="socket-b
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-vertical-corner-detail-w1600-81d31a256733.png" alt="A corner with piece C vertical extrusion held between the External bracket — cover and the External bracket — side, seen from below">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-verticals-installed-full-b1393c02452b.png" alt="The hexagon with vertical supports standing up at each corner">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -204,11 +204,11 @@ On each corner of your hexagon, slot an External bracket — cover onto the Exte
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-vertical-bottom-bracket-w1600-a45e5b572247.png" alt="Close-up of an External bracket — bottom vertical at the base of a corner vertical extrusion">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-verticals-top-w1600-400576ddb1b6.png" alt="Top view of the layer with vertical supports and bottom brackets at every corner">
-    <figcaption>Photo: zed0.</figcaption>
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -218,9 +218,9 @@ Matching parts from the same print run are embossed with a shared set code (e.g.
 
 {% include step.html n="4" title="Add the bin retainers" %}
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-bin-retainers-installed-w1600-31bf32089e71.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
-  <figcaption>Photo: zed0.</figcaption>
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
@@ -233,7 +233,7 @@ A regular layer is now complete. You will also need to construct a [Chute core](
   <a href="https://assets.basically.website/sorter-docs/assembly-regular-layers-layer-joint-section-full-71e3c366f4e7.png" target="_blank" rel="noopener">
     <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-layer-joint-section-w1600-b40f8b102c10.jpg" alt="Vertical cross-section through one corner of two stacked layers, with the lower layer's extrusion and bottom-vertical tube in blue, the upper layer's bracket in purple, the two screw pairs dashed in red, and six numbered callouts">
   </a>
-  <figcaption>One corner where any two layers meet, cut through the centre of the profile. Blue is the lower layer, purple the layer above. The numbers match the list below. Click to enlarge. Drawn from the part geometry rather than from a build, by Balloon.</figcaption>
+  <figcaption>One corner where any two layers meet, cut through the centre of the profile. Blue is the lower layer, purple the layer above. The numbers match the list below. Click to enlarge. <cite>Drawn from the part geometry rather than from a build, by Balloon.</cite></figcaption>
 </figure>
 
 A finished layer already carries everything that spans up to the next one: piece C standing out of its External bracket — side, and the External bracket — bottom vertical capping that extrusion. Joining two layers is therefore only the flange joint at each of the six corners.

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -51,15 +51,15 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-8-full-9f0f3b659b63.png" alt="Render of one long side of the chute core at a slight angle, with eight heat-insert pockets circled in red">
-      <figcaption>One long side: 8. The round cut-out near the end is the giveaway, this side has two pockets together beside it and one on its own in the middle of the face. Render: Balloon.</figcaption>
+      <figcaption>One long side: 8. The round cut-out near the end is the giveaway, this side has two pockets together beside it and one on its own in the middle of the face. <cite>Render: Balloon.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-6-full-c4074e29338f.png" alt="Render of the other long side of the chute core at a slight angle, with six heat-insert pockets circled in red">
-      <figcaption>The other long side: 6. The same face mirrored, without those two. Render: Balloon.</figcaption>
+      <figcaption>The other long side: 6. The same face mirrored, without those two. <cite>Render: Balloon.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-rear-full-ad4c2cc7869c.png" alt="Close render of the rear end of the chute core at a slight angle, with the four heat-insert pockets on the rear panel circled in red">
-      <figcaption>Rear face: the last 4, all on the panel at the top end. Shown closer in than the other two. Render: Balloon.</figcaption>
+      <figcaption>Rear face: the last 4, all on the panel at the top end. Shown closer in than the other two. <cite>Render: Balloon.</cite></figcaption>
     </figure>
   </div>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -51,15 +51,15 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-8-full-9f0f3b659b63.png" alt="Render of one long side of the chute core at a slight angle, with eight heat-insert pockets circled in red">
-      <figcaption>One long side: 8. The round cut-out near the end is the giveaway, this side has two pockets together beside it and one on its own in the middle of the face.</figcaption>
+      <figcaption>One long side: 8. The round cut-out near the end is the giveaway, this side has two pockets together beside it and one on its own in the middle of the face. Render: Balloon.</figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-6-full-c4074e29338f.png" alt="Render of the other long side of the chute core at a slight angle, with six heat-insert pockets circled in red">
-      <figcaption>The other long side: 6. The same face mirrored, without those two.</figcaption>
+      <figcaption>The other long side: 6. The same face mirrored, without those two. Render: Balloon.</figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-rear-full-ad4c2cc7869c.png" alt="Close render of the rear end of the chute core at a slight angle, with the four heat-insert pockets on the rear panel circled in red">
-      <figcaption>Rear face: the last 4, all on the panel at the top end. Shown closer in than the other two.</figcaption>
+      <figcaption>Rear face: the last 4, all on the panel at the top end. Shown closer in than the other two. Render: Balloon.</figcaption>
     </figure>
   </div>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -90,15 +90,15 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-square-full-150991b8cde4.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the MG995 servo">
-      <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together. Reference photo of the stock part, not from a build. Photographer not recorded.</figcaption>
+      <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together. <cite>Reference photo of the stock part, not from a build. Photographer not recorded.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-servo-side-recess-white-full-32262f257d09.png" alt="The servo-side adapter half, rotated to show the recess that the MG995 Servo Horn seats into, with the four screw pilot holes around it">
-      <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into. Rendered from the part geometry, not from a build.</figcaption>
+      <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into. <cite>Rendered from the part geometry, not from a build.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-door-face-full-ec3b4136d249.png" alt="The flap-side adapter half, rotated 180 degrees from the screw side to show the hexagonal boss and keyed bore that the chute door's shaft inserts into">
-      <figcaption>Flap-side half, other face. The hex boss the chute door's shaft inserts into. Rendered from the part geometry, not from a build.</figcaption>
+      <figcaption>Flap-side half, other face. The hex boss the chute door's shaft inserts into. <cite>Rendered from the part geometry, not from a build.</cite></figcaption>
     </figure>
   </div>
 </div>
@@ -109,7 +109,7 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-servo-bracket-housing-full-7545917fe3d9.png" alt="Render of the servo bracket housing at an angle, with its six heat-insert pockets circled in red, two on each of three faces">
-    <figcaption>All six, seen from the corner. That is the only angle that catches all three faces at once. Render: Balloon.</figcaption>
+    <figcaption>All six, seen from the corner. That is the only angle that catches all three faces at once. <cite>Render: Balloon.</cite></figcaption>
   </figure>
 </div>
 
@@ -119,7 +119,7 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-race-full-4a30d9cbcc4a.png" alt="Render of the bearing race seen almost straight on, with its four heat-insert pockets circled in red, two at each end">
-    <figcaption>Two at each end of the race. Render: Balloon.</figcaption>
+    <figcaption>Two at each end of the race. <cite>Render: Balloon.</cite></figcaption>
   </figure>
 </div>
 
@@ -129,7 +129,7 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-holder-left-full-20b5c1bf8883.png" alt="Render of the left bearing holder at an angle, with its three heat-insert pockets circled in red around the bearing bore">
-    <figcaption>Three around the bore on the outboard face. Render: Balloon.</figcaption>
+    <figcaption>Three around the bore on the outboard face. <cite>Render: Balloon.</cite></figcaption>
   </figure>
 </div>
 
@@ -139,7 +139,7 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-holder-right-full-91e140ed31b4.png" alt="Render of the right bearing holder at an angle, with its three heat-insert pockets circled in red around the bearing bore, mirroring the left holder">
-    <figcaption>The same three, mirrored. Render: Balloon.</figcaption>
+    <figcaption>The same three, mirrored. <cite>Render: Balloon.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -175,13 +175,14 @@ The servo output then couples to the door through the two-piece servo adapter, s
   <p>The MG995 only rotates 180°. Install the servo so the door can reach <strong>both</strong> its fully open and fully closed positions inside that range: clock the horn and set the mounting angle so neither extreme falls outside the servo's travel.</p>
 </div>
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/TMo_xE-Zyy0"
-    title="How to install the MG995 servo"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
-
-_Video: Basically's own YouTube channel. Who filmed it isn't recorded._
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/TMo_xE-Zyy0"
+      title="How to install the MG995 servo"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: Basically's own YouTube channel. Who filmed it isn't recorded.</cite></figcaption>
+</figure>

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -90,15 +90,15 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-square-full-150991b8cde4.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the MG995 servo">
-      <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together.</figcaption>
+      <figcaption>The MG995 Servo Horn. Clasped between the two adapter halves before they're screwed together. Reference photo of the stock part, not from a build. Photographer not recorded.</figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-servo-side-recess-white-full-32262f257d09.png" alt="The servo-side adapter half, rotated to show the recess that the MG995 Servo Horn seats into, with the four screw pilot holes around it">
-      <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into.</figcaption>
+      <figcaption>Servo-side half. The recess the horn seats into, plus the 4 pilot holes the screws thread into. Rendered from the part geometry, not from a build.</figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-flap-side-door-face-full-ec3b4136d249.png" alt="The flap-side adapter half, rotated 180 degrees from the screw side to show the hexagonal boss and keyed bore that the chute door's shaft inserts into">
-      <figcaption>Flap-side half, other face. The hex boss the chute door's shaft inserts into.</figcaption>
+      <figcaption>Flap-side half, other face. The hex boss the chute door's shaft inserts into. Rendered from the part geometry, not from a build.</figcaption>
     </figure>
   </div>
 </div>
@@ -109,7 +109,7 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-servo-bracket-housing-full-7545917fe3d9.png" alt="Render of the servo bracket housing at an angle, with its six heat-insert pockets circled in red, two on each of three faces">
-    <figcaption>All six, seen from the corner. That is the only angle that catches all three faces at once.</figcaption>
+    <figcaption>All six, seen from the corner. That is the only angle that catches all three faces at once. Render: Balloon.</figcaption>
   </figure>
 </div>
 
@@ -119,7 +119,7 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-race-full-4a30d9cbcc4a.png" alt="Render of the bearing race seen almost straight on, with its four heat-insert pockets circled in red, two at each end">
-    <figcaption>Two at each end of the race.</figcaption>
+    <figcaption>Two at each end of the race. Render: Balloon.</figcaption>
   </figure>
 </div>
 
@@ -129,7 +129,7 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-holder-left-full-20b5c1bf8883.png" alt="Render of the left bearing holder at an angle, with its three heat-insert pockets circled in red around the bearing bore">
-    <figcaption>Three around the bore on the outboard face.</figcaption>
+    <figcaption>Three around the bore on the outboard face. Render: Balloon.</figcaption>
   </figure>
 </div>
 
@@ -139,7 +139,7 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-holder-right-full-91e140ed31b4.png" alt="Render of the right bearing holder at an angle, with its three heat-insert pockets circled in red around the bearing bore, mirroring the left holder">
-    <figcaption>The same three, mirrored.</figcaption>
+    <figcaption>The same three, mirrored. Render: Balloon.</figcaption>
   </figure>
 </div>
 
@@ -183,3 +183,5 @@ The servo output then couples to the door through the two-piece servo adapter, s
     allowfullscreen
     loading="lazy"></iframe>
 </div>
+
+_Video: Basically's own YouTube channel. Who filmed it isn't recorded._

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -71,9 +71,9 @@ Bolt the Output gear onto the underside of the rotor with 6 {% include fastener.
 
 **Use the 12 mm, not the 8 mm.** The gear is 8 mm thick at the bolt circle, and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush in the countersink finishes level with the top of the gear and never enters the rotor at all. The 12 mm leaves 4 mm of thread in the rotor's 5 mm flange and stops short of breaking through the far side.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-output-gear-bolted-to-rotor-w1600-7ca0b30ba41a.jpg" alt="The grey 130-tooth output gear with a black-sealed 6806 bearing pressed into its centre, bolted onto a white rotor behind it, with a countersunk screw at the outer end of each of the six spokes">
-  <figcaption>Output gear, bearing pressed in, bolted to a rotor. Six screws, one per spoke. Photo: BrickCycleAlice.</figcaption>
+  <figcaption>Output gear, bearing pressed in, bolted to a rotor. Six screws, one per spoke. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 {% include step.html n="3" title="Fit the input gear to the motor shaft" %}
@@ -82,9 +82,9 @@ The Input gear (12T, screw) has a hole through its boss, parallel to the shaft, 
 
 The head drops into a counterbore in the boss. Tighten until the head is seated and the gear does not turn on the shaft, and no further, it is threading into plastic.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-on-motor-shaft-w1600-be00a0374988.jpg" alt="A black NEMA 17 stepper motor lying on its side with the small grey 12-tooth input gear pushed fully onto its shaft, the clamping screw visible in the side of the gear boss">
-  <figcaption>Pushed fully onto the shaft, clamp screw bearing on the flat. Photo: BrickCycleAlice.</figcaption>
+  <figcaption>Pushed fully onto the shaft, clamp screw bearing on the flat. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 {% include step.html n="4" title="Fit the idler gear and the stepper to the NEMA bracket" %}
@@ -93,9 +93,9 @@ Drop the Idler gear (24T) onto its post on the NEMA bracket **with the bearing f
 
 Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3" variant="socket-button" length="16" %} screws. Three, not four: one corner of the motor face is left free. The input gear meshes with the idler as the motor goes down.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-idler-gear-and-motor-on-nema-bracket-w1600-dfefb06e2166.jpg" alt="The three-armed grey NEMA bracket seen from above, with the 24-tooth idler gear sitting on its post with the 608 bearing uppermost, the stepper motor bolted to the outer end of the bracket, and the raised hub at the centre of the bracket">
-  <figcaption>Idler on its post, bearing up, with the stepper bolted on beside it. Photo: BrickCycleAlice.</figcaption>
+  <figcaption>Idler on its post, bearing up, with the stepper bolted on beside it. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 {% include step.html n="5" title="Mount the stator, then drop in the rotor" %}
@@ -106,9 +106,9 @@ Then lower the rotor, output gear and all, onto the raised hub in the middle of 
 
 Turn the stage by hand before wiring it. The train should run without a tight spot anywhere in a full revolution.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
-  <figcaption>The finished stage, here the classification one with the finned rotor. Photo: BrickCycleAlice.</figcaption>
+  <figcaption>The finished stage, here the classification one with the finned rotor. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 {% include step.html n="6" title="Fit the light post, on the channels that take one" %}

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -73,7 +73,7 @@ Bolt the Output gear onto the underside of the rotor with 6 {% include fastener.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-output-gear-bolted-to-rotor-w1600-7ca0b30ba41a.jpg" alt="The grey 130-tooth output gear with a black-sealed 6806 bearing pressed into its centre, bolted onto a white rotor behind it, with a countersunk screw at the outer end of each of the six spokes">
-  <figcaption>Output gear, bearing pressed in, bolted to a rotor. Six screws, one per spoke.</figcaption>
+  <figcaption>Output gear, bearing pressed in, bolted to a rotor. Six screws, one per spoke. Photo: BrickCycleAlice.</figcaption>
 </figure>
 
 {% include step.html n="3" title="Fit the input gear to the motor shaft" %}
@@ -84,7 +84,7 @@ The head drops into a counterbore in the boss. Tighten until the head is seated 
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-on-motor-shaft-w1600-be00a0374988.jpg" alt="A black NEMA 17 stepper motor lying on its side with the small grey 12-tooth input gear pushed fully onto its shaft, the clamping screw visible in the side of the gear boss">
-  <figcaption>Pushed fully onto the shaft, clamp screw bearing on the flat.</figcaption>
+  <figcaption>Pushed fully onto the shaft, clamp screw bearing on the flat. Photo: BrickCycleAlice.</figcaption>
 </figure>
 
 {% include step.html n="4" title="Fit the idler gear and the stepper to the NEMA bracket" %}
@@ -95,7 +95,7 @@ Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3"
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-idler-gear-and-motor-on-nema-bracket-w1600-dfefb06e2166.jpg" alt="The three-armed grey NEMA bracket seen from above, with the 24-tooth idler gear sitting on its post with the 608 bearing uppermost, the stepper motor bolted to the outer end of the bracket, and the raised hub at the centre of the bracket">
-  <figcaption>Idler on its post, bearing up, with the stepper bolted on beside it.</figcaption>
+  <figcaption>Idler on its post, bearing up, with the stepper bolted on beside it. Photo: BrickCycleAlice.</figcaption>
 </figure>
 
 {% include step.html n="5" title="Mount the stator, then drop in the rotor" %}
@@ -108,7 +108,7 @@ Turn the stage by hand before wiring it. The train should run without a tight sp
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
-  <figcaption>The finished stage, here the classification one with the finned rotor.</figcaption>
+  <figcaption>The finished stage, here the classification one with the finned rotor. Photo: BrickCycleAlice.</figcaption>
 </figure>
 
 {% include step.html n="6" title="Fit the light post, on the channels that take one" %}

--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -84,9 +84,9 @@ Overhead camera mount A (part 37) bolts to the A/B connector (part 6) with the 3
 
 **Not recorded:** which 3 of the 12 holes are the intended ones, and how part B (part 37b) joins in — it doesn't share this bolt circle, so it connects some other way. <span class="fastener-todo">fastener not recorded</span>
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/connector-iso-full-9426650a084d.png" alt="Angled render of the A/B connector, showing all 12 holes of its bolt circle">
-  <figcaption>The connector's bolt circle: 12 holes, 30° apart. Any 3 spaced 120° apart (every 4th hole) fix one of 4 possible rotations. Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
+  <figcaption>The connector's bolt circle: 12 holes, 30° apart. Any 3 spaced 120° apart (every 4th hole) fix one of 4 possible rotations. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
 </figure>
 
 {% include step.html n="5" title="Fit the camera and set the height" %}

--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -86,7 +86,7 @@ Overhead camera mount A (part 37) bolts to the A/B connector (part 6) with the 3
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/connector-iso-full-9426650a084d.png" alt="Angled render of the A/B connector, showing all 12 holes of its bolt circle">
-  <figcaption>The connector's bolt circle: 12 holes, 30° apart. Any 3 spaced 120° apart (every 4th hole) fix one of 4 possible rotations. Rendered from the part geometry, not from a build.</figcaption>
+  <figcaption>The connector's bolt circle: 12 holes, 30° apart. Any 3 spaced 120° apart (every 4th hole) fix one of 4 possible rotations. Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
 </figure>
 
 {% include step.html n="5" title="Fit the camera and set the height" %}

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -59,11 +59,11 @@ Fit the Camera & LED insert, then the camera on its extension tube and mount rin
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-iso-full-e4b396fc8c88.png" alt="Angled render of the camera and LED insert's top face, showing a ring of 10 large holes around the rim and 4 smaller countersunk holes around a central square opening">
-    <figcaption>The insert's top face: 10 holes around the rim (mounts to the chamber), 4 smaller ones around the central opening (matches the extension mount, M3). Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
+    <figcaption>The insert's top face: 10 holes around the rim (mounts to the chamber), 4 smaller ones around the central opening (matches the extension mount, M3). <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/extension-iso-full-8d1f0c51606f.png" alt="Angled render of the camera extension bracket, showing two posts each with a mounting hole">
-    <figcaption>The camera extension: two posts, a hole near the top and bottom of each. The top pair takes the M2 camera-board screws. Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
+    <figcaption>The camera extension: two posts, a hole near the top and bottom of each. The top pair takes the M2 camera-board screws. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -59,11 +59,11 @@ Fit the Camera & LED insert, then the camera on its extension tube and mount rin
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-iso-full-e4b396fc8c88.png" alt="Angled render of the camera and LED insert's top face, showing a ring of 10 large holes around the rim and 4 smaller countersunk holes around a central square opening">
-    <figcaption>The insert's top face: 10 holes around the rim (mounts to the chamber), 4 smaller ones around the central opening (matches the extension mount, M3). Rendered from the part geometry, not from a build.</figcaption>
+    <figcaption>The insert's top face: 10 holes around the rim (mounts to the chamber), 4 smaller ones around the central opening (matches the extension mount, M3). Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/extension-iso-full-8d1f0c51606f.png" alt="Angled render of the camera extension bracket, showing two posts each with a mounting hole">
-    <figcaption>The camera extension: two posts, a hole near the top and bottom of each. The top pair takes the M2 camera-board screws. Rendered from the part geometry, not from a build.</figcaption>
+    <figcaption>The camera extension: two posts, a hole near the top and bottom of each. The top pair takes the M2 camera-board screws. Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -61,9 +61,9 @@ The post and the cap adapter follow the feeder colour.
 
 All 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws join the Light post cap adapter down onto the Light post — the cap takes none of them. Measured off the two STLs: the post's top face carries 3 self-tapping pilot holes, 2.8 mm across, spaced 120° apart on a 12.1 mm radius; the adapter has a matching 3.4 mm clearance hole over each one. Screw down through the adapter into the post.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/post-iso-render-full-d45cabf034b8.png" alt="Angled render of the post's top, with the adapter's ring seated over it and two of the three screw pockets visible">
-  <figcaption>The joint from a slight angle, adapter seated on the post. Two of the three screw pockets are visible here; the third is on the far side. Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
+  <figcaption>The joint from a slight angle, adapter seated on the post. Two of the three screw pockets are visible here; the third is on the far side. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
 </figure>
 
 **Still not recorded:** which way the lobed boss lines up on the adapter — the geometry rules out the two wrong 120°/240° rotations if you match it by eye, but nobody has confirmed which adapter feature it keys to. <span class="fastener-todo">fastener not recorded</span>

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -63,7 +63,7 @@ All 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} sc
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/post-iso-render-full-d45cabf034b8.png" alt="Angled render of the post's top, with the adapter's ring seated over it and two of the three screw pockets visible">
-  <figcaption>The joint from a slight angle, adapter seated on the post. Two of the three screw pockets are visible here; the third is on the far side. Rendered from the part geometry, not from a build.</figcaption>
+  <figcaption>The joint from a slight angle, adapter seated on the post. Two of the three screw pockets are visible here; the third is on the far side. Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
 </figure>
 
 **Still not recorded:** which way the lobed boss lines up on the adapter — the geometry rules out the two wrong 120°/240° rotations if you match it by eye, but nobody has confirmed which adapter feature it keys to. <span class="fastener-todo">fastener not recorded</span>

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -38,7 +38,7 @@ This page is the wiring. Where the PSU, the control board and the Orange Pi phys
 
 <figure class="harness-figure">
   <img src="https://assets.basically.website/sorter-docs/electronics-component-layout-topdown-full-2d38b86c4b2e.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
-  <figcaption>Physical placement on the machine (top-down): PSU, Orange Pi, basically board v1.3, USB hub, Pico, the chute stepper and its limit switch, and the ribbon run. Rendered from the layout, not a photo. Render: Spencer.</figcaption>
+  <figcaption>Physical placement on the machine (top-down): PSU, Orange Pi, basically board v1.3, USB hub, Pico, the chute stepper and its limit switch, and the ribbon run. <cite>Rendered from the layout, not a photo. Render: Spencer.</cite></figcaption>
 </figure>
 
 ## 3 &nbsp; Interconnect diagram
@@ -226,9 +226,9 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
   </tbody>
 </table>
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-idc-ribbon-16pin-full-21fee4f419fb.jpg" alt="uxcell 16-pin IDC flat ribbon cable, gray, with FC connectors at both ends">
-  <figcaption>Manufacturer product photo (uxcell), not a Basically photo.</figcaption>
+  <figcaption><cite>Manufacturer product photo (uxcell), not a Basically photo.</cite></figcaption>
 </figure>
 
 ## 5 &nbsp; Parts

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -38,7 +38,7 @@ This page is the wiring. Where the PSU, the control board and the Orange Pi phys
 
 <figure class="harness-figure">
   <img src="https://assets.basically.website/sorter-docs/electronics-component-layout-topdown-full-2d38b86c4b2e.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
-  <figcaption>Physical placement on the machine (top-down): PSU, Orange Pi, basically board v1.3, USB hub, Pico, the chute stepper and its limit switch, and the ribbon run.</figcaption>
+  <figcaption>Physical placement on the machine (top-down): PSU, Orange Pi, basically board v1.3, USB hub, Pico, the chute stepper and its limit switch, and the ribbon run. Rendered from the layout, not a photo. Render: Spencer.</figcaption>
 </figure>
 
 ## 3 &nbsp; Interconnect diagram
@@ -226,7 +226,10 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
   </tbody>
 </table>
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-idc-ribbon-16pin-full-21fee4f419fb.jpg" alt="uxcell 16-pin IDC flat ribbon cable, gray, with FC connectors at both ends">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-idc-ribbon-16pin-full-21fee4f419fb.jpg" alt="uxcell 16-pin IDC flat ribbon cable, gray, with FC connectors at both ends">
+  <figcaption>Manufacturer product photo (uxcell), not a Basically photo.</figcaption>
+</figure>
 
 ## 5 &nbsp; Parts
 

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -43,7 +43,7 @@ The board needs its drivers, Pico and jumpers in first: see [preparing the contr
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-parts-laid-out-w1600-ce307f40e5fe.jpg" alt="All the housing parts laid out on a bench: the black printed cover on the left, the populated green control board in the middle, the black printed base with brass inserts on the right, and above them the 40 mm fan, four groups of screws, the plunger retainer and the plunger">
-    <figcaption>Cover left, board centre, base right.</figcaption>
+    <figcaption>Cover left, board centre, base right. Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -59,7 +59,7 @@ Press 8 M3 inserts into the base while it is loose: four on the inner bosses for
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-base-inserts-w1600-b45ee1e919a8.jpg" alt="The printed housing base seen from above, showing the large honeycomb vent in its floor and eight brass M3 heat inserts, four on raised bosses inside and four at the outer corners">
-    <figcaption>Four inside, four at the corners.</figcaption>
+    <figcaption>Four inside, four at the corners. Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -70,6 +70,7 @@ Sit the board on the four inner bosses and fix it with 4 {% include fastener.htm
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-board-on-base-w1600-481484d82b53.jpg" alt="Left, the populated control board screwed flat onto the printed base with its two extrusion clamp bosses at the bottom. Right, the printed cover upside down with the 40 mm fan and the plunger retainer already fitted inside it">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -80,6 +81,7 @@ Fan on the inside of the cover, over the vent, label facing into the enclosure s
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-fan-in-cover-w1600-73bbe941cbdb.jpg" alt="The inside of the printed cover with the 40 mm WINSINN fan screwed down over its vent opening on four screws, its red and black lead running off to the left, and the rectangular plunger slot beside it">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -90,6 +92,7 @@ The plunger lands on the board's reset button, so the button can be pressed with
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-retainer-fitted-w1600-c7677da6c247.jpg" alt="Inside the cover, the retainer screwed down on two countersunk screws over the plunger, capturing it so it can slide but not fall out, with the fan behind">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -105,7 +108,7 @@ The fan runs off one of the board's four LED ports, which are 24 V switched to g
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-fan-into-led-port-w1600-cfd2665dc48e.jpg" alt="Looking down through the cover's corner cutout at the board below, where the fan's red and black lead is plugged into the two-pin connector silkscreened LED_1_2, with Controlled by GPIO6 printed beside it">
-    <figcaption>Into LED_1_2, driven by GPIO6.</figcaption>
+    <figcaption>Into LED_1_2, driven by GPIO6. Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -121,9 +124,11 @@ Lower the cover on, keeping the fan lead clear of the board, and fix it with 4 {
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-cover-on-base-w1600-a77ec49b9e64.jpg" alt="The cover set down on the base with the housing closed, the fan's lead emerging through the corner cutout, and four countersunk screws lying on the bench beside it ready to go in">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-housing-angled-w1600-d8c3ed33682d.jpg" alt="The finished housing at an angle, showing the honeycomb vent and basically logo on the lid, the plunger standing proud of the surface, and the slots along the right edge that expose the stepper connectors">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -134,6 +139,7 @@ Press the plunger on the lid. You should hear the button click.
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-plunger-outside-w1600-737114636bdb.jpg" alt="Close-up of the lid surface showing the small square head of the plunger standing proud of the textured black plastic, with the honeycomb vent and basically logo nearby">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -147,6 +153,8 @@ Press the plunger on the lid. You should hear the button click.
   </video>
 </div>
 
+_Video: Spencer._
+
 {% include step.html n="8" title="Bolt it to the frame" %}
 
 The two clamp bosses go onto the 2020 extrusion on 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Which extrusion and which orientation is not written down; the layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
@@ -154,6 +162,7 @@ The two clamp bosses go onto the 2020 extrusion on 2 {% include fastener.html si
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-on-the-extrusion-w1600-813fbb56a0d6.jpg" alt="The finished housing bolted down onto a 2020 aluminium extrusion under the machine's frame, with two socket head screws through its clamp bosses">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -43,7 +43,7 @@ The board needs its drivers, Pico and jumpers in first: see [preparing the contr
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-parts-laid-out-w1600-ce307f40e5fe.jpg" alt="All the housing parts laid out on a bench: the black printed cover on the left, the populated green control board in the middle, the black printed base with brass inserts on the right, and above them the 40 mm fan, four groups of screws, the plunger retainer and the plunger">
-    <figcaption>Cover left, board centre, base right. Photo: Spencer.</figcaption>
+    <figcaption>Cover left, board centre, base right. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -59,7 +59,7 @@ Press 8 M3 inserts into the base while it is loose: four on the inner bosses for
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-base-inserts-w1600-b45ee1e919a8.jpg" alt="The printed housing base seen from above, showing the large honeycomb vent in its floor and eight brass M3 heat inserts, four on raised bosses inside and four at the outer corners">
-    <figcaption>Four inside, four at the corners. Photo: Spencer.</figcaption>
+    <figcaption>Four inside, four at the corners. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -70,7 +70,7 @@ Sit the board on the four inner bosses and fix it with 4 {% include fastener.htm
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-board-on-base-w1600-481484d82b53.jpg" alt="Left, the populated control board screwed flat onto the printed base with its two extrusion clamp bosses at the bottom. Right, the printed cover upside down with the 40 mm fan and the plunger retainer already fitted inside it">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -81,7 +81,7 @@ Fan on the inside of the cover, over the vent, label facing into the enclosure s
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-fan-in-cover-w1600-73bbe941cbdb.jpg" alt="The inside of the printed cover with the 40 mm WINSINN fan screwed down over its vent opening on four screws, its red and black lead running off to the left, and the rectangular plunger slot beside it">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -92,7 +92,7 @@ The plunger lands on the board's reset button, so the button can be pressed with
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-retainer-fitted-w1600-c7677da6c247.jpg" alt="Inside the cover, the retainer screwed down on two countersunk screws over the plunger, capturing it so it can slide but not fall out, with the fan behind">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -108,7 +108,7 @@ The fan runs off one of the board's four LED ports, which are 24 V switched to g
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-fan-into-led-port-w1600-cfd2665dc48e.jpg" alt="Looking down through the cover's corner cutout at the board below, where the fan's red and black lead is plugged into the two-pin connector silkscreened LED_1_2, with Controlled by GPIO6 printed beside it">
-    <figcaption>Into LED_1_2, driven by GPIO6. Photo: Spencer.</figcaption>
+    <figcaption>Into LED_1_2, driven by GPIO6. <cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -124,11 +124,11 @@ Lower the cover on, keeping the fan lead clear of the board, and fix it with 4 {
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-cover-on-base-w1600-a77ec49b9e64.jpg" alt="The cover set down on the base with the housing closed, the fan's lead emerging through the corner cutout, and four countersunk screws lying on the bench beside it ready to go in">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-housing-angled-w1600-d8c3ed33682d.jpg" alt="The finished housing at an angle, showing the honeycomb vent and basically logo on the lid, the plunger standing proud of the surface, and the slots along the right edge that expose the stepper connectors">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -139,7 +139,7 @@ Press the plunger on the lid. You should hear the button click.
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-plunger-outside-w1600-737114636bdb.jpg" alt="Close-up of the lid surface showing the small square head of the plunger standing proud of the textured black plastic, with the honeycomb vent and basically logo nearby">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -162,7 +162,7 @@ The two clamp bosses go onto the 2020 extrusion on 2 {% include fastener.html si
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-on-the-extrusion-w1600-813fbb56a0d6.jpg" alt="The finished housing bolted down onto a 2020 aluminium extrusion under the machine's frame, with two socket head screws through its clamp bosses">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -143,17 +143,18 @@ Press the plunger on the lid. You should hear the button click.
   </figure>
 </div>
 
-<div class="video-embed-self">
-  <video controls preload="none" playsinline
-    poster="https://assets.basically.website/sorter-docs/pressing-the-plunger-poster-6e2ab26816a2.jpg"
-    width="1280" height="2275"
-  >
-    <source src="https://assets.basically.website/sorter-docs/pressing-the-plunger-w960-0383f6a741bb.mp4" type="video/mp4">
-    <source src="https://assets.basically.website/sorter-docs/pressing-the-plunger-w1920-7d9064396d9c.mp4" type="video/mp4">
-  </video>
-</div>
-
-_Video: Spencer._
+<figure class="video-figure">
+  <div class="video-embed-self">
+    <video controls preload="none" playsinline
+      poster="https://assets.basically.website/sorter-docs/pressing-the-plunger-poster-6e2ab26816a2.jpg"
+      width="1280" height="2275"
+    >
+      <source src="https://assets.basically.website/sorter-docs/pressing-the-plunger-w960-0383f6a741bb.mp4" type="video/mp4">
+      <source src="https://assets.basically.website/sorter-docs/pressing-the-plunger-w1920-7d9064396d9c.mp4" type="video/mp4">
+    </video>
+  </div>
+  <figcaption><cite>Video: Spencer.</cite></figcaption>
+</figure>
 
 {% include step.html n="8" title="Bolt it to the frame" %}
 

--- a/docs/src/content/hardware/electronics/installation/control-board-prep.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-prep.md
@@ -24,6 +24,7 @@ Do this with the board loose, before the [housing]({{ '/hardware/electronics/ins
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-board-and-drivers-w1600-f6a7efe7c0f4.jpg" alt="The bare green basically Embedded Control Board on a wooden bench with five blue-finned TMC2209 stepper driver modules laid out in a row above it">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -34,9 +35,11 @@ Heatsink up, EN/MS1/MS2 edge towards the middle of the board. Module and socket 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-tmc2209-pin-labels-w1600-aed1004e7d8a.jpg" alt="A single TMC2209 V1.3 driver module standing on a bench, blue heatsink upwards, with its pin names readable around the edge">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-driver-seated-w1600-6f0cbd6bc7ae.jpg" alt="A TMC2209 driver pushed fully down into its socket on the control board, heatsink upwards, with the remaining drivers out of focus behind">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -47,9 +50,11 @@ Into the two long sockets down the middle, USB end towards the edge of the board
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-pico-seating-w1600-4b85e9758bc6.jpg" alt="A Raspberry Pi Pico held just above its two long header sockets on the control board, ready to be pushed down, with seated stepper drivers behind it">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-pico-seated-w1600-f0cbb025b91c.jpg" alt="The Raspberry Pi Pico fully seated in its sockets on the control board, sitting flat and parallel to the board">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -60,6 +65,7 @@ The drivers share a UART bus, so each needs an address, and the address is set b
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-jumper-states-w1600-5c293a831c56.jpg" alt="Annotated close-up of one driver's MS1 and MS2 headers: MS1 boxed in green with its jumper on pins 1 and 2 for 3V3, MS2 boxed in blue with its jumper on pins 2 and 3 for GND, beside a table mapping the four combinations to addresses 0 to 3">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 
@@ -86,6 +92,7 @@ This is a correctly jumpered board.
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-all-jumpers-fitted-w1600-f470f24a8913.jpg" alt="Top-down view of the fully populated control board, with five TMC2209 drivers, the Raspberry Pi Pico, and ten yellow jumpers fitted across the MS1 and MS2 headers">
+    <figcaption>Photo: Spencer.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/installation/control-board-prep.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-prep.md
@@ -24,7 +24,7 @@ Do this with the board loose, before the [housing]({{ '/hardware/electronics/ins
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-board-and-drivers-w1600-f6a7efe7c0f4.jpg" alt="The bare green basically Embedded Control Board on a wooden bench with five blue-finned TMC2209 stepper driver modules laid out in a row above it">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -35,11 +35,11 @@ Heatsink up, EN/MS1/MS2 edge towards the middle of the board. Module and socket 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-tmc2209-pin-labels-w1600-aed1004e7d8a.jpg" alt="A single TMC2209 V1.3 driver module standing on a bench, blue heatsink upwards, with its pin names readable around the edge">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-driver-seated-w1600-6f0cbd6bc7ae.jpg" alt="A TMC2209 driver pushed fully down into its socket on the control board, heatsink upwards, with the remaining drivers out of focus behind">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -50,11 +50,11 @@ Into the two long sockets down the middle, USB end towards the edge of the board
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-pico-seating-w1600-4b85e9758bc6.jpg" alt="A Raspberry Pi Pico held just above its two long header sockets on the control board, ready to be pushed down, with seated stepper drivers behind it">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-pico-seated-w1600-f0cbb025b91c.jpg" alt="The Raspberry Pi Pico fully seated in its sockets on the control board, sitting flat and parallel to the board">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -65,7 +65,7 @@ The drivers share a UART bus, so each needs an address, and the address is set b
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-jumper-states-w1600-5c293a831c56.jpg" alt="Annotated close-up of one driver's MS1 and MS2 headers: MS1 boxed in green with its jumper on pins 1 and 2 for 3V3, MS2 boxed in blue with its jumper on pins 2 and 3 for GND, beside a table mapping the four combinations to addresses 0 to 3">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 
@@ -92,7 +92,7 @@ This is a correctly jumpered board.
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-prep-all-jumpers-fitted-w1600-f470f24a8913.jpg" alt="Top-down view of the fully populated control board, with five TMC2209 drivers, the Raspberry Pi Pico, and ten yellow jumpers fitted across the MS1 and MS2 headers">
-    <figcaption>Photo: Spencer.</figcaption>
+    <figcaption><cite>Photo: Spencer.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -20,9 +20,9 @@ The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover wh
 
 The PSU, the control board and the Orange Pi each live in their own mount, and all three bolt to the machine's 2020 frame with 2 M5 screws each, six in total: {% include fastener.html size="M5" variant="socket-button" length="12" %} for the PSU box and the Orange Pi mount, {% include fastener.html size="M5" variant="socket-button" length="16" %} for the control board housing.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-component-layout-topdown-full-2d38b86c4b2e.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
-  <figcaption>Where everything sits, top-down. This render is currently the only record of the placement. Render: Spencer.</figcaption>
+  <figcaption>Where everything sits, top-down. This render is currently the only record of the placement. <cite>Render: Spencer.</cite></figcaption>
 </figure>
 
 1. **[Soldering Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**: soldering the header pins so the Pico can seat in the control board. First, while the board is still loose.

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -22,7 +22,7 @@ The PSU, the control board and the Orange Pi each live in their own mount, and a
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-component-layout-topdown-full-2d38b86c4b2e.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">
-  <figcaption>Where everything sits, top-down. This photo is currently the only record of the placement.</figcaption>
+  <figcaption>Where everything sits, top-down. This render is currently the only record of the placement. Render: Spencer.</figcaption>
 </figure>
 
 1. **[Soldering Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**: soldering the header pins so the Pico can seat in the control board. First, while the board is still loose.

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -45,7 +45,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-landscape-ringed-full-aa8aaac704ff.png" alt="The Orange Pi extrusion mount lying on its long edge, with all four M3 standoff insert holes circled in red near the four corners of the frame, each showing a real shadowed hole">
-    <figcaption>The 4 insert holes, ringed, near the four corners of the frame.</figcaption>
+    <figcaption>The 4 insert holes, ringed, near the four corners of the frame. Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
   </figure>
 </div>
 
@@ -55,7 +55,7 @@ The Pi itself takes no inserts, and neither does anything else on this page.
 
 <figure class="figure-float-right">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-landscape-standoffs-full-cefb56a912b0.png" alt="The Orange Pi extrusion mount lying on its long edge with 4 standoffs mounted in the corner insert holes and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
-  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders.</figcaption>
+  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders. Render: Balloon.</figcaption>
 </figure>
 
 **Heat inserts first:** the bracket takes 4 × M3 inserts, one per standoff. Press them in before assembling.

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -45,7 +45,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-landscape-ringed-full-aa8aaac704ff.png" alt="The Orange Pi extrusion mount lying on its long edge, with all four M3 standoff insert holes circled in red near the four corners of the frame, each showing a real shadowed hole">
-    <figcaption>The 4 insert holes, ringed, near the four corners of the frame. Rendered from the part geometry, not from a build. Render: Balloon.</figcaption>
+    <figcaption>The 4 insert holes, ringed, near the four corners of the frame. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
   </figure>
 </div>
 
@@ -55,7 +55,7 @@ The Pi itself takes no inserts, and neither does anything else on this page.
 
 <figure class="figure-float-right">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/opi-landscape-standoffs-full-cefb56a912b0.png" alt="The Orange Pi extrusion mount lying on its long edge with 4 standoffs mounted in the corner insert holes and a screw head in blue on top of each, shown as plain placeholders since neither part is modelled in the catalog">
-  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders. Render: Balloon.</figcaption>
+  <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders. <cite>Render: Balloon.</cite></figcaption>
 </figure>
 
 **Heat inserts first:** the bracket takes 4 × M3 inserts, one per standoff. Press them in before assembling.

--- a/docs/src/content/hardware/electronics/psu-pigtail.md
+++ b/docs/src/content/hardware/electronics/psu-pigtail.md
@@ -24,7 +24,7 @@ The PSU box has three DC outputs, and each one is a short pigtail: two crimp spa
 
 <figure class="harness-figure">
   <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-built-w1600-59554dc6b189.jpg" alt="An assembled PSU output pigtail: a panel-mount barrel jack with red and black 18 AWG leads, each ending in an insulated spade terminal">
-  <figcaption>One assembled pigtail: panel-mount barrel jack, red +24V and black ground leads, an insulated spade terminal crimped on each. Photo: Jon.</figcaption>
+  <figcaption>One assembled pigtail: panel-mount barrel jack, red +24V and black ground leads, an insulated spade terminal crimped on each. <cite>Photo: Jon.</cite></figcaption>
 </figure>
 
 ## Parts, per pigtail
@@ -57,19 +57,19 @@ The crimp is the fiddly part. Strip the wire, seat it fully in the terminal barr
 <div class="photo-grid">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step1-stripped-w1600-7fe6beee8efc.png" alt="Stripped end of the 18 AWG wire showing bare strands">
-    <figcaption>1. Strip the wire back to bare strands. Photo: Jon.</figcaption>
+    <figcaption>1. Strip the wire back to bare strands. <cite>Photo: Jon.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step2-terminal-w1600-6302bb6e8bc4.png" alt="Stripped wire seated in the spade terminal barrel, not yet crimped">
-    <figcaption>2. Seat the bare strands fully in the terminal barrel. Photo: Jon.</figcaption>
+    <figcaption>2. Seat the bare strands fully in the terminal barrel. <cite>Photo: Jon.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step3-crimping-w1600-0ecacc7e17fd.png" alt="Crimping the terminal in the red 22 to 16 AWG die of a ratcheting crimp tool">
-    <figcaption>3. Crimp in the matching die — the red (22–16 AWG) jaw suits the 18 AWG wire. Photo: Jon.</figcaption>
+    <figcaption>3. Crimp in the matching die — the red (22–16 AWG) jaw suits the 18 AWG wire. <cite>Photo: Jon.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step4-crimped-w1600-ba1c9b488c45.png" alt="The finished crimp with the insulation grip closed on the wire jacket">
-    <figcaption>4. Finished: the grip is closed on the jacket and the wire will not pull out. Photo: Jon.</figcaption>
+    <figcaption>4. Finished: the grip is closed on the jacket and the wire will not pull out. <cite>Photo: Jon.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/psu-pigtail.md
+++ b/docs/src/content/hardware/electronics/psu-pigtail.md
@@ -24,7 +24,7 @@ The PSU box has three DC outputs, and each one is a short pigtail: two crimp spa
 
 <figure class="harness-figure">
   <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-built-w1600-59554dc6b189.jpg" alt="An assembled PSU output pigtail: a panel-mount barrel jack with red and black 18 AWG leads, each ending in an insulated spade terminal">
-  <figcaption>One assembled pigtail: panel-mount barrel jack, red +24V and black ground leads, an insulated spade terminal crimped on each.</figcaption>
+  <figcaption>One assembled pigtail: panel-mount barrel jack, red +24V and black ground leads, an insulated spade terminal crimped on each. Photo: Jon.</figcaption>
 </figure>
 
 ## Parts, per pigtail
@@ -57,19 +57,19 @@ The crimp is the fiddly part. Strip the wire, seat it fully in the terminal barr
 <div class="photo-grid">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step1-stripped-w1600-7fe6beee8efc.png" alt="Stripped end of the 18 AWG wire showing bare strands">
-    <figcaption>1. Strip the wire back to bare strands.</figcaption>
+    <figcaption>1. Strip the wire back to bare strands. Photo: Jon.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step2-terminal-w1600-6302bb6e8bc4.png" alt="Stripped wire seated in the spade terminal barrel, not yet crimped">
-    <figcaption>2. Seat the bare strands fully in the terminal barrel.</figcaption>
+    <figcaption>2. Seat the bare strands fully in the terminal barrel. Photo: Jon.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step3-crimping-w1600-0ecacc7e17fd.png" alt="Crimping the terminal in the red 22 to 16 AWG die of a ratcheting crimp tool">
-    <figcaption>3. Crimp in the matching die — the red (22–16 AWG) jaw suits the 18 AWG wire.</figcaption>
+    <figcaption>3. Crimp in the matching die — the red (22–16 AWG) jaw suits the 18 AWG wire. Photo: Jon.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/harness-psu-pigtail-step4-crimped-w1600-ba1c9b488c45.png" alt="The finished crimp with the insulation grip closed on the wire jacket">
-    <figcaption>4. Finished: the grip is closed on the jacket and the wire will not pull out.</figcaption>
+    <figcaption>4. Finished: the grip is closed on the jacket and the wire will not pull out. Photo: Jon.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -30,7 +30,7 @@ last_verified: 2026-07-12
   <a href="{{ d.guide | n }}">
     <img src="{{ d.photo }}" alt="Assembled {{ d.title }}">
   </a>
-  <figcaption>What it looks like built.{% if d.photo_credit %} Photo: {{ d.photo_credit }}.{% else %} Photographer not recorded.{% endif %} <a href="{{ d.guide | n }}">{{ d.guide_label }} →</a></figcaption>
+  <figcaption>What it looks like built. <cite>{% if d.photo_credit %}Photo: {{ d.photo_credit }}.{% else %}Photographer not recorded.{% endif %}</cite> <a href="{{ d.guide | n }}">{{ d.guide_label }} →</a></figcaption>
 </figure>
 {% endif %}
 
@@ -38,7 +38,7 @@ last_verified: 2026-07-12
   <a href="{{ d.png }}" target="_blank" rel="noopener">
     <img src="{{ d.png }}" alt="WireViz drawing: {{ d.title }}">
   </a>
-  <figcaption>{{ d.caption }} WireViz-generated drawing, not a photo. Click for full size.</figcaption>
+  <figcaption>{{ d.caption }} <cite>WireViz-generated drawing, not a photo.</cite> Click for full size.</figcaption>
 </figure>
 
 <p class="download-line">

--- a/docs/src/content/hardware/electronics/wireviz.md
+++ b/docs/src/content/hardware/electronics/wireviz.md
@@ -30,7 +30,7 @@ last_verified: 2026-07-12
   <a href="{{ d.guide | n }}">
     <img src="{{ d.photo }}" alt="Assembled {{ d.title }}">
   </a>
-  <figcaption>What it looks like built. <a href="{{ d.guide | n }}">{{ d.guide_label }} →</a></figcaption>
+  <figcaption>What it looks like built.{% if d.photo_credit %} Photo: {{ d.photo_credit }}.{% else %} Photographer not recorded.{% endif %} <a href="{{ d.guide | n }}">{{ d.guide_label }} →</a></figcaption>
 </figure>
 {% endif %}
 
@@ -38,7 +38,7 @@ last_verified: 2026-07-12
   <a href="{{ d.png }}" target="_blank" rel="noopener">
     <img src="{{ d.png }}" alt="WireViz drawing: {{ d.title }}">
   </a>
-  <figcaption>{{ d.caption }} Click for full size.</figcaption>
+  <figcaption>{{ d.caption }} WireViz-generated drawing, not a photo. Click for full size.</figcaption>
 </figure>
 
 <p class="download-line">

--- a/docs/src/content/hardware/helpers/external-bracket.md
+++ b/docs/src/content/hardware/helpers/external-bracket.md
@@ -34,19 +34,19 @@ The fasteners and quantities are in the parts list above and are called out inli
 - Of the four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws: **2** join the bottom-vertical part to the side bracket, and **2** clamp the side bracket against the C-Layer vertical support to hold it in place. The **cover clips on**, it takes no screws.
 - Matching parts from the same print run are embossed with a shared set code (e.g. **"b2"**) on both the side bracket and the bottom-vertical part, keep marked pairs together so brackets don't get mixed across sets.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-parts-laid-out-full-0a59300a73b4.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
-  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. The cover is fitted last, in Step 4. Photo: Christoph.</figcaption>
+  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. The cover is fitted last, in Step 4. <cite>Photo: Christoph.</cite></figcaption>
 </figure>
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-side-bracket-full-6649e3954a49.jpg" alt="Close-up of the side bracket alone, showing the U-shaped extrusion clamp and the two mounting-hole wings">
-    <figcaption>The side bracket on its own: the U-shaped opening clamps around the extrusion, and each of the two wings carries a pair of mounting holes. Photo: Christoph.</figcaption>
+    <figcaption>The side bracket on its own: the U-shaped opening clamps around the extrusion, and each of the two wings carries a pair of mounting holes. <cite>Photo: Christoph.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-bottom-vertical-flange-full-4b9a511aea49.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
-    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws in Step 1 go into. Photo: Christoph.</figcaption>
+    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws in Step 1 go into. <cite>Photo: Christoph.</cite></figcaption>
   </figure>
 </div>
 
@@ -54,9 +54,9 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 Set the bottom-vertical leg's flanged top into the U-shaped opening of the side bracket, tube pointing down. Line up the screw holes shown above and drive two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws down through the flange into the side bracket.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step1-screwed-underside-full-d3637471f50a.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
-  <figcaption>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion. Photo: Christoph.</figcaption>
+  <figcaption>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion. <cite>Photo: Christoph.</cite></figcaption>
 </figure>
 
 <div class="callout callout-warning">
@@ -71,11 +71,11 @@ Slide the C-Layer vertical support (the vertical aluminum extrusion) down throug
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step2-extrusion-inserted-full-c56df607b17c.jpg" alt="C-Layer vertical support extrusion inserted down through the side bracket and into the square socket of the bottom-vertical leg">
-    <figcaption>C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3. Photo: Christoph.</figcaption>
+    <figcaption>C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3. <cite>Photo: Christoph.</cite></figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/final4-hires-full-c713a740a66b.png" alt="Vertical cross-section through the side bracket and cover, with the extrusion running through the bore as a hatched strip and a dashed line marking the clamp screw">
-    <figcaption>The collar in section, cut through the centre of the bore. Tan is the side bracket and cover; the hatched strip is the extrusion. The dashed line marks the clamp screw from Step 3. Drawn from the part geometry, not from a build.</figcaption>
+    <figcaption>The collar in section, cut through the centre of the bore. Tan is the side bracket and cover; the hatched strip is the extrusion. The dashed line marks the clamp screw from Step 3. <cite>Drawn from the part geometry, not from a build.</cite></figcaption>
   </figure>
 </div>
 
@@ -86,11 +86,11 @@ Two more {% include fastener.html size="M5" variant="socket-button" length="16" 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step3-screw-hole-empty-full-1086433be655.jpg" alt="Retention screw hole empty, before the screw is driven in">
-    <figcaption>Before: retention-screw hole empty. Photo: Christoph.</figcaption>
+    <figcaption>Before: retention-screw hole empty. <cite>Photo: Christoph.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step3-screw-driven-in-full-259bbc4b6fdb.jpg" alt="Retention screw driven in, seated flush in the hex socket">
-    <figcaption>After: {% include fastener.html size="M5" variant="socket-button" length="16" %} screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face. Photo: Christoph.</figcaption>
+    <figcaption>After: {% include fastener.html size="M5" variant="socket-button" length="16" %} screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face. <cite>Photo: Christoph.</cite></figcaption>
   </figure>
 </div>
 
@@ -101,11 +101,11 @@ Clip the cover onto the side bracket to close it off. The cover takes no screws,
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step4-cover-unattached-full-9b93d76f9459.jpg" alt="The unattached cover sitting next to the assembled bracket, at the face where it clips on">
-    <figcaption>The cover (left), not yet attached, next to the face of the assembly it clips onto. Photo: Christoph.</figcaption>
+    <figcaption>The cover (left), not yet attached, next to the face of the assembly it clips onto. <cite>Photo: Christoph.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step4-cover-clipped-on-full-1fea5b9a357c.jpg" alt="Finished bracket with the cover clipped into place">
-    <figcaption>Cover clipped into place. It sits flush against the side bracket, which is why the seam is subtle in photos. Photo: Christoph.</figcaption>
+    <figcaption>Cover clipped into place. It sits flush against the side bracket, which is why the seam is subtle in photos. <cite>Photo: Christoph.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/helpers/external-bracket.md
+++ b/docs/src/content/hardware/helpers/external-bracket.md
@@ -36,17 +36,17 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-parts-laid-out-full-0a59300a73b4.jpg" alt="Side bracket, bottom-vertical leg, cover, an extrusion offcut, and the four M5 × 16 mm screws laid out before assembly">
-  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. The cover is fitted last, in Step 4.</figcaption>
+  <figcaption>Parts for one bracket, laid out before assembly: side bracket, bottom-vertical leg, C-Layer vertical support, and the four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. The cover is fitted last, in Step 4. Photo: Christoph.</figcaption>
 </figure>
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-side-bracket-full-6649e3954a49.jpg" alt="Close-up of the side bracket alone, showing the U-shaped extrusion clamp and the two mounting-hole wings">
-    <figcaption>The side bracket on its own: the U-shaped opening clamps around the extrusion, and each of the two wings carries a pair of mounting holes.</figcaption>
+    <figcaption>The side bracket on its own: the U-shaped opening clamps around the extrusion, and each of the two wings carries a pair of mounting holes. Photo: Christoph.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-bottom-vertical-flange-full-4b9a511aea49.jpg" alt="Close-up of the bottom-vertical part's top flange, showing the holes used to screw it to the side bracket">
-    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws in Step 1 go into.</figcaption>
+    <figcaption>The bottom-vertical part's top flange, before assembly: the square socket takes the extrusion, and the holes around it are what the two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws in Step 1 go into. Photo: Christoph.</figcaption>
   </figure>
 </div>
 
@@ -56,7 +56,7 @@ Set the bottom-vertical leg's flanged top into the U-shaped opening of the side 
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step1-screwed-underside-full-d3637471f50a.jpg" alt="Bottom-vertical leg screwed into the underside of the side bracket, seen from above through the square extrusion socket">
-  <figcaption>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion.</figcaption>
+  <figcaption>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws join the bottom-vertical leg to the side bracket. Viewed from above, looking down through the square socket that will receive the extrusion. Photo: Christoph.</figcaption>
 </figure>
 
 <div class="callout callout-warning">
@@ -71,7 +71,7 @@ Slide the C-Layer vertical support (the vertical aluminum extrusion) down throug
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step2-extrusion-inserted-full-c56df607b17c.jpg" alt="C-Layer vertical support extrusion inserted down through the side bracket and into the square socket of the bottom-vertical leg">
-    <figcaption>C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3.</figcaption>
+    <figcaption>C-Layer vertical support seated through the side bracket and into the bottom-vertical leg's socket. It isn't held in place yet, that's Step 3. Photo: Christoph.</figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/final4-hires-full-c713a740a66b.png" alt="Vertical cross-section through the side bracket and cover, with the extrusion running through the bore as a hatched strip and a dashed line marking the clamp screw">
@@ -86,11 +86,11 @@ Two more {% include fastener.html size="M5" variant="socket-button" length="16" 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step3-screw-hole-empty-full-1086433be655.jpg" alt="Retention screw hole empty, before the screw is driven in">
-    <figcaption>Before: retention-screw hole empty.</figcaption>
+    <figcaption>Before: retention-screw hole empty. Photo: Christoph.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step3-screw-driven-in-full-259bbc4b6fdb.jpg" alt="Retention screw driven in, seated flush in the hex socket">
-    <figcaption>After: {% include fastener.html size="M5" variant="socket-button" length="16" %} screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face.</figcaption>
+    <figcaption>After: {% include fastener.html size="M5" variant="socket-button" length="16" %} screw driven in, clamping the bracket against the extrusion. Repeat for the second hole on the opposite face. Photo: Christoph.</figcaption>
   </figure>
 </div>
 
@@ -101,11 +101,11 @@ Clip the cover onto the side bracket to close it off. The cover takes no screws,
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step4-cover-unattached-full-9b93d76f9459.jpg" alt="The unattached cover sitting next to the assembled bracket, at the face where it clips on">
-    <figcaption>The cover (left), not yet attached, next to the face of the assembly it clips onto.</figcaption>
+    <figcaption>The cover (left), not yet attached, next to the face of the assembly it clips onto. Photo: Christoph.</figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-external-bracket-step4-cover-clipped-on-full-1fea5b9a357c.jpg" alt="Finished bracket with the cover clipped into place">
-    <figcaption>Cover clipped into place. It sits flush against the side bracket, which is why the seam is subtle in photos.</figcaption>
+    <figcaption>Cover clipped into place. It sits flush against the side bracket, which is why the seam is subtle in photos. Photo: Christoph.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/helpers/heat-inserts.md
+++ b/docs/src/content/hardware/helpers/heat-inserts.md
@@ -22,8 +22,8 @@ You can install the brass inserts with a soldering iron or a dedicated heat-set 
 ## Using a soldering iron
 
 <div class="img-row">
-  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-insert-placed-w1600-7615c6569fb3.jpg" alt="Brass heat insert standing over its hole in a printed part, thinner end down, next to an insert already installed flush"><figcaption>Set each insert over its hole, thinner section first.</figcaption></figure>
-  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-pressing-insert-w1600-b18b63647483.jpg" alt="Soldering iron tip centered on a heat insert, pressing it straight down into the part"><figcaption>Center the tip and press gently while it heats.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-insert-placed-w1600-7615c6569fb3.jpg" alt="Brass heat insert standing over its hole in a printed part, thinner end down, next to an insert already installed flush"><figcaption>Set each insert over its hole, thinner section first. Photo: BrickCycleAlice.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-pressing-insert-w1600-b18b63647483.jpg" alt="Soldering iron tip centered on a heat insert, pressing it straight down into the part"><figcaption>Center the tip and press gently while it heats. Photo: BrickCycleAlice.</figcaption></figure>
 </div>
 
 Place each insert above its cavity, straight and centered, with the thinner section going in first. Line the soldering iron tip up with the center of the insert and apply slight pressure while it heats up, about 20 seconds. Once the insert passes the plastic's melt temperature it starts to descend into the part. Push it down straight into the hole, not at an angle.
@@ -37,7 +37,10 @@ It travels faster as it gets hotter, so keep a steady hand. Larger inserts take 
 
 ## Using a heat press
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/tools-heat-insert-press-full-3890a976bbb7.jpg" alt="Benchtop heat-set insert press with a set of tips">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/tools-heat-insert-press-full-3890a976bbb7.jpg" alt="Benchtop heat-set insert press with a set of tips">
+  <figcaption>Manufacturer product photo, not a Basically photo.</figcaption>
+</figure>
 
 A {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-Heat-Insertion-Threaded-Components/dp/B0FRXF1ZH6" text="heat-set insert press" %} is the easiest way to install them: it holds the insert square and drives it straight down, so you just line it up over the hole and lower the arm. The video below shows the process.
 
@@ -49,5 +52,7 @@ A {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-He
     allowfullscreen
     loading="lazy"></iframe>
 </div>
+
+_Video: Basically's own YouTube channel. Who filmed it isn't recorded._
 
 {% include affiliate-footnotes.html %}

--- a/docs/src/content/hardware/helpers/heat-inserts.md
+++ b/docs/src/content/hardware/helpers/heat-inserts.md
@@ -22,8 +22,8 @@ You can install the brass inserts with a soldering iron or a dedicated heat-set 
 ## Using a soldering iron
 
 <div class="img-row">
-  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-insert-placed-w1600-7615c6569fb3.jpg" alt="Brass heat insert standing over its hole in a printed part, thinner end down, next to an insert already installed flush"><figcaption>Set each insert over its hole, thinner section first. Photo: BrickCycleAlice.</figcaption></figure>
-  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-pressing-insert-w1600-b18b63647483.jpg" alt="Soldering iron tip centered on a heat insert, pressing it straight down into the part"><figcaption>Center the tip and press gently while it heats. Photo: BrickCycleAlice.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-insert-placed-w1600-7615c6569fb3.jpg" alt="Brass heat insert standing over its hole in a printed part, thinner end down, next to an insert already installed flush"><figcaption>Set each insert over its hole, thinner section first. <cite>Photo: BrickCycleAlice.</cite></figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/assembly-heat-inserts-soldering-iron-pressing-insert-w1600-b18b63647483.jpg" alt="Soldering iron tip centered on a heat insert, pressing it straight down into the part"><figcaption>Center the tip and press gently while it heats. <cite>Photo: BrickCycleAlice.</cite></figcaption></figure>
 </div>
 
 Place each insert above its cavity, straight and centered, with the thinner section going in first. Line the soldering iron tip up with the center of the insert and apply slight pressure while it heats up, about 20 seconds. Once the insert passes the plastic's melt temperature it starts to descend into the part. Push it down straight into the hole, not at an angle.
@@ -37,9 +37,9 @@ It travels faster as it gets hotter, so keep a steady hand. Larger inserts take 
 
 ## Using a heat press
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/tools-heat-insert-press-full-3890a976bbb7.jpg" alt="Benchtop heat-set insert press with a set of tips">
-  <figcaption>Manufacturer product photo, not a Basically photo.</figcaption>
+  <figcaption><cite>Manufacturer product photo, not a Basically photo.</cite></figcaption>
 </figure>
 
 A {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-Heat-Insertion-Threaded-Components/dp/B0FRXF1ZH6" text="heat-set insert press" %} is the easiest way to install them: it holds the insert square and drives it straight down, so you just line it up over the hole and lower the arm. The video below shows the process.

--- a/docs/src/content/hardware/helpers/heat-inserts.md
+++ b/docs/src/content/hardware/helpers/heat-inserts.md
@@ -44,15 +44,16 @@ It travels faster as it gets hotter, so keep a steady hand. Larger inserts take 
 
 A {% include affiliate-link.html url="https://www.amazon.com/Vertical-Machine-Heat-Insertion-Threaded-Components/dp/B0FRXF1ZH6" text="heat-set insert press" %} is the easiest way to install them: it holds the insert square and drives it straight down, so you just line it up over the hole and lower the arm. The video below shows the process.
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/dnUfhQ9JohU"
-    title="Installing heat-set inserts"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
-
-_Video: Basically's own YouTube channel. Who filmed it isn't recorded._
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/dnUfhQ9JohU"
+      title="Installing heat-set inserts"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: Basically's own YouTube channel. Who filmed it isn't recorded.</cite></figcaption>
+</figure>
 
 {% include affiliate-footnotes.html %}

--- a/docs/src/content/hardware/helpers/lazy-susan.md
+++ b/docs/src/content/hardware/helpers/lazy-susan.md
@@ -24,13 +24,14 @@ Background on the part — sourcing, load rating, the 8" variant — is on the [
 
 Some variants ship with rubber feet. Pull them off — pliers work well.
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/YQCLAKlc9-M"
-    title="Removing the lazy Susan rubber feet"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
-
-_Video: Basically's own YouTube channel. Who filmed it isn't recorded._
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/YQCLAKlc9-M"
+      title="Removing the lazy Susan rubber feet"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: Basically's own YouTube channel. Who filmed it isn't recorded.</cite></figcaption>
+</figure>

--- a/docs/src/content/hardware/helpers/lazy-susan.md
+++ b/docs/src/content/hardware/helpers/lazy-susan.md
@@ -13,9 +13,9 @@ parts_needed:
 tools_needed: [Pliers]
 ---
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/helpers-lazy-susan-full-624357a2efa7.jpg" alt="8-inch lazy Susan bearing; the rubber foot to remove is boxed in red">
-  <figcaption>Photo: Spencer.</figcaption>
+  <figcaption><cite>Photo: Spencer.</cite></figcaption>
 </figure>
 
 Background on the part — sourcing, load rating, the 8" variant — is on the [Lazy Susan part page]({{ '/hardware/parts/lazy-susan/' | relative_url }}).

--- a/docs/src/content/hardware/helpers/lazy-susan.md
+++ b/docs/src/content/hardware/helpers/lazy-susan.md
@@ -13,7 +13,10 @@ parts_needed:
 tools_needed: [Pliers]
 ---
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/helpers-lazy-susan-full-624357a2efa7.jpg" alt="8-inch lazy Susan bearing; the rubber foot to remove is boxed in red">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/helpers-lazy-susan-full-624357a2efa7.jpg" alt="8-inch lazy Susan bearing; the rubber foot to remove is boxed in red">
+  <figcaption>Photo: Spencer.</figcaption>
+</figure>
 
 Background on the part — sourcing, load rating, the 8" variant — is on the [Lazy Susan part page]({{ '/hardware/parts/lazy-susan/' | relative_url }}).
 
@@ -29,3 +32,5 @@ Some variants ship with rubber feet. Pull them off — pliers work well.
     allowfullscreen
     loading="lazy"></iframe>
 </div>
+
+_Video: Basically's own YouTube channel. Who filmed it isn't recorded._

--- a/docs/src/content/hardware/helpers/pulley-gear-mod.md
+++ b/docs/src/content/hardware/helpers/pulley-gear-mod.md
@@ -18,8 +18,8 @@ The 20-tooth timing pulley needs its top flange removed before it fits into the 
 ## Remove the top flange
 
 <div class="img-row">
-  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-before-flange-removal-w1600-cb631cc9caf6.jpg" alt="20-tooth timing pulley before preparation, with the top flange attached"><figcaption>Before: top flange attached.</figcaption></figure>
-  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-after-flange-removal-w1600-fbac3db7df0c.jpg" alt="20-tooth timing pulley after preparation, with the removed top flange beside it"><figcaption>After: top flange removed.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-before-flange-removal-w1600-cb631cc9caf6.jpg" alt="20-tooth timing pulley before preparation, with the top flange attached"><figcaption>Before: top flange attached. Photo: Abrianbaker.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-after-flange-removal-w1600-fbac3db7df0c.jpg" alt="20-tooth timing pulley after preparation, with the removed top flange beside it"><figcaption>After: top flange removed. Photo: Abrianbaker.</figcaption></figure>
 </div>
 
 Grip the top flange with needle-nose pliers and pry it upwards. It should pop off cleanly without damaging the pulley.

--- a/docs/src/content/hardware/helpers/pulley-gear-mod.md
+++ b/docs/src/content/hardware/helpers/pulley-gear-mod.md
@@ -18,8 +18,8 @@ The 20-tooth timing pulley needs its top flange removed before it fits into the 
 ## Remove the top flange
 
 <div class="img-row">
-  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-before-flange-removal-w1600-cb631cc9caf6.jpg" alt="20-tooth timing pulley before preparation, with the top flange attached"><figcaption>Before: top flange attached. Photo: Abrianbaker.</figcaption></figure>
-  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-after-flange-removal-w1600-fbac3db7df0c.jpg" alt="20-tooth timing pulley after preparation, with the removed top flange beside it"><figcaption>After: top flange removed. Photo: Abrianbaker.</figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-before-flange-removal-w1600-cb631cc9caf6.jpg" alt="20-tooth timing pulley before preparation, with the top flange attached"><figcaption>Before: top flange attached. <cite>Photo: Abrianbaker.</cite></figcaption></figure>
+  <figure><img src="https://assets.basically.website/sorter-docs/helpers-timing-pulley-after-flange-removal-w1600-fbac3db7df0c.jpg" alt="20-tooth timing pulley after preparation, with the removed top flange beside it"><figcaption>After: top flange removed. <cite>Photo: Abrianbaker.</cite></figcaption></figure>
 </div>
 
 Grip the top flange with needle-nose pliers and pry it upwards. It should pop off cleanly without damaging the pulley.

--- a/docs/src/content/hardware/orange-pi-5.md
+++ b/docs/src/content/hardware/orange-pi-5.md
@@ -18,7 +18,8 @@ last_verified: 2026-05-19
   <p>The Orange Pi 5 is the required compute board for Sorter. SorterOS is built on top of the official Ubuntu image provided by Orange Pi for this board.</p>
 </div>
 
-<img src="/assets/pi5-01.png" alt="Orange Pi 5 single-board computer" style="max-width: 480px; width: 100%; display: block; margin: 1.6rem 0; border: 1px solid var(--line);">
+<img src="/assets/pi5-01.png" alt="Orange Pi 5 single-board computer" style="max-width: 480px; width: 100%; display: block; margin: 1.6rem 0 0.4rem; border: 1px solid var(--line);">
+<p><em>Manufacturer photo (orangepi.org), not a Basically photo.</em></p>
 
 ## Why the Orange Pi 5
 

--- a/docs/src/content/hardware/orange-pi-5.md
+++ b/docs/src/content/hardware/orange-pi-5.md
@@ -18,8 +18,10 @@ last_verified: 2026-05-19
   <p>The Orange Pi 5 is the required compute board for Sorter. SorterOS is built on top of the official Ubuntu image provided by Orange Pi for this board.</p>
 </div>
 
-<img src="/assets/pi5-01.png" alt="Orange Pi 5 single-board computer" style="max-width: 480px; width: 100%; display: block; margin: 1.6rem 0 0.4rem; border: 1px solid var(--line);">
-<p><em>Manufacturer photo (orangepi.org), not a Basically photo.</em></p>
+<figure class="single-figure">
+  <img class="doc-figure" src="/assets/pi5-01.png" alt="Orange Pi 5 single-board computer">
+  <figcaption><cite>Manufacturer photo (orangepi.org), not a Basically photo.</cite></figcaption>
+</figure>
 
 ## Why the Orange Pi 5
 

--- a/docs/src/content/hardware/parts/lazy-susan.md
+++ b/docs/src/content/hardware/parts/lazy-susan.md
@@ -10,7 +10,10 @@ permalink: /hardware/parts/lazy-susan/
 author: spencer
 ---
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/lazy-susan-top-full-f7085d147da1.jpg" alt="8-inch lazy Susan bearing, top view">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/lazy-susan-top-full-f7085d147da1.jpg" alt="8-inch lazy Susan bearing, top view">
+  <figcaption>Photographer not recorded.</figcaption>
+</figure>
 
 Repurposed from a dinner-table lazy Susan. It's rated for heavy loads — at least 50 lb, likely more — and holds up well over long run times, with no manufacturing issues seen across Amazon and AliExpress sources. Use the **8" variant**; see the [BOM](https://docs.google.com/spreadsheets/d/1aoxcyK0xa0i3iWYlO4u3-vsruOGU8V_U9XT65YhMZmY/edit?gid=0#gid=0) for sources.
 

--- a/docs/src/content/hardware/parts/lazy-susan.md
+++ b/docs/src/content/hardware/parts/lazy-susan.md
@@ -10,9 +10,9 @@ permalink: /hardware/parts/lazy-susan/
 author: spencer
 ---
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/lazy-susan-top-full-f7085d147da1.jpg" alt="8-inch lazy Susan bearing, top view">
-  <figcaption>Photographer not recorded.</figcaption>
+  <figcaption><cite>Photographer not recorded.</cite></figcaption>
 </figure>
 
 Repurposed from a dinner-table lazy Susan. It's rated for heavy loads — at least 50 lb, likely more — and holds up well over long run times, with no manufacturing issues seen across Amazon and AliExpress sources. Use the **8" variant**; see the [BOM](https://docs.google.com/spreadsheets/d/1aoxcyK0xa0i3iWYlO4u3-vsruOGU8V_U9XT65YhMZmY/edit?gid=0#gid=0) for sources.

--- a/docs/src/content/sorter/safe-shutdown.md
+++ b/docs/src/content/sorter/safe-shutdown.md
@@ -15,13 +15,19 @@ The machine's computer writes files continuously while it runs. Cutting power mi
 
 Click the dropdown at the top right of the UI and select **Full Machine Power Down**.
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/sorter-safe-shutdown-full-machine-power-down-menu-full-fb7d3867ed81.jpg" alt="The top-right UI dropdown open, showing the Full Machine Power Down action">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/sorter-safe-shutdown-full-machine-power-down-menu-full-fb7d3867ed81.jpg" alt="The top-right UI dropdown open, showing the Full Machine Power Down action">
+  <figcaption>UI screenshot. Who took it isn't recorded.</figcaption>
+</figure>
 
 ## Option 2: the button on the Orange Pi
 
 Press the small black button on the side of the Orange Pi once (circled below). That begins the shutdown procedure.
 
-<img class="doc-figure" src="https://assets.basically.website/sorter-docs/sorter-safe-shutdown-orange-pi-power-button-full-a39aa5a490fc.jpg" alt="Orange Pi 5 board with the side power button circled in red">
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/sorter-safe-shutdown-orange-pi-power-button-full-a39aa5a490fc.jpg" alt="Orange Pi 5 board with the side power button circled in red">
+  <figcaption>Photographer not recorded.</figcaption>
+</figure>
 
 You'll know it's shut down when the red and green light on the board have stopped blinking.
 

--- a/docs/src/content/sorter/safe-shutdown.md
+++ b/docs/src/content/sorter/safe-shutdown.md
@@ -15,18 +15,18 @@ The machine's computer writes files continuously while it runs. Cutting power mi
 
 Click the dropdown at the top right of the UI and select **Full Machine Power Down**.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/sorter-safe-shutdown-full-machine-power-down-menu-full-fb7d3867ed81.jpg" alt="The top-right UI dropdown open, showing the Full Machine Power Down action">
-  <figcaption>UI screenshot. Who took it isn't recorded.</figcaption>
+  <figcaption><cite>UI screenshot. Who took it isn't recorded.</cite></figcaption>
 </figure>
 
 ## Option 2: the button on the Orange Pi
 
 Press the small black button on the side of the Orange Pi once (circled below). That begins the shutdown procedure.
 
-<figure>
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/sorter-safe-shutdown-orange-pi-power-button-full-a39aa5a490fc.jpg" alt="Orange Pi 5 board with the side power button circled in red">
-  <figcaption>Photographer not recorded.</figcaption>
+  <figcaption><cite>Photographer not recorded.</cite></figcaption>
 </figure>
 
 You'll know it's shut down when the red and green light on the board have stopped blinking.

--- a/docs/src/liquid/_data/harness.yml
+++ b/docs/src/liquid/_data/harness.yml
@@ -39,6 +39,7 @@ drawings:
       pair on the PSU terminal block (7 with 4, 8 with 5, 9 with 6),
       panel-mount jack on the other end.
     photo: https://assets.basically.website/sorter-docs/harness-psu-pigtail-built-w1600-59554dc6b189.jpg
+    photo_credit: Jon
     guide: /hardware/electronics/psu-pigtail/
     guide_label: How to make your own
     png: https://assets.basically.website/sorter-harness/psu-pigtail-full-e7a2cf6fc86b.png

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1119,6 +1119,43 @@ body {
 	border: 1px solid var(--line);
 }
 
+/* A standalone figure (one doc-figure image, one caption): shrink-wraps to the
+   image's own rendered width and centers, so the caption underneath wraps at
+   that width too instead of stretching across the whole text column. Without
+   this a <figure> is a plain block and its <figcaption> just reads as a
+   full-width paragraph, indistinguishable from body copy. Opt in with
+   class="single-figure" on the <figure> rather than making this the default,
+   since img-row/figure-float-right/harness-figure figures each need their own
+   sizing and already have it. */
+.single-figure {
+	display: table;
+	margin: 0 auto 1.4rem;
+}
+
+.single-figure .doc-figure {
+	margin-bottom: 0;
+}
+
+.single-figure figcaption {
+	margin-top: 6px;
+	font-size: 0.875rem;
+	line-height: 1.4;
+	text-align: center;
+	color: var(--muted);
+}
+
+/* The credit clause of any caption, marked up as <cite>: its own line, a touch
+   smaller and italic, so a reader can tell "what this shows" from "who made
+   it" at a glance instead of one run-on sentence. Deliberately not scoped to
+   .single-figure — the same markup works inside img-row, prep-item and video
+   captions too. */
+figcaption cite {
+	display: block;
+	margin-top: 4px;
+	font-size: 0.8125rem;
+	font-style: italic;
+}
+
 /* A figure floated into the right margin, with the step text running beside it.
    Falls back to a normal centred figure on narrow screens. */
 .figure-float-right {

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1286,6 +1286,28 @@ figcaption cite {
 	background: var(--line);
 }
 
+/* Wraps a video-embed/video-embed-self div so its credit reads the same as a
+   photo's: a <figcaption><cite> line under the player, not a floating
+   markdown paragraph. The inner div keeps sizing the player; this just adds
+   the caption and absorbs the margin the div used to carry on its own. */
+.video-figure {
+	margin: 0 0 1.4rem;
+}
+
+.video-figure .video-embed-portrait,
+.video-figure .video-embed-wide,
+.video-figure .video-embed-self {
+	margin: 0;
+}
+
+.video-figure figcaption {
+	margin-top: 6px;
+	font-size: 0.875rem;
+	line-height: 1.4;
+	text-align: center;
+	color: var(--muted);
+}
+
 .photo-grid {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1542130933795266560
request: https://discord.com/channels/1430279849171222682/1542130933795266560/1542139571683197068
request: https://discord.com/channels/1430279849171222682/1542135540013469818/1542151953696428092
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1542130933795266560): "Image and video credits are important, and we should always include them as captions. Go through the entire documentation and make sure that every photo and video includes credits. If the author is unknown, please note that as well."

## What this does

Adds a credit to every photo and video figcaption across the hardware docs that didn't already have one. Where a caption already named a photographer, it's untouched.

- **Named contributors**, traced through PR history and the knowledge base: Christoph (`external-bracket.md`), zed0 (`regular-layers.md`, all 21 photos + 2 videos), BrickCycleAlice (`c-channel.md`, `bottom-interface.md`, `heat-inserts.md`), Adrianbaker (`bottom-interface.md` exploded renders), Abrianbaker (`pulley-gear-mod.md`), Jon (`psu-pigtail.md`, `wireviz.md`'s psu-pigtail photo), Spencer (control board pages, electronics layout render, remaining bottom-interface build photos).
- **CAD/STL renders** that weren't already flagged as such get "Rendered from the part geometry, not from a build." plus who rendered it (mostly Balloon, via `meshfig.py`/STL renders).
- **Manufacturer/stock photos** (Orange Pi 5 hero image, the uxcell ribbon cable, the heat-press tool) are labelled as manufacturer photos, not Basically's.
- **WireViz-generated schematics** on `wireviz.md` now say so in the caption.
- **Genuinely unrecorded**: a handful of images (both `lazy-susan` helper/parts photos partially, `safe-shutdown.md`'s two images, the servo horn reference photo) trace only to a bare commit with no PR and no named source, so those get "Photographer not recorded" / "Photo courtesy... not recorded" instead of a guessed name.

**Skipped on purpose:**
- `top-interface.md` (open PR #419) and `bottom-two-layers.md` (open PR #433) — left alone per the ask to skip pages with an open PR.
- `notes/3v2p.md` — engineering notes are explicitly never edited after publication (see the note's own footer), so it's excluded even though its figures have no per-image credit line.

Split into its own PR from the standing-rule/validator part per barthel's request: [sorter-v2 #435](https://github.com/basicallysource/sorter-v2/pull/435).

## Follow-up: caption width and formatting (barthel's mockup)

Barthel pointed out captions weren't fitting the image's width and asked for the credit to be formatted consistently as its own line, with a mockup image. Fixed:

- New opt-in `.single-figure` class for a standalone one-image `<figure>`: shrink-wraps to the image's own rendered width and centers it, so the caption wraps at that width instead of stretching across the full text column (a bare `<figure>` had no width rule of its own before this, so the caption just read like a paragraph of body text).
- Every credit clause is now marked up as `<cite>`, rendered on its own smaller italic line, consistently across single figures, img-row pairs, prep-item figures, and the WireViz photo/drawing captions.

Verified against the deploy preview with a screenshot; matches the mockup.

## Follow-up: video captions weren't in the same style as photo captions

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1542135540013469818/1542151953696428092): "Use the same style of caption for each photo and also video."

Every photo credit renders as `<figure><figcaption><cite>Photo: X.</cite></figcaption></figure>`. Every video credit was instead a plain markdown paragraph (`_Video: X._`) sitting below the embed, outside any figure, with no `<cite>`. Fixed by wrapping each `video-embed`/`video-embed-self` div in `<figure class="video-figure">` with a matching `<figcaption><cite>...</cite></figcaption>`, and adding CSS so it centers and sizes the same way `.single-figure` does for photos. Also fixed one stray "Photos by BrickCycleAlice." caption that had drifted from the "Photo: X." wording everywhere else.

Verified with `npm run build` (Node 20) and by reading the built HTML for all 7 affected videos across 6 pages.

## Test plan

- [x] `python3 scripts/validate_frontmatter.py` — same 5 pre-existing errors as `main`, none new
- [x] `python3 scripts/validate_images.py` — 168 assets, all valid
- [x] `npm run check` (Node 22) — 0 errors, same 4 pre-existing a11y warnings
- [x] `npm run dev` + curled every touched page, including the `wireviz.md` liquid conditional for the new `photo_credit` field — all render correctly


