### PR TITLE
docs(parts-calculator): note 2020 extrusion corner profile varies

### DIFF
--- a/parts-calculator/src/lib/components/CutPlan.svelte
+++ b/parts-calculator/src/lib/components/CutPlan.svelte
@@ -328,6 +328,12 @@
 	<Callout variant="info" title="Notes">
 		<ul class="list-disc space-y-2 pl-4 leading-relaxed">
 			<li>
+				<b class="text-text">Not all 2020 extrusion is the same stock.</b> Builders have found that
+				secondhand 20×20 mm profile varies: one with more angular, square corners on the T-slot seats
+				tightly against the crossbeam brackets, while a profile with more rounded corners can fit
+				loosely and add friction. Check the corner profile before buying, especially secondhand.
+			</li>
+			<li>
 				<b class="text-text">D stands in for C at the bottom.</b> Every layer above the bottom two
 				gets 6 layer supports (<b class="text-text">C</b>, {lenC} mm). The bottom two share 6 foot
 				extensions (<b class="text-text">D</b>, {lenD} mm), one spanning both, in place of a C on

--- a/parts-calculator/src/lib/components/CutPlan.svelte
+++ b/parts-calculator/src/lib/components/CutPlan.svelte
@@ -5,6 +5,7 @@
 	import { ftin, expand, packOptimal, packBundle, planGroups } from '$lib/cutplan';
 	import Popover from '$lib/components/Popover.svelte';
 	import Callout from '$lib/components/Callout.svelte';
+	import Figure from '$lib/components/Figure.svelte';
 	import { framingCsv } from '$lib/parts-csv';
 	import { download, exportSpec, filename } from '$lib/csv';
 
@@ -332,6 +333,14 @@
 				secondhand 20×20 mm profile varies: one with more angular, square corners on the T-slot seats
 				tightly against the crossbeam brackets, while a profile with more rounded corners can fit
 				loosely and add friction. Check the corner profile before buying, especially secondhand.
+				<div class="mt-2 max-w-xs">
+					<Figure
+						src="https://assets.basically.website/sorter-parts/img-0036-full-76e2483ec1e7.jpg"
+						alt="Two 2020 extrusion profiles held end-on side by side — the right one has angular T-slot corners, the left one has rounded corners"
+						caption="Right: angular corners, seats tight. Left: rounded corners, fits loose."
+						imgClass="max-h-40"
+					/>
+				</div>
 			</li>
 			<li>
 				<b class="text-text">D stands in for C at the bottom.</b> Every layer above the bottom two

--- a/parts-calculator/src/lib/components/CutPlan.svelte
+++ b/parts-calculator/src/lib/components/CutPlan.svelte
@@ -4,14 +4,8 @@
 	import { layerStore } from '$lib/layers.svelte';
 	import { ftin, expand, packOptimal, packBundle, planGroups } from '$lib/cutplan';
 	import Popover from '$lib/components/Popover.svelte';
-	import Callout from '$lib/components/Callout.svelte';
-	import Figure from '$lib/components/Figure.svelte';
 	import { framingCsv } from '$lib/parts-csv';
 	import { download, exportSpec, filename } from '$lib/csv';
-
-	// lengths quoted in the C/D note below, read off the pieces themselves
-	const lenC = FRAMING_PIECES.find((p) => p.letter === 'C')?.len ?? 0;
-	const lenD = FRAMING_PIECES.find((p) => p.letter === 'D')?.len ?? 0;
 
 	let stock = $state(STOCK_MM);
 	let kerf = $state(3);
@@ -323,41 +317,6 @@
 			{/each}
 		</div>
 	</div>
-
-	<!-- notes: sat at the very bottom of the page, under the cut sheet, where
-	     nobody read them. They matter before you start cutting, so they go here -->
-	<Callout variant="info" title="Notes">
-		<ul class="list-disc space-y-2 pl-4 leading-relaxed">
-			<li>
-				<b class="text-text">Not all 2020 extrusion is the same stock.</b> Builders have found that
-				secondhand 20×20 mm profile varies: one with more angular, square corners on the T-slot seats
-				tightly against the crossbeam brackets, while a profile with more rounded corners can fit
-				loosely and add friction. Check the corner profile before buying, especially secondhand.
-				<div class="mt-2 max-w-xs">
-					<Figure
-						src="https://assets.basically.website/sorter-parts/img-0036-full-76e2483ec1e7.jpg"
-						alt="Two 2020 extrusion profiles held end-on side by side — the right one has angular T-slot corners, the left one has rounded corners"
-						caption="Right: angular corners, seats tight. Left: rounded corners, fits loose."
-						imgClass="max-h-40"
-					/>
-				</div>
-			</li>
-			<li>
-				<b class="text-text">D stands in for C at the bottom.</b> Every layer above the bottom two
-				gets 6 layer supports (<b class="text-text">C</b>, {lenC} mm). The bottom two share 6 foot
-				extensions (<b class="text-text">D</b>, {lenD} mm), one spanning both, in place of a C on
-				each. So a 1 or 2 layer build has no C in the list at all, and that is not a missing piece.
-			</li>
-			<li>
-				Pieces that share a cut length stack together at the saw — mark and cut the top bar, the rest
-				follow: <b class="text-text">A &amp; G</b> = 320 mm, <b class="text-text">B &amp; H</b> = 158 mm.
-			</li>
-			<li>
-				Where the cut length is under the CAD length, the piece is trimmed {CLEARANCE_MM} mm for
-				tolerance (see the <b class="text-text">Cut length</b> note above).
-			</li>
-		</ul>
-	</Callout>
 
 	<!-- cut sheet -->
 	<div>

