### PR TITLE
docs: bin-frame reorg — hex frame, bottom interface, top interface

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -117,6 +117,28 @@ pages are rendered through liquidjs at build time. Includes live in
   ```
 - **Placeholder** for a not-yet-supplied image: `<div class="img-placeholder">Image coming</div>`
   (standalone, or inside an `img-row` `<figure>`).
+- **Required pre-built component** (a page needs something assembled on
+  another page before it can start, e.g. "build a hex frame first"): a bold
+  sentence naming and linking the prerequisite, next to a photo of the
+  finished thing, using `prep-item` — the same layout the Preparation step
+  uses for a part-plus-photo row, but it works standalone anywhere in the
+  page, not just inside a step.
+  ```html
+  <div class="prep-item">
+    <div class="prep-item-body">
+      <p><strong>Build a <a href="…">thing</a> before you start.</strong> One sentence on why/where.</p>
+    </div>
+    <figure class="prep-item-figure">
+      <img class="doc-figure" src="…" alt="…">
+      <figcaption>Caption. <cite>Photo: whoever.</cite></figcaption>
+    </figure>
+  </div>
+  ```
+  See `assembly/distribution/bin-frame/bottom-interface.md` for the pattern
+  in place. Don't invent a `parts_needed` entry for the prerequisite itself —
+  `resolveParts()` only resolves real catalog parts (STL/vendor data), not an
+  assembly built across several of those, so a sub-assembly like this always
+  gets linked in prose, never listed as a part.
 - **Callout:** neutral, or `callout-warning` (amber). Use for warnings/notes
   that belong in the flow of a step, NOT in the parts catalog.
   ```html

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -40,6 +40,8 @@ parts_needed:
     qty: 6
 ---
 
+**Build a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) before you start.** It's a required component of this page, not optional or covered here — step 4 bolts onto one, it doesn't build one.
+
 The parts list above is only the Lazy Susan bearing stack and the extrusion mounts added in step 4; the hex frame itself is [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})'s own parts list, built ordinary and unmodified. The fasteners and quantities below are called out inline at each step.
 
 {% include fastener-legend.html %}

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -12,11 +12,7 @@ contributors: [abrianbaker, brickcyclealice, barthel]
 warning: >-
   **Reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
   instead of describing frame construction inline, not yet reviewed by a
-  builder.** Steps 1-3 (the Lazy Susan bearing stack) are unchanged. Step 4
-  now points at that page for an ordinary, unmodified hex frame; the Lazy
-  Susan extrusion mounts bolt directly onto 3 of its already-built spokes
-  rather than replacing anything, and only the parts specific to that
-  addition are listed below. Correct it as you build.
+  builder.** Correct it as you build.
 parts_needed:
   - part: brg-lazy-susan
     qty: 1

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -13,8 +13,10 @@ warning: >-
   **Reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
   instead of describing frame construction inline, not yet reviewed by a
   builder.** Steps 1-3 (the Lazy Susan bearing stack) are unchanged. Step 4
-  now points at that page for the hex frame itself; only the parts specific
-  to this page's substitution are listed below. Correct it as you build.
+  now points at that page for an ordinary, unmodified hex frame; the Lazy
+  Susan extrusion mounts bolt directly onto 3 of its already-built spokes
+  rather than replacing anything, and only the parts specific to that
+  addition are listed below. Correct it as you build.
 parts_needed:
   - part: brg-lazy-susan
     qty: 1
@@ -32,15 +34,13 @@ parts_needed:
     qty: 8
   - part: scr-m4-12-cs
     qty: 8
-  - part: ext-2020-bh
-    qty: 3
   - part: scr-m5-16-shcs
     qty: 9
   - part: tnut-m5-2020
     qty: 6
 ---
 
-The parts list above is only the Lazy Susan bearing stack and the extrusion-mount substitution in step 4; the hex frame itself (outer ring and the other 3 ordinary spoke positions) is [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})'s own parts list. The fasteners and quantities below are called out inline at each step.
+The parts list above is only the Lazy Susan bearing stack and the extrusion mounts added in step 4; the hex frame itself is [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})'s own parts list, built ordinary and unmodified. The fasteners and quantities below are called out inline at each step.
 
 {% include fastener-legend.html %}
 
@@ -201,24 +201,18 @@ The bearing stack is now complete:
 
 {% include step.html n="4" title="Prepare the frame" %}
 
-The bottom interface's frame is a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) with a substitution: at **3 of its 6 spoke positions, alternating around the ring**, a Lazy Susan extrusion mount pair replaces the ordinary Frame 90° bracket + B/H spoke + Frame crossbeam combination. Build the outer ring (hex frame step 1) and the other 3 spoke positions (hex frame steps 2-4) exactly as that page describes; the rest of this step covers only the 3 substituted positions.
+The bottom interface's frame is an ordinary [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}), built exactly as that page describes with no changes. Once it's built, a Lazy Susan extrusion mount pair bolts directly onto 3 of its spokes, alternating around the ring, on top of the spoke's existing Frame 90° bracket and crossbeam rather than replacing anything.
 
 Three Lazy Susan extrusion mounts carry the bearing assembly's weight; a hold in place bolts to each one first, as a pair, before either touches the extrusion. **They don't fix the chute itself**, that's attached up at the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}).
 
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-w1600-06391df95795.jpg" alt="A Lazy Susan extrusion mount and a Lazy Susan hold in place bolted together, forming a grey wedge with a triangular window through its web and two counterbored holes along its bottom face">
-    <figcaption>Mount and hold in place, bolted together. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-on-2020-w1600-36f5200925fd.jpg" alt="The same pair with a length of 2020 aluminum extrusion seated in the channel along its sloped edge">
-    <figcaption>Seated on its length of 2020. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-  </figure>
-</div>
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-step4-extrusion-mount-w1600-06391df95795.jpg" alt="A Lazy Susan extrusion mount and a Lazy Susan hold in place bolted together, forming a grey wedge with a triangular window through its web and two counterbored holes along its bottom face">
+  <figcaption>Mount and hold in place, bolted together. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
 
 The screw between the extrusion mount and the hold in place is an {% include fastener.html size="M5" variant="socket" length="16" %}.
 
-Each mount then bolts to the spoke through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion:
+Each mount then bolts directly onto the B/H spoke (158mm) already in place in the hex frame, through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion:
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-step4-extrusion-mount-bolt-holes-full-9104e9681f61.jpg" alt="The end of a Lazy Susan extrusion mount seated on a length of 2020 extrusion, with two screws visible in counterbored holes bolting it down">
@@ -238,11 +232,4 @@ That's two {% include fastener.html size="M5" variant="socket" length="16" %} sc
   </figure>
 </div>
 
-The mounts fix to **piece B/H (Spoke, 158mm)**, the same cut any hex frame uses, standing in for three of the frame's six spokes rather than adding new pieces. Cut lengths are on the [framing cut list](https://parts-calculator.basically.website/framing).
-
-You end this step with four separate pieces: the bearing stack from steps 1-3, and three mount pairs each on their own length of extrusion. The mounts go on with the frame in [bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}); the bearing stack takes the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}).
-
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-step4-four-pieces-complete-full-b63f796f63e6.jpg" alt="Four finished pieces laid out: the assembled bearing stack in the centre, and three Lazy Susan extrusion mounts each on a length of extrusion around it">
-  <figcaption>What you have at the end of this step. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-</figure>
+You end this step with two pieces: the bearing stack from steps 1-3, and the hex frame with its three Lazy Susan extrusion mounts now bolted onto alternating spokes. The frame goes on in [bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}); the bearing stack takes the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}).

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -8,7 +8,13 @@ kicker: Bin frame — Bottom interface
 lede: The component the chute rests on top of.
 permalink: /hardware/assembly/distribution/bin-frame/bottom-interface/
 author: spencer
-contributors: [abrianbaker, brickcyclealice]
+contributors: [abrianbaker, brickcyclealice, barthel]
+warning: >-
+  **Reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
+  instead of describing frame construction inline, not yet reviewed by a
+  builder.** Steps 1-3 (the Lazy Susan bearing stack) are unchanged. Step 4
+  now points at that page for the hex frame itself; only the parts specific
+  to this page's substitution are listed below. Correct it as you build.
 parts_needed:
   - part: brg-lazy-susan
     qty: 1
@@ -34,7 +40,7 @@ parts_needed:
     qty: 6
 ---
 
-The fasteners and quantities in the parts list are called out inline at each step.
+The parts list above is only the Lazy Susan bearing stack and the extrusion-mount substitution in step 4; the hex frame itself (outer ring and the other 3 ordinary spoke positions) is [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})'s own parts list. The fasteners and quantities below are called out inline at each step.
 
 {% include fastener-legend.html %}
 
@@ -195,6 +201,8 @@ The bearing stack is now complete:
 
 {% include step.html n="4" title="Prepare the frame" %}
 
+The bottom interface's frame is a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) with a substitution: at **3 of its 6 spoke positions, alternating around the ring**, a Lazy Susan extrusion mount pair replaces the ordinary Frame 90° bracket + B/H spoke + Frame crossbeam combination. Build the outer ring (hex frame step 1) and the other 3 spoke positions (hex frame steps 2-4) exactly as that page describes; the rest of this step covers only the 3 substituted positions.
+
 Three Lazy Susan extrusion mounts carry the bearing assembly's weight; a hold in place bolts to each one first, as a pair, before either touches the extrusion. **They don't fix the chute itself**, that's attached up at the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}).
 
 <div class="img-row">
@@ -230,7 +238,7 @@ That's two {% include fastener.html size="M5" variant="socket" length="16" %} sc
   </figure>
 </div>
 
-The mounts fix to **piece B/H (Spoke)**, the same 158 mm cut a regular layer uses, standing in for three of that layer's six spokes rather than adding new pieces. Cut lengths are on the [framing cut list](https://parts-calculator.basically.website/framing).
+The mounts fix to **piece B/H (Spoke, 158mm)**, the same cut any hex frame uses, standing in for three of the frame's six spokes rather than adding new pieces. Cut lengths are on the [framing cut list](https://parts-calculator.basically.website/framing).
 
 You end this step with four separate pieces: the bearing stack from steps 1-3, and three mount pairs each on their own length of extrusion. The mounts go on with the frame in [bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}); the bearing stack takes the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}).
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -40,7 +40,15 @@ parts_needed:
     qty: 6
 ---
 
-**Build a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) before you start.** It's a required component of this page, not optional or covered here — step 4 bolts onto one, it doesn't build one.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Build a <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}">hex frame</a> before you start.</strong> It's a required component of this page, not optional or covered here — step 4 bolts onto one, it doesn't build one.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-finished-top-down-full-c6abfb4dad6e.jpg" alt="A finished hex frame from above, the alternating grey spoke and teal crossbeam pieces forming the inner ring inside the aluminum outer hexagon">
+    <figcaption>A finished hex frame. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 The parts list above is only the Lazy Susan bearing stack and the extrusion mounts added in step 4; the hex frame itself is [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})'s own parts list, built ordinary and unmodified. The fasteners and quantities below are called out inline at each step.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -214,14 +214,9 @@ Three Lazy Susan extrusion mounts carry the bearing assembly's weight; a hold in
 
 The screw between the extrusion mount and the hold in place is an {% include fastener.html size="M5" variant="socket" length="16" %}.
 
-Each mount then bolts directly onto the B/H spoke (158mm) already in place in the hex frame, through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion:
+Each mount then bolts directly onto the B/H spoke (158mm) already in place in the hex frame, through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion.
 
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-step4-extrusion-mount-bolt-holes-full-9104e9681f61.jpg" alt="The end of a Lazy Susan extrusion mount seated on a length of 2020 extrusion, with two screws visible in counterbored holes bolting it down">
-  <figcaption>The two bolt holes that connect the mount to the spoke. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-</figure>
-
-That's two {% include fastener.html size="M5" variant="socket" length="16" %} screws per mount, 6 more on top of the 3 between mount and hold in place. Mount order around the ring isn't recorded.
+That's two {% include fastener.html size="M5" variant="socket" length="16" %} screws per mount, 6 more on top of the 3 between mount and hold in place.
 
 <div class="img-row">
   <figure>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -66,7 +66,15 @@ Everything else about these two layers is the same as any other. Build each one 
 
 The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece D. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
 
-**Build the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) before you start.** It is step 1 of the bin frame and it mounts to this frame with three Lazy Susan extrusion mounts, each on an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw into a {% include fastener.html size="M5" variant="t-nut" text="T-nut" %}. Getting T-nuts into an extrusion that already has both layers built around it is the kind of job you only do once.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Build the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> before you start.</strong> It is step 1 of the bin frame and it mounts to this frame with three Lazy Susan extrusion mounts, each on an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw into a {% include fastener.html size="M5" variant="t-nut" text="T-nut" %}. Getting T-nuts into an extrusion that already has both layers built around it is the kind of job you only do once.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-mounted-in-frame-full-476d171d148e.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
+    <figcaption>The bottom interface, mounted into a frame.</figcaption>
+  </figure>
+</div>
 
 {% include fastener-legend.html %}
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -10,16 +10,19 @@ permalink: /hardware/assembly/distribution/bin-frame/bottom-two-layers/
 author: spencer
 contributors: [brickcyclealice, christoph]
 warning: >-
-  **AI-generated first draft.** Written from the [framing cut
-  list](https://parts-calculator.basically.website/framing), the machine assembly tree in the
-  [parts calculator](https://parts-calculator.basically.website/assembly?focus=layer-frame) and
-  photos of finished machines in the Discord, not from an actual build. No step here has been
-  checked against a machine. The fastener counts are derived from Regular layers rather than
-  measured, the tally under step 1 shows the arithmetic, and one count is genuinely unknown.
-  Correct it as you build.
+  **AI-generated first draft, reorganized to reference [Build the hex
+  frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
+  instead of Regular layers' old steps 1-2.** No step here has been checked
+  against a machine. `ext-bracket-left` and `ext-2020-ag` were removed from
+  the parts list since they're now the hex frame page's own parts (2 frames'
+  worth); `tnut-m5-2020` was removed too since its 48 exactly matched 2
+  hex frames' own bin-retainer-prep T-nuts (2 × 24) and nothing here needs
+  more beyond that, but this hasn't been re-verified against a build.
+  `scr-m5-16-shcs` dropped from 64 to 48, removing the 16 that were the two
+  hex frames' own outer-ring screws. The fastener counts are derived from
+  Regular layers rather than measured, the tally under step 1 shows the
+  arithmetic, and one count is genuinely unknown. Correct it as you build.
 parts_needed:
-  - part: ext-bracket-left
-    qty: 12
   - part: ext-bracket-cover
     qty: 6
   - part: ext-bracket-bottom-vertical
@@ -30,8 +33,6 @@ parts_needed:
     qty: 12
   - part: bin-retainer-right
     qty: 12
-  - part: ext-2020-ag
-    qty: 12
   - part: ext-2020-d
     qty: 6
   - part: foot-connector-2020-m6
@@ -39,10 +40,8 @@ parts_needed:
   - part: caster-wheel-m6
     qty: 6
   - part: scr-m5-16-shcs
-    qty: 64
-  - part: scr-m5-12-shcs
     qty: 48
-  - part: tnut-m5-2020
+  - part: scr-m5-12-shcs
     qty: 48
 ---
 
@@ -55,7 +54,9 @@ The bottom two layers are two ordinary bin layers built at the same time, becaus
 
 Everything else about these two layers is the same as any other. Build each one with the [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) guide and come back here for the parts that differ, which are only the verticals, the corners at floor level, and the feet.
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and D. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
+**Build two [hex frames]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) before you start**, one for each layer. They're required components of this page, not covered here.
+
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece D. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
 
 **Build the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) before you start.** It is step 1 of the bin frame and it mounts to this frame with three Lazy Susan extrusion mounts, each on an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw into a {% include fastener.html size="M5" variant="t-nut" text="T-nut" %}. Getting T-nuts into an extrusion that already has both layers built around it is the kind of job you only do once.
 
@@ -71,26 +72,21 @@ Cut the extrusion first. These two layers use **6 × piece D (Foot extension), 2
   <p>D is 1.5 × a single layer's vertical support, not 2 ×, so the bottom layer sits about half a layer's height off the floor.</p>
 </div>
 
-Where the {% include fastener.html size="M5" variant="socket-button" length="16" %} count in the parts list comes from, since nobody has counted these off a built machine:
+Where the {% include fastener.html size="M5" variant="socket-button" length="16" %} count in the parts list comes from, since nobody has counted these off a built machine (the two hex frames' own outer-ring screws are on that page's own list, not counted here):
 
-- **16** for the two hexagons' outer rings, which is [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 1 done twice
 - **24** for the foot extensions, 4 per corner (step 3 below), two into each layer
 - **12** for the second layer's External bracket — bottom verticals, 2 per corner (step 4 below)
 - **12** for the bottom layer's External bracket - foot covers, 2 per corner (step 4 below), the same as the bottom vertical it replaces
 
 The {% include fastener.html size="M5" variant="socket-button" length="12" %} count is the same arithmetic: **24** per layer for the bin retainers, so **48** across both.
 
-{% include step.html n="2" title="Build two layer frames" %}
+{% include step.html n="2" title="Start from two hex frames" %}
 
-Work through [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) steps 1 and 2 twice, once per layer: the hexagon of six A/G extrusions in six External bracket — sides, then the six B/H spokes on their Frame 90° brackets with a Frame crossbeam each side — see [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}) for the parts and the method.
-
-**Stop before that guide's step 3 (Install the verticals).** The verticals are the part that differs here, and they are step 3 below.
-
-If you are using slide-in T-nuts, put them in as that guide says. The ends of the extrusion are no more accessible on these two layers than on any other.
+You should already have two [hex frames]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) built, one for each layer. The verticals are the part that differs here, and they are step 3 below.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Put the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a>'s three T-nuts into this frame now, while the extrusion is still open. Three Lazy Susan extrusion mounts each take one {% include fastener.html size="M5" variant="socket-button" length="16" %} into a {% include fastener.html size="M5" variant="t-nut" text="T-nut" %}, and once both layers are built around the extrusion a slide-in T-nut has nowhere to go in.</p>
+  <p>This callout predates the hex frame reorg and hasn't been re-checked against it: put the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a>'s three T-nuts into this frame now, while the extrusion is still open. Three Lazy Susan extrusion mounts each take one {% include fastener.html size="M5" variant="socket-button" length="16" %} into a {% include fastener.html size="M5" variant="t-nut" text="T-nut" %}, and once both layers are built around the extrusion a slide-in T-nut has nowhere to go in. But bottom-interface.md now says those mounts bolt onto <em>its own</em> hex frame's spokes, not onto this page's extrusion — this note may be describing a mounting relationship that no longer holds. Flagged, not resolved.</p>
 </div>
 
 {% include step.html n="3" title="Run the foot extensions through both layers" %}
@@ -144,7 +140,7 @@ The numbers on the drawing:
   <li><strong>Piece D</strong>, 231 mm cut. It runs from below the bottom layer, through that layer's collar, and up to 3 mm below the flange face of the second layer's collar, replacing a piece C in each of the two layers.</li>
   <li class="key-screw"><strong>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws per collar</strong> clamp the bracket onto piece D, at the bottom layer and again at the second layer. Same screws, same holes as on a regular layer.</li>
   <li class="key-note"><strong>The exposed end of piece D</strong>, which takes the 2020 M6 foot connector and the caster. On the lengths as drawn it stands about 54 mm below the foot cover, but how far it should protrude is not recorded anywhere, so hold a foot connector against the end before you tighten the corner screws.</li>
-  <li><strong>The second layer's collar</strong>, with its External bracket — bottom vertical below it. From here up, every joint is the ordinary layer joint described in <a href="{{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-5">regular layers, step 5</a>.</li>
+  <li><strong>The second layer's collar</strong>, with its External bracket — bottom vertical below it. From here up, every joint is the ordinary layer joint described in <a href="{{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-3">regular layers, step 3</a>.</li>
 </ol>
 
 The two layers are now one rigid unit and their spacing is set by the bracket positions, not by anything you have to measure.
@@ -155,7 +151,7 @@ The bottom layer does not get an External bracket — bottom vertical or an Exte
 
 The foot cover fastens the same way the bottom vertical it replaces would: 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes into the External bracket — side. Mount it before the extrusion goes in, at the same point as the second layer's cover in step 3.
 
-The second layer's corners are ordinary, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 3: an External bracket — bottom vertical slid onto piece D with its angles aligned at the bottom, 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes.
+The second layer's corners are ordinary, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 1: an External bracket — bottom vertical slid onto piece D with its angles aligned at the bottom, 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes.
 
 {% include step.html n="5" title="Fit the feet" %}
 
@@ -170,7 +166,7 @@ Screw a **swivel stem caster (M6 × 15 mm)** into the connector's M6 thread. The
 
 {% include step.html n="6" title="Add the bin retainers" %}
 
-Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 4: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into T-nuts.
+Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 2: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into T-nuts.
 
 ## What comes next
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -13,21 +13,7 @@ warning: >-
   **AI-generated first draft, reorganized to reference [Build the hex
   frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
   instead of Regular layers' old steps 1-2.** No step here has been checked
-  against a machine. `ext-bracket-left` and `ext-2020-ag` were removed from
-  the parts list since they're now the hex frame page's own parts (2 frames'
-  worth); `tnut-m5-2020` was removed too since its 48 exactly matched 2
-  hex frames' own bin-retainer-prep T-nuts (2 × 24) and nothing here needs
-  more beyond that, but this hasn't been re-verified against a build.
-  `scr-m5-16-shcs` dropped from 64 to 48, removing the 16 that were the two
-  hex frames' own outer-ring screws. Steps renumbered again after folding
-  the old "Start from two hex frames" step (which had shrunk to one
-  sentence plus a warning) into step 1; the rest shifted down by one. The
-  fastener counts are derived from Regular layers rather than measured, the
-  tally under step 1 shows the arithmetic, and one count is genuinely
-  unknown. Added step 6, "Attach the bottom interface", as a placeholder —
-  it's the missing joint between this page and bottom-interface.md, not
-  written yet since the physical mechanism isn't confirmed. Correct it as
-  you build.
+  against a machine. Correct it as you build.
 parts_needed:
   - part: ext-bracket-cover
     qty: 6

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -54,7 +54,15 @@ The bottom two layers are two ordinary bin layers built at the same time, becaus
 
 Everything else about these two layers is the same as any other. Build each one with the [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) guide and come back here for the parts that differ, which are only the verticals, the corners at floor level, and the feet.
 
-**Build two [hex frames]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) before you start**, one for each layer. They're required components of this page, not covered here.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Build two <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}">hex frames</a> before you start</strong>, one for each layer. They're required components of this page, not covered here.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-finished-top-down-full-c6abfb4dad6e.jpg" alt="A finished hex frame from above, the alternating grey spoke and teal crossbeam pieces forming the inner ring inside the aluminum outer hexagon">
+    <figcaption>A finished hex frame. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece D. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -19,9 +19,12 @@ warning: >-
   hex frames' own bin-retainer-prep T-nuts (2 × 24) and nothing here needs
   more beyond that, but this hasn't been re-verified against a build.
   `scr-m5-16-shcs` dropped from 64 to 48, removing the 16 that were the two
-  hex frames' own outer-ring screws. The fastener counts are derived from
-  Regular layers rather than measured, the tally under step 1 shows the
-  arithmetic, and one count is genuinely unknown. Correct it as you build.
+  hex frames' own outer-ring screws. Steps renumbered again after folding
+  the old "Start from two hex frames" step (which had shrunk to one
+  sentence plus a warning) into step 1; the rest shifted down by one. The
+  fastener counts are derived from Regular layers rather than measured, the
+  tally under step 1 shows the arithmetic, and one count is genuinely
+  unknown. Correct it as you build.
 parts_needed:
   - part: ext-bracket-cover
     qty: 6
@@ -68,7 +71,7 @@ The aluminum extrusion is cut to length; the [framing cut list](https://parts-ca
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Build the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> before you start.</strong> It is step 1 of the bin frame and it mounts to this frame with three Lazy Susan extrusion mounts, each on an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw into a {% include fastener.html size="M5" variant="t-nut" text="T-nut" %}. Getting T-nuts into an extrusion that already has both layers built around it is the kind of job you only do once.</p>
+    <p><strong>Build the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> before you start.</strong> It mounts to this frame with three Lazy Susan extrusion mounts, each on an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw into a {% include fastener.html size="M5" variant="t-nut" text="T-nut" %}. Getting T-nuts into an extrusion that already has both layers built around it is the kind of job you only do once.</p>
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-mounted-in-frame-full-476d171d148e.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
@@ -90,22 +93,20 @@ Cut the extrusion first. These two layers use **6 × piece D (Foot extension), 2
 
 Where the {% include fastener.html size="M5" variant="socket-button" length="16" %} count in the parts list comes from, since nobody has counted these off a built machine (the two hex frames' own outer-ring screws are on that page's own list, not counted here):
 
-- **24** for the foot extensions, 4 per corner (step 3 below), two into each layer
-- **12** for the second layer's External bracket — bottom verticals, 2 per corner (step 4 below)
-- **12** for the bottom layer's External bracket - foot covers, 2 per corner (step 4 below), the same as the bottom vertical it replaces
+- **24** for the foot extensions, 4 per corner (step 2 below), two into each layer
+- **12** for the second layer's External bracket — bottom verticals, 2 per corner (step 3 below)
+- **12** for the bottom layer's External bracket - foot covers, 2 per corner (step 3 below), the same as the bottom vertical it replaces
 
 The {% include fastener.html size="M5" variant="socket-button" length="12" %} count is the same arithmetic: **24** per layer for the bin retainers, so **48** across both.
 
-{% include step.html n="2" title="Start from two hex frames" %}
-
-You should already have two [hex frames]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) built, one for each layer. The verticals are the part that differs here, and they are step 3 below.
+You should already have two [hex frames]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) built, one for each layer. The verticals are the part that differs here, and they are step 2 below.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p>This callout predates the hex frame reorg and hasn't been re-checked against it: put the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a>'s three T-nuts into this frame now, while the extrusion is still open. Three Lazy Susan extrusion mounts each take one {% include fastener.html size="M5" variant="socket-button" length="16" %} into a {% include fastener.html size="M5" variant="t-nut" text="T-nut" %}, and once both layers are built around the extrusion a slide-in T-nut has nowhere to go in. But bottom-interface.md now says those mounts bolt onto <em>its own</em> hex frame's spokes, not onto this page's extrusion — this note may be describing a mounting relationship that no longer holds. Flagged, not resolved.</p>
 </div>
 
-{% include step.html n="3" title="Run the foot extensions through both layers" %}
+{% include step.html n="2" title="Run the foot extensions through both layers" %}
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-two-layers-c-and-d-extrusion-w1600-71a8f20c58c5.jpg" alt="The bottom corner of a built machine, with the C layer vertical support marked between the second and third frames and the longer D foot extension marked running from the caster up past the bottom frame to the second">
@@ -139,7 +140,7 @@ On each of the six corners, working on the second layer first:
   </figure>
 </div>
 
-Let the bottom end of piece D stand proud of the bottom layer's corner rather than sitting flush with it: the foot connector bolts into that exposed end, and the External bracket - foot cover in step 4 is deliberately shorter than an ordinary cover so the extrusion pops out far enough to take it.
+Let the bottom end of piece D stand proud of the bottom layer's corner rather than sitting flush with it: the foot connector bolts into that exposed end, and the External bracket - foot cover in step 3 is deliberately shorter than an ordinary cover so the extrusion pops out far enough to take it.
 
 <figure class="figure-float-right">
   <a href="https://assets.basically.website/sorter-docs/assembly-bottom-two-layers-foot-corner-section-full-6ec3353ee6cf.png" target="_blank" rel="noopener">
@@ -161,15 +162,15 @@ The numbers on the drawing:
 
 The two layers are now one rigid unit and their spacing is set by the bracket positions, not by anything you have to measure.
 
-{% include step.html n="4" title="Close off the corners at floor level" %}
+{% include step.html n="3" title="Close off the corners at floor level" %}
 
-The bottom layer does not get an External bracket — bottom vertical or an External bracket — cover. It gets an **External bracket - foot cover** instead, one per corner, which is the single printed part that replaces both of them. It is shorter than the pair it replaces, on purpose, so the extrusion stands out past it far enough for the foot connector in step 5.
+The bottom layer does not get an External bracket — bottom vertical or an External bracket — cover. It gets an **External bracket - foot cover** instead, one per corner, which is the single printed part that replaces both of them. It is shorter than the pair it replaces, on purpose, so the extrusion stands out past it far enough for the foot connector in step 4.
 
-The foot cover fastens the same way the bottom vertical it replaces would: 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes into the External bracket — side. Mount it before the extrusion goes in, at the same point as the second layer's cover in step 3.
+The foot cover fastens the same way the bottom vertical it replaces would: 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes into the External bracket — side. Mount it before the extrusion goes in, at the same point as the second layer's cover in step 2.
 
 The second layer's corners are ordinary, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 1: an External bracket — bottom vertical slid onto piece D with its angles aligned at the bottom, 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes.
 
-{% include step.html n="5" title="Fit the feet" %}
+{% include step.html n="4" title="Fit the feet" %}
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -180,7 +181,7 @@ Bolt a **2020 M6 foot connector** into the open bottom end of each piece D. The 
 
 Screw a **swivel stem caster (M6 × 15 mm)** into the connector's M6 thread. The casters have brakes; leave them on while you build.
 
-{% include step.html n="6" title="Add the bin retainers" %}
+{% include step.html n="5" title="Add the bin retainers" %}
 
 Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 2: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into T-nuts.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -24,7 +24,10 @@ warning: >-
   sentence plus a warning) into step 1; the rest shifted down by one. The
   fastener counts are derived from Regular layers rather than measured, the
   tally under step 1 shows the arithmetic, and one count is genuinely
-  unknown. Correct it as you build.
+  unknown. Added step 6, "Attach the bottom interface", as a placeholder —
+  it's the missing joint between this page and bottom-interface.md, not
+  written yet since the physical mechanism isn't confirmed. Correct it as
+  you build.
 parts_needed:
   - part: ext-bracket-cover
     qty: 6
@@ -185,8 +188,16 @@ Screw a **swivel stem caster (M6 × 15 mm)** into the connector's M6 thread. The
 
 Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 2: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into T-nuts.
 
+{% include step.html n="6" title="Attach the bottom interface" %}
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>Not written yet — this step is a placeholder.</strong> Build the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> separately, then it joins the bottom of this frame here, but the physical mechanism isn't confirmed: whether it shares piece D's legs with this stack or connects some other way, and how that reconciles with the T-nut note under step 1. Needs a builder to confirm before this step can be written for real.</p>
+</div>
+
+<div class="img-placeholder">Image coming</div>
+
 ## What comes next
 
 - Each of these two layers takes a [chute]({{ '/hardware/assembly/distribution/chute/' | relative_url }}), the same as any other layer.
 - Above them, build N−2 [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) for an N-layer machine.
-- The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) mounts to this frame on its three extrusion mounts.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -31,14 +31,14 @@ parts_needed:
   - part: scr-m5-16-shcs
     qty: 8
   - part: tnut-m5-2020
-    qty: 8
+    qty: 24
 ---
 
 This guide builds one hexagonal frame: the outer ring of A/G extrusion and External bracket — side, with the six B/H spokes and Frame crossbeams held inside it by the Frame 90° brackets. No fasteners are used from step 2 onward — the spokes, crossbeams and brackets are a friction-and-slide fit, no screws or T-nuts.
 
 An N-layer machine needs **N + 1 of these**: one per planned layer, plus one for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) and one for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}).
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions. Each frame uses 6 A/G (320mm) and 6 B/H (158mm).
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions. Each frame uses 6 A/G (320mm) and 6 B/H (158mm). The 24 T-nuts in the list above aren't used by anything in this guide — they're pre-installed in step 1 while the extrusion ends are still accessible, for the bin retainers a later page attaches to the outer ring.
 
 {% include fastener-legend.html %}
 
