### PR TITLE
docs: placeholder step for the bottom interface / bottom two layers joint

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -13,21 +13,7 @@ warning: >-
   **AI-generated first draft, reorganized to reference [Build the hex
   frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
   instead of Regular layers' old steps 1-2.** No step here has been checked
-  against a machine. `ext-bracket-left` and `ext-2020-ag` were removed from
-  the parts list since they're now the hex frame page's own parts (2 frames'
-  worth); `tnut-m5-2020` was removed too since its 48 exactly matched 2
-  hex frames' own bin-retainer-prep T-nuts (2 × 24) and nothing here needs
-  more beyond that, but this hasn't been re-verified against a build.
-  `scr-m5-16-shcs` dropped from 64 to 48, removing the 16 that were the two
-  hex frames' own outer-ring screws. Steps renumbered again after folding
-  the old "Start from two hex frames" step (which had shrunk to one
-  sentence plus a warning) into step 1; the rest shifted down by one. The
-  fastener counts are derived from Regular layers rather than measured, the
-  tally under step 1 shows the arithmetic, and one count is genuinely
-  unknown. Added step 6, "Attach the bottom interface", as a placeholder —
-  it's the missing joint between this page and bottom-interface.md, not
-  written yet since the physical mechanism isn't confirmed. Correct it as
-  you build.
+  against a machine. Correct it as you build.
 parts_needed:
   - part: ext-bracket-cover
     qty: 6

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -24,7 +24,10 @@ warning: >-
   sentence plus a warning) into step 1; the rest shifted down by one. The
   fastener counts are derived from Regular layers rather than measured, the
   tally under step 1 shows the arithmetic, and one count is genuinely
-  unknown. Correct it as you build.
+  unknown. Added step 6, "Attach the bottom interface", as a placeholder —
+  it's the missing joint between this page and bottom-interface.md, not
+  written yet since the physical mechanism isn't confirmed. Correct it as
+  you build.
 parts_needed:
   - part: ext-bracket-cover
     qty: 6
@@ -185,8 +188,16 @@ Screw a **swivel stem caster (M6 × 15 mm)** into the connector's M6 thread. The
 
 Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 2: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into T-nuts.
 
+{% include step.html n="6" title="Attach the bottom interface" %}
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>Not written yet — this step is a placeholder.</strong> Build the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> separately, then it joins the bottom of this frame here, but the physical mechanism isn't confirmed: whether it shares piece D's legs with this stack or connects some other way, and how that reconciles with the T-nut note under step 1. Needs a builder to confirm before this step can be written for real.</p>
+</div>
+
+<div class="img-placeholder">Image coming</div>
+
 ## What comes next
 
 - Each of these two layers takes a [chute]({{ '/hardware/assembly/distribution/chute/' | relative_url }}), the same as any other layer.
 - Above them, build N−2 [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) for an N-layer machine.
-- The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) mounts to this frame on its three extrusion mounts.


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1542862600935702619/1543199809333108766
request: https://discord.com/channels/1430279849171222682/1542862600935702619/1543200620725534770
preview: /hardware/assembly/distribution/bin-frame/bottom-two-layers/
-->

## Summary

Split out from #449 at barthel's request, for the one real gap the narrative review turned up: how bottom interface's own hex frame physically joins the bottom-two-layers stack is never actually shown anywhere.

- `bottom-interface.md` ends with "the frame goes on in bottom two layers"
- `bottom-two-layers.md`'s old "What comes next" said "the bottom interface mounts to this frame"
- Neither page ever walked through that joint

Added it as a real, numbered **step 6, "Attach the bottom interface"**, on `bottom-two-layers.md` — the last-built base component, matching `bin-frame/index.md`'s own reading order (hex frame → bottom interface → bottom two layers) — rather than a new page, so the five-page structure from #449 stays intact.

**Deliberately a placeholder, not real content.** The physical mechanism isn't confirmed: does bottom interface's own hex frame share piece D's legs with this stack, or attach some other way? That's the same open question already flagged under this page's step 1 T-nut callout ("this callout... may be describing a mounting relationship that no longer holds"). Writing real content here would mean guessing at a physical joint nobody's confirmed — flagged instead, same as everywhere else this session a physical fact was missing.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1542862600935702619/1543199809333108766): "Maybe let's start a new pr for the big picture idea."**, confirming scope [from Discord](https://discord.com/channels/1430279849171222682/1542862600935702619/1543200620725534770) against the narrative-review finding above.

## Branch note

This branches off `docs/build-the-hex-frame` (#449), not `main` — `bottom-two-layers.md`'s hex-frame-referencing content only exists on that branch so far. Retarget to `main` once #449 merges.

## Test plan

- [x] `python3 docs/scripts/validate_frontmatter.py` — same 5 pre-existing errors as main, nothing new
- [x] `python3 docs/scripts/validate_images.py` — 175 assets validated
- [x] Full site build (`npm run build`, Node 20) succeeds (one transient "Killed" on first attempt, unrelated resource blip, succeeded clean on retry); step 6 renders with the placeholder callout and image placeholder
- [ ] Not real content yet — needs a builder to confirm the physical joint first
