### PR TITLE
parts-calculator: scope #403 clamp-standoff notice to the cable-mount bracket

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -300,7 +300,6 @@
       "targets": {
         "parts": [
           "ribbon-cable-clamp",
-          "interface-cage-bracket",
           "interface-cage-bracket-cable"
         ],
         "assemblies": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -314,7 +314,6 @@
 			"targets": {
 				"parts": [
 					"ribbon-cable-clamp",
-					"interface-cage-bracket",
 					"interface-cage-bracket-cable"
 				],
 				"assemblies": [


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1542490133784428684
preview: /changes
-->
`interface-cage-bracket` (RESZ, the plain "Cable cage bracket") only has the
M3 heat-insert bore; the post the ribbon cable clamp hooks onto is on
`interface-cage-bracket-cable` (CY58, "Cable cage bracket (cable mount)").
Removes RESZ from the `fix-ribbon-cable-clamp-standoffs` P1 entry's targets so
the notice only shows on CY58.

`catalog.generated.json`'s `changes` array is a verbatim copy of
`parts.json`'s (`generate.py` line 1047/1229), so this edits both directly.
Running the full `catalog/generate.py --metadata-only` currently crashes with
`NameError: name 'rebased_render' is not defined` on unrelated part versions
(a leftover call site from #418's cleanup, reproduces on clean `main` too) —
worth a look separately, not fixed here since `generate.py` isn't mine to
touch. Verified the two files' `changes` arrays are byte-identical after this
edit and `scripts/check_generated_pins.py` passes.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1542490133784428684): "Remove P1 problem marker regarding to #403 from Cable cage bracket (RESZ) because this problem is only valid for Cable cage bracket (cable mount) (CY58)"
