### PR TITLE
docs+parts: top-interface idler gear screw is M3x20 countersunk, not M3x35

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -100,8 +100,10 @@ parts_needed:
     qty: 6
   - part: scr-m3-16-shcs
     qty: 2
+  - part: scr-m3-20-cs
+    qty: 1
   - part: scr-m3-35-bhcs
-    qty: 2
+    qty: 1
   - part: scr-m4-12-cs
     qty: 8
   - part: scr-m5-8-cs

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -314,6 +314,13 @@ Attach the whole assembly to the bottom of the Top plate with {% include fastene
 
 <div class="img-row">
   <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4305-full-931aaff1af40.jpg" alt="Close-up of a hand-cut plywood Top plate showing a countersunk screw hole near the S3 hole position">
+    <figcaption>A hand-cut Top plate with the S2/S3 holes countersunk. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="img-row">
+  <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step2-ribs-upper-fixed-section-w1600-4ebd47453115.jpg" alt="Six grey Interface ribs attached around the circular Interface upper fixed section">
     <figcaption>The 6 Interface ribs attached to the Interface upper fixed section. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
@@ -352,6 +359,13 @@ Slide the extrusion into the Interface bracket, careful not to dislodge the T-nu
   <p>Thread the four screws a couple of turns into the T-nuts before sliding the extrusion in, so they hang in place instead of sitting loose in the channel. Easier than aligning four free T-nuts by feel. <cite>Tip: BrickCycleAlice.</cite></p>
 </div>
 
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4293-full-d11cce819ba3.jpg" alt="Four M5 screws threaded a few turns into T-nuts hanging in the Interface bracket's channel before the extrusion is slid in">
+    <figcaption>Screws threaded into the T-nuts first, ready for the extrusion. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
 Repeat for all 6 Interface brackets.
 
 {% include step.html n="4" title="Prepare the limit switch interface bracket" %}
@@ -383,6 +397,13 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
   <p>Same trick as the Interface brackets above: thread the two screws into the T-nuts first, then slide the extrusion in with them already hanging in place. <cite>Tip: BrickCycleAlice.</cite></p>
 </div>
 
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4301-full-9ca956feeb74.jpg" alt="Two T-nuts threaded onto their screws on the Limit switch housing's mounting face, ready for the extrusion">
+    <figcaption>T-nuts threaded on before the extrusion goes in. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
 {% include step.html n="5" title="Install the brackets" %}
 
 <figure class="video-figure">
@@ -402,6 +423,13 @@ Slide a T-nut just into the end of the extrusion of the limit switch interface b
 <div class="callout">
   <span class="callout-icon" aria-hidden="true">💡</span>
   <p>Keep this loose for now, the bracket also gets fixed through the Top plate in the next step. Check by looking straight through the Top plate's own screw hole, not by feel alone. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4311-full-f9e44da3df95.jpg" alt="Looking down through one of the Top plate's screw holes, with light visible through it into the extrusion channel below">
+    <figcaption>What a clear sightline through the hole looks like. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
 </div>
 
 <div class="callout callout-warning">
@@ -545,6 +573,13 @@ Push the prepared Interface idler gear — bearing, inner retainer cap, and oute
 Drive an {% include fastener.html size="M3" variant="countersunk" length="20" %} screw through the middle of the gear and into the bracket. The inner retainer cap sits between the screw head and the bearing, spanning the 8 mm bore, so the screw head on its own (narrower than the bore) has something to clamp against. Tighten until it's seated, then check that the idler gear still spins freely.
 
 The head has to be low here — countersunk (flat/pancake) is the only head type confirmed to clear the Limit switch hammer as it sweeps past. If you only have a pan head on hand, check clearance by hand-rotating the chute past this screw before closing everything up. The screw self-taps straight into the printed NEMA 23 bracket; it does not reach through to the plywood Top plate underneath, which is why 20 mm is enough.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4329-full-5511485c850a.jpg" alt="The Interface idler gear seated on the NEMA 23 bracket with an M3 countersunk screw driven flush through its centre">
+    <figcaption>The M3 × 20 mm countersunk screw seated flush. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four {% include fastener.html size="M5" variant="socket-button" length="12" %} screws.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -310,6 +310,8 @@ Slot the Interface NEMA 23 bracket into the Interface upper fixed section and se
 
 Attach the whole assembly to the bottom of the Top plate with {% include fastener.html size="M5" variant="countersunk" length="22" %} screws through holes S2 and S3 into the Interface NEMA 23 bracket.
 
+**Alternative:** whether these need a countersunk head depends on how your Top plate was cut. If the S2/S3 holes have a countersink cut in, use a countersunk head; if they don't, {% include fastener.html size="M5" variant="socket-button" length="20" %} screws work here instead. Builder's call depending on their plate, the same as the I1-I6/O1-O6 screws in step 5.
+
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step2-ribs-upper-fixed-section-w1600-4ebd47453115.jpg" alt="Six grey Interface ribs attached around the circular Interface upper fixed section">

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -401,7 +401,7 @@ Slide a T-nut just into the end of the extrusion of the limit switch interface b
 
 <div class="callout">
   <span class="callout-icon" aria-hidden="true">💡</span>
-  <p>Keep this loose for now, the bracket also gets fixed through the Top plate in the next step. You can confirm the T-nut is lined up by looking through the Top plate's own screw hole for it, rather than by feel alone. <cite>Tip: BrickCycleAlice.</cite></p>
+  <p>Keep this loose for now, the bracket also gets fixed through the Top plate in the next step. Check by looking straight through the Top plate's own screw hole, not by feel alone. <cite>Tip: BrickCycleAlice.</cite></p>
 </div>
 
 <div class="callout callout-warning">
@@ -420,7 +420,7 @@ Flip the whole assembly and screw all 6 Interface brackets into place with {% in
 
 <div class="callout">
   <span class="callout-icon" aria-hidden="true">💡</span>
-  <p>Go back and fully tighten the M5 × 8 mm screws left loose earlier in this step, now that each bracket is also fixed through the Top plate. <cite>Tip: BrickCycleAlice.</cite></p>
+  <p>Go back and fully tighten the M5 × 8 mm screws left loose earlier in this step, now that each bracket is also bolted through its I/O holes. This is also where a hand-cut Top plate's I/O holes show up as inaccurate, if they do; widen them if a bolt is binding. <cite>Tip: BrickCycleAlice.</cite></p>
 </div>
 
 {% include step.html n="6" title="Prepare the interface chute gear and mount" %}

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -345,6 +345,11 @@ Place T-nuts in the extrusion, lined up with the 4 holes on the side of the Inte
 
 Slide the extrusion into the Interface bracket, careful not to dislodge the T-nuts, and drive four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into them.
 
+<div class="callout">
+  <span class="callout-icon" aria-hidden="true">💡</span>
+  <p>Thread the four screws a couple of turns into the T-nuts before sliding the extrusion in, so they hang in place instead of sitting loose in the channel. Easier than aligning four free T-nuts by feel. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
 Repeat for all 6 Interface brackets.
 
 {% include step.html n="4" title="Prepare the limit switch interface bracket" %}
@@ -371,6 +376,11 @@ Attach the Roller lever limit switch (the "endstop-mechanical" part in your kit)
 
 Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
+<div class="callout">
+  <span class="callout-icon" aria-hidden="true">💡</span>
+  <p>Same trick as the Interface brackets above: thread the two screws into the T-nuts first, then slide the extrusion in with them already hanging in place. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
 {% include step.html n="5" title="Install the brackets" %}
 
 <figure class="video-figure">
@@ -387,6 +397,11 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
 
 Slide a T-nut just into the end of the extrusion of the limit switch interface bracket. Slide the extrusion into the Interface rib (switch gap) and Interface upper fixed section, securing it loosely with an {% include fastener.html size="M5" variant="countersunk" length="8" %} screw. Slide the extrusion slightly in and out to align the holes on the Interface bracket with the holes on the Top plate, then tighten the screw.
 
+<div class="callout">
+  <span class="callout-icon" aria-hidden="true">💡</span>
+  <p>Keep this loose for now, the bracket also gets fixed through the Top plate in the next step. You can confirm the T-nut is lined up by looking through the Top plate's own screw hole for it, rather than by feel alone. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p>The M5 × 8 mm is a snug fit here, it barely reaches the T-nut. Opening the countersink a little and tightening firmly gets the head to sit flush.</p>
@@ -399,6 +414,11 @@ Flip the whole assembly and screw all 6 Interface brackets into place with {% in
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p>Alternative: the Top plate's laser-cut holes are not countersunk, so a countersunk head does not seat flush. {% include fastener.html size="M5" variant="socket-button" length="20" %} screws work here instead.</p>
+</div>
+
+<div class="callout">
+  <span class="callout-icon" aria-hidden="true">💡</span>
+  <p>Go back and fully tighten the M5 × 8 mm screws left loose earlier in this step, now that each bracket is also fixed through the Top plate. <cite>Tip: BrickCycleAlice.</cite></p>
 </div>
 
 {% include step.html n="6" title="Prepare the interface chute gear and mount" %}
@@ -520,9 +540,9 @@ Slide the prepared [Timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | rel
 
 Push the prepared Interface idler gear — bearing, inner retainer cap, and outer retainer already fitted, see step 1 — onto the Interface NEMA 23 bracket with the bearing facing outwards.
 
-Drive an {% include fastener.html size="M3" variant="flat" length="35" %} screw through the middle of the gear and into the bracket. The inner retainer cap sits between the screw head and the bearing, spanning the 8 mm bore, so the screw head on its own (narrower than the bore) has something to clamp against. Tighten until it's seated, then check that the idler gear still spins freely.
+Drive an {% include fastener.html size="M3" variant="countersunk" length="20" %} screw through the middle of the gear and into the bracket. The inner retainer cap sits between the screw head and the bearing, spanning the 8 mm bore, so the screw head on its own (narrower than the bore) has something to clamp against. Tighten until it's seated, then check that the idler gear still spins freely.
 
-The head has to be low here — countersunk (flat/pancake) is the only head type confirmed to clear the Limit switch hammer as it sweeps past. If you only have a pan head on hand, check clearance by hand-rotating the chute past this screw before closing everything up. It is the same screw as the one on the Cable clamp in step 11, so buy two of the one head type.
+The head has to be low here — countersunk (flat/pancake) is the only head type confirmed to clear the Limit switch hammer as it sweeps past. If you only have a pan head on hand, check clearance by hand-rotating the chute past this screw before closing everything up. The screw self-taps straight into the printed NEMA 23 bracket; it does not reach through to the plywood Top plate underneath, which is why 20 mm is enough.
 
 Slot the NEMA 23 onto the Interface NEMA 23 bracket and secure it with four {% include fastener.html size="M5" variant="socket-button" length="12" %} screws.
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3312,9 +3312,9 @@
       "name": "M3 × 35 mm flat head",
       "category": "Screws",
       "alternative": "Flat or pan head",
-      "description": "The two long M3s on the top interface: one clamps the two cable-clamp halves together, one retains the idler gear on the NEMA 23 bracket. Same screw for both. The head has to stay low because of the idler joint: a socket or button head stands proud enough for the limit switch hammer to catch on it as the chute sweeps past.",
+      "description": "The long M3 that clamps the two cable-clamp halves together at the top interface, threading into an M3 nut in the bottom of the Cable clamp (outer).",
       "created_at": "2026-07-18",
-      "updated_at": "2026-08-21",
+      "updated_at": "2026-08-30",
       "attributes": [
         {
           "label": "Thread",
@@ -3326,7 +3326,7 @@
         },
         {
           "label": "Head",
-          "value": "Flat (pancake) head, hex socket. Pan head works too; both are flat-bottomed and low enough to clear the limit switch hammer, which a socket or button head is not."
+          "value": "Flat (pancake) head, hex socket. Pan head works too."
         }
       ]
     },
@@ -7203,7 +7203,7 @@
       "uid": "cwji",
       "version": "1",
       "name": "Chute Stepper Gearing",
-      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3×35 keeps it clear of the limit switch hammer.",
+      "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-20-cs]] runs through into the bracket, self-tapping straight into the printed NEMA 23 bracket rather than reaching all the way to the plywood Top plate.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",
       "lines": [
@@ -7224,7 +7224,7 @@
           "qty": 1
         },
         {
-          "part": "scr-m3-35-bhcs",
+          "part": "scr-m3-20-cs",
           "qty": 1
         },
         {

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7200,8 +7200,8 @@
     },
     {
       "id": "chute-stepper-gearing",
-      "uid": "cwji",
-      "version": "1",
+      "uid": "1cfd",
+      "version": "2",
       "name": "Chute Stepper Gearing",
       "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-20-cs]] runs through into the bracket, self-tapping straight into the printed NEMA 23 bracket rather than reaching all the way to the plywood Top plate.",
       "docs": "/hardware/assembly/distribution/top-interface/",
@@ -7250,6 +7250,69 @@
           "to": "interface-idler-gear",
           "qty": 1,
           "method": "press"
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "uid": "cwji",
+          "date": "2026-08-30",
+          "commit": null,
+          "message": "Original recording: the idler gear's axle screw was listed as 1 x M3 x 35 flat head, the same screw as the cable clamp's.",
+          "lines": [
+            {
+              "part": "interface-nema23-bracket",
+              "qty": 1,
+              "uid": "if4v"
+            },
+            {
+              "part": "interface-spur-gear",
+              "qty": 1,
+              "uid": "ywxy"
+            },
+            {
+              "part": "interface-idler-gear",
+              "qty": 1,
+              "uid": "ptl7"
+            },
+            {
+              "part": "brg-608-2rs",
+              "qty": 1,
+              "uid": "mi1l"
+            },
+            {
+              "part": "scr-m3-35-bhcs",
+              "qty": 1,
+              "uid": "38vn"
+            },
+            {
+              "part": "chute-stepper-idler-bearing-retainer-outer",
+              "qty": 1,
+              "uid": "wgsc"
+            },
+            {
+              "part": "chute-stepper-idler-bearing-retainer-inner",
+              "qty": 1,
+              "uid": "zzql"
+            },
+            {
+              "part": "scr-m3-8-cs",
+              "qty": 4,
+              "uid": "l6br"
+            },
+            {
+              "part": "hsi-m3",
+              "qty": 4,
+              "uid": "ksut"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-09-01",
+          "message": "Recording correction: the idler gear's axle screw is 1 x M3 x 20 countersunk, not M3 x 35. It self-taps into the printed NEMA 23 bracket and never reaches the plywood Top plate, measured on BrickCycleAlice's build (sorter-v2#458). No physical change.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2091,7 +2091,7 @@
 			"uid": "cwji",
 			"version": "1",
 			"name": "Chute Stepper Gearing",
-			"description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
+			"description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-20-cs]] runs through into the bracket, self-tapping straight into the printed NEMA 23 bracket rather than reaching all the way to the plywood Top plate.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
 			"status": "partial",
 			"lines": [
@@ -2112,7 +2112,7 @@
 					"qty": 1
 				},
 				{
-					"part": "scr-m3-35-bhcs",
+					"part": "scr-m3-20-cs",
 					"qty": 1
 				},
 				{
@@ -16278,10 +16278,10 @@
 			},
 			"name": "M3 \u00d7 35 mm flat head",
 			"category": "Screws",
-			"description": "The two long M3s on the top interface: one clamps the two cable-clamp halves together, one retains the idler gear on the NEMA 23 bracket. Same screw for both. The head has to stay low because of the idler joint: a socket or button head stands proud enough for the limit switch hammer to catch on it as the chute sweeps past.",
+			"description": "The long M3 that clamps the two cable-clamp halves together at the top interface, threading into an M3 nut in the bottom of the Cable clamp (outer).",
 			"note": null,
 			"created_at": "2026-07-18",
-			"updated_at": "2026-08-21",
+			"updated_at": "2026-08-30",
 			"attributes": [
 				{
 					"label": "Thread",
@@ -16293,7 +16293,7 @@
 				},
 				{
 					"label": "Head",
-					"value": "Flat (pancake) head, hex socket. Pan head works too; both are flat-bottomed and low enough to clear the limit switch hammer, which a socket or button head is not."
+					"value": "Flat (pancake) head, hex socket. Pan head works too."
 				}
 			],
 			"sheet_qty": null,

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2088,8 +2088,8 @@
 		},
 		{
 			"id": "chute-stepper-gearing",
-			"uid": "cwji",
-			"version": "1",
+			"uid": "1cfd",
+			"version": "2",
 			"name": "Chute Stepper Gearing",
 			"description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-20-cs]] runs through into the bracket, self-tapping straight into the printed NEMA 23 bracket rather than reaching all the way to the plywood Top plate.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
@@ -2138,6 +2138,70 @@
 					"to": "interface-idler-gear",
 					"qty": 1,
 					"method": "press"
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "cwji",
+					"date": "2026-08-30",
+					"commit": null,
+					"message": "Original recording: the idler gear's axle screw was listed as 1 x M3 x 35 flat head, the same screw as the cable clamp's.",
+					"lines": [
+						{
+							"part": "interface-nema23-bracket",
+							"qty": 1,
+							"uid": "if4v"
+						},
+						{
+							"part": "interface-spur-gear",
+							"qty": 1,
+							"uid": "ywxy"
+						},
+						{
+							"part": "interface-idler-gear",
+							"qty": 1,
+							"uid": "ptl7"
+						},
+						{
+							"part": "brg-608-2rs",
+							"qty": 1,
+							"uid": "mi1l"
+						},
+						{
+							"part": "scr-m3-35-bhcs",
+							"qty": 1,
+							"uid": "38vn"
+						},
+						{
+							"part": "chute-stepper-idler-bearing-retainer-outer",
+							"qty": 1,
+							"uid": "wgsc"
+						},
+						{
+							"part": "chute-stepper-idler-bearing-retainer-inner",
+							"qty": 1,
+							"uid": "zzql"
+						},
+						{
+							"part": "scr-m3-8-cs",
+							"qty": 4,
+							"uid": "l6br"
+						},
+						{
+							"part": "hsi-m3",
+							"qty": 4,
+							"uid": "ksut"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "1cfd",
+					"date": "2026-09-01",
+					"message": "Recording correction: the idler gear's axle screw is 1 x M3 x 20 countersunk, not M3 x 35. It self-taps into the printed NEMA 23 bracket and never reaches the plywood Top plate, measured on BrickCycleAlice's build (sorter-v2#458). No physical change.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},


### PR DESCRIPTION
BrickCycleAlice measured the actual build: [the idler gear axle screw self-taps into the printed NEMA 23 bracket only](https://discord.com/channels/1430279849171222682/1543494474443784285/1543496752080883816), it never reaches the plywood Top plate, so the documented M3x35 flat head + shared cable-clamp screw was always longer than the joint needs. Her [M3x20 countersunk](https://discord.com/channels/1430279849171222682/1536088194557419660/1543494474443784285) also matches [zed0's independent guess from 2026-08-16](https://discord.com/channels/1430279849171222682/1538458430262476810/1538503025868537958), made from the assembly video before anyone had measured anything.

- **parts-calculator**: `chute-stepper-gearing`'s idler screw line moves from `scr-m3-35-bhcs` to the existing `scr-m3-20-cs` (already in the catalog for the C-channel light post joint, same self-tapping-into-a-printed-part behavior). `scr-m3-35-bhcs`'s own description/attributes drop the idler-specific reasoning now that it's cable-clamp only.
- **docs**: step 9's screw call and explanation updated to match, and the page's parts list is now 1 × M3x35 plus 1 × M3x20 countersunk instead of 2 × M3x35. The [sort by diameter then by length](https://discord.com/channels/1430279849171222682/1543539297775394817/1544059690953211904) barthel asked for landed on `main` separately (#490), so this branch only slots `scr-m3-20-cs` into the order main already has.
- **parts-calculator**: the swap is stamped as a revision under the rule that landed in [VERSIONING.md](https://github.com/basicallysource/sorter-v2/blob/main/parts-calculator/VERSIONING.md) on 2026-08-31, so `chute-stepper-gearing` goes to v2 (new uid `1cfd`, old `cwji` archived with its lines) with `breaking: false`: nothing physical changed, the catalog had the wrong screw recorded, and an already-built gearing unit is still usable.
- **docs**: three build tips added as callouts, no spec changes: thread T-nuts onto the screws before sliding an extrusion in (steps 2 and 4), and step 5's loose M5×8 can be checked by sight through the Top plate hole and needs tightening once the bracket is also fixed through the plate.

Rebased onto `main` on 2026-08-31 at barthel's request. The only conflict was step 9's head-clearance paragraph, which #472 had reworded in the meantime: that wording is kept, minus its "same screw as the one on the Cable clamp in step 11" sentence, which this change makes false.

**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543494474443784285):** "This was an m3x20mm countersunk."

The rest of the thread, each on its own message:

- "It's self taping into the nema bracket which sits proud in the bearing, so doesn't need to be 35mm, unless it's supposed to go the whole way through into the plywood, but there is nothing there to hold it." ([source](https://discord.com/channels/1430279849171222682/1543494474443784285/1543496752080883816))
- "It's actually easier to lightly screw the t nuts onto the bolts first and then slide the extrusion on, saves having to line up four nuts." ([source](https://discord.com/channels/1430279849171222682/1543494474443784285/1543533863534329927))
- "again, nuts on first then slide onto extrusion" ([source](https://discord.com/channels/1430279849171222682/1543494474443784285/1543534235204321301))
- "mounting the interface bracket, the t nut goes on the very tip of the extrusion. Only do this loosely, as the bracket is also attached through the top plate. Make sure you can see through the top plate when sliding the extrusion in, photos showing where to look through." ([source](https://discord.com/channels/1430279849171222682/1543494474443784285/1543535168340369478))
- "Don't forgot to go back and tighten those screws that were loose." ([source](https://discord.com/channels/1430279849171222682/1543494474443784285/1543536599390752870))
- "that's all the photos I've got, can you summarise before preparing a preview" ([source](https://discord.com/channels/1430279849171222682/1543494474443784285/1543537281703477329))

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543494474443784285
request: https://discord.com/channels/1430279849171222682/1543494474443784285/1543496752080883816
request: https://discord.com/channels/1430279849171222682/1543494474443784285/1543533863534329927
request: https://discord.com/channels/1430279849171222682/1543494474443784285/1543534235204321301
request: https://discord.com/channels/1430279849171222682/1543494474443784285/1543535168340369478
request: https://discord.com/channels/1430279849171222682/1543494474443784285/1543536599390752870
request: https://discord.com/channels/1430279849171222682/1543494474443784285/1543537281703477329
request: https://discord.com/channels/1430279849171222682/1543539297775394817/1544059690953211904
preview: /hardware/assembly/distribution/top-interface/
-->



