### PR TITLE
docs: orient readers on the hardware landing page

### DIFF
--- a/docs/src/content/hardware/index.md
+++ b/docs/src/content/hardware/index.md
@@ -10,6 +10,11 @@ permalink: /hardware/
 author: spencer
 ---
 
-- **[Assembly]({{ '/hardware/assembly/' | relative_url }})**: the build order, structured like a set of instructions.
+The machine is still in active development. Pages under Assembly and
+Electronics range from steps verified on a built machine to unverified first
+drafts; each page states its own status.
+
+- **[Assembly]({{ '/hardware/assembly/' | relative_url }})**: the build order, structured like a set of instructions. Electronics is part of this same build order (see its order of operations), not a separate track.
 - **[Electronics]({{ '/hardware/electronics/' | relative_url }})**: the wire harness, stepper connectors and polarity, the cable order spec, the rendered WireViz drawings, and [installing the electronics]({{ '/hardware/electronics/installation/' | relative_url }}).
+- **[Parts]({{ '/hardware/parts/' | relative_url }})**: reference pages for individual parts, like the Lazy Susan bearing.
 - **[Bill of materials](https://parts-calculator.basically.website/hardware)**: every part, with sources and part numbers.


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1543523992437137518/1543582155169603627
preview: /hardware/
-->

Requested by uwe_barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543523992437137518/1543534143886069840): "Do we need (more) explanations on this page about intension or similar topics?" (and the follow-up "Start working in it")

Three fixes from the interim assembly documentation review, all on `hardware/index.md`:

- Added a line stating the machine is still in active development and that Assembly/Electronics pages range from build-verified to unverified draft.
- Added a link to Parts, which had no path in from this landing page.
- Resolved the build-order ambiguity: Electronics reads as a peer bullet of Assembly here, but assembly/index.md's own order lists it as step 3. Added a line saying it's part of the same build order.
