### PR TITLE
docs: hexagonal frame spokes have no hardware

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -26,17 +26,11 @@ parts_needed:
     qty: 6
   - part: ext-bracket-foot-cover
     qty: 6
-  - part: frame-90deg-bracket
-    qty: 24
-  - part: frame-crossbeam
-    qty: 12
   - part: bin-retainer-left
     qty: 12
   - part: bin-retainer-right
     qty: 12
   - part: ext-2020-ag
-    qty: 12
-  - part: ext-2020-bh
     qty: 12
   - part: ext-2020-d
     qty: 6
@@ -45,13 +39,11 @@ parts_needed:
   - part: caster-wheel-m6
     qty: 6
   - part: scr-m5-16-shcs
-    qty: 96
-  - part: scr-m5-20-shcs
-    qty: 24
+    qty: 64
   - part: scr-m5-12-shcs
-    qty: 72
+    qty: 48
   - part: tnut-m5-2020
-    qty: 72
+    qty: 48
 ---
 
 The bottom two layers are two ordinary bin layers built at the same time, because the vertical extrusion between them is one continuous piece per corner instead of one per layer. That piece is the machine's leg: the caster screws into the bottom of it, so running it up through the bottom layer and into the second gives the wheel something much stiffer to push against than a single layer's worth of extrusion would.
@@ -81,16 +73,16 @@ Cut the extrusion first. These two layers use **6 × piece D (Foot extension), 2
 
 Where the {% include fastener.html size="M5" variant="socket-button" length="16" %} count in the parts list comes from, since nobody has counted these off a built machine:
 
-- **48** for the two hexagons and their spokes, which is [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) steps 1 and 2 done twice
+- **16** for the two hexagons' outer rings, which is [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 1 done twice
 - **24** for the foot extensions, 4 per corner (step 3 below), two into each layer
 - **12** for the second layer's External bracket — bottom verticals, 2 per corner (step 4 below)
 - **12** for the bottom layer's External bracket - foot covers, 2 per corner (step 4 below), the same as the bottom vertical it replaces
 
-The {% include fastener.html size="M5" variant="socket-button" length="12" %} count is the same arithmetic: **12** per layer holding the Frame 90° brackets and **24** per layer for the bin retainers, so **72** across both.
+The {% include fastener.html size="M5" variant="socket-button" length="12" %} count is the same arithmetic: **24** per layer for the bin retainers, so **48** across both.
 
 {% include step.html n="2" title="Build two layer frames" %}
 
-Work through [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) steps 1 and 2 twice, once per layer: the hexagon of six A/G extrusions in six External bracket — sides, then the six B/H spokes on their Frame 90° brackets with a Frame crossbeam each side.
+Work through [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) steps 1 and 2 twice, once per layer: the hexagon of six A/G extrusions in six External bracket — sides, then the six B/H spokes on their Frame 90° brackets with a Frame crossbeam each side — see [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}) for the parts and the method.
 
 **Stop before that guide's step 3 (Install the verticals).** The verticals are the part that differs here, and they are step 3 below.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -16,28 +16,18 @@ parts_needed:
     qty: 6
   - part: ext-bracket-bottom-vertical
     qty: 6
-  - part: frame-90deg-bracket
-    qty: 12
-  - part: frame-crossbeam
-    qty: 6
   - part: bin-retainer-left
     qty: 6
   - part: bin-retainer-right
     qty: 6
   - part: ext-2020-ag
     qty: 6
-  - part: ext-2020-bh
-    qty: 6
   - part: ext-2020-c
     qty: 6
   - part: scr-m5-16-shcs
-    qty: 36
-  - part: scr-m5-20-shcs
-    qty: 12
-  - part: scr-m5-12-shcs
-    qty: 12
+    qty: 24
   - part: tnut-m5-2020
-    qty: 36
+    qty: 24
 ---
 
 This guide covers creating a regular layer. It's also the basis for creating the top and bottom layers, so build N−2 of these for an N-layer machine (the [bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}) are covered separately).
@@ -97,18 +87,7 @@ Repeat these steps to make two semi-circles of three sections of extrusion and t
   <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-hexagon-assembled-full-a1fb3a1b6fb4.png" alt="The completed hexagon frame of six A/G extrusions and six corner brackets">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-hexagon-assembled-top-w1600-5a469702622a.png" alt="Top-down view of the completed hexagon frame">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-</div>
-
-{% include step.html n="2" title="Preparation" %}
+{% include step.html n="2" title="Attach the spokes" %}
 
 <div class="prep-item">
   <div class="prep-item-body">

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -87,7 +87,7 @@ Repeat these steps to make two semi-circles of three sections of extrusion and t
   <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
-{% include step.html n="2" title="Attach the spokes" %}
+{% include step.html n="2" title="Attach the hexagonal frame's spokes" %}
 
 <div class="prep-item">
   <div class="prep-item-body">

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -46,7 +46,7 @@ Note that some of the ordering in this guide may seem unusual, but it's written 
 
 The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
 
