### PR TITLE
parts-calculator: fix scr-m5-12-shcs count on regular layers (12 -> 36)

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -35,7 +35,7 @@ parts_needed:
   - part: scr-m5-20-shcs
     qty: 12
   - part: scr-m5-12-shcs
-    qty: 12
+    qty: 36
   - part: tnut-m5-2020
     qty: 36
 ---

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6531,6 +6531,10 @@
         {
           "part": "frame-90deg-bracket",
           "qty": 12
+        },
+        {
+          "part": "scr-m5-12-shcs",
+          "qty": 12
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1460,6 +1460,10 @@
 				{
 					"part": "frame-90deg-bracket",
 					"qty": 12
+				},
+				{
+					"part": "scr-m5-12-shcs",
+					"qty": 12
 				}
 			]
 		},


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1542146533968052367
preview: /hardware/assembly/distribution/bin-frame/regular-layers/
-->

Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1542146533968052367): "can you look at the count for the m5x12. It's every 90deg bracket and every bin retainer from my understating."

`scr-m5-12-shcs` was listed as 12 in both `parts-calculator/catalog/parts.json` and the `regular-layers.md` docs page. The page's own steps use it for:

- 12 Frame 90° brackets, 1 screw each (step 2, lines ~114/~142)
- 24 for the bin retainers, 4 per side across 6 sides (step 4, line ~191)

= 36 total. The `layer-frame` assembly node was missing the 90°-bracket screw line entirely (it only had `frame-90deg-bracket` qty 12, no fastener), so it undercounted by 12. Added that line and corrected the docs page's `parts_needed` from 12 to 36, then regenerated `catalog.generated.json`. `scr-m5-16-shcs` and `tnut-m5-2020` on this page already reconcile and are untouched.

`check_generated_pins.py` and `check_asset_urls.py` both pass against this branch.