@@ -57,7 +57,7 @@ The aluminum extrusion is cut to length; the [framing cut list](https://parts-ca
 
 Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side, bracing it against the extrusion. If you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes to fasten into them instead.
 
-If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2 into the innermost section of the extrusion and 4 into the outermost section before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
+If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 4 into the outermost section of the extrusion before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
 
 <figure class="video-figure">
   <div class="video-embed video-embed-wide">
@@ -71,16 +71,15 @@ If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2
   <figcaption><cite>Video: zed0.</cite></figcaption>
 </figure>
 
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-tnut-holes-w1600-b5863688aeea.png" alt="Side view of an A/G extrusion showing the row of holes where T-nuts sit and the screws pass through">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-into-bracket-w1600-1cd20074b56c.png" alt="An A/G extrusion sliding into an External bracket — side">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Only the 4 outer T-nuts per extrusion are needed, for the bin retainers added on a later page. The video also shows 2 inner T-nuts partway along the extrusion — skip those, they're no longer necessary.</p>
 </div>
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-tnut-holes-w1600-b5863688aeea.png" alt="Side view of an A/G extrusion showing the row of holes where T-nuts sit and the screws pass through">
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
+</figure>
 
 Repeat these steps to make two semi-circles of three sections of A/G extrusion (320mm) and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -1,0 +1,177 @@
+---
+layout: default
+title: Build the hex frame
+type: how-to
+section: hardware
+slug: assembly-hex-frame
+kicker: Bin frame — Build the hex frame
+lede: The hexagonal aluminum-and-bracket ring shared by every layer. Build one per planned layer, plus one for the bottom interface and one for the top interface.
+permalink: /hardware/assembly/distribution/bin-frame/hex-frame/
+author: barthel
+contributors: [brickcyclealice, zed0]
+warning: >-
+  **Reorganized from a Discord build walkthrough, not yet reviewed by a
+  builder.** Step 1 is carried over unchanged from Regular layers. Steps 2
+  onward are BrickCycleAlice's own screw-free construction method,
+  transcribed from her build photos, replacing the old
+  [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }})
+  helper page's untested method. This page has not been checked step-by-step
+  against a build. Correct it as you go.
+parts_needed:
+  - part: ext-2020-ag
+    qty: 6
+  - part: ext-bracket-left
+    qty: 6
+  - part: ext-2020-bh
+    qty: 6
+  - part: frame-crossbeam
+    qty: 6
+  - part: frame-90deg-bracket
+    qty: 12
+  - part: scr-m5-16-shcs
+    qty: 8
+  - part: tnut-m5-2020
+    qty: 8
+---
+
+This guide builds one hexagonal frame: the outer ring of A/G extrusion and External bracket — side, with the six B/H spokes and Frame crossbeams held inside it by the Frame 90° brackets. No fasteners are used from step 2 onward — the spokes, crossbeams and brackets are a friction-and-slide fit, no screws or T-nuts.
+
+An N-layer machine needs **N + 1 of these**: one per planned layer, plus one for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) and one for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}).
+
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions. Each frame uses 6 A/G (320mm) and 6 B/H (158mm).
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Assemble the outer ring" %}
+
+<div class="img-row">
+  <figure>
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-w1600-a47ad55fb797.png" alt="Two A/G aluminum extrusions meeting at an External bracket — side, forming one corner of the hexagon">
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
+  </figure>
+  <figure>
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-angled-w1600-6265c41bbf5f.png" alt="Angled view of the same corner joint, showing the fasteners along the extrusion">
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
+  </figure>
+</div>
+
+Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side, bracing it against the extrusion. If you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes to fasten into them instead.
+
+If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2 into the innermost section of the extrusion and 4 into the outermost section before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
+
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/LWruBv-fMz4"
+      title="Assembling the frame brackets"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
+
+<div class="img-row">
+  <figure>
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-tnut-holes-w1600-b5863688aeea.png" alt="Side view of an A/G extrusion showing the row of holes where T-nuts sit and the screws pass through">
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
+  </figure>
+  <figure>
+    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-into-bracket-w1600-1cd20074b56c.png" alt="An A/G extrusion sliding into an External bracket — side">
+    <figcaption><cite>Photo: zed0.</cite></figcaption>
+  </figure>
+</div>
+
+Repeat these steps to make two semi-circles of three sections of A/G extrusion (320mm) and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-two-half-hexagons-full-5e7c0f80f57f.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
+</figure>
+
+Set the ring aside; it goes on last, in step 5.
+
+{% include step.html n="2" title="Slide a spoke and crossbeam together" %}
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-spoke-crossbeam-slide-full-dbf46c1f9948.jpg" alt="A grey B/H spoke and a teal Frame crossbeam slid together over a length of aluminum extrusion, the crossbeam upside down">
+  <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+This part of the build has no hardware at all — every joint from here is a slide-in fit. It's a little fiddly, and a second pair of hands helps, but it's doable solo. Until the whole hexagon of spokes is closed the parts can feel loose and want to fall out with a small bump; once it's all together it's stable.
+
+Slide a B/H spoke (158mm) and a Frame crossbeam together. For easy assembly, start with the crossbeam **upside down**.
+
+{% include step.html n="3" title="Continue around the hexagon" %}
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-ring-nearly-closed-full-e0399f3e9cf2.jpg" alt="Five spoke-and-crossbeam joints forming most of a hexagon, one B/H spoke and its extrusion still sitting loose at the open side">
+    <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+Repeat step 2 around the hexagon until you have used **6 Frame crossbeams and 5 B/H spokes (158mm)**. Deliberately hold the 6th spoke back — it closes the loop later, in step 7.
+
+{% include step.html n="4" title="Fit 10 of the 12 Frame 90° brackets" %}
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-brackets-ten-on-full-377acf718d17.jpg" alt="The near-complete spoke ring with a Frame 90 degree bracket pair at five of the six spoke junctions, two spare brackets and the loose spoke sitting at the open sixth junction"><figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-bracket-seating-closeup-full-ebd9a6cd0532.jpg" alt="Close-up of a Frame 90 degree bracket's short leg seated on the spoke extrusion and its long leg reaching out toward where the outer ring will sit">
+    <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+At each of the 5 closed spoke junctions, slide a pair of Frame 90° brackets on: the **short leg onto the spoke**, the **long leg facing outward**. Use 10 brackets for now — hold the last 2 back for the 6th junction, closed in step 7.
+
+{% include step.html n="5" title="Fit the outer ring" %}
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-outer-ring-dropped-on-full-acf8eb045b56.jpg" alt="The outer aluminum hexagon ring from step 1 dropped over the spoke assembly, mostly seated with one corner still proud">
+    <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-bracket-leg-in-extrusion-closeup-full-7f60da969225.jpg" alt="Close-up of a Frame 90 degree bracket's long leg slotted into the T-slot channel of the A/G extrusion">
+    <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+Grab the outer hexagon ring you set aside in step 1 and place it over the top of the spoke assembly. Wiggle it and apply outward pressure until all 10 long legs of the Frame 90° brackets are slotted into the T-slot channel of the A/G extrusion (320mm) — this is a slide fit, not a screw.
+
+{% include step.html n="6" title="Flip the frame" %}
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-flipped-full-c10c5444b41b.jpg" alt="The assembled frame flipped over, held together with outward pressure on the brackets">
+  <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+While holding the brackets in the ring, flip the whole assembly over — outward pressure on the brackets helps keep everything seated as you do. This is not just a change of viewing angle: the spoke assembly flips relative to the outer ring. Once flipped, the frame is the right way up for the finished build. (It's flipped again later, when it's actually attached to the machine — not relevant at this stage.)
+
+{% include step.html n="7" title="Close the ring" %}
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-closing-final-joint-full-0ca2fb7b60c0.jpg" alt="Close-up of the final spoke joint closing, with the last two Frame 90 degree brackets going onto the corner">
+  <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+Slide the final B/H spoke (158mm) in from the top to close the ring, then fit the last 2 Frame 90° brackets at that junction.
+
+{% include step.html n="8" title="Check and snug every joint" %}
+
+Double-check that every Frame 90° bracket is still fully seated in its slot. A light hammer tap on each bracket, from the inside of the ring toward the outside, helps snug all the connections.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-finished-top-down-full-c6abfb4dad6e.jpg" alt="A finished hex frame from above, the alternating grey spoke and teal crossbeam pieces forming the inner ring inside the aluminum outer hexagon">
+  <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+A hex frame is now complete. Build as many as your machine needs (see the note at the top of this page), then move on to [Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}), [Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}), [Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) or [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) to turn one into the layer you need.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>The fastener counts above cover step 1 only (the outer ring). This page hasn't yet been reconciled against the parts calculator's assembly groupings, which don't currently line up with hex-frame-first construction — see the open discussion in Discord before treating the totals here as final.</p>
+</div>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -168,5 +168,5 @@ A hex frame is now complete. Build as many as your machine needs (see the note a
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>The fastener counts above cover step 1 only (the outer ring). This page hasn't yet been reconciled against the parts calculator's assembly groupings, which don't currently line up with hex-frame-first construction — see the open discussion in Discord before treating the totals here as final.</p>
+  <p>The fastener counts above are the complete per-frame total: 8 screws and 24 T-nuts, all from step 1 — steps 2-8 use no fasteners at all. Regular layers and bottom two layers reuse these 24 T-nuts for their bin retainers rather than listing their own, so don't double them up in a shopping list. This page still hasn't been reconciled against the parts calculator's assembly groupings, which don't currently line up with hex-frame-first construction — see the open discussion in Discord before treating that side as final.</p>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -11,12 +11,8 @@ author: barthel
 contributors: [brickcyclealice, zed0]
 warning: >-
   **Reorganized from a Discord build walkthrough, not yet reviewed by a
-  builder.** Step 1 is carried over unchanged from Regular layers. Steps 2
-  onward are BrickCycleAlice's own screw-free construction method,
-  transcribed from her build photos, replacing the old
-  [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }})
-  helper page's untested method. This page has not been checked step-by-step
-  against a build. Correct it as you go.
+  builder.** This page has not been checked step-by-step against a build.
+  Correct it as you go.
 parts_needed:
   - part: ext-2020-ag
     qty: 6

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
@@ -10,6 +10,7 @@ permalink: /hardware/assembly/distribution/bin-frame/
 author: spencer
 ---
 
-1. **[Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }})** — the base the frame builds up from.
-2. **[Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }})** — the paired base layers on the long vertical extrusions.
-3. **[Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }})** — build N−2 of these, one per remaining layer.
+1. **[Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})** — the shared hexagonal ring. Build N+1 of these first: one per planned layer, plus one each for the bottom and top interface.
+2. **[Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }})** — the base the frame builds up from.
+3. **[Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }})** — the paired base layers on the long vertical extrusions.
+4. **[Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }})** — build N−2 of these, one per remaining layer.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -13,11 +13,7 @@ warning: >-
   **Reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
   instead of describing frame construction inline, not yet reviewed by a
   builder.** The old steps 1-2 (outer ring, spokes) are gone; build a hex
-  frame on that page first. Steps below are renumbered — old step 3 is now
-  1, old step 4 is now 2, old step 5 is now 3. `ext-bracket-left` and
-  `ext-2020-ag` were removed from the parts list since they're now the hex
-  frame page's own parts; the fastener totals here have not been re-split.
-  Correct it as you build.
+  frame on that page first. Correct it as you build.
 parts_needed:
   - part: ext-bracket-cover
     qty: 6

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -92,7 +92,16 @@ Matching parts from the same print run are embossed with a shared set code (e.g.
 
 On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
 
-A regular layer is now complete. You will also need to construct a [Chute core]({{ '/hardware/assembly/distribution/chute/' | relative_url }}) for each layer you build.
+A regular layer is now complete.
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>You will also need to construct a <a href="{{ '/hardware/assembly/distribution/chute/' | relative_url }}">Chute core</a> for each layer you build.</strong> Not covered on this page.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
 
 {% include step.html n="3" title="Join the layer to the one below" %}
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -37,7 +37,15 @@ parts_needed:
 
 This guide covers creating a regular layer. It's also the basis for creating the top and bottom layers, so build N−2 of these for an N-layer machine (the [bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}) are covered separately).
 
-**Build a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) before you start.** It's a required component of this page, not covered here.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Build a <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}">hex frame</a> before you start.</strong> It's a required component of this page, not covered here.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-finished-top-down-full-c6abfb4dad6e.jpg" alt="A finished hex frame from above, the alternating grey spoke and teal crossbeam pieces forming the inner ring inside the aluminum outer hexagon">
+    <figcaption>A finished hex frame. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -9,9 +9,16 @@ lede: The repeating bin layers above the base. Build N−2 for an N-layer machin
 permalink: /hardware/assembly/distribution/bin-frame/regular-layers/
 author: zed0
 contributors: [brickcyclealice, barthel]
+warning: >-
+  **Reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
+  instead of describing frame construction inline, not yet reviewed by a
+  builder.** The old steps 1-2 (outer ring, spokes) are gone; build a hex
+  frame on that page first. Steps below are renumbered — old step 3 is now
+  1, old step 4 is now 2, old step 5 is now 3. `ext-bracket-left` and
+  `ext-2020-ag` were removed from the parts list since they're now the hex
+  frame page's own parts; the fastener totals here have not been re-split.
+  Correct it as you build.
 parts_needed:
-  - part: ext-bracket-left
-    qty: 6
   - part: ext-bracket-cover
     qty: 6
   - part: ext-bracket-bottom-vertical
@@ -19,8 +26,6 @@ parts_needed:
   - part: bin-retainer-left
     qty: 6
   - part: bin-retainer-right
-    qty: 6
-  - part: ext-2020-ag
     qty: 6
   - part: ext-2020-c
     qty: 6
@@ -32,78 +37,15 @@ parts_needed:
 
 This guide covers creating a regular layer. It's also the basis for creating the top and bottom layers, so build N−2 of these for an N-layer machine (the [bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}) are covered separately).
 
-Note that some of the ordering in this guide may seem unusual, but it's written this way to avoid both putting unnecessary strain on pieces, and allowing for the use of slide-in T-nuts.
+**Build a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) before you start.** It's a required component of this page, not covered here.
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for pieces A/G, B/H and C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
 
-See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | relative_url }}) for a look at the three bracket parts on their own, and [Attaching the hexagonal frame's spokes]({{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}) for how the Frame 90° bracket, B/H spoke and Frame crossbeam are prepared and attached as needed.
+See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | relative_url }}) for a look at the three bracket parts on their own.
 
 {% include fastener-legend.html %}
 
-{% include step.html n="1" title="Assemble the frame brackets" %}
-
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-w1600-a47ad55fb797.png" alt="Two A/G aluminum extrusions meeting at an External bracket — side, forming one corner of the hexagon">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-frame-corner-joint-angled-w1600-6265c41bbf5f.png" alt="Angled view of the same corner joint, showing the fasteners along the extrusion">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-</div>
-
-Slide piece A/G (Outer horizontal / Horizontal interface frame) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side, bracing it against the extrusion. If you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes to fasten into them instead.
-
-If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 2 into the innermost section of the extrusion and 4 into the outermost section before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
-
-<figure class="video-figure">
-  <div class="video-embed video-embed-wide">
-    <iframe
-      src="https://www.youtube.com/embed/LWruBv-fMz4"
-      title="Assembling the frame brackets"
-      allow="encrypted-media; picture-in-picture; web-share"
-      allowfullscreen
-      loading="lazy"></iframe>
-  </div>
-  <figcaption><cite>Video: zed0.</cite></figcaption>
-</figure>
-
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-tnut-holes-w1600-b5863688aeea.png" alt="Side view of an A/G extrusion showing the row of holes where T-nuts sit and the screws pass through">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-docs/assembly-regular-layers-extrusion-into-bracket-w1600-1cd20074b56c.png" alt="An A/G extrusion sliding into an External bracket — side">
-    <figcaption><cite>Photo: zed0.</cite></figcaption>
-  </figure>
-</div>
-
-Repeat these steps to make two semi-circles of three sections of extrusion and three External bracket — sides, then slot the two half-hexagons together into a full hexagon and secure it with 2 more {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Joining in this manner, rather than working your way around the hexagon, prevents having to force the brackets into awkward angles.
-
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-two-half-hexagons-full-5e7c0f80f57f.png" alt="Two three-section half-hexagons laid out before being joined into a full hexagon">
-  <figcaption><cite>Photo: zed0.</cite></figcaption>
-</figure>
-
-{% include step.html n="2" title="Attach the hexagonal frame's spokes" %}
-
-<div class="prep-item">
-  <div class="prep-item-body">
-    <p>Attach the six B/H spokes and their Frame crossbeams to the inside of the hexagon, using the Frame 90° bracket. See <a href="{{ '/hardware/helpers/hex-frame-spokes/' | relative_url }}">Attaching the hexagonal frame's spokes</a> for the parts and the method.</p>
-  </div>
-  <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-spokes-complete-top-full-f9b0a154d84b.png" alt="Top-down view of the finished hexagon with all six spokes and crossbeams forming the central ring">
-    <figcaption>A pre-made hexagon, with all six spokes and crossbeams fitted.</figcaption>
-  </figure>
-</div>
-
-<div class="callout">
-  <p>If you are currently building the interface layer, stop here and return to the interface layer guide.</p>
-</div>
-
-{% include step.html n="3" title="Install the verticals" %}
+{% include step.html n="1" title="Install the verticals" %}
 
 <div class="img-row">
   <figure>
@@ -133,7 +75,7 @@ On each corner, slide an External bracket — bottom vertical onto piece C (Laye
 
 Matching parts from the same print run are embossed with a shared set code (e.g. **"b2"**) on both the External bracket — side and the External bracket — bottom vertical. Keep marked pairs together so brackets don't get mixed across corners.
 
-{% include step.html n="4" title="Add the bin retainers" %}
+{% include step.html n="2" title="Add the bin retainers" %}
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-bin-retainers-installed-w1600-31bf32089e71.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
@@ -144,7 +86,7 @@ On each side of the hexagon, attach both the Bin retainer (left) and Bin retaine
 
 A regular layer is now complete. You will also need to construct a [Chute core]({{ '/hardware/assembly/distribution/chute/' | relative_url }}) for each layer you build.
 
-{% include step.html n="5" title="Join the layer to the one below" %}
+{% include step.html n="3" title="Join the layer to the one below" %}
 
 <figure class="figure-float-right">
   <a href="https://assets.basically.website/sorter-docs/assembly-regular-layers-layer-joint-section-full-71e3c366f4e7.png" target="_blank" rel="noopener">

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -26,8 +26,8 @@ parts_needed:
   - part: ext-2020-c
     qty: 6
   - part: scr-m5-16-shcs
-    qty: 24
-  - part: tnut-m5-2020
+    qty: 36
+  - part: scr-m5-12-shcs
     qty: 24
 ---
 
@@ -43,7 +43,7 @@ This guide covers creating a regular layer. It's also the basis for creating the
   </figure>
 </div>
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. The number of {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} listed above is the minimum you'll need if you thread the printed parts directly wherever possible; this number increases if you use T-nuts throughout instead.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. This page needs no {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} of its own: the bin retainers in step 2 use the 4 T-nuts per A/G extrusion that [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) already pre-installs for exactly this purpose.
 
 See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | relative_url }}) for a look at the three bracket parts on their own.
 
@@ -86,7 +86,7 @@ Matching parts from the same print run are embossed with a shared set code (e.g.
   <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
-On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws, either into the T-nuts already installed there or with drop-in / roll-in T-nuts.
+On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front side of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into the T-nuts your hex frame already has installed there.
 
 A regular layer is now complete.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -150,7 +150,7 @@ parts_needed:
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Have the Cable cage top laser-cut and ready by step 10, and the Cable cage bottom by step 12.</strong> Same as the Top plate: laser-cut ahead of time, not built on this page.</p>
+    <p><strong>Have the <a href="https://parts-calculator.basically.website/lasercut">Cable cage top</a> laser-cut and ready by step 10, and the Cable cage bottom by step 12.</strong> Same as the Top plate: laser-cut ahead of time, not built on this page.</p>
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -221,8 +221,8 @@ Before assembling anything, press the heat inserts into the parts that take them
     <p><strong>Interface bracket:</strong> 3 × M5 (each of the 6)</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-interface-bracket-inserts-full-ab1f495c0778.png" alt="An Interface bracket held up, showing three brass M5 heat inserts: one on each long side and one on the tail end">
-    <figcaption>One M5 on each long side and one on the tail end.</figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/top-interface-prep-interface-bracket-inserts-full-799264fe5508.jpg" alt="An Interface bracket held up, showing three brass M5 heat inserts: one near the top boss, one in the middle of the channel, and one at the bottom end">
+    <figcaption>One M5 on each long side and one on the tail end, including the one in the channel that's easy to miss. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -185,7 +185,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-upper-fixed-section-inserts-full-ful-4f73af3a5587.png" alt="The Interface upper fixed section ring, underside with the NEMA 23 bracket attached, showing four brass M4 heat inserts around its face">
-    <figcaption>Underside, with the NEMA 23 bracket attached.</figcaption>
+    <figcaption>Underside, with the NEMA 23 bracket attached. <cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -196,7 +196,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-nema23-inserts-full-5fda8f6ef8c0.png" alt="The Interface NEMA 23 bracket held up, showing four brass M5 inserts on the top edges and one M3 insert on the long tail">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-nema23-inserts-underside-full-97cf1ce3e1b0.png" alt="The underside of the Interface NEMA 23 bracket, showing the two remaining brass M5 heat inserts">
-    <figcaption>Top: four M5 on the edges and one M3 on the tail. Underside: the two remaining M5.</figcaption>
+    <figcaption>Top: four M5 on the edges and one M3 on the tail. Underside: the two remaining M5. <cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -207,11 +207,11 @@ Before assembling anything, press the heat inserts into the parts that take them
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-chute-mount-inserts-underside-full-ec67c0262221.png" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
-      <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face.</figcaption>
+      <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. <cite>Photo: zed0.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-chute-mount-inserts-underside-grey-w-52b54ffa44db.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
-      <figcaption>A closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw.</figcaption>
+      <figcaption>A closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw. <cite>Photo: zed0.</cite></figcaption>
     </figure>
   </div>
 </div>
@@ -232,7 +232,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-limit-switch-housing-inserts-grey-w1-ef9cced25713.jpg" alt="The grey Limit switch housing, showing two brass M3 heat inserts on the angled face where the roller lever limit switch mounts, with the dowel pin hole above them">
-    <figcaption>The two M3 inserts, where the roller lever limit switch mounts.</figcaption>
+    <figcaption>The two M3 inserts, where the roller lever limit switch mounts. <cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -242,7 +242,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-limit-switch-hammer-inserts-full-ff286afdd969.png" alt="The Limit switch hammer held up, showing a single brass M3 heat insert in its round disc">
-    <figcaption>One M3 insert in the round disc.</figcaption>
+    <figcaption>One M3 insert in the round disc. <cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 
@@ -252,7 +252,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-cable-cage-bracket-cable-inserts-ful-9188d3883103.png" alt="The Cable cage bracket (cable mount) held up, showing a single brass M3 heat insert">
-    <figcaption>The one M3 insert in the Cable cage bracket (cable mount).</figcaption>
+    <figcaption>The one M3 insert in the Cable cage bracket (cable mount). <cite>Photo: zed0.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -99,7 +99,7 @@ parts_needed:
   - part: scr-m5-20-shcs
     qty: 24
   - part: scr-m5-16-shcs
-    qty: 38
+    qty: 50
   - part: scr-m5-12-shcs
     qty: 4
   - part: scr-m4-12-cs
@@ -117,7 +117,7 @@ parts_needed:
   - part: scr-m3-6-cs
     qty: 1
   - part: tnut-m5-2020
-    qty: 50
+    qty: 56
   - part: nut-m5
     qty: 6
   - part: nut-m3

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -138,6 +138,32 @@ parts_needed:
   </figure>
 </div>
 
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Have the <a href="https://parts-calculator.basically.website/lasercut">Top plate</a> laser-cut and ready by step 2.</strong> It's not printed or built on any page, it's ordered or hand-cut ahead of time — see the parts calculator's lasercut page for the DXF and hand-cut instructions.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/top-interface-top-plate-w1600-00182ea8156d.jpg" alt="The machine's hexagonal top plate, laser-cut, with cable holes and stepper mount holes visible">
+    <figcaption>The Top plate.</figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Have the Cable cage top laser-cut and ready by step 10, and the Cable cage bottom by step 12.</strong> Same as the Top plate: laser-cut ahead of time, not built on this page.</p>
+  </div>
+  <div class="prep-item-figure prep-item-figure-split">
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/top-interface-cable-cage-top-full-9e4c43a620ca.png" alt="The Cable cage top, a laser-cut hexagonal plate with a keyed centre cutout">
+      <figcaption>Cable cage top.</figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/top-interface-cable-cage-bottom-full-283aeb114195.png" alt="The Cable cage bottom, a laser-cut hexagonal plate with a large centre cutout">
+      <figcaption>Cable cage bottom.</figcaption>
+    </figure>
+  </div>
+</div>
+
 The fasteners and quantities in the parts list come from the build notes and are called out inline at each step.
 
 {% include fastener-legend.html %}

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -9,6 +9,14 @@ lede: The interface between the feeder and the bin tower.
 permalink: /hardware/assembly/distribution/top-interface/
 author: zed0
 contributors: [barthel, brickcyclealice]
+warning: >-
+  **Step 13 reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
+  instead of describing frame construction inline, not yet reviewed by a
+  builder.** The rest of the page is unchanged. `ext-bracket-left` and
+  `ext-2020-ag` were removed from the parts list below since they're now the
+  hex frame page's own parts; the fastener totals here (`scr-m5-16-shcs`,
+  `tnut-m5-2020`) still span the whole page and have not been split into
+  "the hex frame's own" vs "specific to this page". Correct it as you build.
 parts_needed:
   - part: interface-upper-fixed-section
     qty: 1
@@ -60,8 +68,6 @@ parts_needed:
     qty: 1
   - part: ribbon-cable-clamp
     qty: 1
-  - part: ext-bracket-left
-    qty: 6
   - part: ext-bracket-cover
     qty: 6
   - part: extrusion-e
@@ -518,10 +524,10 @@ Slide an Interface spacer onto each piece of extrusion, with the lip at the top 
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-2-w1600-f626512783f3.jpg" alt="An interface spacer slid onto each vertical extrusion support, lips facing inward">
 </figure>
 