-See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | relative_url }}) for a look at the three bracket parts on their own.
+See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | relative_url }}) for a look at the three bracket parts on their own, and [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}) for how the Frame 90° bracket, B/H spoke and Frame crossbeam are prepared and attached as needed.
 
 {% include fastener-legend.html %}
 
@@ -110,79 +110,7 @@ Repeat these steps to make two semi-circles of three sections of extrusion and t
 
 {% include step.html n="2" title="Attach the spokes" %}
 
-Prepare 12 Frame 90° brackets by drilling out the holes on the long side to allow an M5 screw to rotate freely. If you do not have a drill of the correct diameter, this can also be done using an electric screwdriver to overtighten an M5 screw, thus breaking the threads.
-
-<figure class="video-figure">
-  <div class="video-embed video-embed-wide">
-    <iframe
-      src="https://www.youtube.com/embed/ULeByfqfVZs"
-      title="Preparing the Frame 90° brackets and attaching the spokes"
-      allow="encrypted-media; picture-in-picture; web-share"
-      allowfullscreen
-      loading="lazy"></iframe>
-  </div>
-  <figcaption><cite>Video: zed0.</cite></figcaption>
-</figure>
-
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-brackets-attached-w1600-47b3c12e2344.png" alt="Two Frame 90° brackets fastened to the inner face of an A/G extrusion, seen from inside the hexagon">
-  <figcaption><cite>Photo: zed0.</cite></figcaption>
-</figure>
-
-Loosely attach the long side of 2 Frame 90° brackets to the inner of one piece of the A/G (Outer horizontal / Horizontal interface frame) extrusion of your hexagon using 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts.
-
-Slide piece B/H (Spoke / Interface spoke (short)) of aluminum extrusion into the 2 Frame 90° brackets that you have just placed, and secure it with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped directly into the Frame 90° brackets, bracing against the extrusion. You can now tighten up the {% include fastener.html size="M5" variant="socket-button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
-
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-installed-w1600-536d49087ec4.png" alt="A B/H spoke extrusion standing up in the two Frame 90° brackets">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spoke-crossbeams-first-full-dca5e96ee46d.png" alt="A spoke with a Frame crossbeam slid into place on each side">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-</div>
-
-On each side of this B/H (Spoke / Interface spoke (short)) slide a Frame crossbeam into place until it is level with the end of the extrusion, and secure it with an {% include fastener.html size="M5" variant="socket-button" length="20" %} screw.
-
-Perform these steps 2 more times, on every 2nd side of the hexagon.
-
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-crossbeams-top-full-d16c233ea6e1.png" alt="Top-down view of three spokes with crossbeams, forming a partial inner ring">
-  <figcaption><cite>Photo: zed0.</cite></figcaption>
-</figure>
-
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-1-w1600-bfbe2a608499.png" alt="The hexagon partway through spoke installation, some sides done">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-2-w1600-5a478c564363.png" alt="More spokes and crossbeams filled in around the hexagon">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-</div>
-
-On each of the remaining 3 sides of the hexagon, use 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws (either into your 2 existing slide-in T-nuts or with drop-in / roll-in T-nuts) to loosely fasten 2 Frame 90° brackets, aligning them with the gap in the Frame crossbeams. Slide the remaining B/H (Spoke / Interface spoke (short)) pieces into the slots, through both the Frame crossbeams and Frame 90° brackets.
-
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-progress-3-w1600-e63cf43ad122.png" alt="Nearly all spokes and crossbeams installed">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-nearly-complete-w1600-8911fb6fef42.png" alt="The spoke ring almost complete, seen at an angle">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-</div>
-
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-complete-top-full-f9b0a154d84b.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
-  <figcaption><cite>Photo: zed0.</cite></figcaption>
-</figure>
-
-Secure them in place with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped into the Frame 90° brackets and 2 {% include fastener.html size="M5" variant="socket-button" length="20" %} screws through the Frame crossbeams. You can now tighten up the {% include fastener.html size="M5" variant="socket-button" length="12" %} screws that were previously holding the Frame 90° brackets loosely in place.
+Attach the six B/H spokes and their Frame crossbeams to the inside of the hexagon, using the Frame 90° bracket. See [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}) for the parts and the method — prepare and attach them as needed.
 
 <div class="callout">
   <p>If you are currently building the interface layer, stop here and return to the interface layer guide.</p>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -108,9 +108,17 @@ Repeat these steps to make two semi-circles of three sections of extrusion and t
   </figure>
 </div>
 
-{% include step.html n="2" title="Attach the spokes" %}
+{% include step.html n="2" title="Preparation" %}
 
-Attach the six B/H spokes and their Frame crossbeams to the inside of the hexagon, using the Frame 90° bracket. See [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}) for the parts and the method — prepare and attach them as needed.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p>Attach the six B/H spokes and their Frame crossbeams to the inside of the hexagon, using the Frame 90° bracket. See <a href="{{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}">Attaching the hexagonal frame's spokes</a> for the parts and the method.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-complete-top-full-f9b0a154d84b.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
+    <figcaption>A pre-made hexagon, with all six spokes and crossbeams fitted.</figcaption>
+  </figure>
+</div>
 
 <div class="callout">
   <p>If you are currently building the interface layer, stop here and return to the interface layer guide.</p>

