### PR TITLE
docs+parts-calculator: retire the classification chamber's M3 screw TBD placeholder

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -13,7 +13,7 @@ warning: >-
   **AI-generated first draft.** Written from the parts registry in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=classification-chamber),
   not from an actual build. The assembly order is still not recorded, so this page mostly lists
-  what the chamber is made of rather than how it goes together — one fastener is now measured
+  what the chamber is made of rather than how it goes together — two fasteners are now measured
   off the STLs, everything else about how the pieces join is still open. Correct it as you build.
 parts_needed:
   - part: classification-dome
@@ -29,6 +29,8 @@ parts_needed:
   - part: cam-imx415
     qty: 1
   - part: scr-m2-8-shcs
+    qty: 4
+  - part: scr-m3-12-bhcs
     qty: 4
 ---
 
@@ -51,15 +53,15 @@ Build the classification channel as a normal [C-channel]({{ '/hardware/assembly/
 
 Fit the Camera & LED insert, then the camera on its extension tube and mount ring, then close the chamber with the dome.
 
-- **Insert to camera extension's mount ring:** 4 × M3, 46 mm square pattern around the central opening.
+- **Insert to camera extension's mount ring:** 4 × {% include fastener.html size="M3" variant="socket-button" length="12" %} screws, 46 mm square pattern around the central opening. Measured off the STLs: the mount ring is a plain 6 mm clearance hole, and the insert takes a blind ~9.4 mm deep hole behind it, so 12 mm clears the mount and engages about 6 mm into the insert without bottoming out.
 - **Insert to the rest of the chamber:** an outer ring of 10 larger holes (10 mm). Not recorded what goes through them.
 - **Camera board to the camera extension:** 4 × {% include fastener.html size="M2" variant="socket-button" length="8" %}, self-tapping into the extension's two posts.
 - **Classification dome:** no screw holes anywhere. Not recorded how it closes onto the chamber.
 
 <div class="img-row">
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-iso-full-e4b396fc8c88.png" alt="Angled render of the camera and LED insert's top face, showing a ring of 10 large holes around the rim and 4 smaller countersunk holes around a central square opening">
-    <figcaption>The insert's top face: 10 holes around the rim (mounts to the chamber), 4 smaller ones around the central opening (matches the extension mount, M3). <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/insert-iso-full-e4b396fc8c88.png" alt="Angled render of the camera and LED insert's top face, showing a ring of 10 large holes around the rim and 4 smaller blind holes around a central square opening">
+    <figcaption>The insert's top face: 10 holes around the rim (mounts to the chamber), 4 smaller blind ones around the central opening (matches the extension mount, M3 × 12 mm). <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/extension-iso-full-8d1f0c51606f.png" alt="Angled render of the camera extension bracket, showing two posts each with a mounting hole">

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -323,6 +323,17 @@
           "scr-m5-12-shcs"
         ]
       }
+    },
+    {
+      "id": "delete-unused-m3-tbd-placeholder",
+      "name": "Delete the unused M3 screw placeholder",
+      "priority": "P4",
+      "description": "This placeholder screw is not used anywhere in the machine any more — every joint that carried it (the cable-mount cage bracket, the camera extension, the Orange Pi mount) turned out to already have a specific screw recorded, and those catalog lines have been updated to point at the real ones. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #453.",
+      "targets": {
+        "hardware": [
+          "scr-m3-tbd"
+        ]
+      }
     }
   ],
   "folders": [

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -334,6 +334,17 @@
           "scr-m3-tbd"
         ]
       }
+    },
+    {
+      "id": "delete-unused-m3-shcs-tbd-placeholder",
+      "name": "Delete the unused M3 socket/button head length-TBD placeholder",
+      "priority": "P4",
+      "description": "This placeholder screw is not used anywhere in the machine — it stood in for the basically Embedded Control Board's screws before they were measured as M3 x 6 mm button head (scr-m3-6-bhcs), and nothing has called for it since. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #454.",
+      "targets": {
+        "hardware": [
+          "scr-m3-shcs-tbd"
+        ]
+      }
     }
   ],
   "folders": [

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6005,7 +6005,7 @@
           "qty": 4
         },
         {
-          "part": "scr-m3-tbd",
+          "part": "scr-m3-12-bhcs",
           "qty": 4
         }
       ]

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -2799,10 +2799,10 @@
       },
       "name": "M3 screw — type and length TBD",
       "category": "Screws",
