### PR TITLE
docs: fix Assembly landing page per review findings

### DIFF
--- a/docs/src/content/hardware/assembly/index.md
+++ b/docs/src/content/hardware/assembly/index.md
@@ -12,6 +12,8 @@ author: spencer
 
 Before starting, source everything on the [Bill of materials](https://parts-calculator.basically.website/hardware) and print the required parts — see [Parts]({{ '/hardware/parts/' | relative_url }}) for individual part references. Then follow the sections below top to bottom.
 
+A few names recur across these sections and are worth fixing here, once: the feeder's three channels are C1, C2 and C3, first through third; "the control board" means basically board v1.3, the basically Embedded Control Board; and the printed enclosure around each of the PSU, Orange Pi and control board is the same kind of part even though each page names its own differently (housing, box, mount).
+
 ## Order of operations
 
 1. **[Distribution]({{ '/hardware/assembly/distribution/' | relative_url }})** — bin frame, top interface, and chute. The interface layer is built as part of distribution.

--- a/docs/src/content/hardware/assembly/index.md
+++ b/docs/src/content/hardware/assembly/index.md
@@ -10,9 +10,11 @@ permalink: /hardware/assembly/
 author: spencer
 ---
 
+Before starting, source everything on the [Bill of materials](https://parts-calculator.basically.website/hardware) and print the required parts — see [Parts]({{ '/hardware/parts/' | relative_url }}) for individual part references. Then follow the sections below top to bottom.
+
 ## Order of operations
 
 1. **[Distribution]({{ '/hardware/assembly/distribution/' | relative_url }})** — bin frame, top interface, and chute. The interface layer is built as part of distribution.
 2. **[Feeder]({{ '/hardware/assembly/feeder/' | relative_url }})** — the C-channel stages that meter parts in.
-3. **[Electronics]({{ '/hardware/electronics/' | relative_url }})** — boards, wiring, and steppers. Now its own section, alongside Assembly.
+3. **[Electronics]({{ '/hardware/electronics/' | relative_url }})** — boards, wiring, and steppers.
 4. **[Software setup]({{ '/hardware/assembly/software-setup/' | relative_url }})** — flash and configure. Hands off to the [Sorter]({{ '/sorter/' | relative_url }}) section.


### PR DESCRIPTION
Fixes the three findings from the review of `hardware/assembly/index.md`:

- Item 3 ("Electronics") carried an internal editorial note in reader-facing text ("Now its own section, alongside Assembly.") — dropped.
- No signal that the reader needs the BOM sourced and parts printed before starting — added a lead-in sentence before the order-of-operations list.
- No link back to the BOM or Parts pages from this entry point — the new sentence links both.

Requested by Uwe Barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543594424829739038): "Review: Assembly (hardware/assembly/index.md)
Collecting all review findings regarding Assembly (hardware/assembly/index.md) from here https://discord.com/channels/1430279849171222682/1543523992437137518/1543529573961048077 and let's start to work on those findings."

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543594424829739038
preview: /hardware/assembly/
-->