### PR TITLE
top-interface: add missing Frame 90 degree brackets and crossbeams

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -66,12 +66,6 @@ parts_needed:
     qty: 6
   - part: ext-2020-ag
     qty: 6
-  - part: ext-2020-bh
-    qty: 6
-  - part: frame-90deg-bracket
-    qty: 12
-  - part: frame-crossbeam
-    qty: 6
   - part: extrusion-e
     qty: 6
   - part: extrusion-f
@@ -526,7 +520,7 @@ Slide an Interface spacer onto each piece of extrusion, with the lip at the top 
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-2-w1600-f626512783f3.jpg" alt="An interface spacer slid onto each vertical extrusion support, lips facing inward">
 </figure>
 
-Follow the first two stages of [a regular layer]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}), then place the regular layer assembly onto the interface assembly.
+Follow the first two stages of [a regular layer]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) — the hexagon of six A/G extrusions in six External bracket — sides, then the six B/H spokes on their Frame 90° brackets with a Frame crossbeam each side, see [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}) for the parts and the method — then place the regular layer assembly onto the interface assembly.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-3-full-b9ae16940954.jpg" alt="A regular layer assembly lowered onto the interface assembly">

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -64,6 +64,14 @@ parts_needed:
     qty: 6
   - part: ext-bracket-cover
     qty: 6
+  - part: ext-2020-ag
+    qty: 6
+  - part: ext-2020-bh
+    qty: 6
+  - part: frame-90deg-bracket
+    qty: 12
+  - part: frame-crossbeam
+    qty: 6
   - part: extrusion-e
     qty: 6
   - part: extrusion-f
@@ -99,7 +107,7 @@ parts_needed:
   - part: scr-m5-16-shcs
     qty: 38
   - part: scr-m5-12-shcs
-    qty: 4
+    qty: 16
   - part: scr-m4-12-cs
     qty: 8
   - part: scr-m3-35-bhcs

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -107,7 +107,7 @@ parts_needed:
   - part: scr-m5-16-shcs
     qty: 38
   - part: scr-m5-12-shcs
-    qty: 16
+    qty: 4
   - part: scr-m4-12-cs
     qty: 8
   - part: scr-m3-35-bhcs

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6218,10 +6218,6 @@
         {
           "part": "frame-crossbeam",
           "qty": 6
-        },
-        {
-          "part": "scr-m5-12-shcs",
-          "qty": 12
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6110,6 +6110,12 @@
       "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
+      "joining": [
+        {
+          "method": "friction",
+          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
+        }
+      ],
       "lines": [
         {
           "assembly": "interface-bracket-mount",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6202,6 +6202,26 @@
         {
           "part": "scr-m5-8-cs",
           "qty": 6
+        },
+        {
+          "part": "ext-2020-ag",
+          "qty": 6
+        },
+        {
+          "part": "ext-2020-bh",
+          "qty": 6
+        },
+        {
+          "part": "frame-90deg-bracket",
+          "qty": 12
+        },
+        {
+          "part": "frame-crossbeam",
+          "qty": 6
+        },
+        {
+          "part": "scr-m5-12-shcs",
+          "qty": 12
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1131,6 +1131,26 @@
 				{
 					"part": "scr-m5-8-cs",
 					"qty": 6
+				},
+				{
+					"part": "ext-2020-ag",
+					"qty": 6
+				},
+				{
+					"part": "ext-2020-bh",
+					"qty": 6
+				},
+				{
+					"part": "frame-90deg-bracket",
+					"qty": 12
+				},
+				{
+					"part": "frame-crossbeam",
+					"qty": 6
+				},
+				{
+					"part": "scr-m5-12-shcs",
+					"qty": 12
 				}
 			]
 		},

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1039,6 +1039,12 @@
 			"description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
 			"status": "partial",
+			"joining": [
+				{
+					"method": "friction",
+					"note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
+				}
+			],
 			"lines": [
 				{
 					"assembly": "interface-bracket-mount",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1147,10 +1147,6 @@
 				{
 					"part": "frame-crossbeam",
 					"qty": 6
-				},
-				{
-					"part": "scr-m5-12-shcs",
-					"qty": 12
 				}
 			]
 		},


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1542146533968052367/1542168039095795732
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542448914748284958
preview: /hardware/assembly/distribution/top-interface/
-->

Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1542146533968052367/1542168039095795732): "this is a photo of the top interface upside down. It has 12x 90 deg brackets, and 6 of the frame cross beam. You will need a pr for this"

`top-interface.md` already says "Follow the first two stages of a regular layer, then place the regular layer assembly onto the interface assembly," but the parts that requires were never added: 12 `frame-90deg-bracket`, 6 `frame-crossbeam`, and the extrusion they mount to/on (`ext-2020-ag` x6, `ext-2020-bh` x6). Added all four to the `interface` assembly in `parts-calculator/catalog/parts.json` and to the docs page's `parts_needed`, matched by her build photo and the existing prose.

Also bumped `scr-m5-12-shcs` from 4 to 16 on this page: the existing 4 is for the NEMA 23 bracket (unrelated, already in the page text), and the new brackets need 1 each for their T-nut screw, same pattern as the regular-layers fix in #438.

**Not included, flagged for a separate conversation:** she also said "the hex frames constructed are n+1" (5 bin frames + 1 interface frame for what the site calls a 5-layer machine), which implies the site's `middle-layers = layers − 2` formula should be `layers − 1` so the bottom-interface + middle layers total N bin frames. That's a resolver-level change (`parts-calculator/src/lib/filament.ts`) that also feeds chute counts, which sorter-v2#424 specifically fixed to total N — I didn't want to touch that formula without more time to verify it doesn't reopen that fix. Left as an open question rather than guessed at.

`check_generated_pins.py` and `check_asset_urls.py` both pass against this branch.



---

Follow-up from the hex-frame-no-hardware thread (sorter-v2#443): Spencer confirmed 2026-08-26 the Frame 90° bracket and Frame crossbeam this PR adds to top-interface's parts list take no hardware at all -- see [Attaching the hexagonal frame's spokes](https://docs.basically.website/hardware/helpers/hex-frame-spokes/). Dropped `frame-90deg-bracket`, `frame-crossbeam` and `ext-2020-bh` from this page's `parts_needed` (kept `ext-2020-ag`, unaffected) to match the convention set on `regular-layers.md`/`bottom-two-layers.md`: that parts list is the helper page's job now. Linked the helper page directly from the "follow the first two stages of a regular layer" sentence. Also added a `joining` note to the `interface` assembly in `parts-calculator/catalog/parts.json` documenting the no-hardware design, matching `external-bracket`'s existing self-tap note.
