### PR TITLE
docs: add renders for the hex-frame-spokes helper page's three steps

### DIFF
--- a/docs/src/content/hardware/helpers/hex-frame-spokes.md
+++ b/docs/src/content/hardware/helpers/hex-frame-spokes.md
@@ -26,7 +26,10 @@ This covers attaching the six B/H spokes and their Frame crossbeams to the insid
 
 {% include step.html n="1" title="Fit the Frame 90° brackets" %}
 
-<div class="img-placeholder">Image coming</div>
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-spokes-step1-brackets-full-d113bfec9db7.png" alt="Rendering of two Frame 90 degree brackets, in blue, resting against a grey A/G extrusion, before a spoke is inserted between them">
+  <figcaption>Rendering, not a photo: two Frame 90&deg; brackets (blue) resting against the A/G extrusion (grey), at the point where a spoke will land. The gap between the two brackets is where the spoke goes in Step 2. Colours are only to tell the parts apart and this has not been checked against a machine.</figcaption>
+</figure>
 
 Rest 2 Frame 90° brackets against the inner face of one A/G extrusion of your assembled outer hexagon, at the point where a B/H spoke will land. Alignment nubs on the bracket key against the extrusion and hold it in place on their own.
 
@@ -37,7 +40,10 @@ Rest 2 Frame 90° brackets against the inner face of one A/G extrusion of your a
 
 {% include step.html n="2" title="Slide in the spoke and crossbeams" %}
 
-<div class="img-placeholder">Image coming</div>
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-spokes-step2-spoke-crossbeam-full-ad9eceb2df9e.png" alt="Rendering of a B/H spoke, in tan, slid into the two Frame 90 degree brackets on the A/G extrusion, with a Frame crossbeam, in orange, seated on the spoke's tip">
+  <figcaption>Rendering, not a photo: the B/H spoke (tan) slid down into the two Frame 90&deg; brackets (blue) on the A/G extrusion (grey), with a Frame crossbeam (orange) seated on the spoke's tip. The crossbeam's far end (off-frame here) lands on the matching spoke on the next side of the hexagon. Not checked against a machine.</figcaption>
+</figure>
 
 Slide piece B/H (Spoke / Interface spoke (short)) into the 2 Frame 90° brackets you just placed.
 
@@ -46,5 +52,10 @@ Slide a Frame crossbeam into place on the spoke until it is level with the end o
 Perform these two steps 2 more times, on every 2nd side of the hexagon, then repeat for the remaining 3 sides.
 
 {% include step.html n="3" title="Close the hexagon in two halves" %}
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-spokes-step3-seated-full-e773cefada2b.png" alt="The same single-spoke section, extrusion, brackets, spoke and crossbeam, seen from the opposite side once fully seated">
+  <figcaption>The same single-spoke section seen from the other side once everything is seated. Nothing in this joint is screwed or T-nutted — it holds by friction and the alignment nubs alone.</figcaption>
+</figure>
 
 Build three spoke assemblies on one half of the hexagon, then the other three on the other half, and only then bring the two halves together — completing the whole hexagon one side at a time makes the last piece impossible to fit. Once the hexagon is closed, the spokes and crossbeams hold themselves in place.


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1542507177615425536
preview: /hardware/helpers/hex-frame-spokes
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1542507177615425536): "Create renderings for the "Attaching the Hexagonal Frame's Spokes" documentation that correspond to each step, illustrate that step, and can temporarily replace the missing images. It is sufficient to show only the section of a single spoke and its connected parts in each rendering. Use a viewing angle that clearly distinguishes the individual elements."

## What this does

Fills the two "Image coming" placeholders on `hardware/helpers/hex-frame-spokes.md` (steps 1 and 2) and adds a third image for step 3, which had no placeholder at all. Each is a colour-coded render of just one spoke's worth of hardware, not the whole hexagon, per the request:

- **Step 1** — the A/G extrusion (grey) and the two Frame 90° brackets (blue), before the spoke is inserted.
- **Step 2** — the same plus the B/H spoke (tan) slid into the brackets and a Frame crossbeam (orange) seated on its tip.
- **Step 3** — the same closed sub-assembly, seen from the other side once seated.

## How these were made

Downloaded the real `frame-90deg-bracket` and `frame-crossbeam` STLs off the parts bucket (both already used for the geometric analysis in the same page's Discord thread earlier today) and rendered them with `parts-calculator/scripts/meshfig.py`, extended with a per-part colour so each element reads apart at a glance. The A/G extrusion and B/H spoke have no STL in the catalog (they're generic 2020 cut-to-length extrusion), so those are drawn as plain 20x20mm boxes at their real cut lengths.

**Placement is approximate, not a verified assembly.** There's no shared-assembly-frame export for these four parts to mate them exactly, so the bracket and crossbeam sit at measured, plausible positions against the extrusion/spoke rather than at exact CAD contact points. That's consistent with the page's own existing warning ("written from a Discord conversation, not from an actual build. No step here has been checked against a machine.") — these renders are illustrative, not a substitute for a real photo once one exists.

Uploaded to the asset service under `sorter-parts` (my token's `sorter-docs` scope is still 403, same workaround as every other docs image this month — see sorter-v2#408). All three URLs are live and pass `docs/scripts/validate_images.py`. Built the full docs site locally (Node 20) and confirmed the page renders with all three images in place and no leftover placeholders.