-      "description": "Placeholder for the M3s whose head type and length nobody has written down yet: the cable-mount cage bracket, the camera extension, and the two board mounts.",
+      "description": "Retired placeholder, no longer used anywhere. Every joint that carried this (the cable-mount cage bracket, the camera extension, and the Orange Pi mount) turned out to already have a specific screw recorded in the docs; the catalog just hadn't been updated to match. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md).",
       "created_at": "2026-07-18",
-      "updated_at": "2026-07-18",
-      "note": "Neither the head type nor the length is recorded — measure before ordering.",
+      "updated_at": "2026-08-29",
+      "note": "Unused as of 2026-08-29. Do not add a new joint to this placeholder — measure the real screw and use a real catalog part instead.",
       "attributes": [
         {
           "label": "Thread",
@@ -5885,7 +5885,7 @@
           "qty": 6
         },
         {
-          "part": "scr-m3-tbd",
+          "part": "scr-m3-10-shcs",
           "qty": 1
         }
       ]
@@ -6690,7 +6690,7 @@
           "qty": 1
         },
         {
-          "part": "scr-m3-tbd",
+          "part": "scr-m3-6-bhcs",
           "qty": 4
         },
         {

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -814,7 +814,7 @@
 					"qty": 6
 				},
 				{
-					"part": "scr-m3-tbd",
+					"part": "scr-m3-10-shcs",
 					"qty": 1
 				}
 			]
@@ -1620,7 +1620,7 @@
 					"qty": 1
 				},
 				{
-					"part": "scr-m3-tbd",
+					"part": "scr-m3-6-bhcs",
 					"qty": 4
 				},
 				{
@@ -14551,10 +14551,10 @@
 			},
 			"name": "M3 screw \u2014 type and length TBD",
 			"category": "Screws",
-			"description": "Placeholder for the M3s whose head type and length nobody has written down yet: the cable-mount cage bracket, the camera extension, and the two board mounts.",
-			"note": "Neither the head type nor the length is recorded \u2014 measure before ordering.",
+			"description": "Retired placeholder, no longer used anywhere. Every joint that carried this (the cable-mount cage bracket, the camera extension, and the Orange Pi mount) turned out to already have a specific screw recorded in the docs; the catalog just hadn't been updated to match. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md).",
+			"note": "Unused as of 2026-08-29. Do not add a new joint to this placeholder \u2014 measure the real screw and use a real catalog part instead.",
 			"created_at": "2026-07-18",
-			"updated_at": "2026-07-18",
+			"updated_at": "2026-08-29",
 			"attributes": [
 				{
 					"label": "Thread",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -348,6 +348,17 @@
 					"scr-m3-tbd"
 				]
 			}
+		},
+		{
+			"id": "delete-unused-m3-shcs-tbd-placeholder",
+			"name": "Delete the unused M3 socket/button head length-TBD placeholder",
+			"priority": "P4",
+			"description": "This placeholder screw is not used anywhere in the machine \u2014 it stood in for the basically Embedded Control Board's screws before they were measured as M3 x 6 mm button head (scr-m3-6-bhcs), and nothing has called for it since. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #454.",
+			"targets": {
+				"hardware": [
+					"scr-m3-shcs-tbd"
+				]
+			}
 		}
 	],
 	"folders": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -934,7 +934,7 @@
 					"qty": 4
 				},
 				{
-					"part": "scr-m3-tbd",
+					"part": "scr-m3-12-bhcs",
 					"qty": 4
 				}
 			]

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -337,6 +337,17 @@
 					"scr-m5-12-shcs"
 				]
 			}
