### PR TITLE
parts-calculator: drop provenance note from M2 screw

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -2999,8 +2999,7 @@
           "label": "Head",
           "value": "Socket or button head"
         }
-      ],
-      "note": "First M2 in the catalog -- every other screw here is M3/M4/M5/M6. Length worked from what barthel gave directly (module datasheet: M2, board 1.57 mm thick, self-tapping) plus what's measured off the camera-extension STL: 4 holes, 2.6 mm, on a two-post bracket, each post an 8 mm-deep constant-diameter self-tap bore. 8 mm clears the board and uses most of the post's depth for thread engagement without bottoming out before the head seats."
+      ]
     },
     {
       "id": "scr-m3-8-shcs",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -14773,7 +14773,7 @@
 			"name": "M2 \u00d7 8 mm socket/button head",
 			"category": "Screws",
 			"description": "Self-taps the IMX415 classification camera board to the camera extension's printed post. 4 per module, no insert. May also fit the OV9732 overhead camera mount once that gets a real bracket (sorter-v2#426), not confirmed.",
-			"note": "First M2 in the catalog -- every other screw here is M3/M4/M5/M6. Length worked from what barthel gave directly (module datasheet: M2, board 1.57 mm thick, self-tapping) plus what's measured off the camera-extension STL: 4 holes, 2.6 mm, on a two-post bracket, each post an 8 mm-deep constant-diameter self-tap bore. 8 mm clears the board and uses most of the post's depth for thread engagement without bottoming out before the head seats.",
+			"note": null,
 			"created_at": "2026-08-25",
 			"updated_at": "2026-08-25",
 			"attributes": [


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543290067676827781
preview: /parts-calculator
-->

Drops the provenance note from the M2 x 8mm socket/button head screw
(`scr-m2-8-shcs`) in `catalog/parts.json`. Regenerated the hardware entry in
`catalog.generated.json` to match (via `build_hardware()`; nothing else in the
catalog changed).

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543290067676827781): "Remove note "First M2 in the catalog -- every other screw here is M3/M4/M5/M6. Length worked from what barthel gave directly (module datasheet: M2, board 1.57 mm thick, self-tapping) plus what's measured off the camera-extension STL: 4 holes, 2.6 mm, on a two-post bracket, each post an 8 mm-deep constant-diameter self-tap bore. 8 mm clears the board and uses most of the post's depth for thread engagement without bottoming out before the head seats." from M2 screw in catalog."