--- a/parts-calculator/src/lib/components/Figure.svelte
+++ b/parts-calculator/src/lib/components/Figure.svelte
@@ -8,9 +8,17 @@
 		src,
 		alt = '',
 		caption = '',
+		credit = '',
 		title = '',
 		imgClass = 'max-h-[34vh]'
-	}: { src: string; alt?: string; caption?: string; title?: string; imgClass?: string } = $props();
+	}: {
+		src: string;
+		alt?: string;
+		caption?: string;
+		credit?: string;
+		title?: string;
+		imgClass?: string;
+	} = $props();
 
 	let open = $state(false);
 </script>
@@ -29,7 +37,12 @@
 			<span class="flex items-center justify-center bg-black/55 p-2 text-white"><ZoomIn size={20} /></span>
 		</span>
 	</button>
-	{#if caption}<figcaption class="text-center text-xs text-text-muted">{caption}</figcaption>{/if}
+	{#if caption || credit}
+		<figcaption class="text-center text-xs text-text-muted">
+			{caption}
+			{#if credit}<cite class="mt-0.5 block text-[0.8125rem] italic">Photo: {credit}.</cite>{/if}
+		</figcaption>
+	{/if}
 </figure>
 
 <Modal bind:open title={title || alt}>

--- a/parts-calculator/src/routes/framing/+page.svelte
+++ b/parts-calculator/src/routes/framing/+page.svelte
@@ -4,6 +4,12 @@
 	import LayerControl from '$lib/components/LayerControl.svelte';
 	import CutPlan from '$lib/components/CutPlan.svelte';
 	import Figure from '$lib/components/Figure.svelte';
+	import Callout from '$lib/components/Callout.svelte';
+	import { FRAMING_PIECES, CLEARANCE_MM } from '$lib/framing';
+
+	// lengths quoted in the C/D note below, read off the pieces themselves
+	const lenC = FRAMING_PIECES.find((p) => p.letter === 'C')?.len ?? 0;
+	const lenD = FRAMING_PIECES.find((p) => p.letter === 'D')?.len ?? 0;
 </script>
 
 <Seo
@@ -36,6 +42,41 @@
 				/>
 			{/snippet}
 		</ExtrusionScene>
+	</section>
+
+	<section class="mb-8">
+		<Callout variant="info" title="Notes">
+			<ul class="list-disc space-y-2 pl-4 leading-relaxed">
+				<li>
+					<b class="text-text">Not all 2020 extrusion is the same stock.</b> Builders have found that
+					secondhand 20×20 mm profile varies: one with more angular, square corners on the T-slot seats
+					tightly against the crossbeam brackets, while a profile with more rounded corners can fit
+					loosely and add friction. Check the corner profile before buying, especially secondhand.
+					<div class="mt-2 max-w-xs">
+						<Figure
+							src="https://assets.basically.website/sorter-parts/img-0036-full-76e2483ec1e7.jpg"
+							alt="Two 2020 extrusion profiles held end-on side by side — the right one has angular T-slot corners, the left one has rounded corners"
+							caption="Right: angular corners, seats tight. Left: rounded corners, fits loose."
+							imgClass="max-h-40"
+						/>
+					</div>
+				</li>
+				<li>
+					<b class="text-text">D stands in for C at the bottom.</b> Every layer above the bottom two
+					gets 6 layer supports (<b class="text-text">C</b>, {lenC} mm). The bottom two share 6 foot
+					extensions (<b class="text-text">D</b>, {lenD} mm), one spanning both, in place of a C on
+					each. So a 1 or 2 layer build has no C in the list at all, and that is not a missing piece.
+				</li>
+				<li>
+					Pieces that share a cut length stack together at the saw — mark and cut the top bar, the rest
+					follow: <b class="text-text">A &amp; G</b> = 320 mm, <b class="text-text">B &amp; H</b> = 158 mm.
+				</li>
+				<li>
+					Where the cut length is under the CAD length, the piece is trimmed {CLEARANCE_MM} mm for
+					tolerance (see the <b class="text-text">Cut length</b> note above).
+				</li>
+			</ul>
+		</Callout>
 	</section>
 
 	<section>

--- a/parts-calculator/src/routes/framing/+page.svelte
+++ b/parts-calculator/src/routes/framing/+page.svelte
@@ -53,6 +53,7 @@
 							src="https://assets.basically.website/sorter-parts/img-0036-full-76e2483ec1e7.jpg"
 							alt="Two 2020 extrusion profiles held end-on side by side — the right one has angular T-slot corners, the left one has rounded corners"
 							caption="Right: angular corners, seats tight. Left: rounded corners, fits loose."
+							credit="sytem"
 							imgClass="max-h-40"
 						/>
 					</div>

--- a/parts-calculator/src/routes/framing/+page.svelte
+++ b/parts-calculator/src/routes/framing/+page.svelte
@@ -47,12 +47,8 @@
 	<section class="mb-8">
 		<Callout variant="info" title="Notes">
 			<ul class="list-disc space-y-2 pl-4 leading-relaxed">
-				<li>
-					<b class="text-text">Not all 2020 extrusion is the same stock.</b> Builders have found that
-					secondhand 20×20 mm profile varies: one with more angular, square corners on the T-slot seats
-					tightly against the crossbeam brackets, while a profile with more rounded corners can fit
-					loosely and add friction. Check the corner profile before buying, especially secondhand.
-					<div class="mt-2 max-w-xs">
+				<li class="flow-root">
+					<div class="float-right ml-3 mb-1 w-40 sm:w-48">
 						<Figure
 							src="https://assets.basically.website/sorter-parts/img-0036-full-76e2483ec1e7.jpg"
 							alt="Two 2020 extrusion profiles held end-on side by side — the right one has angular T-slot corners, the left one has rounded corners"
@@ -60,6 +56,10 @@
 							imgClass="max-h-40"
 						/>
 					</div>
+					<b class="text-text">Not all 2020 extrusion is the same stock.</b> Builders have found that
+					secondhand 20×20 mm profile varies: one with more angular, square corners on the T-slot seats
+					tightly against the crossbeam brackets, while a profile with more rounded corners can fit
+					loosely and add friction. Check the corner profile before buying, especially secondhand.
 				</li>
 				<li>
 					<b class="text-text">D stands in for C at the bottom.</b> Every layer above the bottom two


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1503528472818094220/1543179257130385449
request: https://discord.com/channels/1430279849171222682/1503528472818094220/1543177955486728293
request: https://discord.com/channels/1430279849171222682/1543179257130385449/1543181423521964122
request: https://discord.com/channels/1430279849171222682/1543179257130385449/1543182645528109217
request: https://discord.com/channels/1430279849171222682/1543179257130385449/1543182956695392326
request: https://discord.com/channels/1430279849171222682/1543179257130385449/1543185099573567569
request: https://discord.com/channels/1430279849171222682/1543179257130385449/1543186771754356746
preview: /framing
-->
Adds a note to the framing page's "Notes" callout, now its own section ahead of "Cut plan": 2020 (20x20mm) extrusion corner profile isn't consistent across stock, especially secondhand, and one shape seats tighter against the crossbeam brackets than the other. Includes the reference photo (uploaded via `scripts/publish_assets.py`), floated right of the note text so the text runs along its left side, with a photo credit matching the docs site's convention, per barthel's follow-up asks.

Source: sytem posted a photo of two secondhand 2020 profiles held together, noting they don't behave the same against the crossbeam. barthel identified the difference as corner shape (angular vs rounded) and said the angular one, on the right in the photo, is the one he's happy with.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1503528472818094220/1543179257130385449): "Why not.
Post a note on the page https://parts-calculator.basically.website/framing stating that the profile on the right in the photo in https://discord.com/channels/1430279849171222682/1503528472818094220/1543170932389056594 is more suitable than the one on the left."

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543179257130385449/1543181423521964122): "Please include the photo I pointed out to you in the note."

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543179257130385449/1543182645528109217): "Move "Notes" before "Cut plan", please."

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543179257130385449/1543182956695392326): "Move the photo to the right within the note and let the note run along the left side of the photo."

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543179257130385449/1543185099573567569): "Move "Notes" before "Cut plan", please." — already done in the prior commit; no further change, confirmed against the live preview.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543179257130385449/1543186771754356746): "Please add photo credit on the photo like we do in documentation." Added a `credit` prop to `Figure.svelte` (docs uses "Photo: {Name}." in a `<cite>` on its own line under the caption; matched that phrasing here) and set it to sytem, who posted the photo.