--- a/docs/src/content/hardware/helpers/hex-frame-spokes.md
+++ b/docs/src/content/hardware/helpers/hex-frame-spokes.md
@@ -1,0 +1,96 @@
+---
+layout: default
+title: Attaching the hexagonal frame's spokes
+type: how-to
+section: hardware
+slug: helper-hex-frame-spokes
+kicker: Helpers — Hexagonal frame spokes
+lede: How the Frame 90° bracket, the B/H spoke and the Frame crossbeam actually go together — friction and alignment nubs, not screws or T-nuts.
+permalink: /hardware/helpers/hex-frame-spokes/
+author: barthel
+contributors: [spencer, brickcyclealice]
+warning: >-
+  **AI-generated, DRAFT.** Written entirely from a Discord conversation — quoted
+  throughout, with links to every message — not from a build, and not checked
+  against a machine. It exists because [Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }})'s
+  step 2, as currently published, instructs the opposite of what Spencer says
+  the design actually is: drilling out the Frame 90° bracket's holes and
+  fastening the spokes with M5 screws and T-nuts. That page has not yet been
+  reconciled with this one. Until it is, treat both as unapproved for this
+  part of the build, and check with barthel or Spencer before following
+  either.
+parts_needed:
+  - part: frame-90deg-bracket
+    qty: 12
+  - part: frame-crossbeam
+    qty: 6
+  - part: ext-2020-bh
+    qty: 6
+---
+
+This covers one part of building a hexagonal frame: attaching the six B/H spokes and their Frame crossbeams to the inside of the outer hexagon ring, using the Frame 90° bracket. It does not cover the outer ring itself (the A/G extrusions and External bracket — side, joined with M5 × 16 screws) — nothing here contradicts that part of [Regular layers, step 1]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-1), which this page assumes is already built.
+
+## No screws, no T-nuts, no drilling
+
+Spencer confirmed this directly on 2026-08-26, after a Discord thread had gone the other way and ended up with the parts calculator marking the Frame 90° bracket as broken for a hole that "prints too tight" for an M5 screw:
+
+> "Can we never ever ever put something in the docs that says to mod the part to fix a broken stl"
+> "(Which was not actually broken, it was intentionally designed to avoid nuts"
+> "Those parts dont need any hardware at all"
+> — Spencer, [#balloon-general](https://discord.com/channels/1430279849171222682/1542144753641066616/1542194581125337181) ([2](https://discord.com/channels/1430279849171222682/1542144753641066616/1542194655964434644), [3](https://discord.com/channels/1430279849171222682/1542144753641066616/1542195024031129610))
+
+Asked directly whether that meant *zero* hardware, he confirmed it does, for the Frame 90° bracket and the Frame crossbeam both:
+
+> "They're just resting in there and the nubs align it with aluminum but nothing holds it. I left the holes at the time incase it wasn't sufficient. Lots of holes like that in the machine..."
+> "This entire assembly has no hardware"
+> — Spencer, [#balloon-general](https://discord.com/channels/1430279849171222682/1542144753641066616/1542299893329305701) ([2](https://discord.com/channels/1430279849171222682/1542144753641066616/1542300003501084813))
+
+> "\[Frame crossbeam bolted, or also just sitting there?\]" / "Just sitting. Once the hex is together it holds itself"
+> — BrickCycleAlice and [Spencer, #balloon-general](https://discord.com/channels/1430279849171222682/1542144753641066616/1542316381956087938)
+
+So the holes cast into the Frame 90° bracket are a fallback Spencer left in the model in case the friction fit ever proves insufficient, not a feature the standard build uses. **Do not drill them out, and do not fasten through them with an M5 screw and T-nut as [the current Regular layers page]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-2) says to.**
+
+This is the production part, not a one-off experiment: it traces back to a "hot swap" layer-frame redesign Spencer demoed in [#distribution on 2026-06-04](https://discord.com/channels/1430279849171222682/1437144782819426537/1512229833139159100), built with no screws at all, confirming to mistermcghee that it was a drop-in fastener change for the existing brackets —
+
+> "Yes, I just cant muster the thought of more nuts and screws"
+> — [Spencer, #distribution](https://discord.com/channels/1430279849171222682/1437144782819426537/1512236943960838174)
+
+— and he flagged the same caveat that applies here: fit depends on your own printer and extrusion's T-slot tolerance, tuned at the time to 0.2 mm layers on a Bambu printer. If a slot is too shallow the parts won't grip firmly; that's what the leftover holes are for, as a fallback to a screw and T-nut, not the default.
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Fit the Frame 90° brackets" %}
+
+<div class="img-placeholder">Image coming</div>
+
+Rest 2 Frame 90° brackets against the inner face of one A/G extrusion of your assembled outer hexagon, at the point where a B/H spoke will land. Alignment nubs on the bracket key against the extrusion and hold it in place on their own — there is no screw or T-nut here.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><a href="https://discord.com/channels/1430279849171222682/1542144753641066616/1542316458355195904">Spencer's own note</a> on this: "The 90 deg brackets could probably use a tiny bit more friction, one might fall out when youre handling it before inserting into the outer frame." Handle the half-built frame gently until the spoke and crossbeam below are in and the hexagon is closed.</p>
+</div>
+
+{% include step.html n="2" title="Slide in the spoke and crossbeams" %}
+
+<div class="img-placeholder">Image coming</div>
+
+Slide piece B/H (Spoke / Interface spoke (short)) into the 2 Frame 90° brackets you just placed. It is held the same way, by fit against the brackets, not by a fastener.
+
+Slide a Frame crossbeam into place on the spoke until it is level with the end of the extrusion. It also just sits there; nothing screws it down.
+
+Perform these two steps 2 more times, on every 2nd side of the hexagon, then repeat for the remaining 3 sides, same as [Regular layers, step 2]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-2) currently describes for the sequencing — that part of the existing page isn't in question, only its fasteners are.
+
+{% include step.html n="3" title="Close the hexagon in two halves" %}
+
+Spencer's own assembly tip, worth following exactly:
+
+> "The trick is to do the two halves one at a time and then \[join\] them together. Dont try to make the entire hexagon one piece at a time, you wont be able to get the last one"
+> — [Spencer, #balloon-general](https://discord.com/channels/1430279849171222682/1542144753641066616/1542316707970813993)
+
+Build three spoke assemblies on one half of the hexagon, then the other three on the other half, and only then bring the two halves together. Once the hexagon is closed, the spokes and crossbeams hold themselves in place — "once the hex is together it holds itself."
+
+## What this doesn't settle
+
+- **No photo or video of this method exists yet.** Everything above is reasoned from what Spencer wrote, not from watching it built. If you build one of these and it doesn't hold the way this page describes, say so — the fallback is exactly what the holes are for: an M5 screw into a T-nut on the long side, matching what the old instructions said.
+- **The outer hexagon ring (A/G + External bracket — side) is unaffected.** Its M5 × 16 self-tap / T-nut screws are a different part and a different joint; nothing here changes that step.
+- **[Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) and [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) both still describe the old drill-and-fasten method**, with a video and several photos of it, and their parts lists still count M5 × 12 screws and T-nuts for this joint. None of that has been reconciled with this page yet.

--- a/docs/src/content/hardware/helpers/hex-frame-spokes.md
+++ b/docs/src/content/hardware/helpers/hex-frame-spokes.md
@@ -10,8 +10,9 @@ permalink: /hardware/helpers/hex-frame-spokes/
 author: barthel
 contributors: [spencer, brickcyclealice]
 warning: >-
-  **AI-generated, DRAFT.** Written from a Discord conversation, not from a
-  build, and not checked against a machine.
+  **AI-generated first draft.** Written from a Discord conversation, not
+  from an actual build. No step here has been checked against a machine.
+  Correct it as you build.
 parts_needed:
   - part: frame-90deg-bracket
     qty: 12

--- a/docs/src/content/hardware/helpers/hex-frame-spokes.md
+++ b/docs/src/content/hardware/helpers/hex-frame-spokes.md
@@ -5,20 +5,13 @@ type: how-to
 section: hardware
 slug: helper-hex-frame-spokes
 kicker: Helpers — Hexagonal frame spokes
-lede: How the Frame 90° bracket, the B/H spoke and the Frame crossbeam actually go together — friction and alignment nubs, not screws or T-nuts.
+lede: Fitting the Frame 90° bracket, the B/H spoke and the Frame crossbeam inside the hexagon ring — friction and alignment nubs, no fasteners.
 permalink: /hardware/helpers/hex-frame-spokes/
 author: barthel
 contributors: [spencer, brickcyclealice]
 warning: >-
-  **AI-generated, DRAFT.** Written entirely from a Discord conversation — quoted
-  throughout, with links to every message — not from a build, and not checked
-  against a machine. It exists because [Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }})'s
-  step 2, as currently published, instructs the opposite of what Spencer says
-  the design actually is: drilling out the Frame 90° bracket's holes and
-  fastening the spokes with M5 screws and T-nuts. That page has not yet been
-  reconciled with this one. Until it is, treat both as unapproved for this
-  part of the build, and check with barthel or Spencer before following
-  either.
+  **AI-generated, DRAFT.** Written from a Discord conversation, not from a
+  build, and not checked against a machine.
 parts_needed:
   - part: frame-90deg-bracket
     qty: 12
@@ -28,69 +21,29 @@ parts_needed:
     qty: 6
 ---
 
-This covers one part of building a hexagonal frame: attaching the six B/H spokes and their Frame crossbeams to the inside of the outer hexagon ring, using the Frame 90° bracket. It does not cover the outer ring itself (the A/G extrusions and External bracket — side, joined with M5 × 16 screws) — nothing here contradicts that part of [Regular layers, step 1]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-1), which this page assumes is already built.
-
-## No screws, no T-nuts, no drilling
-
-Spencer confirmed this directly on 2026-08-26, after a Discord thread had gone the other way and ended up with the parts calculator marking the Frame 90° bracket as broken for a hole that "prints too tight" for an M5 screw:
-
-> "Can we never ever ever put something in the docs that says to mod the part to fix a broken stl"
-> "(Which was not actually broken, it was intentionally designed to avoid nuts"
-> "Those parts dont need any hardware at all"
-> — Spencer, [#balloon-general](https://discord.com/channels/1430279849171222682/1542144753641066616/1542194581125337181) ([2](https://discord.com/channels/1430279849171222682/1542144753641066616/1542194655964434644), [3](https://discord.com/channels/1430279849171222682/1542144753641066616/1542195024031129610))
-
-Asked directly whether that meant *zero* hardware, he confirmed it does, for the Frame 90° bracket and the Frame crossbeam both:
-
-> "They're just resting in there and the nubs align it with aluminum but nothing holds it. I left the holes at the time incase it wasn't sufficient. Lots of holes like that in the machine..."
-> "This entire assembly has no hardware"
-> — Spencer, [#balloon-general](https://discord.com/channels/1430279849171222682/1542144753641066616/1542299893329305701) ([2](https://discord.com/channels/1430279849171222682/1542144753641066616/1542300003501084813))
-
-> "\[Frame crossbeam bolted, or also just sitting there?\]" / "Just sitting. Once the hex is together it holds itself"
-> — BrickCycleAlice and [Spencer, #balloon-general](https://discord.com/channels/1430279849171222682/1542144753641066616/1542316381956087938)
-
-So the holes cast into the Frame 90° bracket are a fallback Spencer left in the model in case the friction fit ever proves insufficient, not a feature the standard build uses. **Do not drill them out, and do not fasten through them with an M5 screw and T-nut as [the current Regular layers page]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-2) says to.**
-
-This is the production part, not a one-off experiment: it traces back to a "hot swap" layer-frame redesign Spencer demoed in [#distribution on 2026-06-04](https://discord.com/channels/1430279849171222682/1437144782819426537/1512229833139159100), built with no screws at all, confirming to mistermcghee that it was a drop-in fastener change for the existing brackets —
-
-> "Yes, I just cant muster the thought of more nuts and screws"
-> — [Spencer, #distribution](https://discord.com/channels/1430279849171222682/1437144782819426537/1512236943960838174)
-
-— and he flagged the same caveat that applies here: fit depends on your own printer and extrusion's T-slot tolerance, tuned at the time to 0.2 mm layers on a Bambu printer. If a slot is too shallow the parts won't grip firmly; that's what the leftover holes are for, as a fallback to a screw and T-nut, not the default.
-
-{% include fastener-legend.html %}
+This covers attaching the six B/H spokes and their Frame crossbeams to the inside of the outer hexagon ring, using the Frame 90° bracket. It does not cover the outer ring itself (the A/G extrusions and External bracket — side), see [Regular layers, step 1]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-1).
 
 {% include step.html n="1" title="Fit the Frame 90° brackets" %}
 
 <div class="img-placeholder">Image coming</div>
 
-Rest 2 Frame 90° brackets against the inner face of one A/G extrusion of your assembled outer hexagon, at the point where a B/H spoke will land. Alignment nubs on the bracket key against the extrusion and hold it in place on their own — there is no screw or T-nut here.
+Rest 2 Frame 90° brackets against the inner face of one A/G extrusion of your assembled outer hexagon, at the point where a B/H spoke will land. Alignment nubs on the bracket key against the extrusion and hold it in place on their own.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><a href="https://discord.com/channels/1430279849171222682/1542144753641066616/1542316458355195904">Spencer's own note</a> on this: "The 90 deg brackets could probably use a tiny bit more friction, one might fall out when youre handling it before inserting into the outer frame." Handle the half-built frame gently until the spoke and crossbeam below are in and the hexagon is closed.</p>
+  <p>The brackets can sit loosely before the rest of the frame is built up around them — handle the half-built frame gently until the spoke and crossbeam below are in and the hexagon is closed.</p>
 </div>
 
 {% include step.html n="2" title="Slide in the spoke and crossbeams" %}
 
 <div class="img-placeholder">Image coming</div>
 
-Slide piece B/H (Spoke / Interface spoke (short)) into the 2 Frame 90° brackets you just placed. It is held the same way, by fit against the brackets, not by a fastener.
+Slide piece B/H (Spoke / Interface spoke (short)) into the 2 Frame 90° brackets you just placed.
 
-Slide a Frame crossbeam into place on the spoke until it is level with the end of the extrusion. It also just sits there; nothing screws it down.
+Slide a Frame crossbeam into place on the spoke until it is level with the end of the extrusion.
 
-Perform these two steps 2 more times, on every 2nd side of the hexagon, then repeat for the remaining 3 sides, same as [Regular layers, step 2]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-2) currently describes for the sequencing — that part of the existing page isn't in question, only its fasteners are.
+Perform these two steps 2 more times, on every 2nd side of the hexagon, then repeat for the remaining 3 sides.
 
 {% include step.html n="3" title="Close the hexagon in two halves" %}
 
-Spencer's own assembly tip, worth following exactly:
-
-> "The trick is to do the two halves one at a time and then \[join\] them together. Dont try to make the entire hexagon one piece at a time, you wont be able to get the last one"
-> — [Spencer, #balloon-general](https://discord.com/channels/1430279849171222682/1542144753641066616/1542316707970813993)
-
-Build three spoke assemblies on one half of the hexagon, then the other three on the other half, and only then bring the two halves together. Once the hexagon is closed, the spokes and crossbeams hold themselves in place — "once the hex is together it holds itself."
-
-## What this doesn't settle
-
-- **No photo or video of this method exists yet.** Everything above is reasoned from what Spencer wrote, not from watching it built. If you build one of these and it doesn't hold the way this page describes, say so — the fallback is exactly what the holes are for: an M5 screw into a T-nut on the long side, matching what the old instructions said.
-- **The outer hexagon ring (A/G + External bracket — side) is unaffected.** Its M5 × 16 self-tap / T-nut screws are a different part and a different joint; nothing here changes that step.
-- **[Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) and [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) both still describe the old drill-and-fasten method**, with a video and several photos of it, and their parts lists still count M5 × 12 screws and T-nuts for this joint. None of that has been reconciled with this page yet.
+Build three spoke assemblies on one half of the hexagon, then the other three on the other half, and only then bring the two halves together — completing the whole hexagon one side at a time makes the last piece impossible to fit. Once the hexagon is closed, the spokes and crossbeams hold themselves in place.

--- a/docs/src/content/hardware/helpers/index.md
+++ b/docs/src/content/hardware/helpers/index.md
@@ -14,3 +14,4 @@ contributors: [barthel]
 - **[Preparing Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})**
 - **[Prepare timing pulley 20 tooth]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }})**
 - **[Installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }})**