-Follow the first two stages of [a regular layer]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}), then place the regular layer assembly onto the interface assembly.
+Build a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}), then place it onto the interface assembly.
 
 <figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-3-full-b9ae16940954.jpg" alt="A regular layer assembly lowered onto the interface assembly">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-3-full-b9ae16940954.jpg" alt="A hex frame lowered onto the interface assembly">
 </figure>
 
 Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the holes at the base of the External bracket sides, bracing against the extrusion. These holes run parallel to the extrusion profile, and the screws are self-tapping. See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | relative_url }}) for the parts themselves — there is no External bracket — bottom vertical at this joint, see [step 14](#step-14) for what's different here.

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -172,7 +172,7 @@ Several steps below refer to holes in the Top plate by name (S2 and S3 for the s
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-top-plate-hole-map-full-423bbae45ba3.png" alt="Hole map of the hexagonal top plate: three stepper holes S1 to S3 in a row left of the center opening, six inner-ring holes I1 to I6, six outer-ring holes O1 to O6, and five cable holes C1 to C5, colour-coded by group">
-  <figcaption>Top plate hole map. S = stepper trio, I = inner ring, O = outer ring, C = cable holes.</figcaption>
+  <figcaption>Top plate hole map. S = stepper trio, I = inner ring, O = outer ring, C = cable holes. <cite>Render: Balloon.</cite></figcaption>
 </figure>
 
 {% include step.html n="1" title="Preparation" %}
@@ -265,29 +265,32 @@ Before assembling anything, press the heat inserts into the parts that take them
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-exploded-3color-full-227310630981.png" alt="An exploded view from below of the idler gear stack in build order: the grey gear, the bearing highlighted in blue, and the inner and outer bearing retainer caps highlighted in red">
-      <figcaption>Exploded, in build order: gear, bearing, inner cap, outer ring.</figcaption>
+      <figcaption>Exploded, in build order: gear, bearing, inner cap, outer ring. <cite>Render: Balloon.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-idler-gear-bearing-w1600-2fe924b61150.jpg" alt="608 2RS bearing pressed into the centre of the grey Interface idler gear, from before the bearing retainer caps existed">
-      <figcaption>608 2RS bearing pressed into the pocket. Real photo, predates the retainer caps.</figcaption>
+      <figcaption>608 2RS bearing pressed into the pocket. Real photo, predates the retainer caps. <cite>Photo: BrickCycleAlice.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/idler-assembled-3color-full-7de4573e7301.png" alt="The Interface idler gear seen from below at an angle, assembled, with the bearing highlighted in blue showing through the centre and the outer and inner bearing retainer caps highlighted in red, the outer retainer's four countersunk screw holes visible">
-      <figcaption>Assembled: bearing pocket recess with both retainer caps fitted.</figcaption>
+      <figcaption>Assembled: bearing pocket recess with both retainer caps fitted. <cite>Render: Balloon.</cite></figcaption>
     </figure>
   </div>
 </div>
 
 {% include step.html n="2" title="Attach the interface ribs to the upper fixed section" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/O_ApnzrWRsE?mute=1"
-    title="Attaching the interface ribs to the interface upper fixed section"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/O_ApnzrWRsE?mute=1"
+      title="Attaching the interface ribs to the interface upper fixed section"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 **Heat inserts first:** press the 4 × M4 inserts into the Interface upper fixed section and the 6 × M5 and 1 × M3 inserts into the Interface NEMA 23 bracket before you assemble anything here.
 
@@ -302,24 +305,27 @@ Attach the whole assembly to the bottom of the Top plate with {% include fastene
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step2-ribs-upper-fixed-section-w1600-4ebd47453115.jpg" alt="Six grey Interface ribs attached around the circular Interface upper fixed section">
-    <figcaption>The 6 Interface ribs attached to the Interface upper fixed section.</figcaption>
+    <figcaption>The 6 Interface ribs attached to the Interface upper fixed section. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step2-nema23-bracket-underside-w1600-cb1666b20cca.jpg" alt="Underside of the Interface upper fixed section with the Interface NEMA 23 bracket seated in its notch">
-    <figcaption>Underside, with the Interface NEMA 23 bracket seated in its notch.</figcaption>
+    <figcaption>Underside, with the Interface NEMA 23 bracket seated in its notch. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
 {% include step.html n="3" title="Prepare the interface brackets" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/-mtU3WXP73M?mute=1"
-    title="Preparing the interface brackets"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/-mtU3WXP73M?mute=1"
+      title="Preparing the interface brackets"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 **Heat inserts first:** each Interface bracket takes 3 × M5 inserts. Press them in before fitting the extrusion.
 
@@ -333,14 +339,17 @@ Repeat for all 6 Interface brackets.
 
 {% include step.html n="4" title="Prepare the limit switch interface bracket" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/YzYzytRl3p4?mute=1"
-    title="Preparing the limit switch interface bracket"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/YzYzytRl3p4?mute=1"
+      title="Preparing the limit switch interface bracket"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 **Heat inserts first:** the Limit switch housing takes 2 × M3 inserts. Press them in before assembling it.
 
@@ -352,14 +361,17 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
 
 {% include step.html n="5" title="Install the brackets" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/K7r15si5yxI?mute=1"
-    title="Installing the interface brackets"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/K7r15si5yxI?mute=1"
+      title="Installing the interface brackets"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with an {% include fastener.html size="M5" variant="countersunk" length="8" %} screw. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
 
@@ -376,14 +388,17 @@ Flip the whole assembly and screw all 6 Interface brackets into place with {% in
 
 {% include step.html n="6" title="Prepare the interface chute gear and mount" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/7oYiOXYF8rA?mute=1"
-    title="Preparing the interface chute gear and mount"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/7oYiOXYF8rA?mute=1"
+      title="Preparing the interface chute gear and mount"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 **Heat inserts first:** the Top interface chute mount takes 4 × M4 and 7 × M3 inserts, and the Limit switch hammer takes 1 × M3. Press them in before assembling.
 
@@ -408,24 +423,27 @@ Once complete, the free section of the Lazy Susan should rotate freely.
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step6-chute-mount-gear-side-w1600-c3ac0c996f20.jpg" alt="Gear side of the assembled Top interface chute mount, showing the chute gear, Lazy Susan, and Limit switch hammer">
-    <figcaption>Gear side, with the Chute gear, Lazy Susan, and Limit switch hammer installed.</figcaption>
+    <figcaption>Gear side, with the Chute gear, Lazy Susan, and Limit switch hammer installed. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step6-chute-mount-underside-w1600-ef7ef1645c43.jpg" alt="Chute side of the assembled Top interface chute mount with the Limit switch hammer extending from the edge">
-    <figcaption>Chute side of the assembled gear and mount.</figcaption>
+    <figcaption>Chute side of the assembled gear and mount. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
 {% include step.html n="7" title="Attach the interface chute to the assembly" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/FxpaGbyANHA?mute=1"
-    title="Attaching the interface chute to the assembly"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/FxpaGbyANHA?mute=1"
+      title="Attaching the interface chute to the assembly"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 Place the Interface big spacer on the Interface upper fixed section with its 4 holes lined up with the 4 heat inserts.
 
@@ -437,27 +455,33 @@ Once done, check that the chute rotates freely relative to the Interface upper f
 
 {% include step.html n="8" title="Adjust the limit switch" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/FxpaGbyANHA?start=160&mute=1"
-    title="Adjusting the limit switch"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/FxpaGbyANHA?start=160&mute=1"
+      title="Adjusting the limit switch"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 Loosen the screws attaching the Limit switch housing to the extrusion. Slide the housing so the Limit switch hammer rotates into place between the Roller lever limit switch and the Printed dowel pin in both directions of rotation. The switch clicks when it is being activated correctly. Avoid friction between the Limit switch hammer and the Printed dowel pin. Tighten the screws to keep the housing in this position.
 
 {% include step.html n="9" title="Install the chute stepper motor" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/z-L7_pNB8A8?mute=1"
-    title="Installing the chute stepper motor"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/z-L7_pNB8A8?mute=1"
+      title="Installing the chute stepper motor"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -479,24 +503,27 @@ At this point the chute should still rotate, but you will now feel resistance fr
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-timing-pulley-on-motor-w1600-0b0a8e04d17c.jpg" alt="Timing pulley installed on the shaft of a NEMA 23 stepper motor">
-    <figcaption>Timing pulley installed on the NEMA 23 shaft.</figcaption>
+    <figcaption>Timing pulley installed on the NEMA 23 shaft. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step9-interface-spur-gear-w1600-7dcec28e692a.jpg" alt="Grey Interface spur gear secured over the timing pulley with five countersunk screws">
-    <figcaption>Interface spur gear secured over the Timing pulley with five M3 × 8 mm screws.</figcaption>
+    <figcaption>Interface spur gear secured over the Timing pulley with five M3 × 8 mm screws. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
 {% include step.html n="10" title="Attach the cable cage top" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/NUDDwb5BZH8?mute=1"
-    title="Attaching the cable cage top"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/NUDDwb5BZH8?mute=1"
+      title="Attaching the cable cage top"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 **Heat inserts first:** the Cable cage bracket (cable mount) takes 1 × M3 insert. Press it in before assembling.
 
@@ -508,14 +535,17 @@ Screw the remaining Cable cage brackets to the other 5 corners of the Cable cage
 
 {% include step.html n="11" title="Put the cable in the cable cage" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/aCNjETS1X9A?mute=1"
-    title="Installing the cable in the cable cage"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/aCNjETS1X9A?mute=1"
+      title="Installing the cable in the cable cage"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 Place an {% include fastener.html size="M3" variant="nut" %} into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two {% include fastener.html size="M3" variant="socket-button" length="10" %} screws.
 
@@ -531,14 +561,17 @@ Check that the chute can rotate fully to the limit switch in both directions, th
 
 {% include step.html n="12" title="Attach the cable cage bottom" %}
 
-<div class="video-embed video-embed-wide">
-  <iframe
-    src="https://www.youtube.com/embed/CE3OKs5nXSk?mute=1"
-    title="Attaching the cable cage bottom"
-    allow="encrypted-media; picture-in-picture; web-share"
-    allowfullscreen
-    loading="lazy"></iframe>
-</div>
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/CE3OKs5nXSk?mute=1"
+      title="Attaching the cable cage bottom"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption><cite>Video: zed0.</cite></figcaption>
+</figure>
 
 Place the Cable cage bottom over the Top interface chute mount. Use 6 {% include fastener.html size="M5" variant="flat" length="35" %} screws and {% include fastener.html size="M5" variant="nut" %}s to clamp the Cable cage bottom, Cable cage top, and Cable cage brackets together.
 
@@ -552,18 +585,21 @@ Insert an extrusion piece F (Interface vertical support) into each of the Interf
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-1-full-b8dacf182230.jpg" alt="Six vertical extrusion supports bolted into the interface brackets, seen from above on the hexagonal top plate">
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 Slide an Interface spacer onto each piece of extrusion, with the lip at the top facing toward the center of the assembly.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-2-w1600-f626512783f3.jpg" alt="An interface spacer slid onto each vertical extrusion support, lips facing inward">
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 Build a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}), then place it onto the interface assembly.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-3-full-b9ae16940954.jpg" alt="A hex frame lowered onto the interface assembly">
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 Attach an External bracket cover to each of the External bracket sides, then fasten each one with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the holes at the base of the External bracket sides, bracing against the extrusion. These holes run parallel to the extrusion profile, and the screws are self-tapping. See [Assembling External bracket]({{ '/hardware/helpers/external-bracket/' | relative_url }}) for the parts themselves — there is no External bracket — bottom vertical at this joint, see [step 14](#step-14) for what's different here.
@@ -574,14 +610,14 @@ Attach an External bracket cover to each of the External bracket sides, then fas
   <a href="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-joint-full-ed0a06d244ff.png" target="_blank" rel="noopener">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-joint-full-ed0a06d244ff.png" alt="The interface assembly upside down on its top plate with six vertical extrusions standing out of it, each held in an interface bracket and sleeved by an interface spacer">
   </a>
-  <figcaption>The interface framing before the top layer goes on, with one arm marked 1 to 3. Click the photo to open it full size.</figcaption>
+  <figcaption>The interface framing before the top layer goes on, with one arm marked 1 to 3. Click the photo to open it full size. <cite>Photo: zed0.</cite></figcaption>
 </figure>
 
 <figure class="figure-float-right">
   <a href="https://assets.basically.website/sorter-docs/assembly-top-interface-joint-section-full-e96f8eb4493c.png" target="_blank" rel="noopener">
     <img src="https://assets.basically.website/sorter-docs/assembly-top-interface-joint-section-full-e96f8eb4493c.png" alt="Vertical cross-section through one interface corner, showing the interface bracket and spacer in purple, piece F in grey running down into the top layer's bracket in blue">
   </a>
-  <figcaption>The same corner in section, cut through the centre of the profile. Purple is the interface, blue the top layer's bracket, grey the extrusion. Click to enlarge. The interface parts are not exported in a shared frame with the layer parts, so the part lengths are measured but their heights come from seating each one on the part below it.</figcaption>
+  <figcaption>The same corner in section, cut through the centre of the profile. Purple is the interface, blue the top layer's bracket, grey the extrusion. Click to enlarge. The interface parts are not exported in a shared frame with the layer parts, so the part lengths are measured but their heights come from seating each one on the part below it. <cite>Drawn from the part geometry rather than from a build, by Balloon.</cite></figcaption>
 </figure>
 
 This joint is not the same as the one between two layers, so it is worth naming what is different. There is **no External bracket — bottom vertical and no flange here**, and therefore none of the vertical screws that hold one layer to the next. Piece F is instead gripped at the interface end and clamped at the layer end, and it is sleeved the whole way between them, so no extrusion shows on a finished machine.
@@ -604,5 +640,5 @@ The top interface is now complete.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-4-full-b9ae16940954.jpg" alt="The completed top interface: the hexagonal top plate on its framed leg structure with the chute opening in the centre">
-  <figcaption>The finished interface, seen from above with the top plate on.</figcaption>
+  <figcaption>The finished interface, seen from above with the top plate on. <cite>Photo: zed0.</cite></figcaption>
 </figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -128,6 +128,8 @@ parts_needed:
     qty: 1
 ---
 
+**Have a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) ready by step 13.** It's a required component of this page — step 13 places one onto the assembly, it doesn't build one. The rest of this page (steps 1-12, 14+) doesn't need it.
+
 The fasteners and quantities in the parts list come from the build notes and are called out inline at each step.
 
 {% include fastener-legend.html %}

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -12,11 +12,7 @@ contributors: [barthel, brickcyclealice]
 warning: >-
   **Step 13 reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
   instead of describing frame construction inline, not yet reviewed by a
-  builder.** The rest of the page is unchanged. `ext-bracket-left` and
-  `ext-2020-ag` were removed from the parts list below since they're now the
-  hex frame page's own parts; the fastener totals here (`scr-m5-16-shcs`,
-  `tnut-m5-2020`) still span the whole page and have not been split into
-  "the hex frame's own" vs "specific to this page". Correct it as you build.
+  builder.** The rest of the page is unchanged. Correct it as you build.
 parts_needed:
   - part: interface-upper-fixed-section
     qty: 1

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -181,7 +181,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-upper-fixed-section-inserts-full-ful-4f73af3a5587.png" alt="The Interface upper fixed section ring, underside with the NEMA 23 bracket attached, showing four brass M4 heat inserts around its face">
-    <figcaption>Underside, with the NEMA 23 bracket attached. <cite>Photo: zed0.</cite></figcaption>
+    <figcaption>Underside, with the NEMA 23 bracket attached. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -192,7 +192,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-nema23-inserts-full-5fda8f6ef8c0.png" alt="The Interface NEMA 23 bracket held up, showing four brass M5 inserts on the top edges and one M3 insert on the long tail">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-nema23-inserts-underside-full-97cf1ce3e1b0.png" alt="The underside of the Interface NEMA 23 bracket, showing the two remaining brass M5 heat inserts">
-    <figcaption>Top: four M5 on the edges and one M3 on the tail. Underside: the two remaining M5. <cite>Photo: zed0.</cite></figcaption>
+    <figcaption>Top: four M5 on the edges and one M3 on the tail. Underside: the two remaining M5. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -203,11 +203,11 @@ Before assembling anything, press the heat inserts into the parts that take them
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-chute-mount-inserts-underside-full-ec67c0262221.png" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
-      <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. <cite>Photo: zed0.</cite></figcaption>
+      <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. <cite>Photo: BrickCycleAlice.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-chute-mount-inserts-underside-grey-w-52b54ffa44db.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
-      <figcaption>A closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw. <cite>Photo: zed0.</cite></figcaption>
+      <figcaption>A closer look at two of the M3 inserts, next to the recess for the Limit switch hammer screw. <cite>Photo: BrickCycleAlice.</cite></figcaption>
     </figure>
   </div>
 </div>
@@ -228,7 +228,7 @@ Before assembling anything, press the heat inserts into the parts that take them
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-limit-switch-housing-inserts-grey-w1-ef9cced25713.jpg" alt="The grey Limit switch housing, showing two brass M3 heat inserts on the angled face where the roller lever limit switch mounts, with the dowel pin hole above them">
-    <figcaption>The two M3 inserts, where the roller lever limit switch mounts. <cite>Photo: zed0.</cite></figcaption>
+    <figcaption>The two M3 inserts, where the roller lever limit switch mounts. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -128,7 +128,15 @@ parts_needed:
     qty: 1
 ---
 
-**Have a [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) ready by step 13.** It's a required component of this page — step 13 places one onto the assembly, it doesn't build one. The rest of this page (steps 1-12, 14+) doesn't need it.
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Have a <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}">hex frame</a> ready by step 13.</strong> It's a required component of this page — step 13 places one onto the assembly, it doesn't build one. The rest of this page (steps 1-12, 14+) doesn't need it.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-finished-top-down-full-c6abfb4dad6e.jpg" alt="A finished hex frame from above, the alternating grey spoke and teal crossbeam pieces forming the inner ring inside the aluminum outer hexagon">
+    <figcaption>A finished hex frame. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 The fasteners and quantities in the parts list come from the build notes and are called out inline at each step.
 

--- a/docs/src/content/hardware/helpers/external-bracket.md
+++ b/docs/src/content/hardware/helpers/external-bracket.md
@@ -109,4 +109,4 @@ Clip the cover onto the side bracket to close it off. The cover takes no screws,
   </figure>
 </div>
 
-This is the bracket as a stand-alone unit. For how it's actually installed on the frame — and the one difference at the layer-to-layer joint — see [regular layers, step 3]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-3) and [step 5]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-5).
+This is the bracket as a stand-alone unit. For how it's actually installed on the frame — and the one difference at the layer-to-layer joint — see [regular layers, step 1]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-1) and [step 3]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}#step-3).

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -28,6 +28,8 @@ sections:
               - title: Bin frame
                 url: /hardware/assembly/distribution/bin-frame/
                 children:
+                  - title: Build the hex frame
+                    url: /hardware/assembly/distribution/bin-frame/hex-frame/
                   - title: Bottom interface
                     url: /hardware/assembly/distribution/bin-frame/bottom-interface/
                   - title: Bottom two layers

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column — both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) — these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until §5.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit — 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, §5.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views.",
+  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column \u2014 both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) \u2014 these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until \u00a75.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit \u2014 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, \u00a75.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views.",
   "sections": [
     {
       "id": "feeder",
@@ -271,7 +271,7 @@
       "name": "Stator's four NEMA-bracket holes are too small for an M3",
       "priority": "P0",
       "condition": "broken",
-      "description": "The four holes the NEMA bracket bolts into are Ø2.40 mm and 10 mm deep. M3's minor (thread-root) diameter is 2.459 mm, so the hole is already narrower than the root before print tolerance takes another 0.1-0.2 mm off it, and the screw has to form a full-depth thread through 10 mm of plastic. It cams out or splits the boss instead, so the bracket cannot be fastened to the stator as printed. Every other M3 thread-forming hole in this assembly is Ø2.80 — the rotor's six, the light post's five, and four more in this same stator — so Ø2.40 is the odd one out inside its own part, which reads as a CAD slip rather than an intent. The fix is to open the four to Ø2.80 in CAD. Reported by aleph1111/christoph from a build; measured off the pinned stator STL. Tracked as sorter-v2 issue #405.",
+      "description": "The four holes the NEMA bracket bolts into are \u00d82.40 mm and 10 mm deep. M3's minor (thread-root) diameter is 2.459 mm, so the hole is already narrower than the root before print tolerance takes another 0.1-0.2 mm off it, and the screw has to form a full-depth thread through 10 mm of plastic. It cams out or splits the boss instead, so the bracket cannot be fastened to the stator as printed. Every other M3 thread-forming hole in this assembly is \u00d82.80 \u2014 the rotor's six, the light post's five, and four more in this same stator \u2014 so \u00d82.40 is the odd one out inside its own part, which reads as a CAD slip rather than an intent. The fix is to open the four to \u00d82.80 in CAD. Reported by aleph1111/christoph from a build; measured off the pinned stator STL. Tracked as sorter-v2 issue #405.",
       "targets": {
         "parts": [
           "stator"
@@ -778,8 +778,8 @@
     {
       "id": "frame-90deg-bracket",
       "uid": "3l20",
-      "name": "Frame 90° bracket",
-      "description": "Distribution frame 90° bracket. Two per frame section.",
+      "name": "Frame 90\u00b0 bracket",
+      "description": "Distribution frame 90\u00b0 bracket. Two per frame section.",
       "internal_notes": "12 per frame (per layer); interface qty ASSUMED 12 (Spencer said 'one set per interface' - confirm). Frame color. File: inner_90_bracket.",
       "version": "1",
       "created_at": "2026-06-27",
@@ -801,7 +801,7 @@
     {
       "id": "ls-mount-to-chute",
       "uid": "lma9",
-      "name": "Lazy Susan — chute mount",
+      "name": "Lazy Susan \u2014 chute mount",
       "aliases": [
         "bottom interface lazy Susan chute mount",
         "bottom interface chute mount"
@@ -831,7 +831,7 @@
     {
       "id": "ls-bottom-static",
       "uid": "4mmh",
-      "name": "Lazy Susan — bottom static",
+      "name": "Lazy Susan \u2014 bottom static",
       "aliases": [
         "bottom interface lazy Susan fixed section",
         "bottom interface fixed section"
@@ -861,7 +861,7 @@
     {
       "id": "ls-mount-to-extrusion",
       "uid": "bmt4",
-      "name": "Lazy Susan — extrusion mount",
+      "name": "Lazy Susan \u2014 extrusion mount",
       "description": "Bottom lazy Susan mount to the external extrusion.",
       "internal_notes": "Frame color. QUANTITY ASSUMED 1.",
       "version": "1",
@@ -882,7 +882,7 @@
     {
       "id": "ls-hold-in-place",
       "uid": "ss05",
-      "name": "Lazy Susan — hold in place",
+      "name": "Lazy Susan \u2014 hold in place",
       "description": "Bottom lazy Susan hold-in-place. Optional.",
       "internal_notes": "Optional (file: 'optional hold in place'). Frame color. QUANTITY ASSUMED 1.",
       "version": "1",
@@ -903,7 +903,7 @@
     {
       "id": "ls-washer",
       "uid": "9c4a",
-      "name": "Lazy Susan — washer",
+      "name": "Lazy Susan \u2014 washer",
       "description": "Bottom lazy Susan washer.",
       "internal_notes": "Frame color. QUANTITY UNCONFIRMED (assumed 1; may be several).",
       "version": "1",
@@ -923,7 +923,7 @@
     {
       "id": "ext-bracket-left",
       "uid": "0b4g",
-      "name": "External bracket — side",
+      "name": "External bracket \u2014 side",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Interface qty confirmed at 6, side and cover only, no bottom vertical there (top-interface.md step 14). Frame color.",
       "version": "1",
@@ -942,14 +942,14 @@
       "optional": false,
       "support": false,
       "low_tolerance": true,
-      "low_tolerance_note": "A test print is suggested. This part is a tight fit around the 2020 aluminum profile, so print one first and confirm it seats properly before committing to the full set — dial in your printer and profile together.",
+      "low_tolerance_note": "A test print is suggested. This part is a tight fit around the 2020 aluminum profile, so print one first and confirm it seats properly before committing to the full set \u2014 dial in your printer and profile together.",
       "onshape_version": "https://cad.onshape.com/documents/a4a1965bbaf3a15aff2b13ed/v/7279a42b05833c7b828efb0d/e/b0ee2e787191265cba1c1a31",
       "docs_page": "/hardware/helpers/external-bracket/"
     },
     {
       "id": "ext-bracket-bottom-vertical",
       "uid": "xgzj",
-      "name": "External bracket — bottom vertical",
+      "name": "External bracket \u2014 bottom vertical",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Not used at the top interface: that joint has no bottom vertical or flange (top-interface.md step 14, confirmed 2026-08-25). The earlier 'interface: 6' assumption here was wrong, removed. Frame color.",
       "version": "1",
@@ -973,7 +973,7 @@
     {
       "id": "ext-bracket-cover",
       "uid": "1r5i",
-      "name": "External bracket — cover",
+      "name": "External bracket \u2014 cover",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Interface qty confirmed at 6, side and cover only, no bottom vertical there (top-interface.md step 14). Frame color.",
       "version": "1",
@@ -1170,7 +1170,7 @@
       "uid": "50dv",
       "name": "Cable clamp (outer)",
       "description": "Outer half of the ribbon cable clamp. White.",
-      "internal_notes": "1 per interface. White. Pairs with the inner clamp (cable-clamp assembly). v2 (2026-07-18): enlarged the M3 nut pocket so the nut seats — it did not fit in v1.",
+      "internal_notes": "1 per interface. White. Pairs with the inner clamp (cable-clamp assembly). v2 (2026-07-18): enlarged the M3 nut pocket so the nut seats \u2014 it did not fit in v1.",
       "version": "2",
       "created_at": "2026-06-27",
       "updated_at": "2026-07-18",
@@ -1292,7 +1292,7 @@
     {
       "id": "chute-stepper-idler-bearing-retainer-outer",
       "uid": "wgsc",
-      "name": "Chute Stepper Idler Gear Bearing Retainer — Outer",
+      "name": "Chute Stepper Idler Gear Bearing Retainer \u2014 Outer",
       "aliases": [
         "Idler Gear Bearing Retainer - Outer",
         "idler bearing retainer"
@@ -1317,7 +1317,7 @@
     {
       "id": "chute-stepper-idler-bearing-retainer-inner",
       "uid": "zzql",
-      "name": "Chute Stepper Idler Gear Bearing Retainer — Inner",
+      "name": "Chute Stepper Idler Gear Bearing Retainer \u2014 Inner",
       "aliases": [
         "Idler Gear Bearing Retainer - Inner",
         "idler gear cap"
@@ -1491,7 +1491,7 @@
         "chute core mount"
       ],
       "description": "Section 3 of 3 of the top interface split spur gear (Spur 2M 120T).",
-      "internal_notes": "Split spur gear for the top interface; the 3 sections print separately and assemble into one gear. Chute-core color. Carries 4× M4 inserts, plus 7× M3: 2 for the cable clamp and 5 on the underside that the chute gear screws down into. Counted on the physical part by barthel 2026-08-21 and confirmed against the STL (7 x 4.20 mm bores, ruthex's recommended M3 insert hole, re-measured with the detection thresholds loosened in case any were missed). The previous count of 9 added 2 for the layer connector, which the published model does not have; resolves the docs-merge-2026-08-21 conflict.",
+      "internal_notes": "Split spur gear for the top interface; the 3 sections print separately and assemble into one gear. Chute-core color. Carries 4\u00d7 M4 inserts, plus 7\u00d7 M3: 2 for the cable clamp and 5 on the underside that the chute gear screws down into. Counted on the physical part by barthel 2026-08-21 and confirmed against the STL (7 x 4.20 mm bores, ruthex's recommended M3 insert hole, re-measured with the detection thresholds loosened in case any were missed). The previous count of 9 added 2 for the layer connector, which the published model does not have; resolves the docs-merge-2026-08-21 conflict.",
       "version": "1",
       "created_at": "2026-07-03",
       "updated_at": "2026-07-03",
@@ -1823,7 +1823,7 @@
     {
       "id": "servo-adapter-servo-side",
       "uid": "fu2t",
-      "name": "Servo adapter — servo side",
+      "name": "Servo adapter \u2014 servo side",
       "description": "MG995 servo adapter, servo side.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1843,7 +1843,7 @@
     {
       "id": "servo-adapter-flap-side",
       "uid": "lv7n",
-      "name": "Servo adapter — flap side",
+      "name": "Servo adapter \u2014 flap side",
       "description": "MG995 servo adapter, flap side.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1863,7 +1863,7 @@
     {
       "id": "servo-bracket-lower-arm",
       "uid": "yqz1",
-      "name": "Servo bracket — lower arm",
+      "name": "Servo bracket \u2014 lower arm",
       "description": "MG995 servo bracket, lower arm.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1883,7 +1883,7 @@
     {
       "id": "servo-bracket-side-arm",
       "uid": "75na",
-      "name": "Servo bracket — side arm",
+      "name": "Servo bracket \u2014 side arm",
       "description": "MG995 servo bracket, side arm.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1903,7 +1903,7 @@
     {
       "id": "servo-bracket-cover",
       "uid": "rqor",
-      "name": "Servo bracket — cover",
+      "name": "Servo bracket \u2014 cover",
       "description": "MG995 servo bracket, cover.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1923,7 +1923,7 @@
     {
       "id": "servo-bracket-housing",
       "uid": "tr15",
-      "name": "Servo bracket — housing",
+      "name": "Servo bracket \u2014 housing",
       "description": "MG995 servo bracket, housing.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -2028,7 +2028,7 @@
     {
       "id": "camera-mount-part-6",
       "uid": "v9dv",
-      "name": "Overhead camera mount — A/B connector",
+      "name": "Overhead camera mount \u2014 A/B connector",
       "description": "Camera mount part 6. 2 per machine.",
       "internal_notes": "1 per camera mount x 2 mounts. Color not important (feeder).",
       "version": "1",
@@ -2085,7 +2085,7 @@
     {
       "id": "camera-mount-rod-mount",
       "uid": "twuu",
-      "name": "Camera mount — rod-to-C-channel mount",
+      "name": "Camera mount \u2014 rod-to-C-channel mount",
       "description": "Rod-to-C-channel mount (Part 33). 2 per camera mount, 4 total.",
       "internal_notes": "Part 33, the rod-to-c-channel mount. 2 per camera mount x 2 mounts = 4. Color not important (feeder).",
       "version": "1",
@@ -2547,7 +2547,7 @@
     {
       "id": "ctrl-board-housing-base",
       "uid": "204b",
-      "name": "Control Board Housing — Base",
+      "name": "Control Board Housing \u2014 Base",
       "description": "Base of the basically Embedded Control Board housing. The board screws straight to it on four heat inserts and the cover screws down onto four more; no standoffs.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Entered the machine on 2026-08-23 when candidate rns2 was promoted to ctrl-board-mount v2. Eight standard M3 inserts (hsi-m3, RX-M3x5.7 -- Spencer said 'the long variant', which is this one relative to the short M3S): four under the board, four for the cover.",
       "version": "1",
@@ -2574,8 +2574,8 @@
     {
       "id": "ctrl-board-housing-cover",
       "uid": "ksh2",
-      "name": "Control Board Housing — Cover",
-      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 × 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 × 12 mm button head screws, and the plunger passes through it.",
+      "name": "Control Board Housing \u2014 Cover",
+      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 \u00d7 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 \u00d7 12 mm button head screws, and the plunger passes through it.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
       "created_at": "2026-08-22",
@@ -2595,7 +2595,7 @@
     {
       "id": "ctrl-board-housing-plunger",
       "uid": "cljt",
-      "name": "Control Board Housing — Plunger",
+      "name": "Control Board Housing \u2014 Plunger",
       "description": "Plunger that passes through the housing cover, held in by the plunger retainer.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
@@ -2616,8 +2616,8 @@
     {
       "id": "ctrl-board-housing-plunger-retainer",
       "uid": "g9sx",
-      "name": "Control Board Housing — Plunger Retainer",
-      "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 × 8 mm countersunk screws.",
+      "name": "Control Board Housing \u2014 Plunger Retainer",
+      "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 \u00d7 8 mm countersunk screws.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Entered the machine on 2026-08-23 when candidate rns2 was promoted to ctrl-board-mount v2. Two countersunk holes either side of the plunger slot (counted off the STL).",
       "version": "1",
       "created_at": "2026-08-22",
@@ -2679,7 +2679,7 @@
       "uid": "3ufy",
       "name": "40 mm Fan Bracket",
       "description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
-      "internal_notes": "Was 2 per machine — the control board and the Orange Pi each had one. The control board's housing carries its own fan as of ctrl-board-mount v2 (2026-08-23), so only the Orange Pi mount still uses this.",
+      "internal_notes": "Was 2 per machine \u2014 the control board and the Orange Pi each had one. The control board's housing carries its own fan as of ctrl-board-mount v2 (2026-08-23), so only the Orange Pi mount still uses this.",
       "version": "1",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-23",
@@ -2698,7 +2698,7 @@
     {
       "id": "meanwell-psu-housing-shell-rear",
       "uid": "7qz3",
-      "name": "PSU Housing — Shell Rear Tray",
+      "name": "PSU Housing \u2014 Shell Rear Tray",
       "description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell rear tray.stl'. Carries the self-tapping M3 holes for both lids.",
       "version": "1",
@@ -2717,7 +2717,7 @@
     {
       "id": "meanwell-psu-housing-shell-front",
       "uid": "1h8p",
-      "name": "PSU Housing — Shell Front Module",
+      "name": "PSU Housing \u2014 Shell Front Module",
       "description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell front module.stl'.",
       "version": "1",
@@ -2736,7 +2736,7 @@
     {
       "id": "meanwell-psu-housing-lid-rear",
       "uid": "m26o",
-      "name": "PSU Housing — Lid Rear",
+      "name": "PSU Housing \u2014 Lid Rear",
       "description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid rear.stl'.",
       "version": "1",
@@ -2755,7 +2755,7 @@
     {
       "id": "meanwell-psu-housing-lid-front",
       "uid": "avux",
-      "name": "PSU Housing — Lid Front",
+      "name": "PSU Housing \u2014 Lid Front",
       "description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid front.stl'.",
       "version": "1",
@@ -2774,7 +2774,7 @@
     {
       "id": "meanwell-psu-housing-front-panel",
       "uid": "n1oh",
-      "name": "PSU Housing — Front Panel",
+      "name": "PSU Housing \u2014 Front Panel",
       "description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - front panel.stl'.",
       "version": "1",
@@ -2798,12 +2798,12 @@
         "type": "screw",
         "size": "M3"
       },
-      "name": "M3 screw — type and length TBD",
+      "name": "M3 screw \u2014 type and length TBD",
       "category": "Screws",
       "description": "Placeholder for the M3s whose head type and length nobody has written down yet: the cable-mount cage bracket, the camera extension, and the two board mounts.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
-      "note": "Neither the head type nor the length is recorded — measure before ordering.",
+      "note": "Neither the head type nor the length is recorded \u2014 measure before ordering.",
       "attributes": [
         {
           "label": "Thread",
@@ -2831,10 +2831,10 @@
       "name": "M3 socket/button head, length TBD",
       "category": "Screws",
       "alternative": "Socket or button head",
-      "description": "Was the placeholder for the screws holding the basically Embedded Control Board to the housing base, before they were measured as M3 × 6 mm button head. Nothing calls for it now; the uid is kept because it was minted.",
+      "description": "Was the placeholder for the screws holding the basically Embedded Control Board to the housing base, before they were measured as M3 \u00d7 6 mm button head. Nothing calls for it now; the uid is kept because it was minted.",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-22",
-      "note": "Superseded before it was ever ordered — nothing in the catalog calls for it.",
+      "note": "Superseded before it was ever ordered \u2014 nothing in the catalog calls for it.",
       "attributes": [
         {
           "label": "Thread",
@@ -2860,7 +2860,7 @@
         "variant": "countersunk",
         "length_mm": 6
       },
-      "name": "M3 × 6 mm countersunk",
+      "name": "M3 \u00d7 6 mm countersunk",
       "category": "Screws",
       "description": "Secures the limit switch hammer into the top interface chute mount from below, into the hammer's M3 insert.",
       "created_at": "2026-08-18",
@@ -2882,7 +2882,7 @@
       "sheet_qty": {
         "per_machine": 1
       },
-      "note": "The ×1 is the top-interface count (limit-switch hammer). Screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "The \u00d71 is the top-interface count (limit-switch hammer). Screws used elsewhere on the machine aren't tallied here yet.",
       "image_url": "https://assets.basically.website/sorter-parts/hardware-screws-countersunk-full-faf0edbe3324.jpg"
     },
     {
@@ -2895,7 +2895,7 @@
         "variant": "socket",
         "length_mm": 10
       },
-      "name": "M3 × 10 mm socket/button head",
+      "name": "M3 \u00d7 10 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-10-shcs-full-26e52d7d5bcd.png",
@@ -2919,7 +2919,7 @@
       "sheet_qty": {
         "per_machine": 3
       },
-      "note": "The ×3 is the top-interface count (2 cable clamp, 1 ribbon clamp). Screws used elsewhere on the machine aren't tallied here yet."
+      "note": "The \u00d73 is the top-interface count (2 cable clamp, 1 ribbon clamp). Screws used elsewhere on the machine aren't tallied here yet."
     },
     {
       "id": "scr-m3-8-cs",
@@ -2931,9 +2931,9 @@
         "variant": "countersunk",
         "length_mm": 8
       },
-      "name": "M3 × 8 mm countersunk",
+      "name": "M3 \u00d7 8 mm countersunk",
       "category": "Screws",
-      "description": "The workhorse M3 screw — used all over the machine wherever a flush head is wanted.",
+      "description": "The workhorse M3 screw \u2014 used all over the machine wherever a flush head is wanted.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -2981,7 +2981,7 @@
         "variant": "socket",
         "length_mm": 8
       },
-      "name": "M2 × 8 mm socket/button head",
+      "name": "M2 \u00d7 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "description": "Self-taps the IMX415 classification camera board to the camera extension's printed post. 4 per module, no insert. May also fit the OV9732 overhead camera mount once that gets a real bracket (sorter-v2#426), not confirmed.",
@@ -3013,7 +3013,7 @@
         "variant": "socket",
         "length_mm": 8
       },
-      "name": "M3 × 8 mm socket/button head",
+      "name": "M3 \u00d7 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "description": "Clamps the C-channel input gear (12T) to the flat of the NEMA 17 shaft. 1 per C-channel.",
@@ -3033,7 +3033,7 @@
           "value": "Socket or button head, interchangeable (both bottom on the counterbore floor, so either just clamps)"
         }
       ],
-      "note": "Head type and length measured off the input-gear STL: the boss carries a Ø2.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the Ø4.87 mm bore; the head sits in a round Ø6.40 mm × 2.7 mm counterbore with a 90° cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (Ø5.5 × 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (Ø5.7 × 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
+      "note": "Head type and length measured off the input-gear STL: the boss carries a \u00d82.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the \u00d84.87 mm bore; the head sits in a round \u00d86.40 mm \u00d7 2.7 mm counterbore with a 90\u00b0 cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (\u00d85.5 \u00d7 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (\u00d85.7 \u00d7 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
     },
     {
       "id": "scr-m3-12-cs",
@@ -3045,7 +3045,7 @@
         "variant": "countersunk",
         "length_mm": 12
       },
-      "name": "M3 × 12 mm countersunk",
+      "name": "M3 \u00d7 12 mm countersunk",
       "category": "Screws",
       "description": "The long M3 countersunk. Used all over the machine.",
       "created_at": "2026-07-18",
@@ -3095,9 +3095,9 @@
         "variant": "countersunk",
         "length_mm": 20
       },
-      "name": "M3 × 20 mm countersunk",
+      "name": "M3 \u00d7 20 mm countersunk",
       "category": "Screws",
-      "description": "Joins the C-channel light post to the NEMA bracket. Threads straight into the printed post — no insert, no nut.",
+      "description": "Joins the C-channel light post to the NEMA bracket. Threads straight into the printed post \u2014 no insert, no nut.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -3142,7 +3142,7 @@
         "variant": "socket",
         "length_mm": 16
       },
-      "name": "M3 × 16 mm socket/button head",
+      "name": "M3 \u00d7 16 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png",
@@ -3174,7 +3174,7 @@
         "variant": "button",
         "length_mm": 6
       },
-      "name": "M3 × 6 mm socket/button head",
+      "name": "M3 \u00d7 6 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-6-bhcs-full-26e52d7d5bcd.png",
@@ -3206,7 +3206,7 @@
         "variant": "button",
         "length_mm": 12
       },
-      "name": "M3 × 12 mm socket/button head",
+      "name": "M3 \u00d7 12 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-12-bhcs-full-26e52d7d5bcd.png",
@@ -3238,7 +3238,7 @@
         "variant": "flat",
         "length_mm": 35
       },
-      "name": "M3 × 35 mm flat head",
+      "name": "M3 \u00d7 35 mm flat head",
       "category": "Screws",
       "alternative": "Flat or pan head",
       "description": "The two long M3s on the top interface: one clamps the two cable-clamp halves together, one retains the idler gear on the NEMA 23 bracket. Same screw for both. The head has to stay low because of the idler joint: a socket or button head stands proud enough for the limit switch hammer to catch on it as the chute sweeps past.",
@@ -3269,7 +3269,7 @@
         "variant": "countersunk",
         "length_mm": 6
       },
-      "name": "M4 × 6 mm countersunk",
+      "name": "M4 \u00d7 6 mm countersunk",
       "category": "Screws",
       "description": "Fastens the printed PSU housing to the power supply's own case threads.",
       "created_at": "2026-07-18",
@@ -3299,9 +3299,9 @@
         "variant": "countersunk",
         "length_mm": 12
       },
-      "name": "M4 × 12 mm countersunk",
+      "name": "M4 \u00d7 12 mm countersunk",
       "category": "Screws",
-      "description": "Bolts each lazy Susan together — 4 a side, through the M4 inserts in the static half and the chute mount. 2 lazy Susans per machine.",
+      "description": "Bolts each lazy Susan together \u2014 4 a side, through the M4 inserts in the static half and the chute mount. 2 lazy Susans per machine.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -3330,7 +3330,7 @@
         "variant": "socket",
         "length_mm": 12
       },
-      "name": "M5 × 12 mm socket/button head",
+      "name": "M5 \u00d7 12 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-12-shcs-full-26e52d7d5bcd.png",
@@ -3362,7 +3362,7 @@
         "variant": "socket",
         "length_mm": 16
       },
-      "name": "M5 × 16 mm socket/button head",
+      "name": "M5 \u00d7 16 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-16-shcs-full-26e52d7d5bcd.png",
@@ -3383,7 +3383,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Designed to self-tap into printed plastic wherever it lands in an external bracket or the upper fixed section — no nut and no insert there."
+      "note": "Designed to self-tap into printed plastic wherever it lands in an external bracket or the upper fixed section \u2014 no nut and no insert there."
     },
     {
       "id": "scr-m5-20-shcs",
@@ -3395,7 +3395,7 @@
         "variant": "socket",
         "length_mm": 20
       },
-      "name": "M5 × 20 mm socket/button head",
+      "name": "M5 \u00d7 20 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-20-shcs-full-26e52d7d5bcd.png",
@@ -3427,7 +3427,7 @@
         "variant": "socket",
         "length_mm": 30
       },
-      "name": "M5 × 30 mm socket/button head",
+      "name": "M5 \u00d7 30 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-30-shcs-full-26e52d7d5bcd.png",
@@ -3459,7 +3459,7 @@
         "variant": "flat",
         "length_mm": 35
       },
-      "name": "M5 × 35 mm flat head",
+      "name": "M5 \u00d7 35 mm flat head",
       "internal_notes": "Flat (pancake) head, hex socket, confirmed by barthel 2026-08-21: \"The m3x35mm must be a flat hat screw like in calculator\" (the M5 x 35 is the only 35 mm screw the two catalogs disagreed about; the M3 x 35 was already settled as flat head in #356). The docs catalog had called it a socket head cap screw; that claim is dropped and the docs prose now says flat head. Resolves the last docs-merge-2026-08-21 conflict.",
       "category": "Screws",
       "description": "The long screws that stack the cable cage together, and that bolt the plywood top plate down onto the interface brackets.",
@@ -3516,7 +3516,7 @@
         "variant": "countersunk",
         "length_mm": 8
       },
-      "name": "M5 × 8 mm countersunk",
+      "name": "M5 \u00d7 8 mm countersunk",
       "category": "Screws",
       "description": "Loosely fixes the limit-switch interface bracket's extrusion into the interface rib while aligning it, into a T-nut.",
       "created_at": "2026-08-18",
@@ -3535,7 +3535,7 @@
           "value": "Countersunk (flat) socket"
         }
       ],
-      "note": "A snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush. The ×6 is the top-interface count (1 per interface bracket); screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "A snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush. The \u00d76 is the top-interface count (1 per interface bracket); screws used elsewhere on the machine aren't tallied here yet.",
       "sheet_qty": {
         "per_machine": 6
       },
@@ -3551,9 +3551,9 @@
         "variant": "countersunk",
         "length_mm": 22
       },
-      "name": "M5 × 22 mm countersunk",
+      "name": "M5 \u00d7 22 mm countersunk",
       "category": "Screws",
-      "description": "Bolts the interface bracket assembly and all six interface brackets down through the laser-cut top plate (holes S2/S3, then I1–I6 and O1–O6).",
+      "description": "Bolts the interface bracket assembly and all six interface brackets down through the laser-cut top plate (holes S2/S3, then I1\u2013I6 and O1\u2013O6).",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-18",
       "attributes": [
@@ -3570,7 +3570,7 @@
           "value": "Countersunk (flat) socket"
         }
       ],
-      "note": "The top plate's laser-cut holes aren't countersunk, so where a flush head won't seat an M5 × 20 button head is used instead. The ×14 is the top-interface count (2 to the top plate, 12 through the bracket holes); screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "The top plate's laser-cut holes aren't countersunk, so where a flush head won't seat an M5 \u00d7 20 button head is used instead. The \u00d714 is the top-interface count (2 to the top plate, 12 through the bracket holes); screws used elsewhere on the machine aren't tallied here yet.",
       "sheet_qty": {
         "per_machine": 14
       },
@@ -3606,7 +3606,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Length unknown — measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
+      "note": "Length unknown \u2014 measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
     },
     {
       "id": "washer-m3-15",
@@ -3616,9 +3616,9 @@
         "type": "washer",
         "size": "M3"
       },
-      "name": "M3 × 15 mm washer",
+      "name": "M3 \u00d7 15 mm washer",
       "category": "Washers",
-      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
+      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-25",
       "attributes": [
@@ -3719,7 +3719,7 @@
         "type": "stock-material",
         "size": "3/8 in"
       },
-      "name": "Steel rod, 3/8 in — 4 ft stock",
+      "name": "Steel rod, 3/8 in \u2014 4 ft stock",
       "category": "Stock material",
       "description": "Bought as a length and cut down. One 4 ft rod yields all four ~1 ft pieces the two overhead camera arms hang from.",
       "created_at": "2026-07-18",
@@ -3734,7 +3734,7 @@
       "attributes": [
         {
           "label": "Diameter",
-          "value": "3/8 in (9.53 mm) · 10 mm in metric"
+          "value": "3/8 in (9.53 mm) \u00b7 10 mm in metric"
         },
         {
           "label": "Buy",
@@ -3742,7 +3742,7 @@
         },
         {
           "label": "Cut into",
-          "value": "4 × ~1 ft (305 mm)"
+          "value": "4 \u00d7 ~1 ft (305 mm)"
         },
         {
           "label": "Material",
@@ -4193,7 +4193,7 @@
         },
         {
           "label": "Thread",
-          "value": "M6 × 1.0"
+          "value": "M6 \u00d7 1.0"
         },
         {
           "label": "Material",
@@ -4230,7 +4230,7 @@
         "type": "wheel",
         "size": "M6"
       },
-      "name": "Swivel stem caster, M6 × 15 mm",
+      "name": "Swivel stem caster, M6 \u00d7 15 mm",
       "category": "Wheels",
       "description": "Screws into the 2020 foot connector so the machine can roll.",
       "created_at": "2026-07-18",
@@ -4238,7 +4238,7 @@
       "attributes": [
         {
           "label": "Thread",
-          "value": "M6 × 1.0, 15 mm stem"
+          "value": "M6 \u00d7 1.0, 15 mm stem"
         },
         {
           "label": "Wheel",
@@ -4418,7 +4418,7 @@
       "attributes": [
         {
           "label": "Size",
-          "value": "30 × 42 × 7 mm (ID × OD × W)"
+          "value": "30 \u00d7 42 \u00d7 7 mm (ID \u00d7 OD \u00d7 W)"
         },
         {
           "label": "Seal",
@@ -4506,7 +4506,7 @@
       "attributes": [
         {
           "label": "Size",
-          "value": "20 × 27 × 4 mm (ID × OD × W)"
+          "value": "20 \u00d7 27 \u00d7 4 mm (ID \u00d7 OD \u00d7 W)"
         },
         {
           "label": "Seal",
@@ -4652,7 +4652,7 @@
         },
         {
           "label": "Size",
-          "value": "22 × 30 mm"
+          "value": "22 \u00d7 30 mm"
         },
         {
           "label": "Fits",
@@ -4889,7 +4889,7 @@
       "cots": {
         "type": "cable"
       },
-      "name": "IDC ribbon cable, 16-pin (2×8), 1 m",
+      "name": "IDC ribbon cable, 16-pin (2\u00d78), 1 m",
       "category": "Electronics",
       "description": "Cable from distribution board to chute",
       "created_at": "2026-07-18",
@@ -4914,7 +4914,7 @@
       "attributes": [
         {
           "label": "Pins",
-          "value": "16 (2×8), FC to FC, A-type"
+          "value": "16 (2\u00d78), FC to FC, A-type"
         },
         {
           "label": "Pitch",
@@ -4937,7 +4937,7 @@
       "cots": {
         "type": "cable"
       },
-      "name": "IDC ribbon cable, 16-pin (2×8), 30 cm",
+      "name": "IDC ribbon cable, 16-pin (2\u00d78), 30 cm",
       "category": "Electronics",
       "description": "Cable between layer and layer below",
       "created_at": "2026-07-18",
@@ -4962,7 +4962,7 @@
       "attributes": [
         {
           "label": "Pins",
-          "value": "16 (2×8), female-to-female FC"
+          "value": "16 (2\u00d78), female-to-female FC"
         },
         {
           "label": "Pitch",
@@ -5137,7 +5137,7 @@
       "cots": {
         "type": "converter"
       },
-      "name": "24 V → 5 V USB-C buck converter",
+      "name": "24 V \u2192 5 V USB-C buck converter",
       "category": "Wire harness",
       "description": "Powers the Orange Pi from the 24 V PSU.",
       "created_at": "2026-07-18",
@@ -5145,7 +5145,7 @@
       "attributes": [
         {
           "label": "Input",
-          "value": "DC 8–32 V (12 V / 24 V nominal)"
+          "value": "DC 8\u201332 V (12 V / 24 V nominal)"
         },
         {
           "label": "Output",
@@ -5231,7 +5231,7 @@
         },
         {
           "label": "Fuse",
-          "value": "10 A installed (5 × 20 mm)"
+          "value": "10 A installed (5 \u00d7 20 mm)"
         },
         {
           "label": "Wiring",
@@ -5239,7 +5239,7 @@
         },
         {
           "label": "Cutout",
-          "value": "47 × 28 mm; holes 40 mm apart, 3.2 mm"
+          "value": "47 \u00d7 28 mm; holes 40 mm apart, 3.2 mm"
         }
       ],
       "sheet_qty": {
@@ -5269,13 +5269,13 @@
       },
       "name": "40 mm 24 V fan (WINSINN 4010)",
       "category": "Electronics",
-      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 × 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
+      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 \u00d7 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-23",
       "attributes": [
         {
           "label": "Size",
-          "value": "40 × 40 × 10 mm"
+          "value": "40 \u00d7 40 \u00d7 10 mm"
         },
         {
           "label": "Voltage",
@@ -5429,7 +5429,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-cable-cage-top-full-9e4c43a620ca.png",
       "assembly": "Cable Cage",
       "description": "Top plate of the cable cage. Has a keyed cutout for easy insertion/removal of the interface.",
-      "thicknessIn": "1/8″",
+      "thicknessIn": "1/8\u2033",
       "thicknessMm": 3,
       "widthMm": 325,
       "heightMm": 375,
@@ -5440,9 +5440,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "cage-top",
-        "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big Ø177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
-        "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
-        "tools": "jigsaw · drill · tape measure"
+        "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big \u00d8177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
+        "stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
+        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
       },
       "printed": {
         "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
@@ -5466,7 +5466,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-cable-cage-bottom-full-283aeb114195.png",
       "assembly": "Cable Cage",
       "description": "Bottom plate of the cable cage.",
-      "thicknessIn": "1/8″",
+      "thicknessIn": "1/8\u2033",
       "thicknessMm": 3,
       "widthMm": 325,
       "heightMm": 375,
@@ -5477,9 +5477,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "cage-bottom",
-        "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big Ø177 mm centre hole and six Ø5.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
-        "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
-        "tools": "jigsaw · drill · tape measure"
+        "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big \u00d8177 mm centre hole and six \u00d85.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
+        "stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
+        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
       },
       "printed": {
         "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
@@ -5499,7 +5499,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-top-plate-w1600-00182ea8156d.jpg",
       "caption": "The machine's hexagonal top plate; the interface mounts under it.",
       "description": "Machine top plate. Has 5 cable holes and holes for the main stepper. Does not yet have mount holes for the C-channels.",
-      "thicknessIn": "3/8″",
+      "thicknessIn": "3/8\u2033",
       "thicknessMm": 10,
       "widthMm": 672,
       "heightMm": 770,
@@ -5510,9 +5510,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "top-plate",
-        "blurb": "This plate is a regular hexagon — it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8″) drill holes.",
-        "stock": "672.4 × 776.4 mm rectangle (26 15/32″ × 30 9/16″)",
-        "tools": "jigsaw · drill · tape measure"
+        "blurb": "This plate is a regular hexagon \u2014 it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8\u2033) drill holes.",
+        "stock": "672.4 \u00d7 776.4 mm rectangle (26 15/32\u2033 \u00d7 30 9/16\u2033)",
+        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
       }
     }
   ],
@@ -5528,7 +5528,7 @@
       "joining": [
         {
           "method": "self-tap",
-          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post — no insert, no nut."
+          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post \u2014 no insert, no nut."
         }
       ],
       "lines": [
@@ -5596,13 +5596,13 @@
       "uid": "99af",
       "version": "1",
       "name": "Fixed upper section",
-      "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 × [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
+      "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 \u00d7 [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "joining": [
         {
           "method": "self-tap",
-          "note": "Both of each rib's [[hw:scr-m5-16-shcs]] thread straight into the printed upper fixed section — no insert, no nut."
+          "note": "Both of each rib's [[hw:scr-m5-16-shcs]] thread straight into the printed upper fixed section \u2014 no insert, no nut."
         }
       ],
       "lines": [
@@ -5668,7 +5668,7 @@
       "uid": "jqhp",
       "version": "1",
       "name": "Chute bearing assembly",
-      "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 × 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
+      "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 \u00d7 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
       "status": "partial",
       "lines": [
         {
@@ -6064,7 +6064,7 @@
       "uid": "s7bo",
       "version": "1",
       "name": "Pico with headers",
-      "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare — the pins are a separate purchase.",
+      "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare \u2014 the pins are a separate purchase.",
       "docs": "/hardware/electronics/installation/pico-headers/",
       "status": "partial",
       "joining": [
@@ -6155,7 +6155,7 @@
       "uid": "bkgq",
       "version": "2",
       "name": "Interface",
-      "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
+      "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6404,7 +6404,7 @@
       "uid": "jog7",
       "version": "2",
       "name": "Distribution layer",
-      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 × [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
+      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
       "lines": [
@@ -6596,7 +6596,7 @@
       "uid": "mttx",
       "version": "1",
       "name": "C-channel drive",
-      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Screw joints: 4 × [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 × [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 × [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 × [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke — the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing (the light post's 2 × [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke \u2014 the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
       "status": "partial",
       "lines": [
@@ -6643,7 +6643,7 @@
       "uid": "cwji",
       "version": "1",
       "name": "Chute Stepper Gearing",
-      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3×35 keeps it clear of the limit switch hammer.",
+      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6732,7 +6732,7 @@
       "uid": "8cjj",
       "version": "1",
       "name": "Interface chute gear + mount",
-      "description": "The chute gear screwed down onto the top interface chute mount — two sections of the split spur gear that become one turning unit.",
+      "description": "The chute gear screwed down onto the top interface chute mount \u2014 two sections of the split spur gear that become one turning unit.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6755,13 +6755,13 @@
       "uid": "8z0e",
       "version": "1",
       "name": "Hex frame",
-      "description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket — side, with six B/H spokes and Frame crossbeams held inside by the Frame 90° brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
+      "description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket \u2014 side, with six B/H spokes and Frame crossbeams held inside by the Frame 90\u00b0 brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
       "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
       "status": "partial",
       "joining": [
         {
           "method": "friction",
-          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
+          "note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
         }
       ],
       "lines": [
@@ -6800,7 +6800,7 @@
       "uid": "22ck",
       "version": "2",
       "name": "Distribution frame",
-      "description": "The frame of one distribution layer: a hex frame plus the External bracket — cover and — bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
+      "description": "The frame of one distribution layer: a hex frame plus the External bracket \u2014 cover and \u2014 bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
       "lines": [
@@ -6825,7 +6825,7 @@
         {
           "version": "1",
           "uid": "adaj",
-          "message": "Original version: bundled the hex frame's own outer ring, spokes, crossbeams and 90° brackets inline instead of as a separate assembly.",
+          "message": "Original version: bundled the hex frame's own outer ring, spokes, crossbeams and 90\u00b0 brackets inline instead of as a separate assembly.",
           "lines": [
             {
               "assembly": "external-bracket",
@@ -6847,7 +6847,7 @@
         {
           "version": "2",
           "date": "2026-08-29",
-          "message": "Split the hex frame (outer ring, spokes, crossbeams, 90° brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
+          "message": "Split the hex frame (outer ring, spokes, crossbeams, 90\u00b0 brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
           "commit": "a2c66436"
         }
       ]
@@ -6857,7 +6857,7 @@
       "uid": "rns2",
       "version": "2",
       "name": "basically Embedded Control Board Housing",
-      "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base — no bracket, no standoffs — and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
+      "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base \u2014 no bracket, no standoffs \u2014 and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
       "section": "electronics",
       "docs": "/hardware/electronics/installation/control-board-housing/",
       "status": "partial",
@@ -6930,7 +6930,7 @@
           "version": "1",
           "uid": "u12m",
           "date": "2026-07-18",
-          "message": "The board stood off a printed bracket on four 10 mm standoffs, and the 40 mm fan sat on a separate bracket cantilevered over it — the same bracket the Orange Pi mount uses. Superseded by the printed housing.",
+          "message": "The board stood off a printed bracket on four 10 mm standoffs, and the 40 mm fan sat on a separate bracket cantilevered over it \u2014 the same bracket the Orange Pi mount uses. Superseded by the printed housing.",
           "images": [
             {
               "url": "https://assets.basically.website/sorter-parts/ctrl-board-mount-v1-render-full-617e995364c7.png",
@@ -6979,7 +6979,7 @@
         {
           "version": "2",
           "date": "2026-08-23",
-          "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 × 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
+          "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 \u00d7 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
           "commit": "9ff8a1e3"
         }
       ]
@@ -7130,10 +7130,10 @@
     },
     {
       "id": "lazy-susan",
-      "uid": "l1un",
-      "version": "1",
+      "uid": "v6ss",
+      "version": "2",
       "name": "Bottom lazy Susan",
-      "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 × [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
+      "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 \u00d7 [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
       "status": "partial",
       "lines": [
@@ -7167,11 +7167,23 @@
         },
         {
           "part": "scr-m5-16-shcs",
-          "qty": 3
+          "qty": 9
         },
         {
           "part": "tnut-m5-2020",
-          "qty": 3
+          "qty": 6
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "message": "Original version: 1 scr-m5-16-shcs + 1 tnut-m5-2020 per extrusion mount (3 total each), before BrickCycleAlice's 2026-08-28 build photos showed it's actually 2 self-tapping-into-plastic screws for the mount-to-hold-in-place joint (no T-nut) plus 2 more screws per mount into a T-nut in the extrusion (sorter-v2#447)."
+        },
+        {
+          "version": "2",
+          "date": "2026-08-29",
+          "message": "Catalog never picked up sorter-v2#447's fastener correction on bottom-interface.md: 1 screw per mount into the hold-in-place (self-tap, 3 total) plus 2 more per mount into a T-nut in the extrusion (6 more), so 9 scr-m5-16-shcs and 6 tnut-m5-2020 total, not 3 and 3.",
+          "commit": null
         }
       ]
     }
@@ -7205,7 +7217,7 @@
         "variant": "flat"
       },
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-35-fhcs-full-cf13d79a5110.jpg",
-      "image_credit": "M5 × 35 flat head listing photo, reused for the head shape"
+      "image_credit": "M5 \u00d7 35 flat head listing photo, reused for the head shape"
     },
     {
       "id": "screw-button",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column \u2014 both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) \u2014 these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until \u00a75.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit \u2014 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, \u00a75.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views.",
+  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column — both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) — these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until §5.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit — 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, §5.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views.",
   "sections": [
     {
       "id": "feeder",
@@ -271,7 +271,7 @@
       "name": "Stator's four NEMA-bracket holes are too small for an M3",
       "priority": "P0",
       "condition": "broken",
-      "description": "The four holes the NEMA bracket bolts into are \u00d82.40 mm and 10 mm deep. M3's minor (thread-root) diameter is 2.459 mm, so the hole is already narrower than the root before print tolerance takes another 0.1-0.2 mm off it, and the screw has to form a full-depth thread through 10 mm of plastic. It cams out or splits the boss instead, so the bracket cannot be fastened to the stator as printed. Every other M3 thread-forming hole in this assembly is \u00d82.80 \u2014 the rotor's six, the light post's five, and four more in this same stator \u2014 so \u00d82.40 is the odd one out inside its own part, which reads as a CAD slip rather than an intent. The fix is to open the four to \u00d82.80 in CAD. Reported by aleph1111/christoph from a build; measured off the pinned stator STL. Tracked as sorter-v2 issue #405.",
+      "description": "The four holes the NEMA bracket bolts into are Ø2.40 mm and 10 mm deep. M3's minor (thread-root) diameter is 2.459 mm, so the hole is already narrower than the root before print tolerance takes another 0.1-0.2 mm off it, and the screw has to form a full-depth thread through 10 mm of plastic. It cams out or splits the boss instead, so the bracket cannot be fastened to the stator as printed. Every other M3 thread-forming hole in this assembly is Ø2.80 — the rotor's six, the light post's five, and four more in this same stator — so Ø2.40 is the odd one out inside its own part, which reads as a CAD slip rather than an intent. The fix is to open the four to Ø2.80 in CAD. Reported by aleph1111/christoph from a build; measured off the pinned stator STL. Tracked as sorter-v2 issue #405.",
       "targets": {
         "parts": [
           "stator"
@@ -778,8 +778,8 @@
     {
       "id": "frame-90deg-bracket",
       "uid": "3l20",
-      "name": "Frame 90\u00b0 bracket",
-      "description": "Distribution frame 90\u00b0 bracket. Two per frame section.",
+      "name": "Frame 90° bracket",
+      "description": "Distribution frame 90° bracket. Two per frame section.",
       "internal_notes": "12 per frame (per layer); interface qty ASSUMED 12 (Spencer said 'one set per interface' - confirm). Frame color. File: inner_90_bracket.",
       "version": "1",
       "created_at": "2026-06-27",
@@ -801,7 +801,7 @@
     {
       "id": "ls-mount-to-chute",
       "uid": "lma9",
-      "name": "Lazy Susan \u2014 chute mount",
+      "name": "Lazy Susan — chute mount",
       "aliases": [
         "bottom interface lazy Susan chute mount",
         "bottom interface chute mount"
@@ -831,7 +831,7 @@
     {
       "id": "ls-bottom-static",
       "uid": "4mmh",
-      "name": "Lazy Susan \u2014 bottom static",
+      "name": "Lazy Susan — bottom static",
       "aliases": [
         "bottom interface lazy Susan fixed section",
         "bottom interface fixed section"
@@ -861,7 +861,7 @@
     {
       "id": "ls-mount-to-extrusion",
       "uid": "bmt4",
-      "name": "Lazy Susan \u2014 extrusion mount",
+      "name": "Lazy Susan — extrusion mount",
       "description": "Bottom lazy Susan mount to the external extrusion.",
       "internal_notes": "Frame color. QUANTITY ASSUMED 1.",
       "version": "1",
@@ -882,7 +882,7 @@
     {
       "id": "ls-hold-in-place",
       "uid": "ss05",
-      "name": "Lazy Susan \u2014 hold in place",
+      "name": "Lazy Susan — hold in place",
       "description": "Bottom lazy Susan hold-in-place. Optional.",
       "internal_notes": "Optional (file: 'optional hold in place'). Frame color. QUANTITY ASSUMED 1.",
       "version": "1",
@@ -903,7 +903,7 @@
     {
       "id": "ls-washer",
       "uid": "9c4a",
-      "name": "Lazy Susan \u2014 washer",
+      "name": "Lazy Susan — washer",
       "description": "Bottom lazy Susan washer.",
       "internal_notes": "Frame color. QUANTITY UNCONFIRMED (assumed 1; may be several).",
       "version": "1",
@@ -923,7 +923,7 @@
     {
       "id": "ext-bracket-left",
       "uid": "0b4g",
-      "name": "External bracket \u2014 side",
+      "name": "External bracket — side",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Interface qty confirmed at 6, side and cover only, no bottom vertical there (top-interface.md step 14). Frame color.",
       "version": "1",
@@ -942,14 +942,14 @@
       "optional": false,
       "support": false,
       "low_tolerance": true,
-      "low_tolerance_note": "A test print is suggested. This part is a tight fit around the 2020 aluminum profile, so print one first and confirm it seats properly before committing to the full set \u2014 dial in your printer and profile together.",
+      "low_tolerance_note": "A test print is suggested. This part is a tight fit around the 2020 aluminum profile, so print one first and confirm it seats properly before committing to the full set — dial in your printer and profile together.",
       "onshape_version": "https://cad.onshape.com/documents/a4a1965bbaf3a15aff2b13ed/v/7279a42b05833c7b828efb0d/e/b0ee2e787191265cba1c1a31",
       "docs_page": "/hardware/helpers/external-bracket/"
     },
     {
       "id": "ext-bracket-bottom-vertical",
       "uid": "xgzj",
-      "name": "External bracket \u2014 bottom vertical",
+      "name": "External bracket — bottom vertical",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Not used at the top interface: that joint has no bottom vertical or flange (top-interface.md step 14, confirmed 2026-08-25). The earlier 'interface: 6' assumption here was wrong, removed. Frame color.",
       "version": "1",
@@ -973,7 +973,7 @@
     {
       "id": "ext-bracket-cover",
       "uid": "1r5i",
-      "name": "External bracket \u2014 cover",
+      "name": "External bracket — cover",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Interface qty confirmed at 6, side and cover only, no bottom vertical there (top-interface.md step 14). Frame color.",
       "version": "1",
@@ -1170,7 +1170,7 @@
       "uid": "50dv",
       "name": "Cable clamp (outer)",
       "description": "Outer half of the ribbon cable clamp. White.",
-      "internal_notes": "1 per interface. White. Pairs with the inner clamp (cable-clamp assembly). v2 (2026-07-18): enlarged the M3 nut pocket so the nut seats \u2014 it did not fit in v1.",
+      "internal_notes": "1 per interface. White. Pairs with the inner clamp (cable-clamp assembly). v2 (2026-07-18): enlarged the M3 nut pocket so the nut seats — it did not fit in v1.",
       "version": "2",
       "created_at": "2026-06-27",
       "updated_at": "2026-07-18",
@@ -1292,7 +1292,7 @@
     {
       "id": "chute-stepper-idler-bearing-retainer-outer",
       "uid": "wgsc",
-      "name": "Chute Stepper Idler Gear Bearing Retainer \u2014 Outer",
+      "name": "Chute Stepper Idler Gear Bearing Retainer — Outer",
       "aliases": [
         "Idler Gear Bearing Retainer - Outer",
         "idler bearing retainer"
@@ -1317,7 +1317,7 @@
     {
       "id": "chute-stepper-idler-bearing-retainer-inner",
       "uid": "zzql",
-      "name": "Chute Stepper Idler Gear Bearing Retainer \u2014 Inner",
+      "name": "Chute Stepper Idler Gear Bearing Retainer — Inner",
       "aliases": [
         "Idler Gear Bearing Retainer - Inner",
         "idler gear cap"
@@ -1491,7 +1491,7 @@
         "chute core mount"
       ],
       "description": "Section 3 of 3 of the top interface split spur gear (Spur 2M 120T).",
-      "internal_notes": "Split spur gear for the top interface; the 3 sections print separately and assemble into one gear. Chute-core color. Carries 4\u00d7 M4 inserts, plus 7\u00d7 M3: 2 for the cable clamp and 5 on the underside that the chute gear screws down into. Counted on the physical part by barthel 2026-08-21 and confirmed against the STL (7 x 4.20 mm bores, ruthex's recommended M3 insert hole, re-measured with the detection thresholds loosened in case any were missed). The previous count of 9 added 2 for the layer connector, which the published model does not have; resolves the docs-merge-2026-08-21 conflict.",
+      "internal_notes": "Split spur gear for the top interface; the 3 sections print separately and assemble into one gear. Chute-core color. Carries 4× M4 inserts, plus 7× M3: 2 for the cable clamp and 5 on the underside that the chute gear screws down into. Counted on the physical part by barthel 2026-08-21 and confirmed against the STL (7 x 4.20 mm bores, ruthex's recommended M3 insert hole, re-measured with the detection thresholds loosened in case any were missed). The previous count of 9 added 2 for the layer connector, which the published model does not have; resolves the docs-merge-2026-08-21 conflict.",
       "version": "1",
       "created_at": "2026-07-03",
       "updated_at": "2026-07-03",
@@ -1823,7 +1823,7 @@
     {
       "id": "servo-adapter-servo-side",
       "uid": "fu2t",
-      "name": "Servo adapter \u2014 servo side",
+      "name": "Servo adapter — servo side",
       "description": "MG995 servo adapter, servo side.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1843,7 +1843,7 @@
     {
       "id": "servo-adapter-flap-side",
       "uid": "lv7n",
-      "name": "Servo adapter \u2014 flap side",
+      "name": "Servo adapter — flap side",
       "description": "MG995 servo adapter, flap side.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1863,7 +1863,7 @@
     {
       "id": "servo-bracket-lower-arm",
       "uid": "yqz1",
-      "name": "Servo bracket \u2014 lower arm",
+      "name": "Servo bracket — lower arm",
       "description": "MG995 servo bracket, lower arm.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1883,7 +1883,7 @@
     {
       "id": "servo-bracket-side-arm",
       "uid": "75na",
-      "name": "Servo bracket \u2014 side arm",
+      "name": "Servo bracket — side arm",
       "description": "MG995 servo bracket, side arm.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1903,7 +1903,7 @@
     {
       "id": "servo-bracket-cover",
       "uid": "rqor",
-      "name": "Servo bracket \u2014 cover",
+      "name": "Servo bracket — cover",
       "description": "MG995 servo bracket, cover.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1923,7 +1923,7 @@
     {
       "id": "servo-bracket-housing",
       "uid": "tr15",
-      "name": "Servo bracket \u2014 housing",
+      "name": "Servo bracket — housing",
       "description": "MG995 servo bracket, housing.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -2028,7 +2028,7 @@
     {
       "id": "camera-mount-part-6",
       "uid": "v9dv",
-      "name": "Overhead camera mount \u2014 A/B connector",
+      "name": "Overhead camera mount — A/B connector",
       "description": "Camera mount part 6. 2 per machine.",
       "internal_notes": "1 per camera mount x 2 mounts. Color not important (feeder).",
       "version": "1",
@@ -2085,7 +2085,7 @@
     {
       "id": "camera-mount-rod-mount",
       "uid": "twuu",
-      "name": "Camera mount \u2014 rod-to-C-channel mount",
+      "name": "Camera mount — rod-to-C-channel mount",
       "description": "Rod-to-C-channel mount (Part 33). 2 per camera mount, 4 total.",
       "internal_notes": "Part 33, the rod-to-c-channel mount. 2 per camera mount x 2 mounts = 4. Color not important (feeder).",
       "version": "1",
@@ -2547,7 +2547,7 @@
     {
       "id": "ctrl-board-housing-base",
       "uid": "204b",
-      "name": "Control Board Housing \u2014 Base",
+      "name": "Control Board Housing — Base",
       "description": "Base of the basically Embedded Control Board housing. The board screws straight to it on four heat inserts and the cover screws down onto four more; no standoffs.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Entered the machine on 2026-08-23 when candidate rns2 was promoted to ctrl-board-mount v2. Eight standard M3 inserts (hsi-m3, RX-M3x5.7 -- Spencer said 'the long variant', which is this one relative to the short M3S): four under the board, four for the cover.",
       "version": "1",
@@ -2574,8 +2574,8 @@
     {
       "id": "ctrl-board-housing-cover",
       "uid": "ksh2",
-      "name": "Control Board Housing \u2014 Cover",
-      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 \u00d7 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 \u00d7 12 mm button head screws, and the plunger passes through it.",
+      "name": "Control Board Housing — Cover",
+      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 × 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 × 12 mm button head screws, and the plunger passes through it.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
       "created_at": "2026-08-22",
@@ -2595,7 +2595,7 @@
     {
       "id": "ctrl-board-housing-plunger",
       "uid": "cljt",
-      "name": "Control Board Housing \u2014 Plunger",
+      "name": "Control Board Housing — Plunger",
       "description": "Plunger that passes through the housing cover, held in by the plunger retainer.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
@@ -2616,8 +2616,8 @@
     {
       "id": "ctrl-board-housing-plunger-retainer",
       "uid": "g9sx",
-      "name": "Control Board Housing \u2014 Plunger Retainer",
-      "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 \u00d7 8 mm countersunk screws.",
+      "name": "Control Board Housing — Plunger Retainer",
+      "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 × 8 mm countersunk screws.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Entered the machine on 2026-08-23 when candidate rns2 was promoted to ctrl-board-mount v2. Two countersunk holes either side of the plunger slot (counted off the STL).",
       "version": "1",
       "created_at": "2026-08-22",
@@ -2679,7 +2679,7 @@
       "uid": "3ufy",
       "name": "40 mm Fan Bracket",
       "description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
-      "internal_notes": "Was 2 per machine \u2014 the control board and the Orange Pi each had one. The control board's housing carries its own fan as of ctrl-board-mount v2 (2026-08-23), so only the Orange Pi mount still uses this.",
+      "internal_notes": "Was 2 per machine — the control board and the Orange Pi each had one. The control board's housing carries its own fan as of ctrl-board-mount v2 (2026-08-23), so only the Orange Pi mount still uses this.",
       "version": "1",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-23",
@@ -2698,7 +2698,7 @@
     {
       "id": "meanwell-psu-housing-shell-rear",
       "uid": "7qz3",
-      "name": "PSU Housing \u2014 Shell Rear Tray",
+      "name": "PSU Housing — Shell Rear Tray",
       "description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell rear tray.stl'. Carries the self-tapping M3 holes for both lids.",
       "version": "1",
@@ -2717,7 +2717,7 @@
     {
       "id": "meanwell-psu-housing-shell-front",
       "uid": "1h8p",
-      "name": "PSU Housing \u2014 Shell Front Module",
+      "name": "PSU Housing — Shell Front Module",
       "description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell front module.stl'.",
       "version": "1",
@@ -2736,7 +2736,7 @@
     {
       "id": "meanwell-psu-housing-lid-rear",
       "uid": "m26o",
-      "name": "PSU Housing \u2014 Lid Rear",
+      "name": "PSU Housing — Lid Rear",
       "description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid rear.stl'.",
       "version": "1",
@@ -2755,7 +2755,7 @@
     {
       "id": "meanwell-psu-housing-lid-front",
       "uid": "avux",
-      "name": "PSU Housing \u2014 Lid Front",
+      "name": "PSU Housing — Lid Front",
       "description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid front.stl'.",
       "version": "1",
@@ -2774,7 +2774,7 @@
     {
       "id": "meanwell-psu-housing-front-panel",
       "uid": "n1oh",
-      "name": "PSU Housing \u2014 Front Panel",
+      "name": "PSU Housing — Front Panel",
       "description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - front panel.stl'.",
       "version": "1",
@@ -2798,12 +2798,12 @@
         "type": "screw",
         "size": "M3"
       },
-      "name": "M3 screw \u2014 type and length TBD",
+      "name": "M3 screw — type and length TBD",
       "category": "Screws",
       "description": "Placeholder for the M3s whose head type and length nobody has written down yet: the cable-mount cage bracket, the camera extension, and the two board mounts.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
-      "note": "Neither the head type nor the length is recorded \u2014 measure before ordering.",
+      "note": "Neither the head type nor the length is recorded — measure before ordering.",
       "attributes": [
         {
           "label": "Thread",
@@ -2831,10 +2831,10 @@
       "name": "M3 socket/button head, length TBD",
       "category": "Screws",
       "alternative": "Socket or button head",
-      "description": "Was the placeholder for the screws holding the basically Embedded Control Board to the housing base, before they were measured as M3 \u00d7 6 mm button head. Nothing calls for it now; the uid is kept because it was minted.",
+      "description": "Was the placeholder for the screws holding the basically Embedded Control Board to the housing base, before they were measured as M3 × 6 mm button head. Nothing calls for it now; the uid is kept because it was minted.",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-22",
-      "note": "Superseded before it was ever ordered \u2014 nothing in the catalog calls for it.",
+      "note": "Superseded before it was ever ordered — nothing in the catalog calls for it.",
       "attributes": [
         {
           "label": "Thread",
@@ -2860,7 +2860,7 @@
         "variant": "countersunk",
         "length_mm": 6
       },
-      "name": "M3 \u00d7 6 mm countersunk",
+      "name": "M3 × 6 mm countersunk",
       "category": "Screws",
       "description": "Secures the limit switch hammer into the top interface chute mount from below, into the hammer's M3 insert.",
       "created_at": "2026-08-18",
@@ -2882,7 +2882,7 @@
       "sheet_qty": {
         "per_machine": 1
       },
-      "note": "The \u00d71 is the top-interface count (limit-switch hammer). Screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "The ×1 is the top-interface count (limit-switch hammer). Screws used elsewhere on the machine aren't tallied here yet.",
       "image_url": "https://assets.basically.website/sorter-parts/hardware-screws-countersunk-full-faf0edbe3324.jpg"
     },
     {
@@ -2895,7 +2895,7 @@
         "variant": "socket",
         "length_mm": 10
       },
-      "name": "M3 \u00d7 10 mm socket/button head",
+      "name": "M3 × 10 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-10-shcs-full-26e52d7d5bcd.png",
@@ -2919,7 +2919,7 @@
       "sheet_qty": {
         "per_machine": 3
       },
-      "note": "The \u00d73 is the top-interface count (2 cable clamp, 1 ribbon clamp). Screws used elsewhere on the machine aren't tallied here yet."
+      "note": "The ×3 is the top-interface count (2 cable clamp, 1 ribbon clamp). Screws used elsewhere on the machine aren't tallied here yet."
     },
     {
       "id": "scr-m3-8-cs",
@@ -2931,9 +2931,9 @@
         "variant": "countersunk",
         "length_mm": 8
       },
-      "name": "M3 \u00d7 8 mm countersunk",
+      "name": "M3 × 8 mm countersunk",
       "category": "Screws",
-      "description": "The workhorse M3 screw \u2014 used all over the machine wherever a flush head is wanted.",
+      "description": "The workhorse M3 screw — used all over the machine wherever a flush head is wanted.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -2981,7 +2981,7 @@
         "variant": "socket",
         "length_mm": 8
       },
-      "name": "M2 \u00d7 8 mm socket/button head",
+      "name": "M2 × 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "description": "Self-taps the IMX415 classification camera board to the camera extension's printed post. 4 per module, no insert. May also fit the OV9732 overhead camera mount once that gets a real bracket (sorter-v2#426), not confirmed.",
@@ -3013,7 +3013,7 @@
         "variant": "socket",
         "length_mm": 8
       },
-      "name": "M3 \u00d7 8 mm socket/button head",
+      "name": "M3 × 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "description": "Clamps the C-channel input gear (12T) to the flat of the NEMA 17 shaft. 1 per C-channel.",
@@ -3033,7 +3033,7 @@
           "value": "Socket or button head, interchangeable (both bottom on the counterbore floor, so either just clamps)"
         }
       ],
-      "note": "Head type and length measured off the input-gear STL: the boss carries a \u00d82.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the \u00d84.87 mm bore; the head sits in a round \u00d86.40 mm \u00d7 2.7 mm counterbore with a 90\u00b0 cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (\u00d85.5 \u00d7 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (\u00d85.7 \u00d7 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
+      "note": "Head type and length measured off the input-gear STL: the boss carries a Ø2.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the Ø4.87 mm bore; the head sits in a round Ø6.40 mm × 2.7 mm counterbore with a 90° cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (Ø5.5 × 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (Ø5.7 × 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
     },
     {
       "id": "scr-m3-12-cs",
@@ -3045,7 +3045,7 @@
         "variant": "countersunk",
         "length_mm": 12
       },
-      "name": "M3 \u00d7 12 mm countersunk",
+      "name": "M3 × 12 mm countersunk",
       "category": "Screws",
       "description": "The long M3 countersunk. Used all over the machine.",
       "created_at": "2026-07-18",
@@ -3095,9 +3095,9 @@
         "variant": "countersunk",
         "length_mm": 20
       },
-      "name": "M3 \u00d7 20 mm countersunk",
+      "name": "M3 × 20 mm countersunk",
       "category": "Screws",
-      "description": "Joins the C-channel light post to the NEMA bracket. Threads straight into the printed post \u2014 no insert, no nut.",
+      "description": "Joins the C-channel light post to the NEMA bracket. Threads straight into the printed post — no insert, no nut.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -3142,7 +3142,7 @@
         "variant": "socket",
         "length_mm": 16
       },
-      "name": "M3 \u00d7 16 mm socket/button head",
+      "name": "M3 × 16 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png",
@@ -3174,7 +3174,7 @@
         "variant": "button",
         "length_mm": 6
       },
-      "name": "M3 \u00d7 6 mm socket/button head",
+      "name": "M3 × 6 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-6-bhcs-full-26e52d7d5bcd.png",
@@ -3206,7 +3206,7 @@
         "variant": "button",
         "length_mm": 12
       },
-      "name": "M3 \u00d7 12 mm socket/button head",
+      "name": "M3 × 12 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-12-bhcs-full-26e52d7d5bcd.png",
@@ -3238,7 +3238,7 @@
         "variant": "flat",
         "length_mm": 35
       },
-      "name": "M3 \u00d7 35 mm flat head",
+      "name": "M3 × 35 mm flat head",
       "category": "Screws",
       "alternative": "Flat or pan head",
       "description": "The two long M3s on the top interface: one clamps the two cable-clamp halves together, one retains the idler gear on the NEMA 23 bracket. Same screw for both. The head has to stay low because of the idler joint: a socket or button head stands proud enough for the limit switch hammer to catch on it as the chute sweeps past.",
@@ -3269,7 +3269,7 @@
         "variant": "countersunk",
         "length_mm": 6
       },
-      "name": "M4 \u00d7 6 mm countersunk",
+      "name": "M4 × 6 mm countersunk",
       "category": "Screws",
       "description": "Fastens the printed PSU housing to the power supply's own case threads.",
       "created_at": "2026-07-18",
@@ -3299,9 +3299,9 @@
         "variant": "countersunk",
         "length_mm": 12
       },
-      "name": "M4 \u00d7 12 mm countersunk",
+      "name": "M4 × 12 mm countersunk",
       "category": "Screws",
-      "description": "Bolts each lazy Susan together \u2014 4 a side, through the M4 inserts in the static half and the chute mount. 2 lazy Susans per machine.",
+      "description": "Bolts each lazy Susan together — 4 a side, through the M4 inserts in the static half and the chute mount. 2 lazy Susans per machine.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -3330,7 +3330,7 @@
         "variant": "socket",
         "length_mm": 12
       },
-      "name": "M5 \u00d7 12 mm socket/button head",
+      "name": "M5 × 12 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-12-shcs-full-26e52d7d5bcd.png",
@@ -3362,7 +3362,7 @@
         "variant": "socket",
         "length_mm": 16
       },
-      "name": "M5 \u00d7 16 mm socket/button head",
+      "name": "M5 × 16 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-16-shcs-full-26e52d7d5bcd.png",
@@ -3383,7 +3383,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Designed to self-tap into printed plastic wherever it lands in an external bracket or the upper fixed section \u2014 no nut and no insert there."
+      "note": "Designed to self-tap into printed plastic wherever it lands in an external bracket or the upper fixed section — no nut and no insert there."
     },
     {
       "id": "scr-m5-20-shcs",
@@ -3395,7 +3395,7 @@
         "variant": "socket",
         "length_mm": 20
       },
-      "name": "M5 \u00d7 20 mm socket/button head",
+      "name": "M5 × 20 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-20-shcs-full-26e52d7d5bcd.png",
@@ -3427,7 +3427,7 @@
         "variant": "socket",
         "length_mm": 30
       },
-      "name": "M5 \u00d7 30 mm socket/button head",
+      "name": "M5 × 30 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-30-shcs-full-26e52d7d5bcd.png",
@@ -3459,7 +3459,7 @@
         "variant": "flat",
         "length_mm": 35
       },
-      "name": "M5 \u00d7 35 mm flat head",
+      "name": "M5 × 35 mm flat head",
       "internal_notes": "Flat (pancake) head, hex socket, confirmed by barthel 2026-08-21: \"The m3x35mm must be a flat hat screw like in calculator\" (the M5 x 35 is the only 35 mm screw the two catalogs disagreed about; the M3 x 35 was already settled as flat head in #356). The docs catalog had called it a socket head cap screw; that claim is dropped and the docs prose now says flat head. Resolves the last docs-merge-2026-08-21 conflict.",
       "category": "Screws",
       "description": "The long screws that stack the cable cage together, and that bolt the plywood top plate down onto the interface brackets.",
@@ -3516,7 +3516,7 @@
         "variant": "countersunk",
         "length_mm": 8
       },
-      "name": "M5 \u00d7 8 mm countersunk",
+      "name": "M5 × 8 mm countersunk",
       "category": "Screws",
       "description": "Loosely fixes the limit-switch interface bracket's extrusion into the interface rib while aligning it, into a T-nut.",
       "created_at": "2026-08-18",
@@ -3535,7 +3535,7 @@
           "value": "Countersunk (flat) socket"
         }
       ],
-      "note": "A snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush. The \u00d76 is the top-interface count (1 per interface bracket); screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "A snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush. The ×6 is the top-interface count (1 per interface bracket); screws used elsewhere on the machine aren't tallied here yet.",
       "sheet_qty": {
         "per_machine": 6
       },
@@ -3551,9 +3551,9 @@
         "variant": "countersunk",
         "length_mm": 22
       },
-      "name": "M5 \u00d7 22 mm countersunk",
+      "name": "M5 × 22 mm countersunk",
       "category": "Screws",
-      "description": "Bolts the interface bracket assembly and all six interface brackets down through the laser-cut top plate (holes S2/S3, then I1\u2013I6 and O1\u2013O6).",
+      "description": "Bolts the interface bracket assembly and all six interface brackets down through the laser-cut top plate (holes S2/S3, then I1–I6 and O1–O6).",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-18",
       "attributes": [
@@ -3570,7 +3570,7 @@
           "value": "Countersunk (flat) socket"
         }
       ],
-      "note": "The top plate's laser-cut holes aren't countersunk, so where a flush head won't seat an M5 \u00d7 20 button head is used instead. The \u00d714 is the top-interface count (2 to the top plate, 12 through the bracket holes); screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "The top plate's laser-cut holes aren't countersunk, so where a flush head won't seat an M5 × 20 button head is used instead. The ×14 is the top-interface count (2 to the top plate, 12 through the bracket holes); screws used elsewhere on the machine aren't tallied here yet.",
       "sheet_qty": {
         "per_machine": 14
       },
@@ -3606,7 +3606,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Length unknown \u2014 measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
+      "note": "Length unknown — measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
     },
     {
       "id": "washer-m3-15",
@@ -3616,9 +3616,9 @@
         "type": "washer",
         "size": "M3"
       },
-      "name": "M3 \u00d7 15 mm washer",
+      "name": "M3 × 15 mm washer",
       "category": "Washers",
-      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
+      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-25",
       "attributes": [
@@ -3719,7 +3719,7 @@
         "type": "stock-material",
         "size": "3/8 in"
       },
-      "name": "Steel rod, 3/8 in \u2014 4 ft stock",
+      "name": "Steel rod, 3/8 in — 4 ft stock",
       "category": "Stock material",
       "description": "Bought as a length and cut down. One 4 ft rod yields all four ~1 ft pieces the two overhead camera arms hang from.",
       "created_at": "2026-07-18",
@@ -3734,7 +3734,7 @@
       "attributes": [
         {
           "label": "Diameter",
-          "value": "3/8 in (9.53 mm) \u00b7 10 mm in metric"
+          "value": "3/8 in (9.53 mm) · 10 mm in metric"
         },
         {
           "label": "Buy",
@@ -3742,7 +3742,7 @@
         },
         {
           "label": "Cut into",
-          "value": "4 \u00d7 ~1 ft (305 mm)"
+          "value": "4 × ~1 ft (305 mm)"
         },
         {
           "label": "Material",
@@ -4193,7 +4193,7 @@
         },
         {
           "label": "Thread",
-          "value": "M6 \u00d7 1.0"
+          "value": "M6 × 1.0"
         },
         {
           "label": "Material",
@@ -4230,7 +4230,7 @@
         "type": "wheel",
         "size": "M6"
       },
-      "name": "Swivel stem caster, M6 \u00d7 15 mm",
+      "name": "Swivel stem caster, M6 × 15 mm",
       "category": "Wheels",
       "description": "Screws into the 2020 foot connector so the machine can roll.",
       "created_at": "2026-07-18",
@@ -4238,7 +4238,7 @@
       "attributes": [
         {
           "label": "Thread",
-          "value": "M6 \u00d7 1.0, 15 mm stem"
+          "value": "M6 × 1.0, 15 mm stem"
         },
         {
           "label": "Wheel",
@@ -4418,7 +4418,7 @@
       "attributes": [
         {
           "label": "Size",
-          "value": "30 \u00d7 42 \u00d7 7 mm (ID \u00d7 OD \u00d7 W)"
+          "value": "30 × 42 × 7 mm (ID × OD × W)"
         },
         {
           "label": "Seal",
@@ -4506,7 +4506,7 @@
       "attributes": [
         {
           "label": "Size",
-          "value": "20 \u00d7 27 \u00d7 4 mm (ID \u00d7 OD \u00d7 W)"
+          "value": "20 × 27 × 4 mm (ID × OD × W)"
         },
         {
           "label": "Seal",
@@ -4652,7 +4652,7 @@
         },
         {
           "label": "Size",
-          "value": "22 \u00d7 30 mm"
+          "value": "22 × 30 mm"
         },
         {
           "label": "Fits",
@@ -4889,7 +4889,7 @@
       "cots": {
         "type": "cable"
       },
-      "name": "IDC ribbon cable, 16-pin (2\u00d78), 1 m",
+      "name": "IDC ribbon cable, 16-pin (2×8), 1 m",
       "category": "Electronics",
       "description": "Cable from distribution board to chute",
       "created_at": "2026-07-18",
@@ -4914,7 +4914,7 @@
       "attributes": [
         {
           "label": "Pins",
-          "value": "16 (2\u00d78), FC to FC, A-type"
+          "value": "16 (2×8), FC to FC, A-type"
         },
         {
           "label": "Pitch",
@@ -4937,7 +4937,7 @@
       "cots": {
         "type": "cable"
       },
-      "name": "IDC ribbon cable, 16-pin (2\u00d78), 30 cm",
+      "name": "IDC ribbon cable, 16-pin (2×8), 30 cm",
       "category": "Electronics",
       "description": "Cable between layer and layer below",
       "created_at": "2026-07-18",
@@ -4962,7 +4962,7 @@
       "attributes": [
         {
           "label": "Pins",
-          "value": "16 (2\u00d78), female-to-female FC"
+          "value": "16 (2×8), female-to-female FC"
         },
         {
           "label": "Pitch",
@@ -5137,7 +5137,7 @@
       "cots": {
         "type": "converter"
       },
-      "name": "24 V \u2192 5 V USB-C buck converter",
+      "name": "24 V → 5 V USB-C buck converter",
       "category": "Wire harness",
       "description": "Powers the Orange Pi from the 24 V PSU.",
       "created_at": "2026-07-18",
@@ -5145,7 +5145,7 @@
       "attributes": [
         {
           "label": "Input",
-          "value": "DC 8\u201332 V (12 V / 24 V nominal)"
+          "value": "DC 8–32 V (12 V / 24 V nominal)"
         },
         {
           "label": "Output",
@@ -5231,7 +5231,7 @@
         },
         {
           "label": "Fuse",
-          "value": "10 A installed (5 \u00d7 20 mm)"
+          "value": "10 A installed (5 × 20 mm)"
         },
         {
           "label": "Wiring",
@@ -5239,7 +5239,7 @@
         },
         {
           "label": "Cutout",
-          "value": "47 \u00d7 28 mm; holes 40 mm apart, 3.2 mm"
+          "value": "47 × 28 mm; holes 40 mm apart, 3.2 mm"
         }
       ],
       "sheet_qty": {
@@ -5269,13 +5269,13 @@
       },
       "name": "40 mm 24 V fan (WINSINN 4010)",
       "category": "Electronics",
-      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 \u00d7 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
+      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 × 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-23",
       "attributes": [
         {
           "label": "Size",
-          "value": "40 \u00d7 40 \u00d7 10 mm"
+          "value": "40 × 40 × 10 mm"
         },
         {
           "label": "Voltage",
@@ -5429,7 +5429,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-cable-cage-top-full-9e4c43a620ca.png",
       "assembly": "Cable Cage",
       "description": "Top plate of the cable cage. Has a keyed cutout for easy insertion/removal of the interface.",
-      "thicknessIn": "1/8\u2033",
+      "thicknessIn": "1/8″",
       "thicknessMm": 3,
       "widthMm": 325,
       "heightMm": 375,
@@ -5440,9 +5440,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "cage-top",
-        "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big \u00d8177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
-        "stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
-        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
+        "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big Ø177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
+        "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
+        "tools": "jigsaw · drill · tape measure"
       },
       "printed": {
         "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
@@ -5466,7 +5466,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-cable-cage-bottom-full-283aeb114195.png",
       "assembly": "Cable Cage",
       "description": "Bottom plate of the cable cage.",
-      "thicknessIn": "1/8\u2033",
+      "thicknessIn": "1/8″",
       "thicknessMm": 3,
       "widthMm": 325,
       "heightMm": 375,
@@ -5477,9 +5477,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "cage-bottom",
-        "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big \u00d8177 mm centre hole and six \u00d85.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
-        "stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
-        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
+        "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big Ø177 mm centre hole and six Ø5.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
+        "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
+        "tools": "jigsaw · drill · tape measure"
       },
       "printed": {
         "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
@@ -5499,7 +5499,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-top-plate-w1600-00182ea8156d.jpg",
       "caption": "The machine's hexagonal top plate; the interface mounts under it.",
       "description": "Machine top plate. Has 5 cable holes and holes for the main stepper. Does not yet have mount holes for the C-channels.",
-      "thicknessIn": "3/8\u2033",
+      "thicknessIn": "3/8″",
       "thicknessMm": 10,
       "widthMm": 672,
       "heightMm": 770,
@@ -5510,9 +5510,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "top-plate",
-        "blurb": "This plate is a regular hexagon \u2014 it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8\u2033) drill holes.",
-        "stock": "672.4 \u00d7 776.4 mm rectangle (26 15/32\u2033 \u00d7 30 9/16\u2033)",
-        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
+        "blurb": "This plate is a regular hexagon — it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8″) drill holes.",
+        "stock": "672.4 × 776.4 mm rectangle (26 15/32″ × 30 9/16″)",
+        "tools": "jigsaw · drill · tape measure"
       }
     }
   ],
@@ -5528,7 +5528,7 @@
       "joining": [
         {
           "method": "self-tap",
-          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post \u2014 no insert, no nut."
+          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post — no insert, no nut."
         }
       ],
       "lines": [
@@ -5596,13 +5596,13 @@
       "uid": "99af",
       "version": "1",
       "name": "Fixed upper section",
-      "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 \u00d7 [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
+      "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 × [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "joining": [
         {
           "method": "self-tap",
-          "note": "Both of each rib's [[hw:scr-m5-16-shcs]] thread straight into the printed upper fixed section \u2014 no insert, no nut."
+          "note": "Both of each rib's [[hw:scr-m5-16-shcs]] thread straight into the printed upper fixed section — no insert, no nut."
         }
       ],
       "lines": [
@@ -5668,7 +5668,7 @@
       "uid": "jqhp",
       "version": "1",
       "name": "Chute bearing assembly",
-      "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 \u00d7 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
+      "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 × 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
       "status": "partial",
       "lines": [
         {
@@ -5866,13 +5866,41 @@
       "versions": [
         {
           "version": "1",
-          "message": "Original version: only modeled the switch-to-housing M3 screws; the housing-to-extrusion scr-m5-16-shcs + tnut-m5-2020 (step 4) weren't in the catalog at all."
+          "uid": "eb8m",
+          "message": "Original version: only modeled the switch-to-housing M3 screws; the housing-to-extrusion scr-m5-16-shcs + tnut-m5-2020 (step 4) weren't in the catalog at all.",
+          "lines": [
+            {
+              "part": "limit-switch-dowel-pin",
+              "qty": 1,
+              "uid": "g68e"
+            },
+            {
+              "part": "limit-switch-housing",
+              "qty": 1,
+              "uid": "mrs0"
+            },
+            {
+              "part": "limit-switch-hammer",
+              "qty": 1,
+              "uid": "lfu7"
+            },
+            {
+              "part": "endstop-mechanical",
+              "qty": 1,
+              "uid": "92h6"
+            },
+            {
+              "part": "scr-m3-12-bhcs",
+              "qty": 2,
+              "uid": "izrb"
+            }
+          ]
         },
         {
           "version": "2",
           "date": "2026-08-29",
           "message": "Added the 2 scr-m5-16-shcs + 2 tnut-m5-2020 that fasten the Limit switch housing to its bracket's extrusion (step 4), previously missing -- only the switch-to-housing M3s were modeled.",
-          "commit": null
+          "commit": "a2c66436"
         }
       ]
     },
@@ -6036,7 +6064,7 @@
       "uid": "s7bo",
       "version": "1",
       "name": "Pico with headers",
-      "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare \u2014 the pins are a separate purchase.",
+      "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare — the pins are a separate purchase.",
       "docs": "/hardware/electronics/installation/pico-headers/",
       "status": "partial",
       "joining": [
@@ -6127,7 +6155,7 @@
       "uid": "bkgq",
       "version": "2",
       "name": "Interface",
-      "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
+      "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6223,13 +6251,151 @@
       "versions": [
         {
           "version": "1",
-          "message": "Original version: duplicated the hex frame's own ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline instead of consuming a shared hex-frame assembly, and carried a stray top-level tnut-m5-2020 qty 8 not tied to any specific step."
+          "uid": "zz8s",
+          "message": "Original version: duplicated the hex frame's own ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline instead of consuming a shared hex-frame assembly, and carried a stray top-level tnut-m5-2020 qty 8 not tied to any specific step.",
+          "lines": [
+            {
+              "assembly": "interface-bracket-mount",
+              "qty": 6,
+              "uid": "rhr6"
+            },
+            {
+              "part": "ext-bracket-left",
+              "qty": 6,
+              "uid": "0b4g"
+            },
+            {
+              "part": "ext-bracket-cover",
+              "qty": 6,
+              "uid": "1r5i"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 12,
+              "uid": "2e0s"
+            },
+            {
+              "assembly": "fixed-upper-section",
+              "qty": 1,
+              "uid": "99af"
+            },
+            {
+              "assembly": "cable-cage",
+              "qty": 1,
+              "uid": "nam6"
+            },
+            {
+              "part": "scr-m5-30-shcs",
+              "qty": 6,
+              "uid": "92kv"
+            },
+            {
+              "assembly": "cable-clamp",
+              "qty": 1,
+              "uid": "e0p9"
+            },
+            {
+              "part": "scr-m3-12-bhcs",
+              "qty": 2,
+              "uid": "izrb"
+            },
+            {
+              "assembly": "limit-switch",
+              "qty": 1,
+              "uid": "eb8m"
+            },
+            {
+              "part": "scr-m5-20-shcs",
+              "qty": 2,
+              "uid": "e4hi"
+            },
+            {
+              "part": "tnut-m5-2020",
+              "qty": 8,
+              "uid": "bpwm"
+            },
+            {
+              "assembly": "chute-stepper-gearing",
+              "qty": 1,
+              "uid": "cwji"
+            },
+            {
+              "assembly": "interface-chute-drive",
+              "qty": 1,
+              "uid": "8cjj"
+            },
+            {
+              "part": "top-interface-split-spur-gear-2",
+              "qty": 1,
+              "uid": "izz5"
+            },
+            {
+              "part": "chute-stepper-support-block",
+              "qty": 1,
+              "uid": "loc0"
+            },
+            {
+              "part": "scr-m5-shcs-tbd",
+              "qty": 2,
+              "uid": "wy04"
+            },
+            {
+              "assembly": "layer-connector",
+              "qty": 1,
+              "uid": "6m38"
+            },
+            {
+              "part": "brg-lazy-susan",
+              "qty": 1,
+              "uid": "wrxu"
+            },
+            {
+              "part": "scr-m4-12-cs",
+              "qty": 8,
+              "uid": "h8h4"
+            },
+            {
+              "part": "top-plate",
+              "qty": 1,
+              "uid": "1g22"
+            },
+            {
+              "part": "scr-m5-35-fhcs",
+              "qty": 6,
+              "uid": "xkl4"
+            },
+            {
+              "part": "scr-m5-8-cs",
+              "qty": 6,
+              "uid": "mqh4"
+            },
+            {
+              "part": "ext-2020-ag",
+              "qty": 6,
+              "uid": "lnvw"
+            },
+            {
+              "part": "ext-2020-bh",
+              "qty": 6,
+              "uid": "tuer"
+            },
+            {
+              "part": "frame-90deg-bracket",
+              "qty": 12,
+              "uid": "3l20"
+            },
+            {
+              "part": "frame-crossbeam",
+              "qty": 6,
+              "uid": "cdeg"
+            }
+          ]
         },
         {
           "version": "2",
           "date": "2026-08-29",
           "message": "Consumes the new hex-frame assembly instead of duplicating its ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline. Dropped the stray top-level tnut-m5-2020 qty 8, now superseded by interface-bracket-mount's and limit-switch's own per-step T-nut lines.",
-          "commit": null
+          "commit": "a2c66436"
         }
       ]
     },
@@ -6238,7 +6404,7 @@
       "uid": "jog7",
       "version": "2",
       "name": "Distribution layer",
-      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
+      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 × [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
       "lines": [
@@ -6270,13 +6436,46 @@
       "versions": [
         {
           "version": "1",
-          "message": "Original version: listed tnut-m5-2020 qty 24 for the bin retainers (double-counting the hex frame's own pre-installed T-nuts) and had no line for the layer-to-layer flange-join screws."
+          "uid": "a17l",
+          "message": "Original version: listed tnut-m5-2020 qty 24 for the bin retainers (double-counting the hex frame's own pre-installed T-nuts) and had no line for the layer-to-layer flange-join screws.",
+          "lines": [
+            {
+              "assembly": "layer-frame",
+              "qty": 1,
+              "uid": "adaj"
+            },
+            {
+              "assembly": "chute",
+              "qty": 1,
+              "uid": "axlb"
+            },
+            {
+              "part": "bin-retainer-left",
+              "qty": 6,
+              "uid": "hqz0"
+            },
+            {
+              "part": "bin-retainer-right",
+              "qty": 6,
+              "uid": "ybpv"
+            },
+            {
+              "part": "scr-m5-12-shcs",
+              "qty": 24,
+              "uid": "kmah"
+            },
+            {
+              "part": "tnut-m5-2020",
+              "qty": 24,
+              "uid": "bpwm"
+            }
+          ]
         },
         {
           "version": "2",
           "date": "2026-08-29",
           "message": "Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones), same double-count barthel already caught on bottom two layers. Added the 12 scr-m5-16-shcs that join this layer's flange up to the layer above, previously missing.",
-          "commit": null
+          "commit": "a2c66436"
         }
       ]
     },
@@ -6397,7 +6596,7 @@
       "uid": "mttx",
       "version": "1",
       "name": "C-channel drive",
-      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke \u2014 the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Screw joints: 4 × [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 × [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 × [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 × [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke — the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing (the light post's 2 × [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
       "status": "partial",
       "lines": [
@@ -6444,7 +6643,7 @@
       "uid": "cwji",
       "version": "1",
       "name": "Chute Stepper Gearing",
-      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
+      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3×35 keeps it clear of the limit switch hammer.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6533,7 +6732,7 @@
       "uid": "8cjj",
       "version": "1",
       "name": "Interface chute gear + mount",
-      "description": "The chute gear screwed down onto the top interface chute mount \u2014 two sections of the split spur gear that become one turning unit.",
+      "description": "The chute gear screwed down onto the top interface chute mount — two sections of the split spur gear that become one turning unit.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6556,13 +6755,13 @@
       "uid": "8z0e",
       "version": "1",
       "name": "Hex frame",
-      "description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket \u2014 side, with six B/H spokes and Frame crossbeams held inside by the Frame 90\u00b0 brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
+      "description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket — side, with six B/H spokes and Frame crossbeams held inside by the Frame 90° brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
       "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
       "status": "partial",
       "joining": [
         {
           "method": "friction",
-          "note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
+          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
         }
       ],
       "lines": [
@@ -6601,7 +6800,7 @@
       "uid": "22ck",
       "version": "2",
       "name": "Distribution frame",
-      "description": "The frame of one distribution layer: a hex frame plus the External bracket \u2014 cover and \u2014 bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
+      "description": "The frame of one distribution layer: a hex frame plus the External bracket — cover and — bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
       "lines": [
@@ -6625,13 +6824,31 @@
       "versions": [
         {
           "version": "1",
-          "message": "Original version: bundled the hex frame's own outer ring, spokes, crossbeams and 90\u00b0 brackets inline instead of as a separate assembly."
+          "uid": "adaj",
+          "message": "Original version: bundled the hex frame's own outer ring, spokes, crossbeams and 90° brackets inline instead of as a separate assembly.",
+          "lines": [
+            {
+              "assembly": "external-bracket",
+              "qty": 6,
+              "uid": "6h3l"
+            },
+            {
+              "part": "frame-crossbeam",
+              "qty": 6,
+              "uid": "cdeg"
+            },
+            {
+              "part": "frame-90deg-bracket",
+              "qty": 12,
+              "uid": "3l20"
+            }
+          ]
         },
         {
           "version": "2",
           "date": "2026-08-29",
-          "message": "Split the hex frame (outer ring, spokes, crossbeams, 90\u00b0 brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
-          "commit": null
+          "message": "Split the hex frame (outer ring, spokes, crossbeams, 90° brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
+          "commit": "a2c66436"
         }
       ]
     },
@@ -6640,7 +6857,7 @@
       "uid": "rns2",
       "version": "2",
       "name": "basically Embedded Control Board Housing",
-      "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base \u2014 no bracket, no standoffs \u2014 and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
+      "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base — no bracket, no standoffs — and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
       "section": "electronics",
       "docs": "/hardware/electronics/installation/control-board-housing/",
       "status": "partial",
@@ -6713,7 +6930,7 @@
           "version": "1",
           "uid": "u12m",
           "date": "2026-07-18",
-          "message": "The board stood off a printed bracket on four 10 mm standoffs, and the 40 mm fan sat on a separate bracket cantilevered over it \u2014 the same bracket the Orange Pi mount uses. Superseded by the printed housing.",
+          "message": "The board stood off a printed bracket on four 10 mm standoffs, and the 40 mm fan sat on a separate bracket cantilevered over it — the same bracket the Orange Pi mount uses. Superseded by the printed housing.",
           "images": [
             {
               "url": "https://assets.basically.website/sorter-parts/ctrl-board-mount-v1-render-full-617e995364c7.png",
@@ -6762,7 +6979,7 @@
         {
           "version": "2",
           "date": "2026-08-23",
-          "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 \u00d7 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
+          "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 × 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
           "commit": "9ff8a1e3"
         }
       ]
@@ -6878,13 +7095,36 @@
       "versions": [
         {
           "version": "1",
-          "message": "Original version: only modeled the piece-F mount (step 13); the piece-E attachment (step 3) and rib-securing T-nut (step 5) weren't in the catalog at all."
+          "uid": "rhr6",
+          "message": "Original version: only modeled the piece-F mount (step 13); the piece-E attachment (step 3) and rib-securing T-nut (step 5) weren't in the catalog at all.",
+          "lines": [
+            {
+              "part": "interface-bracket",
+              "qty": 1,
+              "uid": "jk82"
+            },
+            {
+              "part": "interface-spacer",
+              "qty": 1,
+              "uid": "bfoc"
+            },
+            {
+              "part": "scr-m5-20-shcs",
+              "qty": 4,
+              "uid": "e4hi"
+            },
+            {
+              "part": "tnut-m5-2020",
+              "qty": 4,
+              "uid": "bpwm"
+            }
+          ]
         },
         {
           "version": "2",
           "date": "2026-08-29",
           "message": "Added the piece-E attachment (4 scr-m5-16-shcs into 4 tnut-m5-2020, step 3) and the rib-securing tnut-m5-2020 (step 5), neither previously modeled -- only step 13's piece-F mount (scr-m5-20-shcs + 4 T-nuts) was here before.",
-          "commit": null
+          "commit": "a2c66436"
         }
       ]
     },
@@ -6893,7 +7133,7 @@
       "uid": "l1un",
       "version": "1",
       "name": "Bottom lazy Susan",
-      "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 \u00d7 [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
+      "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 × [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
       "status": "partial",
       "lines": [
@@ -6965,7 +7205,7 @@
         "variant": "flat"
       },
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-35-fhcs-full-cf13d79a5110.jpg",
-      "image_credit": "M5 \u00d7 35 flat head listing photo, reused for the head shape"
+      "image_credit": "M5 × 35 flat head listing photo, reused for the head shape"
     },
     {
       "id": "screw-button",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column \u2014 both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) \u2014 these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until \u00a75.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit \u2014 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, \u00a75.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views.",
+  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column — both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) — these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until §5.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit — 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, §5.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views.",
   "sections": [
     {
       "id": "feeder",
@@ -271,7 +271,7 @@
       "name": "Stator's four NEMA-bracket holes are too small for an M3",
       "priority": "P0",
       "condition": "broken",
-      "description": "The four holes the NEMA bracket bolts into are \u00d82.40 mm and 10 mm deep. M3's minor (thread-root) diameter is 2.459 mm, so the hole is already narrower than the root before print tolerance takes another 0.1-0.2 mm off it, and the screw has to form a full-depth thread through 10 mm of plastic. It cams out or splits the boss instead, so the bracket cannot be fastened to the stator as printed. Every other M3 thread-forming hole in this assembly is \u00d82.80 \u2014 the rotor's six, the light post's five, and four more in this same stator \u2014 so \u00d82.40 is the odd one out inside its own part, which reads as a CAD slip rather than an intent. The fix is to open the four to \u00d82.80 in CAD. Reported by aleph1111/christoph from a build; measured off the pinned stator STL. Tracked as sorter-v2 issue #405.",
+      "description": "The four holes the NEMA bracket bolts into are Ø2.40 mm and 10 mm deep. M3's minor (thread-root) diameter is 2.459 mm, so the hole is already narrower than the root before print tolerance takes another 0.1-0.2 mm off it, and the screw has to form a full-depth thread through 10 mm of plastic. It cams out or splits the boss instead, so the bracket cannot be fastened to the stator as printed. Every other M3 thread-forming hole in this assembly is Ø2.80 — the rotor's six, the light post's five, and four more in this same stator — so Ø2.40 is the odd one out inside its own part, which reads as a CAD slip rather than an intent. The fix is to open the four to Ø2.80 in CAD. Reported by aleph1111/christoph from a build; measured off the pinned stator STL. Tracked as sorter-v2 issue #405.",
       "targets": {
         "parts": [
           "stator"
@@ -778,8 +778,8 @@
     {
       "id": "frame-90deg-bracket",
       "uid": "3l20",
-      "name": "Frame 90\u00b0 bracket",
-      "description": "Distribution frame 90\u00b0 bracket. Two per frame section.",
+      "name": "Frame 90° bracket",
+      "description": "Distribution frame 90° bracket. Two per frame section.",
       "internal_notes": "12 per frame (per layer); interface qty ASSUMED 12 (Spencer said 'one set per interface' - confirm). Frame color. File: inner_90_bracket.",
       "version": "1",
       "created_at": "2026-06-27",
@@ -801,7 +801,7 @@
     {
       "id": "ls-mount-to-chute",
       "uid": "lma9",
-      "name": "Lazy Susan \u2014 chute mount",
+      "name": "Lazy Susan — chute mount",
       "aliases": [
         "bottom interface lazy Susan chute mount",
         "bottom interface chute mount"
@@ -831,7 +831,7 @@
     {
       "id": "ls-bottom-static",
       "uid": "4mmh",
-      "name": "Lazy Susan \u2014 bottom static",
+      "name": "Lazy Susan — bottom static",
       "aliases": [
         "bottom interface lazy Susan fixed section",
         "bottom interface fixed section"
@@ -861,7 +861,7 @@
     {
       "id": "ls-mount-to-extrusion",
       "uid": "bmt4",
-      "name": "Lazy Susan \u2014 extrusion mount",
+      "name": "Lazy Susan — extrusion mount",
       "description": "Bottom lazy Susan mount to the external extrusion.",
       "internal_notes": "Frame color. QUANTITY ASSUMED 1.",
       "version": "1",
@@ -882,7 +882,7 @@
     {
       "id": "ls-hold-in-place",
       "uid": "ss05",
-      "name": "Lazy Susan \u2014 hold in place",
+      "name": "Lazy Susan — hold in place",
       "description": "Bottom lazy Susan hold-in-place. Optional.",
       "internal_notes": "Optional (file: 'optional hold in place'). Frame color. QUANTITY ASSUMED 1.",
       "version": "1",
@@ -903,7 +903,7 @@
     {
       "id": "ls-washer",
       "uid": "9c4a",
-      "name": "Lazy Susan \u2014 washer",
+      "name": "Lazy Susan — washer",
       "description": "Bottom lazy Susan washer.",
       "internal_notes": "Frame color. QUANTITY UNCONFIRMED (assumed 1; may be several).",
       "version": "1",
@@ -923,7 +923,7 @@
     {
       "id": "ext-bracket-left",
       "uid": "0b4g",
-      "name": "External bracket \u2014 side",
+      "name": "External bracket — side",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Interface qty confirmed at 6, side and cover only, no bottom vertical there (top-interface.md step 14). Frame color.",
       "version": "1",
@@ -942,14 +942,14 @@
       "optional": false,
       "support": false,
       "low_tolerance": true,
-      "low_tolerance_note": "A test print is suggested. This part is a tight fit around the 2020 aluminum profile, so print one first and confirm it seats properly before committing to the full set \u2014 dial in your printer and profile together.",
+      "low_tolerance_note": "A test print is suggested. This part is a tight fit around the 2020 aluminum profile, so print one first and confirm it seats properly before committing to the full set — dial in your printer and profile together.",
       "onshape_version": "https://cad.onshape.com/documents/a4a1965bbaf3a15aff2b13ed/v/7279a42b05833c7b828efb0d/e/b0ee2e787191265cba1c1a31",
       "docs_page": "/hardware/helpers/external-bracket/"
     },
     {
       "id": "ext-bracket-bottom-vertical",
       "uid": "xgzj",
-      "name": "External bracket \u2014 bottom vertical",
+      "name": "External bracket — bottom vertical",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Not used at the top interface: that joint has no bottom vertical or flange (top-interface.md step 14, confirmed 2026-08-25). The earlier 'interface: 6' assumption here was wrong, removed. Frame color.",
       "version": "1",
@@ -973,7 +973,7 @@
     {
       "id": "ext-bracket-cover",
       "uid": "1r5i",
-      "name": "External bracket \u2014 cover",
+      "name": "External bracket — cover",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Interface qty confirmed at 6, side and cover only, no bottom vertical there (top-interface.md step 14). Frame color.",
       "version": "1",
@@ -1170,7 +1170,7 @@
       "uid": "50dv",
       "name": "Cable clamp (outer)",
       "description": "Outer half of the ribbon cable clamp. White.",
-      "internal_notes": "1 per interface. White. Pairs with the inner clamp (cable-clamp assembly). v2 (2026-07-18): enlarged the M3 nut pocket so the nut seats \u2014 it did not fit in v1.",
+      "internal_notes": "1 per interface. White. Pairs with the inner clamp (cable-clamp assembly). v2 (2026-07-18): enlarged the M3 nut pocket so the nut seats — it did not fit in v1.",
       "version": "2",
       "created_at": "2026-06-27",
       "updated_at": "2026-07-18",
@@ -1292,7 +1292,7 @@
     {
       "id": "chute-stepper-idler-bearing-retainer-outer",
       "uid": "wgsc",
-      "name": "Chute Stepper Idler Gear Bearing Retainer \u2014 Outer",
+      "name": "Chute Stepper Idler Gear Bearing Retainer — Outer",
       "aliases": [
         "Idler Gear Bearing Retainer - Outer",
         "idler bearing retainer"
@@ -1317,7 +1317,7 @@
     {
       "id": "chute-stepper-idler-bearing-retainer-inner",
       "uid": "zzql",
-      "name": "Chute Stepper Idler Gear Bearing Retainer \u2014 Inner",
+      "name": "Chute Stepper Idler Gear Bearing Retainer — Inner",
       "aliases": [
         "Idler Gear Bearing Retainer - Inner",
         "idler gear cap"
@@ -1491,7 +1491,7 @@
         "chute core mount"
       ],
       "description": "Section 3 of 3 of the top interface split spur gear (Spur 2M 120T).",
-      "internal_notes": "Split spur gear for the top interface; the 3 sections print separately and assemble into one gear. Chute-core color. Carries 4\u00d7 M4 inserts, plus 7\u00d7 M3: 2 for the cable clamp and 5 on the underside that the chute gear screws down into. Counted on the physical part by barthel 2026-08-21 and confirmed against the STL (7 x 4.20 mm bores, ruthex's recommended M3 insert hole, re-measured with the detection thresholds loosened in case any were missed). The previous count of 9 added 2 for the layer connector, which the published model does not have; resolves the docs-merge-2026-08-21 conflict.",
+      "internal_notes": "Split spur gear for the top interface; the 3 sections print separately and assemble into one gear. Chute-core color. Carries 4× M4 inserts, plus 7× M3: 2 for the cable clamp and 5 on the underside that the chute gear screws down into. Counted on the physical part by barthel 2026-08-21 and confirmed against the STL (7 x 4.20 mm bores, ruthex's recommended M3 insert hole, re-measured with the detection thresholds loosened in case any were missed). The previous count of 9 added 2 for the layer connector, which the published model does not have; resolves the docs-merge-2026-08-21 conflict.",
       "version": "1",
       "created_at": "2026-07-03",
       "updated_at": "2026-07-03",
@@ -1823,7 +1823,7 @@
     {
       "id": "servo-adapter-servo-side",
       "uid": "fu2t",
-      "name": "Servo adapter \u2014 servo side",
+      "name": "Servo adapter — servo side",
       "description": "MG995 servo adapter, servo side.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1843,7 +1843,7 @@
     {
       "id": "servo-adapter-flap-side",
       "uid": "lv7n",
-      "name": "Servo adapter \u2014 flap side",
+      "name": "Servo adapter — flap side",
       "description": "MG995 servo adapter, flap side.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1863,7 +1863,7 @@
     {
       "id": "servo-bracket-lower-arm",
       "uid": "yqz1",
-      "name": "Servo bracket \u2014 lower arm",
+      "name": "Servo bracket — lower arm",
       "description": "MG995 servo bracket, lower arm.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1883,7 +1883,7 @@
     {
       "id": "servo-bracket-side-arm",
       "uid": "75na",
-      "name": "Servo bracket \u2014 side arm",
+      "name": "Servo bracket — side arm",
       "description": "MG995 servo bracket, side arm.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1903,7 +1903,7 @@
     {
       "id": "servo-bracket-cover",
       "uid": "rqor",
-      "name": "Servo bracket \u2014 cover",
+      "name": "Servo bracket — cover",
       "description": "MG995 servo bracket, cover.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1923,7 +1923,7 @@
     {
       "id": "servo-bracket-housing",
       "uid": "tr15",
-      "name": "Servo bracket \u2014 housing",
+      "name": "Servo bracket — housing",
       "description": "MG995 servo bracket, housing.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -2028,7 +2028,7 @@
     {
       "id": "camera-mount-part-6",
       "uid": "v9dv",
-      "name": "Overhead camera mount \u2014 A/B connector",
+      "name": "Overhead camera mount — A/B connector",
       "description": "Camera mount part 6. 2 per machine.",
       "internal_notes": "1 per camera mount x 2 mounts. Color not important (feeder).",
       "version": "1",
@@ -2085,7 +2085,7 @@
     {
       "id": "camera-mount-rod-mount",
       "uid": "twuu",
-      "name": "Camera mount \u2014 rod-to-C-channel mount",
+      "name": "Camera mount — rod-to-C-channel mount",
       "description": "Rod-to-C-channel mount (Part 33). 2 per camera mount, 4 total.",
       "internal_notes": "Part 33, the rod-to-c-channel mount. 2 per camera mount x 2 mounts = 4. Color not important (feeder).",
       "version": "1",
@@ -2547,7 +2547,7 @@
     {
       "id": "ctrl-board-housing-base",
       "uid": "204b",
-      "name": "Control Board Housing \u2014 Base",
+      "name": "Control Board Housing — Base",
       "description": "Base of the basically Embedded Control Board housing. The board screws straight to it on four heat inserts and the cover screws down onto four more; no standoffs.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Entered the machine on 2026-08-23 when candidate rns2 was promoted to ctrl-board-mount v2. Eight standard M3 inserts (hsi-m3, RX-M3x5.7 -- Spencer said 'the long variant', which is this one relative to the short M3S): four under the board, four for the cover.",
       "version": "1",
@@ -2574,8 +2574,8 @@
     {
       "id": "ctrl-board-housing-cover",
       "uid": "ksh2",
-      "name": "Control Board Housing \u2014 Cover",
-      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 \u00d7 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 \u00d7 12 mm button head screws, and the plunger passes through it.",
+      "name": "Control Board Housing — Cover",
+      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 × 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 × 12 mm button head screws, and the plunger passes through it.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
       "created_at": "2026-08-22",
@@ -2595,7 +2595,7 @@
     {
       "id": "ctrl-board-housing-plunger",
       "uid": "cljt",
-      "name": "Control Board Housing \u2014 Plunger",
+      "name": "Control Board Housing — Plunger",
       "description": "Plunger that passes through the housing cover, held in by the plunger retainer.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
@@ -2616,8 +2616,8 @@
     {
       "id": "ctrl-board-housing-plunger-retainer",
       "uid": "g9sx",
-      "name": "Control Board Housing \u2014 Plunger Retainer",
-      "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 \u00d7 8 mm countersunk screws.",
+      "name": "Control Board Housing — Plunger Retainer",
+      "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 × 8 mm countersunk screws.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Entered the machine on 2026-08-23 when candidate rns2 was promoted to ctrl-board-mount v2. Two countersunk holes either side of the plunger slot (counted off the STL).",
       "version": "1",
       "created_at": "2026-08-22",
@@ -2679,7 +2679,7 @@
       "uid": "3ufy",
       "name": "40 mm Fan Bracket",
       "description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
-      "internal_notes": "Was 2 per machine \u2014 the control board and the Orange Pi each had one. The control board's housing carries its own fan as of ctrl-board-mount v2 (2026-08-23), so only the Orange Pi mount still uses this.",
+      "internal_notes": "Was 2 per machine — the control board and the Orange Pi each had one. The control board's housing carries its own fan as of ctrl-board-mount v2 (2026-08-23), so only the Orange Pi mount still uses this.",
       "version": "1",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-23",
@@ -2698,7 +2698,7 @@
     {
       "id": "meanwell-psu-housing-shell-rear",
       "uid": "7qz3",
-      "name": "PSU Housing \u2014 Shell Rear Tray",
+      "name": "PSU Housing — Shell Rear Tray",
       "description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell rear tray.stl'. Carries the self-tapping M3 holes for both lids.",
       "version": "1",
@@ -2717,7 +2717,7 @@
     {
       "id": "meanwell-psu-housing-shell-front",
       "uid": "1h8p",
-      "name": "PSU Housing \u2014 Shell Front Module",
+      "name": "PSU Housing — Shell Front Module",
       "description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell front module.stl'.",
       "version": "1",
@@ -2736,7 +2736,7 @@
     {
       "id": "meanwell-psu-housing-lid-rear",
       "uid": "m26o",
-      "name": "PSU Housing \u2014 Lid Rear",
+      "name": "PSU Housing — Lid Rear",
       "description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid rear.stl'.",
       "version": "1",
@@ -2755,7 +2755,7 @@
     {
       "id": "meanwell-psu-housing-lid-front",
       "uid": "avux",
-      "name": "PSU Housing \u2014 Lid Front",
+      "name": "PSU Housing — Lid Front",
       "description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid front.stl'.",
       "version": "1",
@@ -2774,7 +2774,7 @@
     {
       "id": "meanwell-psu-housing-front-panel",
       "uid": "n1oh",
-      "name": "PSU Housing \u2014 Front Panel",
+      "name": "PSU Housing — Front Panel",
       "description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - front panel.stl'.",
       "version": "1",
@@ -2798,12 +2798,12 @@
         "type": "screw",
         "size": "M3"
       },
-      "name": "M3 screw \u2014 type and length TBD",
+      "name": "M3 screw — type and length TBD",
       "category": "Screws",
       "description": "Placeholder for the M3s whose head type and length nobody has written down yet: the cable-mount cage bracket, the camera extension, and the two board mounts.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
-      "note": "Neither the head type nor the length is recorded \u2014 measure before ordering.",
+      "note": "Neither the head type nor the length is recorded — measure before ordering.",
       "attributes": [
         {
           "label": "Thread",
@@ -2831,10 +2831,10 @@
       "name": "M3 socket/button head, length TBD",
       "category": "Screws",
       "alternative": "Socket or button head",
-      "description": "Was the placeholder for the screws holding the basically Embedded Control Board to the housing base, before they were measured as M3 \u00d7 6 mm button head. Nothing calls for it now; the uid is kept because it was minted.",
+      "description": "Was the placeholder for the screws holding the basically Embedded Control Board to the housing base, before they were measured as M3 × 6 mm button head. Nothing calls for it now; the uid is kept because it was minted.",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-22",
-      "note": "Superseded before it was ever ordered \u2014 nothing in the catalog calls for it.",
+      "note": "Superseded before it was ever ordered — nothing in the catalog calls for it.",
       "attributes": [
         {
           "label": "Thread",
@@ -2860,7 +2860,7 @@
         "variant": "countersunk",
         "length_mm": 6
       },
-      "name": "M3 \u00d7 6 mm countersunk",
+      "name": "M3 × 6 mm countersunk",
       "category": "Screws",
       "description": "Secures the limit switch hammer into the top interface chute mount from below, into the hammer's M3 insert.",
       "created_at": "2026-08-18",
@@ -2882,7 +2882,7 @@
       "sheet_qty": {
         "per_machine": 1
       },
-      "note": "The \u00d71 is the top-interface count (limit-switch hammer). Screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "The ×1 is the top-interface count (limit-switch hammer). Screws used elsewhere on the machine aren't tallied here yet.",
       "image_url": "https://assets.basically.website/sorter-parts/hardware-screws-countersunk-full-faf0edbe3324.jpg"
     },
     {
@@ -2895,7 +2895,7 @@
         "variant": "socket",
         "length_mm": 10
       },
-      "name": "M3 \u00d7 10 mm socket/button head",
+      "name": "M3 × 10 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-10-shcs-full-26e52d7d5bcd.png",
@@ -2919,7 +2919,7 @@
       "sheet_qty": {
         "per_machine": 3
       },
-      "note": "The \u00d73 is the top-interface count (2 cable clamp, 1 ribbon clamp). Screws used elsewhere on the machine aren't tallied here yet."
+      "note": "The ×3 is the top-interface count (2 cable clamp, 1 ribbon clamp). Screws used elsewhere on the machine aren't tallied here yet."
     },
     {
       "id": "scr-m3-8-cs",
@@ -2931,9 +2931,9 @@
         "variant": "countersunk",
         "length_mm": 8
       },
-      "name": "M3 \u00d7 8 mm countersunk",
+      "name": "M3 × 8 mm countersunk",
       "category": "Screws",
-      "description": "The workhorse M3 screw \u2014 used all over the machine wherever a flush head is wanted.",
+      "description": "The workhorse M3 screw — used all over the machine wherever a flush head is wanted.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -2981,7 +2981,7 @@
         "variant": "socket",
         "length_mm": 8
       },
-      "name": "M2 \u00d7 8 mm socket/button head",
+      "name": "M2 × 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "description": "Self-taps the IMX415 classification camera board to the camera extension's printed post. 4 per module, no insert. May also fit the OV9732 overhead camera mount once that gets a real bracket (sorter-v2#426), not confirmed.",
@@ -3013,7 +3013,7 @@
         "variant": "socket",
         "length_mm": 8
       },
-      "name": "M3 \u00d7 8 mm socket/button head",
+      "name": "M3 × 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "description": "Clamps the C-channel input gear (12T) to the flat of the NEMA 17 shaft. 1 per C-channel.",
@@ -3033,7 +3033,7 @@
           "value": "Socket or button head, interchangeable (both bottom on the counterbore floor, so either just clamps)"
         }
       ],
-      "note": "Head type and length measured off the input-gear STL: the boss carries a \u00d82.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the \u00d84.87 mm bore; the head sits in a round \u00d86.40 mm \u00d7 2.7 mm counterbore with a 90\u00b0 cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (\u00d85.5 \u00d7 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (\u00d85.7 \u00d7 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
+      "note": "Head type and length measured off the input-gear STL: the boss carries a Ø2.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the Ø4.87 mm bore; the head sits in a round Ø6.40 mm × 2.7 mm counterbore with a 90° cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (Ø5.5 × 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (Ø5.7 × 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
     },
     {
       "id": "scr-m3-12-cs",
@@ -3045,7 +3045,7 @@
         "variant": "countersunk",
         "length_mm": 12
       },
-      "name": "M3 \u00d7 12 mm countersunk",
+      "name": "M3 × 12 mm countersunk",
       "category": "Screws",
       "description": "The long M3 countersunk. Used all over the machine.",
       "created_at": "2026-07-18",
@@ -3095,9 +3095,9 @@
         "variant": "countersunk",
         "length_mm": 20
       },
-      "name": "M3 \u00d7 20 mm countersunk",
+      "name": "M3 × 20 mm countersunk",
       "category": "Screws",
-      "description": "Joins the C-channel light post to the NEMA bracket. Threads straight into the printed post \u2014 no insert, no nut.",
+      "description": "Joins the C-channel light post to the NEMA bracket. Threads straight into the printed post — no insert, no nut.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -3142,7 +3142,7 @@
         "variant": "socket",
         "length_mm": 16
       },
-      "name": "M3 \u00d7 16 mm socket/button head",
+      "name": "M3 × 16 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png",
@@ -3174,7 +3174,7 @@
         "variant": "button",
         "length_mm": 6
       },
-      "name": "M3 \u00d7 6 mm socket/button head",
+      "name": "M3 × 6 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-6-bhcs-full-26e52d7d5bcd.png",
@@ -3206,7 +3206,7 @@
         "variant": "button",
         "length_mm": 12
       },
-      "name": "M3 \u00d7 12 mm socket/button head",
+      "name": "M3 × 12 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-12-bhcs-full-26e52d7d5bcd.png",
@@ -3238,7 +3238,7 @@
         "variant": "flat",
         "length_mm": 35
       },
-      "name": "M3 \u00d7 35 mm flat head",
+      "name": "M3 × 35 mm flat head",
       "category": "Screws",
       "alternative": "Flat or pan head",
       "description": "The two long M3s on the top interface: one clamps the two cable-clamp halves together, one retains the idler gear on the NEMA 23 bracket. Same screw for both. The head has to stay low because of the idler joint: a socket or button head stands proud enough for the limit switch hammer to catch on it as the chute sweeps past.",
@@ -3269,7 +3269,7 @@
         "variant": "countersunk",
         "length_mm": 6
       },
-      "name": "M4 \u00d7 6 mm countersunk",
+      "name": "M4 × 6 mm countersunk",
       "category": "Screws",
       "description": "Fastens the printed PSU housing to the power supply's own case threads.",
       "created_at": "2026-07-18",
@@ -3299,9 +3299,9 @@
         "variant": "countersunk",
         "length_mm": 12
       },
-      "name": "M4 \u00d7 12 mm countersunk",
+      "name": "M4 × 12 mm countersunk",
       "category": "Screws",
-      "description": "Bolts each lazy Susan together \u2014 4 a side, through the M4 inserts in the static half and the chute mount. 2 lazy Susans per machine.",
+      "description": "Bolts each lazy Susan together — 4 a side, through the M4 inserts in the static half and the chute mount. 2 lazy Susans per machine.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -3330,7 +3330,7 @@
         "variant": "socket",
         "length_mm": 12
       },
-      "name": "M5 \u00d7 12 mm socket/button head",
+      "name": "M5 × 12 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-12-shcs-full-26e52d7d5bcd.png",
@@ -3362,7 +3362,7 @@
         "variant": "socket",
         "length_mm": 16
       },
-      "name": "M5 \u00d7 16 mm socket/button head",
+      "name": "M5 × 16 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-16-shcs-full-26e52d7d5bcd.png",
@@ -3383,7 +3383,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Designed to self-tap into printed plastic wherever it lands in an external bracket or the upper fixed section \u2014 no nut and no insert there."
+      "note": "Designed to self-tap into printed plastic wherever it lands in an external bracket or the upper fixed section — no nut and no insert there."
     },
     {
       "id": "scr-m5-20-shcs",
@@ -3395,7 +3395,7 @@
         "variant": "socket",
         "length_mm": 20
       },
-      "name": "M5 \u00d7 20 mm socket/button head",
+      "name": "M5 × 20 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-20-shcs-full-26e52d7d5bcd.png",
@@ -3427,7 +3427,7 @@
         "variant": "socket",
         "length_mm": 30
       },
-      "name": "M5 \u00d7 30 mm socket/button head",
+      "name": "M5 × 30 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-30-shcs-full-26e52d7d5bcd.png",
@@ -3459,7 +3459,7 @@
         "variant": "flat",
         "length_mm": 35
       },
-      "name": "M5 \u00d7 35 mm flat head",
+      "name": "M5 × 35 mm flat head",
       "internal_notes": "Flat (pancake) head, hex socket, confirmed by barthel 2026-08-21: \"The m3x35mm must be a flat hat screw like in calculator\" (the M5 x 35 is the only 35 mm screw the two catalogs disagreed about; the M3 x 35 was already settled as flat head in #356). The docs catalog had called it a socket head cap screw; that claim is dropped and the docs prose now says flat head. Resolves the last docs-merge-2026-08-21 conflict.",
       "category": "Screws",
       "description": "The long screws that stack the cable cage together, and that bolt the plywood top plate down onto the interface brackets.",
@@ -3516,7 +3516,7 @@
         "variant": "countersunk",
         "length_mm": 8
       },
-      "name": "M5 \u00d7 8 mm countersunk",
+      "name": "M5 × 8 mm countersunk",
       "category": "Screws",
       "description": "Loosely fixes the limit-switch interface bracket's extrusion into the interface rib while aligning it, into a T-nut.",
       "created_at": "2026-08-18",
@@ -3535,7 +3535,7 @@
           "value": "Countersunk (flat) socket"
         }
       ],
-      "note": "A snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush. The \u00d76 is the top-interface count (1 per interface bracket); screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "A snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush. The ×6 is the top-interface count (1 per interface bracket); screws used elsewhere on the machine aren't tallied here yet.",
       "sheet_qty": {
         "per_machine": 6
       },
@@ -3551,9 +3551,9 @@
         "variant": "countersunk",
         "length_mm": 22
       },
-      "name": "M5 \u00d7 22 mm countersunk",
+      "name": "M5 × 22 mm countersunk",
       "category": "Screws",
-      "description": "Bolts the interface bracket assembly and all six interface brackets down through the laser-cut top plate (holes S2/S3, then I1\u2013I6 and O1\u2013O6).",
+      "description": "Bolts the interface bracket assembly and all six interface brackets down through the laser-cut top plate (holes S2/S3, then I1–I6 and O1–O6).",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-18",
       "attributes": [
@@ -3570,7 +3570,7 @@
           "value": "Countersunk (flat) socket"
         }
       ],
-      "note": "The top plate's laser-cut holes aren't countersunk, so where a flush head won't seat an M5 \u00d7 20 button head is used instead. The \u00d714 is the top-interface count (2 to the top plate, 12 through the bracket holes); screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "The top plate's laser-cut holes aren't countersunk, so where a flush head won't seat an M5 × 20 button head is used instead. The ×14 is the top-interface count (2 to the top plate, 12 through the bracket holes); screws used elsewhere on the machine aren't tallied here yet.",
       "sheet_qty": {
         "per_machine": 14
       },
@@ -3606,7 +3606,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Length unknown \u2014 measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
+      "note": "Length unknown — measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
     },
     {
       "id": "washer-m3-15",
@@ -3616,9 +3616,9 @@
         "type": "washer",
         "size": "M3"
       },
-      "name": "M3 \u00d7 15 mm washer",
+      "name": "M3 × 15 mm washer",
       "category": "Washers",
-      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
+      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-25",
       "attributes": [
@@ -3719,7 +3719,7 @@
         "type": "stock-material",
         "size": "3/8 in"
       },
-      "name": "Steel rod, 3/8 in \u2014 4 ft stock",
+      "name": "Steel rod, 3/8 in — 4 ft stock",
       "category": "Stock material",
       "description": "Bought as a length and cut down. One 4 ft rod yields all four ~1 ft pieces the two overhead camera arms hang from.",
       "created_at": "2026-07-18",
@@ -3734,7 +3734,7 @@
       "attributes": [
         {
           "label": "Diameter",
-          "value": "3/8 in (9.53 mm) \u00b7 10 mm in metric"
+          "value": "3/8 in (9.53 mm) · 10 mm in metric"
         },
         {
           "label": "Buy",
@@ -3742,7 +3742,7 @@
         },
         {
           "label": "Cut into",
-          "value": "4 \u00d7 ~1 ft (305 mm)"
+          "value": "4 × ~1 ft (305 mm)"
         },
         {
           "label": "Material",
@@ -4193,7 +4193,7 @@
         },
         {
           "label": "Thread",
-          "value": "M6 \u00d7 1.0"
+          "value": "M6 × 1.0"
         },
         {
           "label": "Material",
@@ -4230,7 +4230,7 @@
         "type": "wheel",
         "size": "M6"
       },
-      "name": "Swivel stem caster, M6 \u00d7 15 mm",
+      "name": "Swivel stem caster, M6 × 15 mm",
       "category": "Wheels",
       "description": "Screws into the 2020 foot connector so the machine can roll.",
       "created_at": "2026-07-18",
@@ -4238,7 +4238,7 @@
       "attributes": [
         {
           "label": "Thread",
-          "value": "M6 \u00d7 1.0, 15 mm stem"
+          "value": "M6 × 1.0, 15 mm stem"
         },
         {
           "label": "Wheel",
@@ -4418,7 +4418,7 @@
       "attributes": [
         {
           "label": "Size",
-          "value": "30 \u00d7 42 \u00d7 7 mm (ID \u00d7 OD \u00d7 W)"
+          "value": "30 × 42 × 7 mm (ID × OD × W)"
         },
         {
           "label": "Seal",
@@ -4506,7 +4506,7 @@
       "attributes": [
         {
           "label": "Size",
-          "value": "20 \u00d7 27 \u00d7 4 mm (ID \u00d7 OD \u00d7 W)"
+          "value": "20 × 27 × 4 mm (ID × OD × W)"
         },
         {
           "label": "Seal",
@@ -4652,7 +4652,7 @@
         },
         {
           "label": "Size",
-          "value": "22 \u00d7 30 mm"
+          "value": "22 × 30 mm"
         },
         {
           "label": "Fits",
@@ -4889,7 +4889,7 @@
       "cots": {
         "type": "cable"
       },
-      "name": "IDC ribbon cable, 16-pin (2\u00d78), 1 m",
+      "name": "IDC ribbon cable, 16-pin (2×8), 1 m",
       "category": "Electronics",
       "description": "Cable from distribution board to chute",
       "created_at": "2026-07-18",
@@ -4914,7 +4914,7 @@
       "attributes": [
         {
           "label": "Pins",
-          "value": "16 (2\u00d78), FC to FC, A-type"
+          "value": "16 (2×8), FC to FC, A-type"
         },
         {
           "label": "Pitch",
@@ -4937,7 +4937,7 @@
       "cots": {
         "type": "cable"
       },
-      "name": "IDC ribbon cable, 16-pin (2\u00d78), 30 cm",
+      "name": "IDC ribbon cable, 16-pin (2×8), 30 cm",
       "category": "Electronics",
       "description": "Cable between layer and layer below",
       "created_at": "2026-07-18",
@@ -4962,7 +4962,7 @@
       "attributes": [
         {
           "label": "Pins",
-          "value": "16 (2\u00d78), female-to-female FC"
+          "value": "16 (2×8), female-to-female FC"
         },
         {
           "label": "Pitch",
@@ -5137,7 +5137,7 @@
       "cots": {
         "type": "converter"
       },
-      "name": "24 V \u2192 5 V USB-C buck converter",
+      "name": "24 V → 5 V USB-C buck converter",
       "category": "Wire harness",
       "description": "Powers the Orange Pi from the 24 V PSU.",
       "created_at": "2026-07-18",
@@ -5145,7 +5145,7 @@
       "attributes": [
         {
           "label": "Input",
-          "value": "DC 8\u201332 V (12 V / 24 V nominal)"
+          "value": "DC 8–32 V (12 V / 24 V nominal)"
         },
         {
           "label": "Output",
@@ -5231,7 +5231,7 @@
         },
         {
           "label": "Fuse",
-          "value": "10 A installed (5 \u00d7 20 mm)"
+          "value": "10 A installed (5 × 20 mm)"
         },
         {
           "label": "Wiring",
@@ -5239,7 +5239,7 @@
         },
         {
           "label": "Cutout",
-          "value": "47 \u00d7 28 mm; holes 40 mm apart, 3.2 mm"
+          "value": "47 × 28 mm; holes 40 mm apart, 3.2 mm"
         }
       ],
       "sheet_qty": {
@@ -5269,13 +5269,13 @@
       },
       "name": "40 mm 24 V fan (WINSINN 4010)",
       "category": "Electronics",
-      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 \u00d7 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
+      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 × 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-23",
       "attributes": [
         {
           "label": "Size",
-          "value": "40 \u00d7 40 \u00d7 10 mm"
+          "value": "40 × 40 × 10 mm"
         },
         {
           "label": "Voltage",
@@ -5429,7 +5429,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-cable-cage-top-full-9e4c43a620ca.png",
       "assembly": "Cable Cage",
       "description": "Top plate of the cable cage. Has a keyed cutout for easy insertion/removal of the interface.",
-      "thicknessIn": "1/8\u2033",
+      "thicknessIn": "1/8″",
       "thicknessMm": 3,
       "widthMm": 325,
       "heightMm": 375,
@@ -5440,9 +5440,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "cage-top",
-        "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big \u00d8177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
-        "stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
-        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
+        "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big Ø177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
+        "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
+        "tools": "jigsaw · drill · tape measure"
       },
       "printed": {
         "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
@@ -5466,7 +5466,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-cable-cage-bottom-full-283aeb114195.png",
       "assembly": "Cable Cage",
       "description": "Bottom plate of the cable cage.",
-      "thicknessIn": "1/8\u2033",
+      "thicknessIn": "1/8″",
       "thicknessMm": 3,
       "widthMm": 325,
       "heightMm": 375,
@@ -5477,9 +5477,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "cage-bottom",
-        "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big \u00d8177 mm centre hole and six \u00d85.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
-        "stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
-        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
+        "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big Ø177 mm centre hole and six Ø5.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
+        "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
+        "tools": "jigsaw · drill · tape measure"
       },
       "printed": {
         "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
@@ -5499,7 +5499,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-top-plate-w1600-00182ea8156d.jpg",
       "caption": "The machine's hexagonal top plate; the interface mounts under it.",
       "description": "Machine top plate. Has 5 cable holes and holes for the main stepper. Does not yet have mount holes for the C-channels.",
-      "thicknessIn": "3/8\u2033",
+      "thicknessIn": "3/8″",
       "thicknessMm": 10,
       "widthMm": 672,
       "heightMm": 770,
@@ -5510,9 +5510,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "top-plate",
-        "blurb": "This plate is a regular hexagon \u2014 it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8\u2033) drill holes.",
-        "stock": "672.4 \u00d7 776.4 mm rectangle (26 15/32\u2033 \u00d7 30 9/16\u2033)",
-        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
+        "blurb": "This plate is a regular hexagon — it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8″) drill holes.",
+        "stock": "672.4 × 776.4 mm rectangle (26 15/32″ × 30 9/16″)",
+        "tools": "jigsaw · drill · tape measure"
       }
     }
   ],
@@ -5528,7 +5528,7 @@
       "joining": [
         {
           "method": "self-tap",
-          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post \u2014 no insert, no nut."
+          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post — no insert, no nut."
         }
       ],
       "lines": [
@@ -5596,13 +5596,13 @@
       "uid": "99af",
       "version": "1",
       "name": "Fixed upper section",
-      "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 \u00d7 [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
+      "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 × [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "joining": [
         {
           "method": "self-tap",
-          "note": "Both of each rib's [[hw:scr-m5-16-shcs]] thread straight into the printed upper fixed section \u2014 no insert, no nut."
+          "note": "Both of each rib's [[hw:scr-m5-16-shcs]] thread straight into the printed upper fixed section — no insert, no nut."
         }
       ],
       "lines": [
@@ -5668,7 +5668,7 @@
       "uid": "jqhp",
       "version": "1",
       "name": "Chute bearing assembly",
-      "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 \u00d7 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
+      "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 × 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
       "status": "partial",
       "lines": [
         {
@@ -6064,7 +6064,7 @@
       "uid": "s7bo",
       "version": "1",
       "name": "Pico with headers",
-      "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare \u2014 the pins are a separate purchase.",
+      "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare — the pins are a separate purchase.",
       "docs": "/hardware/electronics/installation/pico-headers/",
       "status": "partial",
       "joining": [
@@ -6155,7 +6155,7 @@
       "uid": "bkgq",
       "version": "2",
       "name": "Interface",
-      "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
+      "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6404,7 +6404,7 @@
       "uid": "jog7",
       "version": "2",
       "name": "Distribution layer",
-      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
+      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 × [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
       "lines": [
@@ -6596,7 +6596,7 @@
       "uid": "mttx",
       "version": "1",
       "name": "C-channel drive",
-      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke \u2014 the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Screw joints: 4 × [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 × [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 × [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 × [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke — the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing (the light post's 2 × [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
       "status": "partial",
       "lines": [
@@ -6643,7 +6643,7 @@
       "uid": "cwji",
       "version": "1",
       "name": "Chute Stepper Gearing",
-      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
+      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3×35 keeps it clear of the limit switch hammer.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6732,7 +6732,7 @@
       "uid": "8cjj",
       "version": "1",
       "name": "Interface chute gear + mount",
-      "description": "The chute gear screwed down onto the top interface chute mount \u2014 two sections of the split spur gear that become one turning unit.",
+      "description": "The chute gear screwed down onto the top interface chute mount — two sections of the split spur gear that become one turning unit.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6755,13 +6755,13 @@
       "uid": "8z0e",
       "version": "1",
       "name": "Hex frame",
-      "description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket \u2014 side, with six B/H spokes and Frame crossbeams held inside by the Frame 90\u00b0 brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
+      "description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket — side, with six B/H spokes and Frame crossbeams held inside by the Frame 90° brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
       "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
       "status": "partial",
       "joining": [
         {
           "method": "friction",
-          "note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
+          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
         }
       ],
       "lines": [
@@ -6800,7 +6800,7 @@
       "uid": "22ck",
       "version": "2",
       "name": "Distribution frame",
-      "description": "The frame of one distribution layer: a hex frame plus the External bracket \u2014 cover and \u2014 bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
+      "description": "The frame of one distribution layer: a hex frame plus the External bracket — cover and — bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
       "lines": [
@@ -6825,7 +6825,7 @@
         {
           "version": "1",
           "uid": "adaj",
-          "message": "Original version: bundled the hex frame's own outer ring, spokes, crossbeams and 90\u00b0 brackets inline instead of as a separate assembly.",
+          "message": "Original version: bundled the hex frame's own outer ring, spokes, crossbeams and 90° brackets inline instead of as a separate assembly.",
           "lines": [
             {
               "assembly": "external-bracket",
@@ -6847,7 +6847,7 @@
         {
           "version": "2",
           "date": "2026-08-29",
-          "message": "Split the hex frame (outer ring, spokes, crossbeams, 90\u00b0 brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
+          "message": "Split the hex frame (outer ring, spokes, crossbeams, 90° brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
           "commit": "a2c66436"
         }
       ]
@@ -6857,7 +6857,7 @@
       "uid": "rns2",
       "version": "2",
       "name": "basically Embedded Control Board Housing",
-      "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base \u2014 no bracket, no standoffs \u2014 and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
+      "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base — no bracket, no standoffs — and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
       "section": "electronics",
       "docs": "/hardware/electronics/installation/control-board-housing/",
       "status": "partial",
@@ -6930,7 +6930,7 @@
           "version": "1",
           "uid": "u12m",
           "date": "2026-07-18",
-          "message": "The board stood off a printed bracket on four 10 mm standoffs, and the 40 mm fan sat on a separate bracket cantilevered over it \u2014 the same bracket the Orange Pi mount uses. Superseded by the printed housing.",
+          "message": "The board stood off a printed bracket on four 10 mm standoffs, and the 40 mm fan sat on a separate bracket cantilevered over it — the same bracket the Orange Pi mount uses. Superseded by the printed housing.",
           "images": [
             {
               "url": "https://assets.basically.website/sorter-parts/ctrl-board-mount-v1-render-full-617e995364c7.png",
@@ -6979,7 +6979,7 @@
         {
           "version": "2",
           "date": "2026-08-23",
-          "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 \u00d7 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
+          "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 × 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
           "commit": "9ff8a1e3"
         }
       ]
@@ -7133,7 +7133,7 @@
       "uid": "v6ss",
       "version": "2",
       "name": "Bottom lazy Susan",
-      "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 \u00d7 [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
+      "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 × [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
       "status": "partial",
       "lines": [
@@ -7177,13 +7177,61 @@
       "versions": [
         {
           "version": "1",
-          "message": "Original version: 1 scr-m5-16-shcs + 1 tnut-m5-2020 per extrusion mount (3 total each), before BrickCycleAlice's 2026-08-28 build photos showed it's actually 2 self-tapping-into-plastic screws for the mount-to-hold-in-place joint (no T-nut) plus 2 more screws per mount into a T-nut in the extrusion (sorter-v2#447)."
+          "uid": "l1un",
+          "message": "Original version: 1 scr-m5-16-shcs + 1 tnut-m5-2020 per extrusion mount (3 total each), before BrickCycleAlice's 2026-08-28 build photos showed it's actually 2 self-tapping-into-plastic screws for the mount-to-hold-in-place joint (no T-nut) plus 2 more screws per mount into a T-nut in the extrusion (sorter-v2#447).",
+          "lines": [
+            {
+              "part": "ls-mount-to-chute",
+              "qty": 1,
+              "uid": "lma9"
+            },
+            {
+              "part": "ls-bottom-static",
+              "qty": 1,
+              "uid": "4mmh"
+            },
+            {
+              "part": "ls-washer",
+              "qty": 1,
+              "uid": "9c4a"
+            },
+            {
+              "part": "ls-mount-to-extrusion",
+              "qty": 3,
+              "uid": "bmt4"
+            },
+            {
+              "part": "ls-hold-in-place",
+              "qty": 3,
+              "uid": "ss05"
+            },
+            {
+              "part": "brg-lazy-susan",
+              "qty": 1,
+              "uid": "wrxu"
+            },
+            {
+              "part": "scr-m4-12-cs",
+              "qty": 8,
+              "uid": "h8h4"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 3,
+              "uid": "2e0s"
+            },
+            {
+              "part": "tnut-m5-2020",
+              "qty": 3,
+              "uid": "bpwm"
+            }
+          ]
         },
         {
           "version": "2",
           "date": "2026-08-29",
           "message": "Catalog never picked up sorter-v2#447's fastener correction on bottom-interface.md: 1 screw per mount into the hold-in-place (self-tap, 3 total) plus 2 more per mount into a T-nut in the extrusion (6 more), so 9 scr-m5-16-shcs and 6 tnut-m5-2020 total, not 3 and 3.",
-          "commit": null
+          "commit": "9708a416"
         }
       ]
     }
@@ -7217,7 +7265,7 @@
         "variant": "flat"
       },
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-35-fhcs-full-cf13d79a5110.jpg",
-      "image_credit": "M5 \u00d7 35 flat head listing photo, reused for the head shape"
+      "image_credit": "M5 × 35 flat head listing photo, reused for the head shape"
     },
     {
       "id": "screw-button",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column — both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) — these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until §5.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit — 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, §5.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views.",
+  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column \u2014 both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) \u2014 these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until \u00a75.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit \u2014 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, \u00a75.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views.",
   "sections": [
     {
       "id": "feeder",
@@ -271,7 +271,7 @@
       "name": "Stator's four NEMA-bracket holes are too small for an M3",
       "priority": "P0",
       "condition": "broken",
-      "description": "The four holes the NEMA bracket bolts into are Ø2.40 mm and 10 mm deep. M3's minor (thread-root) diameter is 2.459 mm, so the hole is already narrower than the root before print tolerance takes another 0.1-0.2 mm off it, and the screw has to form a full-depth thread through 10 mm of plastic. It cams out or splits the boss instead, so the bracket cannot be fastened to the stator as printed. Every other M3 thread-forming hole in this assembly is Ø2.80 — the rotor's six, the light post's five, and four more in this same stator — so Ø2.40 is the odd one out inside its own part, which reads as a CAD slip rather than an intent. The fix is to open the four to Ø2.80 in CAD. Reported by aleph1111/christoph from a build; measured off the pinned stator STL. Tracked as sorter-v2 issue #405.",
+      "description": "The four holes the NEMA bracket bolts into are \u00d82.40 mm and 10 mm deep. M3's minor (thread-root) diameter is 2.459 mm, so the hole is already narrower than the root before print tolerance takes another 0.1-0.2 mm off it, and the screw has to form a full-depth thread through 10 mm of plastic. It cams out or splits the boss instead, so the bracket cannot be fastened to the stator as printed. Every other M3 thread-forming hole in this assembly is \u00d82.80 \u2014 the rotor's six, the light post's five, and four more in this same stator \u2014 so \u00d82.40 is the odd one out inside its own part, which reads as a CAD slip rather than an intent. The fix is to open the four to \u00d82.80 in CAD. Reported by aleph1111/christoph from a build; measured off the pinned stator STL. Tracked as sorter-v2 issue #405.",
       "targets": {
         "parts": [
           "stator"
@@ -778,8 +778,8 @@
     {
       "id": "frame-90deg-bracket",
       "uid": "3l20",
-      "name": "Frame 90° bracket",
-      "description": "Distribution frame 90° bracket. Two per frame section.",
+      "name": "Frame 90\u00b0 bracket",
+      "description": "Distribution frame 90\u00b0 bracket. Two per frame section.",
       "internal_notes": "12 per frame (per layer); interface qty ASSUMED 12 (Spencer said 'one set per interface' - confirm). Frame color. File: inner_90_bracket.",
       "version": "1",
       "created_at": "2026-06-27",
@@ -801,7 +801,7 @@
     {
       "id": "ls-mount-to-chute",
       "uid": "lma9",
-      "name": "Lazy Susan — chute mount",
+      "name": "Lazy Susan \u2014 chute mount",
       "aliases": [
         "bottom interface lazy Susan chute mount",
         "bottom interface chute mount"
@@ -831,7 +831,7 @@
     {
       "id": "ls-bottom-static",
       "uid": "4mmh",
-      "name": "Lazy Susan — bottom static",
+      "name": "Lazy Susan \u2014 bottom static",
       "aliases": [
         "bottom interface lazy Susan fixed section",
         "bottom interface fixed section"
@@ -861,7 +861,7 @@
     {
       "id": "ls-mount-to-extrusion",
       "uid": "bmt4",
-      "name": "Lazy Susan — extrusion mount",
+      "name": "Lazy Susan \u2014 extrusion mount",
       "description": "Bottom lazy Susan mount to the external extrusion.",
       "internal_notes": "Frame color. QUANTITY ASSUMED 1.",
       "version": "1",
@@ -882,7 +882,7 @@
     {
       "id": "ls-hold-in-place",
       "uid": "ss05",
-      "name": "Lazy Susan — hold in place",
+      "name": "Lazy Susan \u2014 hold in place",
       "description": "Bottom lazy Susan hold-in-place. Optional.",
       "internal_notes": "Optional (file: 'optional hold in place'). Frame color. QUANTITY ASSUMED 1.",
       "version": "1",
@@ -903,7 +903,7 @@
     {
       "id": "ls-washer",
       "uid": "9c4a",
-      "name": "Lazy Susan — washer",
+      "name": "Lazy Susan \u2014 washer",
       "description": "Bottom lazy Susan washer.",
       "internal_notes": "Frame color. QUANTITY UNCONFIRMED (assumed 1; may be several).",
       "version": "1",
@@ -923,7 +923,7 @@
     {
       "id": "ext-bracket-left",
       "uid": "0b4g",
-      "name": "External bracket — side",
+      "name": "External bracket \u2014 side",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Interface qty confirmed at 6, side and cover only, no bottom vertical there (top-interface.md step 14). Frame color.",
       "version": "1",
@@ -942,14 +942,14 @@
       "optional": false,
       "support": false,
       "low_tolerance": true,
-      "low_tolerance_note": "A test print is suggested. This part is a tight fit around the 2020 aluminum profile, so print one first and confirm it seats properly before committing to the full set — dial in your printer and profile together.",
+      "low_tolerance_note": "A test print is suggested. This part is a tight fit around the 2020 aluminum profile, so print one first and confirm it seats properly before committing to the full set \u2014 dial in your printer and profile together.",
       "onshape_version": "https://cad.onshape.com/documents/a4a1965bbaf3a15aff2b13ed/v/7279a42b05833c7b828efb0d/e/b0ee2e787191265cba1c1a31",
       "docs_page": "/hardware/helpers/external-bracket/"
     },
     {
       "id": "ext-bracket-bottom-vertical",
       "uid": "xgzj",
-      "name": "External bracket — bottom vertical",
+      "name": "External bracket \u2014 bottom vertical",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Not used at the top interface: that joint has no bottom vertical or flange (top-interface.md step 14, confirmed 2026-08-25). The earlier 'interface: 6' assumption here was wrong, removed. Frame color.",
       "version": "1",
@@ -973,7 +973,7 @@
     {
       "id": "ext-bracket-cover",
       "uid": "1r5i",
-      "name": "External bracket — cover",
+      "name": "External bracket \u2014 cover",
       "description": "Part of the external distribution-frame bracket (3-part assembly).",
       "internal_notes": "External distribution-frame bracket assembly member. 6 per distribution frame (per layer). Interface qty confirmed at 6, side and cover only, no bottom vertical there (top-interface.md step 14). Frame color.",
       "version": "1",
@@ -1170,7 +1170,7 @@
       "uid": "50dv",
       "name": "Cable clamp (outer)",
       "description": "Outer half of the ribbon cable clamp. White.",
-      "internal_notes": "1 per interface. White. Pairs with the inner clamp (cable-clamp assembly). v2 (2026-07-18): enlarged the M3 nut pocket so the nut seats — it did not fit in v1.",
+      "internal_notes": "1 per interface. White. Pairs with the inner clamp (cable-clamp assembly). v2 (2026-07-18): enlarged the M3 nut pocket so the nut seats \u2014 it did not fit in v1.",
       "version": "2",
       "created_at": "2026-06-27",
       "updated_at": "2026-07-18",
@@ -1292,7 +1292,7 @@
     {
       "id": "chute-stepper-idler-bearing-retainer-outer",
       "uid": "wgsc",
-      "name": "Chute Stepper Idler Gear Bearing Retainer — Outer",
+      "name": "Chute Stepper Idler Gear Bearing Retainer \u2014 Outer",
       "aliases": [
         "Idler Gear Bearing Retainer - Outer",
         "idler bearing retainer"
@@ -1317,7 +1317,7 @@
     {
       "id": "chute-stepper-idler-bearing-retainer-inner",
       "uid": "zzql",
-      "name": "Chute Stepper Idler Gear Bearing Retainer — Inner",
+      "name": "Chute Stepper Idler Gear Bearing Retainer \u2014 Inner",
       "aliases": [
         "Idler Gear Bearing Retainer - Inner",
         "idler gear cap"
@@ -1491,7 +1491,7 @@
         "chute core mount"
       ],
       "description": "Section 3 of 3 of the top interface split spur gear (Spur 2M 120T).",
-      "internal_notes": "Split spur gear for the top interface; the 3 sections print separately and assemble into one gear. Chute-core color. Carries 4× M4 inserts, plus 7× M3: 2 for the cable clamp and 5 on the underside that the chute gear screws down into. Counted on the physical part by barthel 2026-08-21 and confirmed against the STL (7 x 4.20 mm bores, ruthex's recommended M3 insert hole, re-measured with the detection thresholds loosened in case any were missed). The previous count of 9 added 2 for the layer connector, which the published model does not have; resolves the docs-merge-2026-08-21 conflict.",
+      "internal_notes": "Split spur gear for the top interface; the 3 sections print separately and assemble into one gear. Chute-core color. Carries 4\u00d7 M4 inserts, plus 7\u00d7 M3: 2 for the cable clamp and 5 on the underside that the chute gear screws down into. Counted on the physical part by barthel 2026-08-21 and confirmed against the STL (7 x 4.20 mm bores, ruthex's recommended M3 insert hole, re-measured with the detection thresholds loosened in case any were missed). The previous count of 9 added 2 for the layer connector, which the published model does not have; resolves the docs-merge-2026-08-21 conflict.",
       "version": "1",
       "created_at": "2026-07-03",
       "updated_at": "2026-07-03",
@@ -1823,7 +1823,7 @@
     {
       "id": "servo-adapter-servo-side",
       "uid": "fu2t",
-      "name": "Servo adapter — servo side",
+      "name": "Servo adapter \u2014 servo side",
       "description": "MG995 servo adapter, servo side.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1843,7 +1843,7 @@
     {
       "id": "servo-adapter-flap-side",
       "uid": "lv7n",
-      "name": "Servo adapter — flap side",
+      "name": "Servo adapter \u2014 flap side",
       "description": "MG995 servo adapter, flap side.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1863,7 +1863,7 @@
     {
       "id": "servo-bracket-lower-arm",
       "uid": "yqz1",
-      "name": "Servo bracket — lower arm",
+      "name": "Servo bracket \u2014 lower arm",
       "description": "MG995 servo bracket, lower arm.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1883,7 +1883,7 @@
     {
       "id": "servo-bracket-side-arm",
       "uid": "75na",
-      "name": "Servo bracket — side arm",
+      "name": "Servo bracket \u2014 side arm",
       "description": "MG995 servo bracket, side arm.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1903,7 +1903,7 @@
     {
       "id": "servo-bracket-cover",
       "uid": "rqor",
-      "name": "Servo bracket — cover",
+      "name": "Servo bracket \u2014 cover",
       "description": "MG995 servo bracket, cover.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -1923,7 +1923,7 @@
     {
       "id": "servo-bracket-housing",
       "uid": "tr15",
-      "name": "Servo bracket — housing",
+      "name": "Servo bracket \u2014 housing",
       "description": "MG995 servo bracket, housing.",
       "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to frame (black); confirm.",
       "version": "1",
@@ -2028,7 +2028,7 @@
     {
       "id": "camera-mount-part-6",
       "uid": "v9dv",
-      "name": "Overhead camera mount — A/B connector",
+      "name": "Overhead camera mount \u2014 A/B connector",
       "description": "Camera mount part 6. 2 per machine.",
       "internal_notes": "1 per camera mount x 2 mounts. Color not important (feeder).",
       "version": "1",
@@ -2085,7 +2085,7 @@
     {
       "id": "camera-mount-rod-mount",
       "uid": "twuu",
-      "name": "Camera mount — rod-to-C-channel mount",
+      "name": "Camera mount \u2014 rod-to-C-channel mount",
       "description": "Rod-to-C-channel mount (Part 33). 2 per camera mount, 4 total.",
       "internal_notes": "Part 33, the rod-to-c-channel mount. 2 per camera mount x 2 mounts = 4. Color not important (feeder).",
       "version": "1",
@@ -2547,7 +2547,7 @@
     {
       "id": "ctrl-board-housing-base",
       "uid": "204b",
-      "name": "Control Board Housing — Base",
+      "name": "Control Board Housing \u2014 Base",
       "description": "Base of the basically Embedded Control Board housing. The board screws straight to it on four heat inserts and the cover screws down onto four more; no standoffs.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Entered the machine on 2026-08-23 when candidate rns2 was promoted to ctrl-board-mount v2. Eight standard M3 inserts (hsi-m3, RX-M3x5.7 -- Spencer said 'the long variant', which is this one relative to the short M3S): four under the board, four for the cover.",
       "version": "1",
@@ -2574,8 +2574,8 @@
     {
       "id": "ctrl-board-housing-cover",
       "uid": "ksh2",
-      "name": "Control Board Housing — Cover",
-      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 × 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 × 12 mm button head screws, and the plunger passes through it.",
+      "name": "Control Board Housing \u2014 Cover",
+      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 \u00d7 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 \u00d7 12 mm button head screws, and the plunger passes through it.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
       "created_at": "2026-08-22",
@@ -2595,7 +2595,7 @@
     {
       "id": "ctrl-board-housing-plunger",
       "uid": "cljt",
-      "name": "Control Board Housing — Plunger",
+      "name": "Control Board Housing \u2014 Plunger",
       "description": "Plunger that passes through the housing cover, held in by the plunger retainer.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
@@ -2616,8 +2616,8 @@
     {
       "id": "ctrl-board-housing-plunger-retainer",
       "uid": "g9sx",
-      "name": "Control Board Housing — Plunger Retainer",
-      "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 × 8 mm countersunk screws.",
+      "name": "Control Board Housing \u2014 Plunger Retainer",
+      "description": "Retains the plunger in the housing cover. Screws to the cover with two M3 \u00d7 8 mm countersunk screws.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Entered the machine on 2026-08-23 when candidate rns2 was promoted to ctrl-board-mount v2. Two countersunk holes either side of the plunger slot (counted off the STL).",
       "version": "1",
       "created_at": "2026-08-22",
@@ -2679,7 +2679,7 @@
       "uid": "3ufy",
       "name": "40 mm Fan Bracket",
       "description": "L-shaped bracket that cantilevers a 40 mm fan over a board on its extrusion mount. The same part on both the control board and the Orange Pi mounts, so two per machine.",
-      "internal_notes": "Was 2 per machine — the control board and the Orange Pi each had one. The control board's housing carries its own fan as of ctrl-board-mount v2 (2026-08-23), so only the Orange Pi mount still uses this.",
+      "internal_notes": "Was 2 per machine \u2014 the control board and the Orange Pi each had one. The control board's housing carries its own fan as of ctrl-board-mount v2 (2026-08-23), so only the Orange Pi mount still uses this.",
       "version": "1",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-23",
@@ -2698,7 +2698,7 @@
     {
       "id": "meanwell-psu-housing-shell-rear",
       "uid": "7qz3",
-      "name": "PSU Housing — Shell Rear Tray",
+      "name": "PSU Housing \u2014 Shell Rear Tray",
       "description": "Rear tray of the v2 PSU housing. The Meanwell supply bolts into it on four M4 countersunk screws, and both lids screw down into it.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell rear tray.stl'. Carries the self-tapping M3 holes for both lids.",
       "version": "1",
@@ -2717,7 +2717,7 @@
     {
       "id": "meanwell-psu-housing-shell-front",
       "uid": "1h8p",
-      "name": "PSU Housing — Shell Front Module",
+      "name": "PSU Housing \u2014 Shell Front Module",
       "description": "Front module of the v2 PSU housing. The front panel slots into it, and the front lid screws down into it and into the rear tray.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - shell front module.stl'.",
       "version": "1",
@@ -2736,7 +2736,7 @@
     {
       "id": "meanwell-psu-housing-lid-rear",
       "uid": "m26o",
-      "name": "PSU Housing — Lid Rear",
+      "name": "PSU Housing \u2014 Lid Rear",
       "description": "Rear lid of the v2 PSU housing, vented over the supply. Screws into the rear tray on four self-tapping M3 countersunk screws.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid rear.stl'.",
       "version": "1",
@@ -2755,7 +2755,7 @@
     {
       "id": "meanwell-psu-housing-lid-front",
       "uid": "avux",
-      "name": "PSU Housing — Lid Front",
+      "name": "PSU Housing \u2014 Lid Front",
       "description": "Front lid of the v2 PSU housing. Spans the joint, screwing two into the front module and two into the rear tray, and traps the front panel once fitted.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - lid front.stl'.",
       "version": "1",
@@ -2774,7 +2774,7 @@
     {
       "id": "meanwell-psu-housing-front-panel",
       "uid": "n1oh",
-      "name": "PSU Housing — Front Panel",
+      "name": "PSU Housing \u2014 Front Panel",
       "description": "Front panel of the v2 PSU housing, carrying the mains inlet cutout. No fasteners of its own: it slots into the front module and the front lid holds it in.",
       "internal_notes": "From 'meanwell psu housing v2.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate 1d0t on meanwell-psu-box, so quantities stay empty and it stays out of the all-parts bundle until that candidate is promoted. Named 'housing - front panel.stl'.",
       "version": "1",
@@ -2798,12 +2798,12 @@
         "type": "screw",
         "size": "M3"
       },
-      "name": "M3 screw — type and length TBD",
+      "name": "M3 screw \u2014 type and length TBD",
       "category": "Screws",
       "description": "Placeholder for the M3s whose head type and length nobody has written down yet: the cable-mount cage bracket, the camera extension, and the two board mounts.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
-      "note": "Neither the head type nor the length is recorded — measure before ordering.",
+      "note": "Neither the head type nor the length is recorded \u2014 measure before ordering.",
       "attributes": [
         {
           "label": "Thread",
@@ -2831,10 +2831,10 @@
       "name": "M3 socket/button head, length TBD",
       "category": "Screws",
       "alternative": "Socket or button head",
-      "description": "Was the placeholder for the screws holding the basically Embedded Control Board to the housing base, before they were measured as M3 × 6 mm button head. Nothing calls for it now; the uid is kept because it was minted.",
+      "description": "Was the placeholder for the screws holding the basically Embedded Control Board to the housing base, before they were measured as M3 \u00d7 6 mm button head. Nothing calls for it now; the uid is kept because it was minted.",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-22",
-      "note": "Superseded before it was ever ordered — nothing in the catalog calls for it.",
+      "note": "Superseded before it was ever ordered \u2014 nothing in the catalog calls for it.",
       "attributes": [
         {
           "label": "Thread",
@@ -2860,7 +2860,7 @@
         "variant": "countersunk",
         "length_mm": 6
       },
-      "name": "M3 × 6 mm countersunk",
+      "name": "M3 \u00d7 6 mm countersunk",
       "category": "Screws",
       "description": "Secures the limit switch hammer into the top interface chute mount from below, into the hammer's M3 insert.",
       "created_at": "2026-08-18",
@@ -2882,7 +2882,7 @@
       "sheet_qty": {
         "per_machine": 1
       },
-      "note": "The ×1 is the top-interface count (limit-switch hammer). Screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "The \u00d71 is the top-interface count (limit-switch hammer). Screws used elsewhere on the machine aren't tallied here yet.",
       "image_url": "https://assets.basically.website/sorter-parts/hardware-screws-countersunk-full-faf0edbe3324.jpg"
     },
     {
@@ -2895,7 +2895,7 @@
         "variant": "socket",
         "length_mm": 10
       },
-      "name": "M3 × 10 mm socket/button head",
+      "name": "M3 \u00d7 10 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-10-shcs-full-26e52d7d5bcd.png",
@@ -2919,7 +2919,7 @@
       "sheet_qty": {
         "per_machine": 3
       },
-      "note": "The ×3 is the top-interface count (2 cable clamp, 1 ribbon clamp). Screws used elsewhere on the machine aren't tallied here yet."
+      "note": "The \u00d73 is the top-interface count (2 cable clamp, 1 ribbon clamp). Screws used elsewhere on the machine aren't tallied here yet."
     },
     {
       "id": "scr-m3-8-cs",
@@ -2931,9 +2931,9 @@
         "variant": "countersunk",
         "length_mm": 8
       },
-      "name": "M3 × 8 mm countersunk",
+      "name": "M3 \u00d7 8 mm countersunk",
       "category": "Screws",
-      "description": "The workhorse M3 screw — used all over the machine wherever a flush head is wanted.",
+      "description": "The workhorse M3 screw \u2014 used all over the machine wherever a flush head is wanted.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -2981,7 +2981,7 @@
         "variant": "socket",
         "length_mm": 8
       },
-      "name": "M2 × 8 mm socket/button head",
+      "name": "M2 \u00d7 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "description": "Self-taps the IMX415 classification camera board to the camera extension's printed post. 4 per module, no insert. May also fit the OV9732 overhead camera mount once that gets a real bracket (sorter-v2#426), not confirmed.",
@@ -3013,7 +3013,7 @@
         "variant": "socket",
         "length_mm": 8
       },
-      "name": "M3 × 8 mm socket/button head",
+      "name": "M3 \u00d7 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "description": "Clamps the C-channel input gear (12T) to the flat of the NEMA 17 shaft. 1 per C-channel.",
@@ -3033,7 +3033,7 @@
           "value": "Socket or button head, interchangeable (both bottom on the counterbore floor, so either just clamps)"
         }
       ],
-      "note": "Head type and length measured off the input-gear STL: the boss carries a Ø2.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the Ø4.87 mm bore; the head sits in a round Ø6.40 mm × 2.7 mm counterbore with a 90° cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (Ø5.5 × 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (Ø5.7 × 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
+      "note": "Head type and length measured off the input-gear STL: the boss carries a \u00d82.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the \u00d84.87 mm bore; the head sits in a round \u00d86.40 mm \u00d7 2.7 mm counterbore with a 90\u00b0 cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (\u00d85.5 \u00d7 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (\u00d85.7 \u00d7 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
     },
     {
       "id": "scr-m3-12-cs",
@@ -3045,7 +3045,7 @@
         "variant": "countersunk",
         "length_mm": 12
       },
-      "name": "M3 × 12 mm countersunk",
+      "name": "M3 \u00d7 12 mm countersunk",
       "category": "Screws",
       "description": "The long M3 countersunk. Used all over the machine.",
       "created_at": "2026-07-18",
@@ -3095,9 +3095,9 @@
         "variant": "countersunk",
         "length_mm": 20
       },
-      "name": "M3 × 20 mm countersunk",
+      "name": "M3 \u00d7 20 mm countersunk",
       "category": "Screws",
-      "description": "Joins the C-channel light post to the NEMA bracket. Threads straight into the printed post — no insert, no nut.",
+      "description": "Joins the C-channel light post to the NEMA bracket. Threads straight into the printed post \u2014 no insert, no nut.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -3142,7 +3142,7 @@
         "variant": "socket",
         "length_mm": 16
       },
-      "name": "M3 × 16 mm socket/button head",
+      "name": "M3 \u00d7 16 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png",
@@ -3174,7 +3174,7 @@
         "variant": "button",
         "length_mm": 6
       },
-      "name": "M3 × 6 mm socket/button head",
+      "name": "M3 \u00d7 6 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-6-bhcs-full-26e52d7d5bcd.png",
@@ -3206,7 +3206,7 @@
         "variant": "button",
         "length_mm": 12
       },
-      "name": "M3 × 12 mm socket/button head",
+      "name": "M3 \u00d7 12 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-12-bhcs-full-26e52d7d5bcd.png",
@@ -3238,7 +3238,7 @@
         "variant": "flat",
         "length_mm": 35
       },
-      "name": "M3 × 35 mm flat head",
+      "name": "M3 \u00d7 35 mm flat head",
       "category": "Screws",
       "alternative": "Flat or pan head",
       "description": "The two long M3s on the top interface: one clamps the two cable-clamp halves together, one retains the idler gear on the NEMA 23 bracket. Same screw for both. The head has to stay low because of the idler joint: a socket or button head stands proud enough for the limit switch hammer to catch on it as the chute sweeps past.",
@@ -3269,7 +3269,7 @@
         "variant": "countersunk",
         "length_mm": 6
       },
-      "name": "M4 × 6 mm countersunk",
+      "name": "M4 \u00d7 6 mm countersunk",
       "category": "Screws",
       "description": "Fastens the printed PSU housing to the power supply's own case threads.",
       "created_at": "2026-07-18",
@@ -3299,9 +3299,9 @@
         "variant": "countersunk",
         "length_mm": 12
       },
-      "name": "M4 × 12 mm countersunk",
+      "name": "M4 \u00d7 12 mm countersunk",
       "category": "Screws",
-      "description": "Bolts each lazy Susan together — 4 a side, through the M4 inserts in the static half and the chute mount. 2 lazy Susans per machine.",
+      "description": "Bolts each lazy Susan together \u2014 4 a side, through the M4 inserts in the static half and the chute mount. 2 lazy Susans per machine.",
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "attributes": [
@@ -3330,7 +3330,7 @@
         "variant": "socket",
         "length_mm": 12
       },
-      "name": "M5 × 12 mm socket/button head",
+      "name": "M5 \u00d7 12 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-12-shcs-full-26e52d7d5bcd.png",
@@ -3362,7 +3362,7 @@
         "variant": "socket",
         "length_mm": 16
       },
-      "name": "M5 × 16 mm socket/button head",
+      "name": "M5 \u00d7 16 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-16-shcs-full-26e52d7d5bcd.png",
@@ -3383,7 +3383,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Designed to self-tap into printed plastic wherever it lands in an external bracket or the upper fixed section — no nut and no insert there."
+      "note": "Designed to self-tap into printed plastic wherever it lands in an external bracket or the upper fixed section \u2014 no nut and no insert there."
     },
     {
       "id": "scr-m5-20-shcs",
@@ -3395,7 +3395,7 @@
         "variant": "socket",
         "length_mm": 20
       },
-      "name": "M5 × 20 mm socket/button head",
+      "name": "M5 \u00d7 20 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-20-shcs-full-26e52d7d5bcd.png",
@@ -3427,7 +3427,7 @@
         "variant": "socket",
         "length_mm": 30
       },
-      "name": "M5 × 30 mm socket/button head",
+      "name": "M5 \u00d7 30 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-30-shcs-full-26e52d7d5bcd.png",
@@ -3459,7 +3459,7 @@
         "variant": "flat",
         "length_mm": 35
       },
-      "name": "M5 × 35 mm flat head",
+      "name": "M5 \u00d7 35 mm flat head",
       "internal_notes": "Flat (pancake) head, hex socket, confirmed by barthel 2026-08-21: \"The m3x35mm must be a flat hat screw like in calculator\" (the M5 x 35 is the only 35 mm screw the two catalogs disagreed about; the M3 x 35 was already settled as flat head in #356). The docs catalog had called it a socket head cap screw; that claim is dropped and the docs prose now says flat head. Resolves the last docs-merge-2026-08-21 conflict.",
       "category": "Screws",
       "description": "The long screws that stack the cable cage together, and that bolt the plywood top plate down onto the interface brackets.",
@@ -3516,7 +3516,7 @@
         "variant": "countersunk",
         "length_mm": 8
       },
-      "name": "M5 × 8 mm countersunk",
+      "name": "M5 \u00d7 8 mm countersunk",
       "category": "Screws",
       "description": "Loosely fixes the limit-switch interface bracket's extrusion into the interface rib while aligning it, into a T-nut.",
       "created_at": "2026-08-18",
@@ -3535,7 +3535,7 @@
           "value": "Countersunk (flat) socket"
         }
       ],
-      "note": "A snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush. The ×6 is the top-interface count (1 per interface bracket); screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "A snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush. The \u00d76 is the top-interface count (1 per interface bracket); screws used elsewhere on the machine aren't tallied here yet.",
       "sheet_qty": {
         "per_machine": 6
       },
@@ -3551,9 +3551,9 @@
         "variant": "countersunk",
         "length_mm": 22
       },
-      "name": "M5 × 22 mm countersunk",
+      "name": "M5 \u00d7 22 mm countersunk",
       "category": "Screws",
-      "description": "Bolts the interface bracket assembly and all six interface brackets down through the laser-cut top plate (holes S2/S3, then I1–I6 and O1–O6).",
+      "description": "Bolts the interface bracket assembly and all six interface brackets down through the laser-cut top plate (holes S2/S3, then I1\u2013I6 and O1\u2013O6).",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-18",
       "attributes": [
@@ -3570,7 +3570,7 @@
           "value": "Countersunk (flat) socket"
         }
       ],
-      "note": "The top plate's laser-cut holes aren't countersunk, so where a flush head won't seat an M5 × 20 button head is used instead. The ×14 is the top-interface count (2 to the top plate, 12 through the bracket holes); screws used elsewhere on the machine aren't tallied here yet.",
+      "note": "The top plate's laser-cut holes aren't countersunk, so where a flush head won't seat an M5 \u00d7 20 button head is used instead. The \u00d714 is the top-interface count (2 to the top plate, 12 through the bracket holes); screws used elsewhere on the machine aren't tallied here yet.",
       "sheet_qty": {
         "per_machine": 14
       },
@@ -3606,7 +3606,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Length unknown — measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
+      "note": "Length unknown \u2014 measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
     },
     {
       "id": "washer-m3-15",
@@ -3616,9 +3616,9 @@
         "type": "washer",
         "size": "M3"
       },
-      "name": "M3 × 15 mm washer",
+      "name": "M3 \u00d7 15 mm washer",
       "category": "Washers",
-      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
+      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
       "created_at": "2026-08-18",
       "updated_at": "2026-08-25",
       "attributes": [
@@ -3719,7 +3719,7 @@
         "type": "stock-material",
         "size": "3/8 in"
       },
-      "name": "Steel rod, 3/8 in — 4 ft stock",
+      "name": "Steel rod, 3/8 in \u2014 4 ft stock",
       "category": "Stock material",
       "description": "Bought as a length and cut down. One 4 ft rod yields all four ~1 ft pieces the two overhead camera arms hang from.",
       "created_at": "2026-07-18",
@@ -3734,7 +3734,7 @@
       "attributes": [
         {
           "label": "Diameter",
-          "value": "3/8 in (9.53 mm) · 10 mm in metric"
+          "value": "3/8 in (9.53 mm) \u00b7 10 mm in metric"
         },
         {
           "label": "Buy",
@@ -3742,7 +3742,7 @@
         },
         {
           "label": "Cut into",
-          "value": "4 × ~1 ft (305 mm)"
+          "value": "4 \u00d7 ~1 ft (305 mm)"
         },
         {
           "label": "Material",
@@ -4193,7 +4193,7 @@
         },
         {
           "label": "Thread",
-          "value": "M6 × 1.0"
+          "value": "M6 \u00d7 1.0"
         },
         {
           "label": "Material",
@@ -4230,7 +4230,7 @@
         "type": "wheel",
         "size": "M6"
       },
-      "name": "Swivel stem caster, M6 × 15 mm",
+      "name": "Swivel stem caster, M6 \u00d7 15 mm",
       "category": "Wheels",
       "description": "Screws into the 2020 foot connector so the machine can roll.",
       "created_at": "2026-07-18",
@@ -4238,7 +4238,7 @@
       "attributes": [
         {
           "label": "Thread",
-          "value": "M6 × 1.0, 15 mm stem"
+          "value": "M6 \u00d7 1.0, 15 mm stem"
         },
         {
           "label": "Wheel",
@@ -4418,7 +4418,7 @@
       "attributes": [
         {
           "label": "Size",
-          "value": "30 × 42 × 7 mm (ID × OD × W)"
+          "value": "30 \u00d7 42 \u00d7 7 mm (ID \u00d7 OD \u00d7 W)"
         },
         {
           "label": "Seal",
@@ -4506,7 +4506,7 @@
       "attributes": [
         {
           "label": "Size",
-          "value": "20 × 27 × 4 mm (ID × OD × W)"
+          "value": "20 \u00d7 27 \u00d7 4 mm (ID \u00d7 OD \u00d7 W)"
         },
         {
           "label": "Seal",
@@ -4652,7 +4652,7 @@
         },
         {
           "label": "Size",
-          "value": "22 × 30 mm"
+          "value": "22 \u00d7 30 mm"
         },
         {
           "label": "Fits",
@@ -4889,7 +4889,7 @@
       "cots": {
         "type": "cable"
       },
-      "name": "IDC ribbon cable, 16-pin (2×8), 1 m",
+      "name": "IDC ribbon cable, 16-pin (2\u00d78), 1 m",
       "category": "Electronics",
       "description": "Cable from distribution board to chute",
       "created_at": "2026-07-18",
@@ -4914,7 +4914,7 @@
       "attributes": [
         {
           "label": "Pins",
-          "value": "16 (2×8), FC to FC, A-type"
+          "value": "16 (2\u00d78), FC to FC, A-type"
         },
         {
           "label": "Pitch",
@@ -4937,7 +4937,7 @@
       "cots": {
         "type": "cable"
       },
-      "name": "IDC ribbon cable, 16-pin (2×8), 30 cm",
+      "name": "IDC ribbon cable, 16-pin (2\u00d78), 30 cm",
       "category": "Electronics",
       "description": "Cable between layer and layer below",
       "created_at": "2026-07-18",
@@ -4962,7 +4962,7 @@
       "attributes": [
         {
           "label": "Pins",
-          "value": "16 (2×8), female-to-female FC"
+          "value": "16 (2\u00d78), female-to-female FC"
         },
         {
           "label": "Pitch",
@@ -5137,7 +5137,7 @@
       "cots": {
         "type": "converter"
       },
-      "name": "24 V → 5 V USB-C buck converter",
+      "name": "24 V \u2192 5 V USB-C buck converter",
       "category": "Wire harness",
       "description": "Powers the Orange Pi from the 24 V PSU.",
       "created_at": "2026-07-18",
@@ -5145,7 +5145,7 @@
       "attributes": [
         {
           "label": "Input",
-          "value": "DC 8–32 V (12 V / 24 V nominal)"
+          "value": "DC 8\u201332 V (12 V / 24 V nominal)"
         },
         {
           "label": "Output",
@@ -5231,7 +5231,7 @@
         },
         {
           "label": "Fuse",
-          "value": "10 A installed (5 × 20 mm)"
+          "value": "10 A installed (5 \u00d7 20 mm)"
         },
         {
           "label": "Wiring",
@@ -5239,7 +5239,7 @@
         },
         {
           "label": "Cutout",
-          "value": "47 × 28 mm; holes 40 mm apart, 3.2 mm"
+          "value": "47 \u00d7 28 mm; holes 40 mm apart, 3.2 mm"
         }
       ],
       "sheet_qty": {
@@ -5269,13 +5269,13 @@
       },
       "name": "40 mm 24 V fan (WINSINN 4010)",
       "category": "Electronics",
-      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 × 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
+      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 \u00d7 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
       "created_at": "2026-08-22",
       "updated_at": "2026-08-23",
       "attributes": [
         {
           "label": "Size",
-          "value": "40 × 40 × 10 mm"
+          "value": "40 \u00d7 40 \u00d7 10 mm"
         },
         {
           "label": "Voltage",
@@ -5429,7 +5429,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-cable-cage-top-full-9e4c43a620ca.png",
       "assembly": "Cable Cage",
       "description": "Top plate of the cable cage. Has a keyed cutout for easy insertion/removal of the interface.",
-      "thicknessIn": "1/8″",
+      "thicknessIn": "1/8\u2033",
       "thicknessMm": 3,
       "widthMm": 325,
       "heightMm": 375,
@@ -5440,9 +5440,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "cage-top",
-        "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big Ø177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
-        "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
-        "tools": "jigsaw · drill · tape measure"
+        "blurb": "A regular hexagon, same outline as the bottom plate. Lays out from a rectangle with a tape measure: the centre is one big \u00d8177 mm drilled-and-jigsawed hole, six mounting holes sit on a 175 mm-radius bolt circle, and a small keyed notch is drilled at each end.",
+        "stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
+        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
       },
       "printed": {
         "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
@@ -5466,7 +5466,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-cable-cage-bottom-full-283aeb114195.png",
       "assembly": "Cable Cage",
       "description": "Bottom plate of the cable cage.",
-      "thicknessIn": "1/8″",
+      "thicknessIn": "1/8\u2033",
       "thicknessMm": 3,
       "widthMm": 325,
       "heightMm": 375,
@@ -5477,9 +5477,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "cage-bottom",
-        "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big Ø177 mm centre hole and six Ø5.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
-        "stock": "325 × 375 mm rectangle (12 13/16″ × 14 3/4″)",
-        "tools": "jigsaw · drill · tape measure"
+        "blurb": "The same regular-hexagon outline as the top cage, but simpler: one big \u00d8177 mm centre hole and six \u00d85.5 mm mounting holes on a 175 mm-radius bolt circle. No small holes, no notch.",
+        "stock": "325 \u00d7 375 mm rectangle (12 13/16\u2033 \u00d7 14 3/4\u2033)",
+        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
       },
       "printed": {
         "blurb": "A community 3D-printed alternative from Alec, in six/five segments (a Bambu A1's bed can't fit the whole hexagon in one piece). Bolt the segments together with M3 nuts and bolts as a clamp, glue the joints, then remove the M3 hardware once the glue has cured.",
@@ -5499,7 +5499,7 @@
       "photo": "https://assets.basically.website/sorter-parts/top-interface-top-plate-w1600-00182ea8156d.jpg",
       "caption": "The machine's hexagonal top plate; the interface mounts under it.",
       "description": "Machine top plate. Has 5 cable holes and holes for the main stepper. Does not yet have mount holes for the C-channels.",
-      "thicknessIn": "3/8″",
+      "thicknessIn": "3/8\u2033",
       "thicknessMm": 10,
       "widthMm": 672,
       "heightMm": 770,
@@ -5510,9 +5510,9 @@
       "updated": "2026-07-10",
       "handcut": {
         "guide": "top-plate",
-        "blurb": "This plate is a regular hexagon — it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8″) drill holes.",
-        "stock": "672.4 × 776.4 mm rectangle (26 15/32″ × 30 9/16″)",
-        "tools": "jigsaw · drill · tape measure"
+        "blurb": "This plate is a regular hexagon \u2014 it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8\u2033) drill holes.",
+        "stock": "672.4 \u00d7 776.4 mm rectangle (26 15/32\u2033 \u00d7 30 9/16\u2033)",
+        "tools": "jigsaw \u00b7 drill \u00b7 tape measure"
       }
     }
   ],
@@ -5528,7 +5528,7 @@
       "joining": [
         {
           "method": "self-tap",
-          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post — no insert, no nut."
+          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post \u2014 no insert, no nut."
         }
       ],
       "lines": [
@@ -5596,13 +5596,13 @@
       "uid": "99af",
       "version": "1",
       "name": "Fixed upper section",
-      "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 × [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
+      "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 \u00d7 [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "joining": [
         {
           "method": "self-tap",
-          "note": "Both of each rib's [[hw:scr-m5-16-shcs]] thread straight into the printed upper fixed section — no insert, no nut."
+          "note": "Both of each rib's [[hw:scr-m5-16-shcs]] thread straight into the printed upper fixed section \u2014 no insert, no nut."
         }
       ],
       "lines": [
@@ -5668,7 +5668,7 @@
       "uid": "jqhp",
       "version": "1",
       "name": "Chute bearing assembly",
-      "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 × 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
+      "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 \u00d7 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
       "status": "partial",
       "lines": [
         {
@@ -5827,8 +5827,8 @@
     },
     {
       "id": "limit-switch",
-      "uid": "eb8m",
-      "version": "1",
+      "uid": "xzje",
+      "version": "2",
       "name": "Chute limit switch",
       "description": "Interface limit switch: printed dowel pin, housing, hammer, and the switch itself. Bolts to the interface frame as a unit.",
       "docs": "/hardware/assembly/distribution/top-interface/",
@@ -5853,6 +5853,22 @@
         {
           "part": "scr-m3-12-bhcs",
           "qty": 2
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 2
+        },
+        {
+          "part": "tnut-m5-2020",
+          "qty": 2
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-08-29",
+          "message": "Added the 2 scr-m5-16-shcs + 2 tnut-m5-2020 that fasten the Limit switch housing to its bracket's extrusion (step 4), previously missing -- only the switch-to-housing M3s were modeled.",
+          "commit": null
         }
       ]
     },
@@ -6016,7 +6032,7 @@
       "uid": "s7bo",
       "version": "1",
       "name": "Pico with headers",
-      "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare — the pins are a separate purchase.",
+      "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare \u2014 the pins are a separate purchase.",
       "docs": "/hardware/electronics/installation/pico-headers/",
       "status": "partial",
       "joining": [
@@ -6104,26 +6120,20 @@
     },
     {
       "id": "interface",
-      "uid": "zz8s",
-      "version": "1",
+      "uid": "bkgq",
+      "version": "2",
       "name": "Interface",
-      "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
+      "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
-      "joining": [
-        {
-          "method": "friction",
-          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
-        }
-      ],
       "lines": [
         {
           "assembly": "interface-bracket-mount",
           "qty": 6
         },
         {
-          "part": "ext-bracket-left",
-          "qty": 6
+          "assembly": "hex-frame",
+          "qty": 1
         },
         {
           "part": "ext-bracket-cover",
@@ -6160,10 +6170,6 @@
         {
           "part": "scr-m5-20-shcs",
           "qty": 2
-        },
-        {
-          "part": "tnut-m5-2020",
-          "qty": 8
         },
         {
           "assembly": "chute-stepper-gearing",
@@ -6208,31 +6214,23 @@
         {
           "part": "scr-m5-8-cs",
           "qty": 6
-        },
+        }
+      ],
+      "versions": [
         {
-          "part": "ext-2020-ag",
-          "qty": 6
-        },
-        {
-          "part": "ext-2020-bh",
-          "qty": 6
-        },
-        {
-          "part": "frame-90deg-bracket",
-          "qty": 12
-        },
-        {
-          "part": "frame-crossbeam",
-          "qty": 6
+          "version": "2",
+          "date": "2026-08-29",
+          "message": "Consumes the new hex-frame assembly instead of duplicating its ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline. Dropped the stray top-level tnut-m5-2020 qty 8, now superseded by interface-bracket-mount's and limit-switch's own per-step T-nut lines.",
+          "commit": null
         }
       ]
     },
     {
       "id": "layer",
-      "uid": "a17l",
-      "version": "1",
+      "uid": "jog7",
+      "version": "2",
       "name": "Distribution layer",
-      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 × [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
+      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
       "lines": [
@@ -6257,8 +6255,16 @@
           "qty": 24
         },
         {
-          "part": "tnut-m5-2020",
-          "qty": 24
+          "part": "scr-m5-16-shcs",
+          "qty": 12
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-08-29",
+          "message": "Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones), same double-count barthel already caught on bottom two layers. Added the 12 scr-m5-16-shcs that join this layer's flange up to the layer above, previously missing.",
+          "commit": null
         }
       ]
     },
@@ -6379,7 +6385,7 @@
       "uid": "mttx",
       "version": "1",
       "name": "C-channel drive",
-      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Screw joints: 4 × [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 × [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 × [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 × [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke — the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing (the light post's 2 × [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke \u2014 the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
       "status": "partial",
       "lines": [
@@ -6426,7 +6432,7 @@
       "uid": "cwji",
       "version": "1",
       "name": "Chute Stepper Gearing",
-      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3×35 keeps it clear of the limit switch hammer.",
+      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6515,7 +6521,7 @@
       "uid": "8cjj",
       "version": "1",
       "name": "Interface chute gear + mount",
-      "description": "The chute gear screwed down onto the top interface chute mount — two sections of the split spur gear that become one turning unit.",
+      "description": "The chute gear screwed down onto the top interface chute mount \u2014 two sections of the split spur gear that become one turning unit.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6534,16 +6540,30 @@
       ]
     },
     {
-      "id": "layer-frame",
-      "uid": "adaj",
+      "id": "hex-frame",
+      "uid": "8z0e",
       "version": "1",
-      "name": "Distribution frame",
-      "description": "The frame of one distribution layer: six external brackets, the crossbeams between them, and the 90° brackets. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
-      "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
+      "name": "Hex frame",
+      "description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket \u2014 side, with six B/H spokes and Frame crossbeams held inside by the Frame 90\u00b0 brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
+      "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
       "status": "partial",
+      "joining": [
+        {
+          "method": "friction",
+          "note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
+        }
+      ],
       "lines": [
         {
-          "assembly": "external-bracket",
+          "part": "ext-2020-ag",
+          "qty": 6
+        },
+        {
+          "part": "ext-bracket-left",
+          "qty": 6
+        },
+        {
+          "part": "ext-2020-bh",
           "qty": 6
         },
         {
@@ -6553,6 +6573,49 @@
         {
           "part": "frame-90deg-bracket",
           "qty": 12
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 8
+        },
+        {
+          "part": "tnut-m5-2020",
+          "qty": 24
+        }
+      ]
+    },
+    {
+      "id": "layer-frame",
+      "uid": "22ck",
+      "version": "2",
+      "name": "Distribution frame",
+      "description": "The frame of one distribution layer: a hex frame plus the External bracket \u2014 cover and \u2014 bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
+      "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
+      "status": "partial",
+      "lines": [
+        {
+          "assembly": "hex-frame",
+          "qty": 1
+        },
+        {
+          "part": "ext-bracket-bottom-vertical",
+          "qty": 6
+        },
+        {
+          "part": "ext-bracket-cover",
+          "qty": 6
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 24
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-08-29",
+          "message": "Split the hex frame (outer ring, spokes, crossbeams, 90\u00b0 brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
+          "commit": null
         }
       ]
     },
@@ -6561,7 +6624,7 @@
       "uid": "rns2",
       "version": "2",
       "name": "basically Embedded Control Board Housing",
-      "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base — no bracket, no standoffs — and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
+      "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base \u2014 no bracket, no standoffs \u2014 and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
       "section": "electronics",
       "docs": "/hardware/electronics/installation/control-board-housing/",
       "status": "partial",
@@ -6634,7 +6697,7 @@
           "version": "1",
           "uid": "u12m",
           "date": "2026-07-18",
-          "message": "The board stood off a printed bracket on four 10 mm standoffs, and the 40 mm fan sat on a separate bracket cantilevered over it — the same bracket the Orange Pi mount uses. Superseded by the printed housing.",
+          "message": "The board stood off a printed bracket on four 10 mm standoffs, and the 40 mm fan sat on a separate bracket cantilevered over it \u2014 the same bracket the Orange Pi mount uses. Superseded by the printed housing.",
           "images": [
             {
               "url": "https://assets.basically.website/sorter-parts/ctrl-board-mount-v1-render-full-617e995364c7.png",
@@ -6683,7 +6746,7 @@
         {
           "version": "2",
           "date": "2026-08-23",
-          "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 × 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
+          "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 \u00d7 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
           "commit": "9ff8a1e3"
         }
       ]
@@ -6764,10 +6827,10 @@
     },
     {
       "id": "interface-bracket-mount",
-      "uid": "rhr6",
-      "version": "1",
+      "uid": "pnl9",
+      "version": "2",
       "name": "Interface bracket",
-      "description": "One interface bracket with its spacer, bolted onto its vertical extrusion. 6 per interface.",
+      "description": "One interface bracket with its spacer, bolted onto its vertical extrusion (piece F) and its spoke extrusion (piece E). 6 per interface.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -6780,12 +6843,28 @@
           "qty": 1
         },
         {
+          "part": "scr-m5-16-shcs",
+          "qty": 4
+        },
+        {
           "part": "scr-m5-20-shcs",
           "qty": 4
         },
         {
+          "part": "scr-m5-8-cs",
+          "qty": 1
+        },
+        {
           "part": "tnut-m5-2020",
-          "qty": 4
+          "qty": 9
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-08-29",
+          "message": "Added the piece-E attachment (4 scr-m5-16-shcs into 4 tnut-m5-2020, step 3) and the rib-securing tnut-m5-2020 (step 5), neither previously modeled -- only step 13's piece-F mount (scr-m5-20-shcs + 4 T-nuts) was here before.",
+          "commit": null
         }
       ]
     },
@@ -6794,7 +6873,7 @@
       "uid": "l1un",
       "version": "1",
       "name": "Bottom lazy Susan",
-      "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 × [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
+      "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 \u00d7 [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
       "status": "partial",
       "lines": [
@@ -6866,7 +6945,7 @@
         "variant": "flat"
       },
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-35-fhcs-full-cf13d79a5110.jpg",
-      "image_credit": "M5 × 35 flat head listing photo, reused for the head shape"
+      "image_credit": "M5 \u00d7 35 flat head listing photo, reused for the head shape"
     },
     {
       "id": "screw-button",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -300,6 +300,7 @@
       "targets": {
         "parts": [
           "ribbon-cable-clamp",
+          "interface-cage-bracket",
           "interface-cage-bracket-cable"
         ],
         "assemblies": [
@@ -6109,6 +6110,12 @@
       "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
+      "joining": [
+        {
+          "method": "friction",
+          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
+        }
+      ],
       "lines": [
         {
           "assembly": "interface-bracket-mount",
@@ -6200,6 +6207,22 @@
         },
         {
           "part": "scr-m5-8-cs",
+          "qty": 6
+        },
+        {
+          "part": "ext-2020-ag",
+          "qty": 6
+        },
+        {
+          "part": "ext-2020-bh",
+          "qty": 6
+        },
+        {
+          "part": "frame-90deg-bracket",
+          "qty": 12
+        },
+        {
+          "part": "frame-crossbeam",
           "qty": 6
         }
       ]
@@ -6518,12 +6541,6 @@
       "description": "The frame of one distribution layer: six external brackets, the crossbeams between them, and the 90° brackets. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
-      "joining": [
-        {
-          "method": "friction",
-          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
-        }
-      ],
       "lines": [
         {
           "assembly": "external-bracket",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5865,6 +5865,10 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "message": "Original version: only modeled the switch-to-housing M3 screws; the housing-to-extrusion scr-m5-16-shcs + tnut-m5-2020 (step 4) weren't in the catalog at all."
+        },
+        {
           "version": "2",
           "date": "2026-08-29",
           "message": "Added the 2 scr-m5-16-shcs + 2 tnut-m5-2020 that fasten the Limit switch housing to its bracket's extrusion (step 4), previously missing -- only the switch-to-housing M3s were modeled.",
@@ -6218,6 +6222,10 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "message": "Original version: duplicated the hex frame's own ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline instead of consuming a shared hex-frame assembly, and carried a stray top-level tnut-m5-2020 qty 8 not tied to any specific step."
+        },
+        {
           "version": "2",
           "date": "2026-08-29",
           "message": "Consumes the new hex-frame assembly instead of duplicating its ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline. Dropped the stray top-level tnut-m5-2020 qty 8, now superseded by interface-bracket-mount's and limit-switch's own per-step T-nut lines.",
@@ -6260,6 +6268,10 @@
         }
       ],
       "versions": [
+        {
+          "version": "1",
+          "message": "Original version: listed tnut-m5-2020 qty 24 for the bin retainers (double-counting the hex frame's own pre-installed T-nuts) and had no line for the layer-to-layer flange-join screws."
+        },
         {
           "version": "2",
           "date": "2026-08-29",
@@ -6612,6 +6624,10 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "message": "Original version: bundled the hex frame's own outer ring, spokes, crossbeams and 90\u00b0 brackets inline instead of as a separate assembly."
+        },
+        {
           "version": "2",
           "date": "2026-08-29",
           "message": "Split the hex frame (outer ring, spokes, crossbeams, 90\u00b0 brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
@@ -6860,6 +6876,10 @@
         }
       ],
       "versions": [
+        {
+          "version": "1",
+          "message": "Original version: only modeled the piece-F mount (step 13); the piece-E attachment (step 3) and rib-securing T-nut (step 5) weren't in the catalog at all."
+        },
         {
           "version": "2",
           "date": "2026-08-29",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -756,8 +756,8 @@
 		},
 		{
 			"id": "limit-switch",
-			"uid": "eb8m",
-			"version": "1",
+			"uid": "xzje",
+			"version": "2",
 			"name": "Chute limit switch",
 			"description": "Interface limit switch: printed dowel pin, housing, hammer, and the switch itself. Bolts to the interface frame as a unit.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
@@ -782,6 +782,23 @@
 				{
 					"part": "scr-m3-12-bhcs",
 					"qty": 2
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 2
+				},
+				{
+					"part": "tnut-m5-2020",
+					"qty": 2
+				}
+			],
+			"versions": [
+				{
+					"version": "2",
+					"uid": "xzje",
+					"date": "2026-08-29",
+					"message": "Added the 2 scr-m5-16-shcs + 2 tnut-m5-2020 that fasten the Limit switch housing to its bracket's extrusion (step 4), previously missing -- only the switch-to-housing M3s were modeled.",
+					"commit": null
 				}
 			]
 		},
@@ -1033,26 +1050,20 @@
 		},
 		{
 			"id": "interface",
-			"uid": "zz8s",
-			"version": "1",
+			"uid": "bkgq",
+			"version": "2",
 			"name": "Interface",
 			"description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
 			"status": "partial",
-			"joining": [
-				{
-					"method": "friction",
-					"note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
-				}
-			],
 			"lines": [
 				{
 					"assembly": "interface-bracket-mount",
 					"qty": 6
 				},
 				{
-					"part": "ext-bracket-left",
-					"qty": 6
+					"assembly": "hex-frame",
+					"qty": 1
 				},
 				{
 					"part": "ext-bracket-cover",
@@ -1089,10 +1100,6 @@
 				{
 					"part": "scr-m5-20-shcs",
 					"qty": 2
-				},
-				{
-					"part": "tnut-m5-2020",
-					"qty": 8
 				},
 				{
 					"assembly": "chute-stepper-gearing",
@@ -1137,29 +1144,22 @@
 				{
 					"part": "scr-m5-8-cs",
 					"qty": 6
-				},
+				}
+			],
+			"versions": [
 				{
-					"part": "ext-2020-ag",
-					"qty": 6
-				},
-				{
-					"part": "ext-2020-bh",
-					"qty": 6
-				},
-				{
-					"part": "frame-90deg-bracket",
-					"qty": 12
-				},
-				{
-					"part": "frame-crossbeam",
-					"qty": 6
+					"version": "2",
+					"uid": "bkgq",
+					"date": "2026-08-29",
+					"message": "Consumes the new hex-frame assembly instead of duplicating its ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline. Dropped the stray top-level tnut-m5-2020 qty 8, now superseded by interface-bracket-mount's and limit-switch's own per-step T-nut lines.",
+					"commit": null
 				}
 			]
 		},
 		{
 			"id": "layer",
-			"uid": "a17l",
-			"version": "1",
+			"uid": "jog7",
+			"version": "2",
 			"name": "Distribution layer",
 			"description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
@@ -1186,8 +1186,17 @@
 					"qty": 24
 				},
 				{
-					"part": "tnut-m5-2020",
-					"qty": 24
+					"part": "scr-m5-16-shcs",
+					"qty": 12
+				}
+			],
+			"versions": [
+				{
+					"version": "2",
+					"uid": "jog7",
+					"date": "2026-08-29",
+					"message": "Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones), same double-count barthel already caught on bottom two layers. Added the 12 scr-m5-16-shcs that join this layer's flange up to the layer above, previously missing.",
+					"commit": null
 				}
 			]
 		},
@@ -1463,16 +1472,30 @@
 			]
 		},
 		{
-			"id": "layer-frame",
-			"uid": "adaj",
+			"id": "hex-frame",
+			"uid": "8z0e",
 			"version": "1",
-			"name": "Distribution frame",
-			"description": "The frame of one distribution layer: six external brackets, the crossbeams between them, and the 90\u00b0 brackets. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
-			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
+			"name": "Hex frame",
+			"description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket \u2014 side, with six B/H spokes and Frame crossbeams held inside by the Frame 90\u00b0 brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
+			"docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
 			"status": "partial",
+			"joining": [
+				{
+					"method": "friction",
+					"note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
+				}
+			],
 			"lines": [
 				{
-					"assembly": "external-bracket",
+					"part": "ext-2020-ag",
+					"qty": 6
+				},
+				{
+					"part": "ext-bracket-left",
+					"qty": 6
+				},
+				{
+					"part": "ext-2020-bh",
 					"qty": 6
 				},
 				{
@@ -1482,6 +1505,50 @@
 				{
 					"part": "frame-90deg-bracket",
 					"qty": 12
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 8
+				},
+				{
+					"part": "tnut-m5-2020",
+					"qty": 24
+				}
+			]
+		},
+		{
+			"id": "layer-frame",
+			"uid": "22ck",
+			"version": "2",
+			"name": "Distribution frame",
+			"description": "The frame of one distribution layer: a hex frame plus the External bracket \u2014 cover and \u2014 bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
+			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
+			"status": "partial",
+			"lines": [
+				{
+					"assembly": "hex-frame",
+					"qty": 1
+				},
+				{
+					"part": "ext-bracket-bottom-vertical",
+					"qty": 6
+				},
+				{
+					"part": "ext-bracket-cover",
+					"qty": 6
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 24
+				}
+			],
+			"versions": [
+				{
+					"version": "2",
+					"uid": "22ck",
+					"date": "2026-08-29",
+					"message": "Split the hex frame (outer ring, spokes, crossbeams, 90\u00b0 brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
+					"commit": null
 				}
 			]
 		},
@@ -1694,10 +1761,10 @@
 		},
 		{
 			"id": "interface-bracket-mount",
-			"uid": "rhr6",
-			"version": "1",
+			"uid": "pnl9",
+			"version": "2",
 			"name": "Interface bracket",
-			"description": "One interface bracket with its spacer, bolted onto its vertical extrusion. 6 per interface.",
+			"description": "One interface bracket with its spacer, bolted onto its vertical extrusion (piece F) and its spoke extrusion (piece E). 6 per interface.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
 			"status": "partial",
 			"lines": [
@@ -1710,12 +1777,29 @@
 					"qty": 1
 				},
 				{
+					"part": "scr-m5-16-shcs",
+					"qty": 4
+				},
+				{
 					"part": "scr-m5-20-shcs",
 					"qty": 4
 				},
 				{
+					"part": "scr-m5-8-cs",
+					"qty": 1
+				},
+				{
 					"part": "tnut-m5-2020",
-					"qty": 4
+					"qty": 9
+				}
+			],
+			"versions": [
+				{
+					"version": "2",
+					"uid": "pnl9",
+					"date": "2026-08-29",
+					"message": "Added the piece-E attachment (4 scr-m5-16-shcs into 4 tnut-m5-2020, step 3) and the rib-securing tnut-m5-2020 (step 5), neither previously modeled -- only step 13's piece-F mount (scr-m5-20-shcs + 4 T-nuts) was here before.",
+					"commit": null
 				}
 			]
 		},

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -314,6 +314,7 @@
 			"targets": {
 				"parts": [
 					"ribbon-cable-clamp",
+					"interface-cage-bracket",
 					"interface-cage-bracket-cable"
 				],
 				"assemblies": [
@@ -1038,6 +1039,12 @@
 			"description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
 			"status": "partial",
+			"joining": [
+				{
+					"method": "friction",
+					"note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
+				}
+			],
 			"lines": [
 				{
 					"assembly": "interface-bracket-mount",
@@ -1129,6 +1136,22 @@
 				},
 				{
 					"part": "scr-m5-8-cs",
+					"qty": 6
+				},
+				{
+					"part": "ext-2020-ag",
+					"qty": 6
+				},
+				{
+					"part": "ext-2020-bh",
+					"qty": 6
+				},
+				{
+					"part": "frame-90deg-bracket",
+					"qty": 12
+				},
+				{
+					"part": "frame-crossbeam",
 					"qty": 6
 				}
 			]
@@ -1447,12 +1470,6 @@
 			"description": "The frame of one distribution layer: six external brackets, the crossbeams between them, and the 90\u00b0 brackets. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
 			"status": "partial",
-			"joining": [
-				{
-					"method": "friction",
-					"note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Attaching the hexagonal frame's spokes helper page."
-				}
-			],
 			"lines": [
 				{
 					"assembly": "external-bracket",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2065,8 +2065,8 @@
 		},
 		{
 			"id": "lazy-susan",
-			"uid": "l1un",
-			"version": "1",
+			"uid": "v6ss",
+			"version": "2",
 			"name": "Bottom lazy Susan",
 			"description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 \u00d7 [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
 			"docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
@@ -2102,11 +2102,72 @@
 				},
 				{
 					"part": "scr-m5-16-shcs",
-					"qty": 3
+					"qty": 9
 				},
 				{
 					"part": "tnut-m5-2020",
-					"qty": 3
+					"qty": 6
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "l1un",
+					"message": "Original version: 1 scr-m5-16-shcs + 1 tnut-m5-2020 per extrusion mount (3 total each), before BrickCycleAlice's 2026-08-28 build photos showed it's actually 2 self-tapping-into-plastic screws for the mount-to-hold-in-place joint (no T-nut) plus 2 more screws per mount into a T-nut in the extrusion (sorter-v2#447).",
+					"lines": [
+						{
+							"part": "ls-mount-to-chute",
+							"qty": 1,
+							"uid": "lma9"
+						},
+						{
+							"part": "ls-bottom-static",
+							"qty": 1,
+							"uid": "4mmh"
+						},
+						{
+							"part": "ls-washer",
+							"qty": 1,
+							"uid": "9c4a"
+						},
+						{
+							"part": "ls-mount-to-extrusion",
+							"qty": 3,
+							"uid": "bmt4"
+						},
+						{
+							"part": "ls-hold-in-place",
+							"qty": 3,
+							"uid": "ss05"
+						},
+						{
+							"part": "brg-lazy-susan",
+							"qty": 1,
+							"uid": "wrxu"
+						},
+						{
+							"part": "scr-m4-12-cs",
+							"qty": 8,
+							"uid": "h8h4"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 3,
+							"uid": "2e0s"
+						},
+						{
+							"part": "tnut-m5-2020",
+							"qty": 3,
+							"uid": "bpwm"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "v6ss",
+					"date": "2026-08-29",
+					"message": "Catalog never picked up sorter-v2#447's fastener correction on bottom-interface.md: 1 screw per mount into the hold-in-place (self-tap, 3 total) plus 2 more per mount into a T-nut in the extrusion (6 more), so 9 scr-m5-16-shcs and 6 tnut-m5-2020 total, not 3 and 3.",
+					"commit": "9708a416"
 				}
 			]
 		}

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -794,11 +794,43 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "eb8m",
+					"message": "Original version: only modeled the switch-to-housing M3 screws; the housing-to-extrusion scr-m5-16-shcs + tnut-m5-2020 (step 4) weren't in the catalog at all.",
+					"lines": [
+						{
+							"part": "limit-switch-dowel-pin",
+							"qty": 1,
+							"uid": "g68e"
+						},
+						{
+							"part": "limit-switch-housing",
+							"qty": 1,
+							"uid": "mrs0"
+						},
+						{
+							"part": "limit-switch-hammer",
+							"qty": 1,
+							"uid": "lfu7"
+						},
+						{
+							"part": "endstop-mechanical",
+							"qty": 1,
+							"uid": "92h6"
+						},
+						{
+							"part": "scr-m3-12-bhcs",
+							"qty": 2,
+							"uid": "izrb"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "xzje",
 					"date": "2026-08-29",
 					"message": "Added the 2 scr-m5-16-shcs + 2 tnut-m5-2020 that fasten the Limit switch housing to its bracket's extrusion (step 4), previously missing -- only the switch-to-housing M3s were modeled.",
-					"commit": null
+					"commit": "a2c66436"
 				}
 			]
 		},
@@ -1148,11 +1180,153 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "zz8s",
+					"message": "Original version: duplicated the hex frame's own ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline instead of consuming a shared hex-frame assembly, and carried a stray top-level tnut-m5-2020 qty 8 not tied to any specific step.",
+					"lines": [
+						{
+							"assembly": "interface-bracket-mount",
+							"qty": 6,
+							"uid": "rhr6"
+						},
+						{
+							"part": "ext-bracket-left",
+							"qty": 6,
+							"uid": "0b4g"
+						},
+						{
+							"part": "ext-bracket-cover",
+							"qty": 6,
+							"uid": "1r5i"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 12,
+							"uid": "2e0s"
+						},
+						{
+							"assembly": "fixed-upper-section",
+							"qty": 1,
+							"uid": "99af"
+						},
+						{
+							"assembly": "cable-cage",
+							"qty": 1,
+							"uid": "nam6"
+						},
+						{
+							"part": "scr-m5-30-shcs",
+							"qty": 6,
+							"uid": "92kv"
+						},
+						{
+							"assembly": "cable-clamp",
+							"qty": 1,
+							"uid": "e0p9"
+						},
+						{
+							"part": "scr-m3-12-bhcs",
+							"qty": 2,
+							"uid": "izrb"
+						},
+						{
+							"assembly": "limit-switch",
+							"qty": 1,
+							"uid": "eb8m"
+						},
+						{
+							"part": "scr-m5-20-shcs",
+							"qty": 2,
+							"uid": "e4hi"
+						},
+						{
+							"part": "tnut-m5-2020",
+							"qty": 8,
+							"uid": "bpwm"
+						},
+						{
+							"assembly": "chute-stepper-gearing",
+							"qty": 1,
+							"uid": "cwji"
+						},
+						{
+							"assembly": "interface-chute-drive",
+							"qty": 1,
+							"uid": "8cjj"
+						},
+						{
+							"part": "top-interface-split-spur-gear-2",
+							"qty": 1,
+							"uid": "izz5"
+						},
+						{
+							"part": "chute-stepper-support-block",
+							"qty": 1,
+							"uid": "loc0"
+						},
+						{
+							"part": "scr-m5-shcs-tbd",
+							"qty": 2,
+							"uid": "wy04"
+						},
+						{
+							"assembly": "layer-connector",
+							"qty": 1,
+							"uid": "6m38"
+						},
+						{
+							"part": "brg-lazy-susan",
+							"qty": 1,
+							"uid": "wrxu"
+						},
+						{
+							"part": "scr-m4-12-cs",
+							"qty": 8,
+							"uid": "h8h4"
+						},
+						{
+							"part": "top-plate",
+							"qty": 1,
+							"uid": "1g22"
+						},
+						{
+							"part": "scr-m5-35-fhcs",
+							"qty": 6,
+							"uid": "xkl4"
+						},
+						{
+							"part": "scr-m5-8-cs",
+							"qty": 6,
+							"uid": "mqh4"
+						},
+						{
+							"part": "ext-2020-ag",
+							"qty": 6,
+							"uid": "lnvw"
+						},
+						{
+							"part": "ext-2020-bh",
+							"qty": 6,
+							"uid": "tuer"
+						},
+						{
+							"part": "frame-90deg-bracket",
+							"qty": 12,
+							"uid": "3l20"
+						},
+						{
+							"part": "frame-crossbeam",
+							"qty": 6,
+							"uid": "cdeg"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "bkgq",
 					"date": "2026-08-29",
 					"message": "Consumes the new hex-frame assembly instead of duplicating its ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline. Dropped the stray top-level tnut-m5-2020 qty 8, now superseded by interface-bracket-mount's and limit-switch's own per-step T-nut lines.",
-					"commit": null
+					"commit": "a2c66436"
 				}
 			]
 		},
@@ -1192,11 +1366,48 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "a17l",
+					"message": "Original version: listed tnut-m5-2020 qty 24 for the bin retainers (double-counting the hex frame's own pre-installed T-nuts) and had no line for the layer-to-layer flange-join screws.",
+					"lines": [
+						{
+							"assembly": "layer-frame",
+							"qty": 1,
+							"uid": "adaj"
+						},
+						{
+							"assembly": "chute",
+							"qty": 1,
+							"uid": "axlb"
+						},
+						{
+							"part": "bin-retainer-left",
+							"qty": 6,
+							"uid": "hqz0"
+						},
+						{
+							"part": "bin-retainer-right",
+							"qty": 6,
+							"uid": "ybpv"
+						},
+						{
+							"part": "scr-m5-12-shcs",
+							"qty": 24,
+							"uid": "kmah"
+						},
+						{
+							"part": "tnut-m5-2020",
+							"qty": 24,
+							"uid": "bpwm"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "jog7",
 					"date": "2026-08-29",
 					"message": "Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones), same double-count barthel already caught on bottom two layers. Added the 12 scr-m5-16-shcs that join this layer's flange up to the layer above, previously missing.",
-					"commit": null
+					"commit": "a2c66436"
 				}
 			]
 		},
@@ -1544,11 +1755,33 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "adaj",
+					"message": "Original version: bundled the hex frame's own outer ring, spokes, crossbeams and 90\u00b0 brackets inline instead of as a separate assembly.",
+					"lines": [
+						{
+							"assembly": "external-bracket",
+							"qty": 6,
+							"uid": "6h3l"
+						},
+						{
+							"part": "frame-crossbeam",
+							"qty": 6,
+							"uid": "cdeg"
+						},
+						{
+							"part": "frame-90deg-bracket",
+							"qty": 12,
+							"uid": "3l20"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "22ck",
 					"date": "2026-08-29",
 					"message": "Split the hex frame (outer ring, spokes, crossbeams, 90\u00b0 brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
-					"commit": null
+					"commit": "a2c66436"
 				}
 			]
 		},
@@ -1795,11 +2028,38 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "rhr6",
+					"message": "Original version: only modeled the piece-F mount (step 13); the piece-E attachment (step 3) and rib-securing T-nut (step 5) weren't in the catalog at all.",
+					"lines": [
+						{
+							"part": "interface-bracket",
+							"qty": 1,
+							"uid": "jk82"
+						},
+						{
+							"part": "interface-spacer",
+							"qty": 1,
+							"uid": "bfoc"
+						},
+						{
+							"part": "scr-m5-20-shcs",
+							"qty": 4,
+							"uid": "e4hi"
+						},
+						{
+							"part": "tnut-m5-2020",
+							"qty": 4,
+							"uid": "bpwm"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "pnl9",
 					"date": "2026-08-29",
 					"message": "Added the piece-E attachment (4 scr-m5-16-shcs into 4 tnut-m5-2020, step 3) and the rib-securing tnut-m5-2020 (step 5), neither previously modeled -- only step 13's piece-F mount (scr-m5-20-shcs + 4 T-nuts) was here before.",
-					"commit": null
+					"commit": "a2c66436"
 				}
 			]
 		},


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1542862600935702619/1543166334211334215
request: https://discord.com/channels/1430279849171222682/1542862600935702619/1543164654493376632
request: https://discord.com/channels/1430279849171222682/1542862600935702619/1543167487661842463
request: https://discord.com/channels/1430279849171222682/1542862600935702619/1543169725008449567
request: https://discord.com/channels/1430279849171222682/1542862600935702619/1543228569512312842
request: https://discord.com/channels/1430279849171222682/1542862600935702619/1543239332331004005
preview: /hardware/assembly/distribution/bin-frame/hex-frame/
preview: /hardware/assembly/distribution/bin-frame/bottom-interface/
preview: /hardware/assembly/distribution/top-interface/
-->

## Summary

First three steps of the bin-frame section reorg barthel and BrickCycleAlice proposed, plus the fastener/T-nut reconciliation and catalog fix that followed it.

**Build the hex frame** (new page):
- The hexagonal aluminum-and-bracket ring shared by every layer, plus the bottom and top interface (N+1 of these for an N-layer machine).
- Step 1 (the outer ring) is regular-layers.md's existing content, unchanged, per BrickCycleAlice's instruction to carry it over as-is.
- Steps 2 onward are BrickCycleAlice's own screw-free construction method for the spokes, crossbeams and Frame 90° brackets, transcribed from her build photos, replacing the untested method currently on the "Attaching the hexagonal frame's spokes" helper page.
- Linked as the first entry in the bin-frame index and nav, per barthel's proposed structure.
- Its own 8 scr-m5-16-shcs + 24 tnut-m5-2020 (step 1) are the complete per-frame total, confirmed against steps 2-8 (no fasteners at all). The 24 T-nuts are pre-installed for the bin retainers a layer attaches later — reused there, not re-listed.

**Bottom interface** (revised):
- Step 4 ("Prepare the frame") now references Build the hex frame instead of describing frame construction inline: the outer ring and 3 of the 6 ordinary spoke positions come from that page, and this page covers only its own substitution — a Lazy Susan extrusion mount pair in place of the usual Frame 90° bracket + B/H spoke + crossbeam at the other 3 (alternating) positions.
- `parts_needed` is now explicitly the delta on top of the hex frame page's own list, not a full BOM, with a note saying so. Already internally consistent against its own steps (9 scr-m5-16-shcs, 6 tnut-m5-2020), no change needed there.

**Top interface** (revised):
- Step 13 ("Attach the framing") now references Build the hex frame instead of describing the outer ring and spoke assembly inline.
- Brings in #439's catalog fix: `frame-90deg-bracket` ×12, `frame-crossbeam` ×6, `ext-2020-bh` ×6 added to the `interface` assembly node in `parts-calculator/catalog/parts.json` (and the generated copy), which previously had none of these despite the page describing a full hex frame in prose. This is the same catalog change #439 already had open; only the docs wording differs (that PR linked regular-layers + the old, now-superseded hex-frame-spokes helper — this one links the new page). Recommend closing #439 once this merges.
- `ext-bracket-left` and `ext-2020-ag` dropped from this page's own `parts_needed`, now covered by the hex frame page's list.
- `scr-m5-16-shcs` and `tnut-m5-2020` re-derived from the page's own steps (below) rather than left as the old un-split totals.

All three touched pages carry a `warning:` frontmatter callout (the mechanism already used on bottom-two-layers.md and the chute pages) flagging them as reorganized and not yet checked against a build.

## Fastener/T-nut reconciliation (barthel: "Do the fastener and t-nuts etc. reconc.")

Itemized every M5×16 screw and T-nut mention against each page's own steps rather than trusting the existing totals:

- **regular-layers.md**: `scr-m5-16-shcs` was undercounted, 24 instead of 36 (missing the 12 layer-to-layer flange-join screws in step 3). `scr-m5-12-shcs` was missing entirely despite step 2's 24 bin-retainer screws — added. `tnut-m5-2020` was listed as 24 but step 2 already says those T-nuts are "already installed" by the hex frame — same double-count barthel already caught and fixed on bottom two layers (48 == 2 hex frames' worth). Dropped the line, reworded the T-nut sentence to say so explicitly.
- **top-interface.md**: `scr-m5-16-shcs`'s own-steps total is 50 (12+24+2+12 across steps 2/3/4/13), not the old 38 — step 13's 12 External bracket cover screws were never folded into the tally. `tnut-m5-2020`'s own-steps total is 56 (24+2+6+24 across steps 3/4/5/13), not the old 50 — step 5's 6 T-nuts (one per Interface bracket, for the M5×8 screw into the rib) were missing.
- **hex-frame.md**: no number changes, reworded the closing warning to state the total is complete and to name the T-nut reuse relationship with regular layers / bottom two layers explicitly.
- **bottom-interface.md** and **bottom-two-layers.md**: already internally consistent against their own steps, no changes.

## Catalog fix (barthel: "create start fix catalog too")

`layer-frame` bundled the hex frame (outer ring, spokes, crossbeams, 90° brackets) with nothing separable as its own "build N of these first" unit — the gap BrickCycleAlice and barthel flagged while proposing this reorg. `interface` separately duplicated the same parts inline, with no shared source between the two.

- New `hex-frame` assembly matches hex-frame.md's own `parts_needed` exactly (including the friction-fit joining note, moved here from `interface`).
- `layer-frame` now consumes 1× `hex-frame` + its own delta (the External bracket — cover / — bottom vertical collar, 24 `scr-m5-16-shcs`).
- `layer` drops the redundant `tnut-m5-2020` qty 24 (reused from the hex frame, not new) and adds the 12 `scr-m5-16-shcs` flange-join screws, previously missing from the catalog entirely.
- `interface` now consumes 1× `hex-frame` instead of duplicating its parts. `interface-bracket-mount` and `limit-switch` gain the step 3/4/5 fasteners (piece-E attachment, limit-switch-to-extrusion, rib-securing T-nut) that were never modeled at all — only step 13's piece-F mount existed before. Dropped a stray top-level `tnut-m5-2020` qty 8, superseded by the proper per-step counts.
- **Also fixed while resolving a sample machine's BOM as a sanity check**: `lazy-susan`'s own fastener lines (3 `scr-m5-16-shcs` / 3 `tnut-m5-2020`) were stale from before sorter-v2#447's build-photo correction on bottom-interface.md (2026-08-28); bumped to 9 and 6 to match.
- Every changed assembly went through the documented `mint_uid.py` → bump `version` → `stamp_versions.py` workflow, so each superseded state is retrievable by its old uid, not just overwritten. `catalog/generate.py --metadata-only` regenerated with the local `rebased_render` patch-then-revert workaround for sorter-v2#423 (still open), reverted before committing.
- **Not done**: the `n+1` total-hex-frame-count formula (`middle-layers = layers - 2` currently gives N hex frames total across the tree, not the confirmed physical N+1 — "bottom two layers" being 2 hex frames rather than 1 has no catalog node of its own yet) and whether bottom-interface needs its own bin retainers are both still open, previously-flagged design questions, not touched here.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1542862600935702619/1543166334211334215): "Start to build a first draft of the first page."**, following his page-structure proposal [from Discord](https://discord.com/channels/1430279849171222682/1542862600935702619/1543164654493376632), his bottom-interface instruction [from Discord](https://discord.com/channels/1430279849171222682/1542862600935702619/1543167487661842463): "The second page will be the existing bottom interface page. However, this page must be revised so that a hexagonal frame from the first page ('Build the hex frame') is referenced and used as a component, and the attachments required for the bottom interface are described.", his top-interface instruction [from Discord](https://discord.com/channels/1430279849171222682/1542862600935702619/1543169725008449567): "The 'Top Interface' page should be revised to include a reference to a hexagonal frame from the 'Build the hex frame' page and to use that frame as a component.", his fastener reconciliation ask [from Discord](https://discord.com/channels/1430279849171222682/1542862600935702619/1543228569512312842): "Do the fastener and t-nuts etc. reconc.", and his catalog-fix ask [from Discord](https://discord.com/channels/1430279849171222682/1542862600935702619/1543239332331004005): "create start fix catalog too".

The hex frame's actual build method is BrickCycleAlice's (@brickcyclealice), walked through step by step with photos in the same thread on 2026-08-28.

## Intentionally left out of this PR

- No cross-reference update to regular-layers.md's own cross-links yet, and no resolution of whether bottom-two-layers.md merges into a future "regular layers" page or stays separate — barthel hasn't said yet.
- The `n+1` hex-frame total-count formula and whether bottom-interface needs its own bin retainers (see above) — flagged, not decided.
- The bottom interface / bottom two layers joint (bottom-two-layers.md step 6) is still a placeholder, needs a builder to confirm the physical mechanism.

## Test plan

- [x] `python3 docs/scripts/validate_frontmatter.py` — same 5 pre-existing errors as main, nothing new
- [x] `python3 docs/scripts/validate_images.py` — 177 assets validated
- [x] Full docs site build (`npm run build`, Node 20) succeeds; pages render with their new cross-references and photos
- [x] `python3 parts-calculator/scripts/check_generated_pins.py` — catalog.generated.json agrees with parts.json
- [x] `python3 parts-calculator/scripts/check_asset_urls.py` — no new failures (12 pre-existing legacy img.basically.website URLs, unrelated to this change)
- [x] `npm run check` (svelte-check) and `npm run build` in `parts-calculator/`, Node 22 — both clean
- [x] Resolved a sample 5-layer machine's full BOM from `machine` down through the new `hex-frame`/`layer-frame`/`layer`/`interface`/`bottom-interface` tree and checked every node's `scr-m5-16-shcs`/`tnut-m5-2020` total against its docs page's own re-derived numbers — all match
- [ ] Not checked against an actual build — that's what the warning banners are for
