### PR TITLE
docs: fill in the software-setup stub

### DIFF
--- a/docs/src/content/hardware/assembly/software-setup.md
+++ b/docs/src/content/hardware/assembly/software-setup.md
@@ -10,6 +10,16 @@ permalink: /hardware/assembly/software-setup/
 author: spencer
 ---
 
-Once the hardware is built, set up the software. This hands off to the [Sorter]({{ '/sorter/' | relative_url }}) section.
+Once the hardware is built, set up the software. This stage flashes SorterOS onto the Orange Pi 5 and the control board firmware onto the Pico controllers, turning the assembled hardware into a machine the Sorter software can actually run on.
 
-_Content pending._
+## Flash SorterOS
+
+Go to [Installation]({{ '/sorter/installation/' | relative_url }}) and pick SorterOS (the recommended path for the Orange Pi 5), the one-command Linux installer, or the manual by-hand sequence. This gets the Pi booted and the Sorter backend and UI running.
+
+## Flash the control boards
+
+With Sorter running, flash the feeder and distribution control boards from **Settings → Control board** in the Sorter UI: pick a release (or upload a `.uf2` directly) and flash it over the Pico's USB serial connection.
+
+## Next
+
+Continue in the [Sorter]({{ '/sorter/' | relative_url }}) section. [Your first sort run]({{ '/sorter/tutorials/first-sort-run/' | relative_url }}) walks through picking a profile, feeding the machine, and checking a bin.


### PR DESCRIPTION
Fills in the `hardware/assembly/software-setup.md` stub, per the review findings collected in barthel's thread.

Two findings from the "Make It Buildable" review specifically targeted this page:
- The page was entirely `_Content pending._` with no actual content, and sits as step 4 of the build order on the Assembly index, so a first-time reader following the build in sequence hit a dead end here.
- The purpose/structure pass flagged the one existing sentence as too thin to say why the stage exists or what it does mechanically.

Both `hardware/electronics/installation/pico-headers.md` and `hardware/electronics/installation/orange-pi-mount.md` already point here for "flashing its firmware" / "flashing and configuring the Pi", so the fix explains what the stage actually covers and bridges straight into the existing (and already-written) Sorter installation docs rather than duplicating them:
- A purpose sentence covering both halves of the stage: flashing SorterOS onto the Orange Pi 5, and flashing the Pico control board firmware.
- A link to Sorter → Installation for the OS flash.
- A short pointer to Settings → Control board in the Sorter UI for flashing the feeder/distribution boards (confirmed against `software/sorter/backend/server/routers/firmware.py` and the frontend's `ControlBoardSection.svelte`, which is exactly this flow).
- A link forward to Your first sort run, so the reader has a next step instead of a dead end.

`validate_frontmatter.py` and `validate_images.py` both pass with no new errors, and `npm run dev` + curling the route confirms the page renders with all three links resolving and no leftover "Content pending" text.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543601407989653546
preview: /hardware/assembly/software-setup/
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543601407989653546): "Review: Software setup (hardware/assembly/software-setup.md)
Collecting all review findings regarding Software setup (hardware/assembly/software-setup.md) from here https://discord.com/channels/1430279849171222682/1543523992437137518/1543529575701684309 and let's start to work on those findings."