+- **[Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }})**

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -103,6 +103,8 @@ sections:
             url: /hardware/electronics/installation/pico-headers/
           - title: Assembling External bracket
             url: /hardware/helpers/external-bracket/
+          - title: Attaching the hexagonal frame's spokes
+            url: /hardware/helpers/hex-frame-spokes/
       - title: Parts
         url: /hardware/parts/
         children:

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6519,6 +6519,12 @@
       "description": "The frame of one distribution layer: six external brackets, the crossbeams between them, and the 90° brackets. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
+      "joining": [
+        {
+          "method": "friction",
+          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
+        }
+      ],
       "lines": [
         {
           "assembly": "external-bracket",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1448,6 +1448,12 @@
 			"description": "The frame of one distribution layer: six external brackets, the crossbeams between them, and the 90\u00b0 brackets. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
 			"status": "partial",
+			"joining": [
+				{
+					"method": "friction",
+					"note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
+				}
+			],
 			"lines": [
 				{
 					"assembly": "external-bracket",


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1542420374791266415
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542426524177670235
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542428442891386950
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542430696788860958
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542432093450276945
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542433975446937650
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542435822551310346
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542437921733353502
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542438081355845682
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542448914748284958
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542457810057429002
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542459574806642729
request: https://discord.com/channels/1430279849171222682/1542420374791266415/1542461563737219173
preview: /hardware/helpers/hex-frame-spokes
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1542420374791266415): "Create a new page in the documentation (flagged with the AI-generated warning and also marked as DRAFT) that explains how to assemble the hexagonal frame. To do this, use Spencer's instructions regarding the avoidance of screws and T-nuts."

New draft page: `docs/src/content/hardware/helpers/hex-frame-spokes.md`, authored to barthel per the credit convention.

## What it says

Spencer confirmed directly on 2026-08-26, in the `#balloon-general` thread linked in the page, that the Frame 90° bracket and Frame crossbeam sub-assembly (the B/H spokes that go inside the outer hexagon ring) is a deliberate no-hardware design: the bracket rests against the extrusion, held only by alignment nubs, and "This entire assembly has no hardware." The holes cast into the bracket are a fallback in case the friction fit isn't enough on a given print, not a feature the standard build uses. He also confirmed the Frame crossbeam is unfastened ("Just sitting. Once the hex is together it holds itself") and gave an assembly-order tip (build the hexagon as two halves, then join them).

This directly contradicts the **currently published** [Regular layers](https://sorter-v2-docs.pages.dev/hardware/assembly/distribution/bin-frame/regular-layers/) page, step 2, which instructs drilling out the same holes and fastening with M5 × 12 screws into T-nuts. That page, its video, its photos of the drill/screw method, and its parts list are **not touched by this PR** — barthel asked to treat the current docs on this point as unapproved for now, and this page is the corrected draft to review before anything downstream is reconciled. The new page says explicitly, twice, that it hasn't been reconciled with Regular layers or Top interface yet.

## What's NOT in this PR, flagged for barthel separately in Discord

- `regular-layers.md` step 2 (text, video `ULeByfqfVZs`, several photos, and its `parts_needed` fastener counts) still needs rewriting to match, once this draft is reviewed.
- `top-interface.md` shares the same step via "follow the first two stages of a regular layer," so it inherits the same problem.
- Two of my own already-open items are now based on the disproved premise that the bracket is broken: issue #436 and PR #437 (marks it `broken` in the parts calculator) should be closed, and PR #439 (adds the bracket/crossbeam to top-interface's parts list) added an M5 × 12 T-nut-screw count for them that should come back out. Handling those separately from this PR so each stays reviewable on its own.

No photo or video of the corrected method exists yet — the page says so and uses `img-placeholder`s, same convention as other AI-generated-draft pages.



---

Edit (barthel, [from Discord](https://discord.com/channels/1430279849171222682/1542420374791266415/1542426524177670235)): "Please remove the instructions entirely—that is, 'No screws, no T-nuts, no drilling.' Also, limit the description to what is being built, how it is built, and what is needed."

Dropped the whole "No screws, no T-nuts, no drilling" section (the Discord quotes and reasoning) and the "What this doesn't settle" caveats. The page is now just scope, parts needed, and the three build steps.



---

Edit (barthel, [from Discord](https://discord.com/channels/1430279849171222682/1542420374791266415/1542428442891386950)): "Replace step 2 in regular layer completly and add a reference to the hexagon helpers page. Add the hexagon as needed preperation. Lets see, how it looks."

Replaced `regular-layers.md` step 2 entirely: dropped the drill-the-holes instruction, the `ULeByfqfVZs` video, and the nine photos of the screwed spoke assembly, and pointed the step at the new helper page instead. Also added the helper page as a second reference alongside the existing External bracket one, in the page's intro, so it's visible before step 1 too.

Not touched: the page's `parts_needed` fastener counts (`scr-m5-12-shcs`, part of `scr-m5-16-shcs`, `scr-m5-20-shcs`, `tnut-m5-2020`) still include quantities for the old screwed spoke method. Those numbers were already inconsistent with the bin-retainer count before this change (a separate, still-open investigation), so I didn't want to guess at a new total in the same pass — flagging it rather than silently leaving stale numbers unmentioned.



---

Edits (barthel, from Discord): "Use roughly the same AI-generated warning as on other pages, such as the PSU box. It should look similar. Add the 'hexagon' page to the tree under 'helpers'" and, four minutes later, "Add a preperation step with a link to the 'hexagon' page and an image of a pre-made hexagon on the 'Regular Layer' page. Adjust the description for Step 2. Use the same style as on the Top Interface page."

- Reworded the helper page's `warning:` to match the PSU box / Bottom two layers phrasing exactly ("AI-generated first draft... not from an actual build... Correct it as you build.").
- Listed it on `/hardware/helpers/`.
- Turned `regular-layers.md` step 2 into a Preparation block in Top Interface's `prep-item` style (image + text side by side): the link to the helper page, and the "finished hexagon" photo that used to illustrate the end of the old drill-and-screw step, reused here since it still shows the same real, correct end state. Kept it as step 2 rather than inserting a new step 1, since `bottom-two-layers.md` and `external-bracket.md` both link to this page's `#step-3` and `#step-5` by anchor — renumbering would have broken those two pages' cross-links for no benefit.



---

Edit (barthel, from Discord): "This isn't how I envisioned implementing the preparation step. But I'll leave it as is, including the photo. Reuse the old heading from Step 2. Remove the two photos showing the fully assembled outer frame and leave only the photo showing the two halves. Remove the section for the 90-degree brackets, spokes, and cross-beams\u2014including the corresponding number of screws\u2014from the \u201cNeeded Parts\u201d list."\n\n- Step 2's title is back to "Attach the spokes" (kept the Preparation-style content and photo).\n- Step 1 keeps only the two-halves photo; dropped the two photos of the fully assembled outer frame.\n- `parts_needed` no longer lists `frame-90deg-bracket`, `frame-crossbeam` or `ext-2020-bh` \u2014 that\u2019s the helper page\u2019s own list now. Screw/T-nut counts reduced by exactly what the old (removed) step 2 text used: `scr-m5-16-shcs` 36\u219224 (12 were the spoke self-tap screws), `scr-m5-20-shcs` and `scr-m5-12-shcs` dropped entirely (12 each, both were wholly for the crossbeam screw and the frame-90 long-side T-nut screw), `tnut-m5-2020` 36\u219224 (one T-nut per removed M5\u00d712). Math is worked from the exact old step-2 wording, not a guess \u2014 happy to re-check if it doesn\u2019t look right.\n


---

Edit (barthel, from Discord): 'Use "Attatch the hexagonal frame\'s spokes" for step2. The "Assembling the hexagonal frame\'s spokes" side isn\'t available under Helpers nor in the tree.'

- Renamed step 2 to "Attach the hexagonal frame's spokes", matching the helper page's own title.
- Found the real bug behind "not available under Helpers nor in the tree": the sidebar nav is a separate manifest, `docs/src/liquid/_data/nav.yml`, from the `/hardware/helpers/` landing page's own body list. I'd only updated the landing page's bullet list in an earlier commit and missed the nav tree entirely. Added it there too, same title/URL as `external-bracket`'s existing entry.



---

Edit (barthel, from Discord): "Check the bottom two layers to see if there are any remnants of the 90-degree bracket, crossbeam, extrusion B, or the screws and T-nuts used for them. Remove these remnants and also double-check that the side for the hexagonal spokes is accessible or used, either directly or indirectly via references in the build text."

`bottom-two-layers.md` had the same remnants as `regular-layers.md` did (it borrows regular layers steps 1+2, doubled for two layers): removed `frame-90deg-bracket`, `frame-crossbeam` and `ext-2020-bh` from `parts_needed`. Recomputed the fastener counts from the actual per-step arithmetic rather than halving the old totals -- the old page's own "48 for the two hexagons and their spokes" bullet didn't reconcile against a precise count even before this change (8 M5x16 for the outer ring x2 hexagons = 16, not the 24 you'd get by splitting 48 proportionally), so I used the real number: `scr-m5-16-shcs` 96->64, `scr-m5-12-shcs` 72->48, `scr-m5-20-shcs` removed entirely (was 100% crossbeams), `tnut-m5-2020` 72->48.

Reachability check: `bottom-two-layers.md` step 2 now links to the helper page directly, on top of the existing indirect path (it already says "work through regular layers steps 1 and 2," and regular-layers step 2 links to the helper). Checked `top-interface.md` too -- it says "follow the first two stages of a regular layer," so it's indirectly reachable the same way; it has no frame-90/crossbeam remnants on `main` to remove (that fix is a separate, still-open PR, #439).



---

Edit (barthel, from Discord): "What's about the top interface page and the part calculator?"

Two separate things this covers:

- **Top interface** (docs) has the same fix as regular-layers and bottom-two-layers, pushed to its own PR (#439, since that's where the missing-brackets bug was already being tracked): dropped `frame-90deg-bracket`, `frame-crossbeam` and `ext-2020-bh` from its `parts_needed`, linked the helper page directly.
- **The parts calculator**: its `layer-frame` assembly (and `interface`, in #439) never actually carried screw lines for the Frame 90 bracket/crossbeam -- that fastener data only ever lived in the docs pages' own hand-maintained `parts_needed`, which is now cleaned up. So there was nothing broken to fix in the catalog itself, but it also said nothing about WHY there's no hardware there. Added a `joining` note to both assemblies (`method: "friction"`, a value the schema already supports), same pattern as `external-bracket`'s existing self-tap note, so the calculator states the design intent rather than silently having zero fasteners.



---

Edit (barthel, from Discord): "Is it a good idea to describe here how to build the outer hexagon using the external brackets and how to connect the two elements (the inner and outer hexagons)?"

Answered no to duplicating the outer-ring build here: it's fully documented on Regular layers step 1 with its own photos and video, and External bracket is the dedicated helper for those three parts. Copying it into this page would just create two places that can drift out of sync, which is exactly what a helper page is for avoiding. Did add the connection itself, since that genuinely wasn't explicit: a new opening paragraph frames the frame as two nested hexagons (outer ring, inner spoke ring) and states that the Frame 90 bracket is the connection, resting against the outer ring's A/G extrusion -- one paragraph, no procedure duplicated.



---

Edit (barthel, from Discord): "Okay. But where does it explain HOW the two elements ... are assembled? Especially since the assembled inner hexagon is very difficult to take apart again?"

The order was already there but implicit across two pages, not stated as an order with a reason: build the outer ring and close it completely (Regular layers step 1), then build the inner spoke ring directly onto that already-closed ring (this page). Added a callout on step 3 ("Close the hexagon in two halves") naming the actual risk barthel raised: no screw to back out once it's closed, so check every bracket/spoke/crossbeam on both halves before joining them, and make sure the outer ring is finished and correct first.



---

Edit (barthel, from Discord, in German): doubted the "close the hexagon in two halves" step, asking whether the two halves (of both the spokes and the outer ring) should be built and joined together, and whether the previous framing would even work geometrically.

He's right to doubt it. Step 2's inherited "every 2nd side, then remaining 3" sequence depended on the Frame 90 bracket being loosely attached and tightened afterward for clearance -- a mechanism that doesn't exist for a friction-fit bracket, so it may not transfer. My own step 3 "two halves" claim, extrapolated from one ambiguous Spencer quote, also directly conflicts with this page's premise that the outer ring is already fully closed before spoke work starts. Retracted the confident claim; step 3 now flags both candidate approaches and why neither is verified, rather than asserting an untested technique on a joint with no screw to undo it. Tagged Spencer in Discord for the real answer, since this is a genuine mechanical question, not something resolvable from the existing conversation.