+		},
+		{
+			"id": "delete-unused-m3-tbd-placeholder",
+			"name": "Delete the unused M3 screw placeholder",
+			"priority": "P4",
+			"description": "This placeholder screw is not used anywhere in the machine any more \u2014 every joint that carried it (the cable-mount cage bracket, the camera extension, the Orange Pi mount) turned out to already have a specific screw recorded, and those catalog lines have been updated to point at the real ones. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #453.",
+			"targets": {
+				"hardware": [
+					"scr-m3-tbd"
+				]
+			}
 		}
 	],
 	"folders": [


### PR DESCRIPTION
Measured off the `camera-led-insert` and `camera-extension-mount` STLs: the mount ring has a plain 6mm M3 clearance hole, and the insert takes a blind ~9.4mm deep M3 pilot behind it, on the same 46 x 46mm square pattern (46mm on both parts, confirming they mate). M3 x 12mm clears the mount's 6mm and engages about 6mm into the insert's pocket, leaving a 3.4mm margin before it bottoms out.

- `parts-calculator/catalog/parts.json`: `camera-extension-assembly`'s `scr-m3-tbd` line becomes `scr-m3-12-bhcs` (an existing catalog part). Regenerated with `generate.py --metadata-only`.
- `docs/.../classification-chamber/index.md`: the "Insert to camera extension's mount ring" bullet now names the screw and the measurement, `scr-m3-12-bhcs` added to `parts_needed`, and the insert render's alt/caption corrected from "countersunk" to "blind" (the STL's taper is a shallow lead-in chamfer, not a real 90° countersink).

Not touched: the separate "extension's bottom pair of posts joins the mount ring" gap the page already flags as not recorded — that's a different joint (tube-to-mount, not insert-to-mount) and wasn't part of this ask.

Requested by barthel (Uwe Barthel) (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543277171865551012/1543280580408385576): "Add this information to the "Classification Chamber/Camera Extension" page and remove the item from the catalog (or create an issue to have it removed)."



**Follow-up:** barthel asked to remove the placeholder entirely rather than leave it stub-referenced elsewhere, since the two other joints that still used it (cable-cage's ribbon-clamp screw, orange-pi-mount's Pi-to-standoff screws) turned out to already have specific screws named in the docs. Both catalog lines now point at `scr-m3-10-shcs` and `scr-m3-6-bhcs` respectively, matching the existing docs prose. `scr-m3-tbd` has zero live uses left; the part object stays (uid permanence) with its description/note updated to say it's retired.

Requested by barthel (Uwe Barthel) (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543277171865551012/1543285866846490694): "Remove the M3 screw—type and length to be determined—entirely from the catalog. We have just identified the referenced installation locations as incorrect, since specific screws are used at those locations."



**Second follow-up:** since the object itself can't be deleted from here (see sorter-v2#453), barthel asked to at least mark it as to-be-deleted in the catalog rather than leave that only in the description text. Added a P4 `changes` entry targeting the hardware id -- the same mechanism the site already uses for a broken/planned-change notice on any part -- so it carries a real notice badge wherever the part renders (dashboard, hardware page), linking to #453.

Requested by barthel (Uwe Barthel) (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543277171865551012/1543287221031796817): "Mark the screw in the catalog as \"to be deleted\" or something similar."



**Third follow-up:** barthel asked for the same two things (remove from every joint, mark as to-be-deleted) on the sibling placeholder `scr-m3-shcs-tbd` ("M3 socket/button head, length TBD"). That one was already unused everywhere -- its own description already explained it was superseded by `scr-m3-6-bhcs` before it was ever ordered -- so this only adds the matching `changes` entry, linking to sorter-v2#454 (opened the same way as #453).

Requested by barthel (Uwe Barthel) (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543277171865551012/1543290486939189299): "Bitte auch für die catalog Position "M3 socket/button head, length TBD" beides durchführen." ("Please do both for the catalog item "M3 socket/button head, length TBD" too.")

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1543277171865551012/1543280580408385576
request: https://discord.com/channels/1430279849171222682/1543277171865551012/1543285866846490694
request: https://discord.com/channels/1430279849171222682/1543277171865551012/1543287221031796817
request: https://discord.com/channels/1430279849171222682/1543277171865551012/1543290486939189299
preview: /hardware/assembly/feeder/classification-chamber/
-->


