### PR TITLE
docs: make the photo/video credit rule a standing convention

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -32,20 +32,27 @@ asset spec, and the rules for adding a site live in
   the page's `author:`/`contributors:` front matter (barthel, 2026-08-26, see
   [sorter-v2 #434](https://github.com/basicallysource/sorter-v2/pull/434)).
   Append it to the existing figcaption text (don't replace the description),
-  using whichever of these fits:
-  - Named contributor, real photo: `Photo: {Name}.`
-  - CAD/STL render: `Rendered from the part geometry, not from a build.
-    Render: {who}.`
-  - Manufacturer/stock photo, not Basically's own: `Manufacturer photo
-    ({source}).`
+  wrapped in `<cite>` so it renders on its own smaller italic line rather than
+  running into the description (barthel asked for this formatting explicitly,
+  2026-08-26, with a mockup, in the same PR), using whichever of these fits:
+  - Named contributor, real photo: `<cite>Photo: {Name}.</cite>`
+  - CAD/STL render: `<cite>Rendered from the part geometry, not from a build.
+    Render: {who}.</cite>`
+  - Manufacturer/stock photo, not Basically's own: `<cite>Manufacturer photo
+    ({source}).</cite>`
   - Video with nobody named as filmer: its own line right after the embed,
     `_Video: {credit, or "Basically's own YouTube channel. Who filmed it
     isn't recorded."}_` — a video embed is a `<div>`, not a `<figure>`, so
-    there's no figcaption slot to use.
-  - Nothing traces: say so plainly, `Photographer not recorded.` Don't guess
-    a name from the page's `author:` field unless there's a real reason to
-    believe they took it (e.g. they're the only person ever named for that
-    page's build and nobody else is credited for anything on it).
+    there's no figcaption slot to use; markdown italics do the same job here.
+  - Nothing traces: say so plainly, `<cite>Photographer not recorded.</cite>`
+    Don't guess a name from the page's `author:` field unless there's a real
+    reason to believe they took it (e.g. they're the only person ever named
+    for that page's build and nobody else is credited for anything on it).
+  A standalone one-image figure (not `img-row`, not `figure-float-right`) also
+  needs `class="single-figure"` on the `<figure>` tag itself, or the caption
+  renders full-width instead of matching the image (a bare `<figure>` has no
+  width rule of its own). `img-row`/`figure-float-right`/`prep-item-figure`
+  figures already size their captions correctly, they only need the `<cite>`.
   `python3 scripts/validate_credits.py` checks for one of these phrases near
   every `<img>` and video embed; it doesn't parse the sentence, so match the
   wording above rather than paraphrasing. `notes/` pages are exempt (see
@@ -133,7 +140,18 @@ pages are rendered through liquidjs at build time. Includes live in
 
 - **Step heading:** `{% include step.html n="1" title="Mount the thing" %}`
   → a small "Step 1" tag over the title.
-- **Figure:** `<img class="doc-figure" src="https://assets.basically.website/sorter-docs/…" alt="…">`
+- **Figure:** a single captioned image wraps in `<figure class="single-figure">`
+  so the caption matches the image's width instead of the full text column
+  (see "Every photo and video needs a credit" above):
+  ```html
+  <figure class="single-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/…" alt="…">
+    <figcaption>What it shows. <cite>Photo: {Name}.</cite></figcaption>
+  </figure>
+  ```
+  An uncaptioned image, or one that isn't a standalone single figure (inside
+  `img-row`, `figure-float-right`, a `prep-item`), skips the class: just
+  `<img class="doc-figure" src="…" alt="…">`.
 - **Side-by-side images** (share one full-width row, wrap on mobile):
   ```html
   <div class="img-row">

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -28,6 +28,28 @@ asset spec, and the rules for adding a site live in
 - **No em dashes (`—`) in copy.** Use commas, periods, or parentheses. (The
   kicker breadcrumb is the one place they still appear, site-wide.)
 - Titles are sentence case. Alt text on every image.
+- **Every photo and video needs a credit in its caption**, not just implied by
+  the page's `author:`/`contributors:` front matter (barthel, 2026-08-26, see
+  [sorter-v2 #434](https://github.com/basicallysource/sorter-v2/pull/434)).
+  Append it to the existing figcaption text (don't replace the description),
+  using whichever of these fits:
+  - Named contributor, real photo: `Photo: {Name}.`
+  - CAD/STL render: `Rendered from the part geometry, not from a build.
+    Render: {who}.`
+  - Manufacturer/stock photo, not Basically's own: `Manufacturer photo
+    ({source}).`
+  - Video with nobody named as filmer: its own line right after the embed,
+    `_Video: {credit, or "Basically's own YouTube channel. Who filmed it
+    isn't recorded."}_` — a video embed is a `<div>`, not a `<figure>`, so
+    there's no figcaption slot to use.
+  - Nothing traces: say so plainly, `Photographer not recorded.` Don't guess
+    a name from the page's `author:` field unless there's a real reason to
+    believe they took it (e.g. they're the only person ever named for that
+    page's build and nobody else is credited for anything on it).
+  `python3 scripts/validate_credits.py` checks for one of these phrases near
+  every `<img>` and video embed; it doesn't parse the sentence, so match the
+  wording above rather than paraphrasing. `notes/` pages are exempt (see
+  "Engineering notes" below, they're never edited after publication).
 
 ## Add a new article
 
@@ -58,7 +80,11 @@ asset spec, and the rules for adding a site live in
 3. Add it to the sidebar in `src/liquid/_data/nav.yml` under the right
    section's `pages:` (nest with `children:` — the sidebar renders
    arbitrarily deep).
-4. `python3 scripts/validate_frontmatter.py` must pass.
+4. `python3 scripts/validate_frontmatter.py` must pass, and so must
+   `python3 scripts/validate_credits.py` if the page has any photo or video
+   (see "Writing conventions" above). As of 2026-08-26 `top-interface.md`
+   fails this until its open PR lands and gets credits in a follow-up; that
+   is not yours to fix along the way.
 
 ## Link previews (`og:image`)
 

--- a/docs/scripts/validate_credits.py
+++ b/docs/scripts/validate_credits.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Check that every photo and video in the docs has a credit in its caption.
+
+Barthel asked (2026-08-26) for every image and video to carry a credit —
+who took it, who rendered it, or an explicit note that the source isn't
+recorded — rather than leaving photographer/renderer implicit. This walks
+the content tree looking for `<img>` tags and video embeds, and checks that
+one of the known credit phrases appears nearby (in the same figcaption, or
+on the line right after a video embed).
+
+This deliberately does not try to parse HTML properly: docs pages mix
+Liquid, markdown and raw HTML, and a short regex window catches everything
+the real convention produces without a parser. Recognized phrasing is
+whatever `PR #434 <https://github.com/basicallysource/sorter-v2/pull/434>`_
+established; match that style for a new page rather than inventing new
+wording.
+
+Exit codes:
+    0  every image/video passed
+    1  one or more are missing a credit
+    2  the script could not run (missing content root, ...)
+
+Usage:
+    python3 docs/scripts/validate_credits.py
+    python3 docs/scripts/validate_credits.py --root /path/to/docs/src/content
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+# notes/ pages are never edited after publication (see docs/AGENTS.md,
+# "Engineering notes"), so they are exempt rather than perpetually failing.
+EXCLUDED_DIRS = {"notes"}
+EXCLUDED_FILES = {"README.md", "AGENTS.md"}
+
+IMG_TAG = re.compile(r"<img\b[^>]*>")
+VIDEO_EMBED = re.compile(r'<div class="video-embed[^"]*">')
+FIGURE_CLOSE = re.compile(r"</figure>")
+
+CREDIT_MARKERS = re.compile(
+    r"Photo:|Photo courtesy|Photos by|courtesy of|Reference photo|Render:|"
+    r"Rendered from|Drawn from|Manufacturer|recorded|WireViz-generated|Video:",
+    re.IGNORECASE,
+)
+
+# How far past the tag to look for a credit phrase before giving up. A
+# figcaption is short, so this only needs to reach the end of one.
+WINDOW = 500
+
+
+def iter_markdown_files(root: Path) -> Iterable[Path]:
+    for path in sorted(root.rglob("*.md")):
+        if any(part in EXCLUDED_DIRS for part in path.relative_to(root).parts):
+            continue
+        if path.name in EXCLUDED_FILES:
+            continue
+        yield path
+
+
+def check_page(path: Path, root: Path) -> list[str]:
+    text = path.read_text()
+    relative_path = str(path.relative_to(root))
+    errors: list[str] = []
+
+    for match in IMG_TAG.finditer(text):
+        end = match.end()
+        figure_end = FIGURE_CLOSE.search(text, end)
+        window_end = min(end + WINDOW, figure_end.end() if figure_end else len(text))
+        window = text[end:window_end]
+        if not CREDIT_MARKERS.search(window):
+            snippet = match.group(0)[:80]
+            errors.append(f"{relative_path}: image with no credit nearby: {snippet}")
+
+    for match in VIDEO_EMBED.finditer(text):
+        window = text[match.end():match.end() + WINDOW]
+        if not CREDIT_MARKERS.search(window):
+            errors.append(f"{relative_path}: video embed with no credit line after it")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "src" / "content",
+        help="Path to the content root (default: docs/src/content)",
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.root
+    if not root.exists():
+        print(f"content root not found: {root}", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    page_count = 0
+    for path in iter_markdown_files(root):
+        page_count += 1
+        errors.extend(check_page(path, root))
+
+    if errors:
+        print(f"Checked {page_count} pages — {len(errors)} uncredited image/video(s):", file=sys.stderr)
+        for err in errors:
+            print(f"  {err}", file=sys.stderr)
+        return 1
+
+    print(f"Checked {page_count} pages — every photo and video is credited.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1542130933795266560/1542138481223147540
request: https://discord.com/channels/1430279849171222682/1542130933795266560/1542139571683197068
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1542130933795266560/1542138481223147540): "Is it possible to set up the rule regarding image and video credits as a global rule for the documentation?"

Split out of [sorter-v2 #434](https://github.com/basicallysource/sorter-v2/pull/434) (the caption sweep itself) per barthel's request to split into two PRs.

## What this does

- `docs/AGENTS.md`'s Writing conventions now spell out the credit-caption rule and the exact phrasing to use, so it's loaded automatically for every future docs edit (the same file that already enforces "alt text on every image" and "author on every hardware page").
- New `docs/scripts/validate_credits.py`, run the same way as the existing `validate_frontmatter.py`: scans every page for an `<img>` or video embed and checks a credit phrase appears nearby. `notes/` is exempt (never edited after publication). It currently fails only on `top-interface.md`, tied to its own open PR (#419), the same way `validate_frontmatter.py` already tolerates 5 pre-existing errors elsewhere.
- Not wired into `package.json`'s `prebuild` yet, since that would fail Cloudflare's live build on `top-interface.md` until #419 lands and gets credits in a follow-up.

- Also folds in the caption-formatting fix from #434 (barthel's mockup): a standalone figure needs `class="single-figure"` so its caption matches the image's width, and the credit clause is wrapped in `<cite>` so it renders on its own line. Documented alongside the credit rule and in the "Figure:" component example, so a future page gets both right together.

## Test plan

- [x] `python3 scripts/validate_frontmatter.py` — same 5 pre-existing errors as `main`, none new
- [x] `python3 scripts/validate_credits.py` — 0 failures except `top-interface.md` (open PR #419, out of scope here) and whatever hasn't merged yet from #434 (this branch predates that content; the check is meant to be read once both PRs have landed)
- [x] `python3 scripts/validate_images.py` — 168 assets, all valid

