### PR TITLE
docs: address review findings on Orange Pi 5 page

### DIFF
--- a/docs/src/content/hardware/orange-pi-5.md
+++ b/docs/src/content/hardware/orange-pi-5.md
@@ -18,6 +18,8 @@ last_verified: 2026-05-19
   <p>The Orange Pi 5 is the required compute board for Sorter. SorterOS is built on top of the official Ubuntu image provided by Orange Pi for this board.</p>
 </div>
 
+The Orange Pi 5 is installed and wired during [Electronics assembly]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }}), where it connects to the Pico controllers and cameras; this page only covers selecting and configuring the board itself.
+
 <figure class="single-figure">
   <img class="doc-figure" src="/assets/pi5-01.png" alt="Orange Pi 5 single-board computer">
   <figcaption><cite>Manufacturer photo (orangepi.org), not a Basically photo.</cite></figcaption>
@@ -60,6 +62,16 @@ The Orange Pi family uses **two distinct M.2 connector formats** depending on th
 | Orange Pi 5 Plus | PCIe M.2 E-KEY | R6 module (Wi-Fi 6 + BT5.2, 1201 Mbps) — [Amazon](https://www.amazon.com/dp/B0CFY7SJRN) |
 
 If you order the wrong module for your board variant it will not physically seat. Double-check which board you have before purchasing.
+
+**Telling the two slots apart by eye:** both are the same width and length, but the keying notch (the gap cut into the row of gold contacts) is in a different place. On the original Orange Pi 5's Standard M.2 PCIe (M-key) slot, the notch sits close to one end of the contact row. On the Orange Pi 5 Plus's E-key slot, the notch sits nearer the middle of the row. The module you buy has a matching notch, so a module only physically seats in the slot it's keyed for, and that mismatch is the fastest way to confirm which one you have before ordering.
+
+### Installing the module
+
+1. Power off the board and disconnect it before opening the case.
+2. Locate the M.2 slot on the underside of the board (check the [Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }}) page for where the board sits in the machine).
+3. Insert the module into the slot at a shallow angle (roughly 30°), gold contacts first, until it's fully seated.
+4. Press the free end down flat and secure it with the small retention screw the module ships with.
+5. Connect the antenna cable(s) to the module's u.FL connectors.
 
 <div class="notice">
   <strong>Driver support</strong>

--- a/docs/src/content/hardware/orange-pi-5.md
+++ b/docs/src/content/hardware/orange-pi-5.md
@@ -72,6 +72,7 @@ If you order the wrong module for your board variant it will not physically seat
 3. Insert the module into the slot at a shallow angle (roughly 30°), gold contacts first, until it's fully seated.
 4. Press the free end down flat and secure it with the small retention screw the module ships with.
 5. Connect the antenna cable(s) to the module's u.FL connectors.
+6. Power the board back on and confirm the OS sees the adapter, e.g. `ip link` or `nmcli device wifi list` should list it.
 
 <div class="notice">
   <strong>Driver support</strong>

--- a/docs/src/content/hardware/orange-pi-5.md
+++ b/docs/src/content/hardware/orange-pi-5.md
@@ -30,6 +30,8 @@ The core reason Sorter requires the Orange Pi 5 is its **Rockchip RK3588S SoC**,
 - Over **30 fps per camera** for YOLO-based piece detection
 - Over **100 fps total** across all three camera feeds simultaneously
 
+Measured running three sustained NPU inference workers in parallel, one per camera; see [Object Detection Research]({{ '/lab/object-detection/' | relative_url }}) for the full benchmark data.
+
 No other single-board computer at this price point sustains that inference throughput with the NPU required by the detection pipeline.
 
 ## Recommended configuration
@@ -59,18 +61,21 @@ The Orange Pi family uses **two distinct M.2 connector formats** depending on th
 
 If you order the wrong module for your board variant it will not physically seat. Double-check which board you have before purchasing.
 
-> **Note on driver support:** The AP6275P module for the original Orange Pi 5 requires drivers included in the official Orange Pi Ubuntu image. It works on SorterOS (which is based on that image) but may not work on other third-party OS images out of the box.
+<div class="notice">
+  <strong>Driver support</strong>
+  <p>The AP6275P module for the original Orange Pi 5 requires drivers included in the official Orange Pi Ubuntu image. It works on SorterOS (which is based on that image) but may not work on other third-party OS images out of the box.</p>
+</div>
 
 ## USB hubs
 
-Use a **powered USB hub** for webcams, Picos, and other attached USB devices.
+Use a **powered USB hub** for webcams, Raspberry Pi Picos, and other attached USB devices.
 We have seen bus-powered hubs let those devices brown out the Orange Pi 5 under load,
 which can trigger severe system crashes instead of a clean USB disconnect.
 
 ## Cooling
 
 If the Orange Pi 5 is pinned hard, especially when running a detection model on the CPU,
-it can heat up enough to hit thermal emergency shutdown at about 105 C. A small fan is
-recommended.
+it can heat up enough to hit thermal emergency shutdown at about 105 C. A small 5V fan
+(e.g. a 30-40mm USB or GPIO-powered fan) mounted over the SoC is recommended.
 *The intent is to run models on the NPU; if a bug or fallback pushes them onto the CPU,
 this can happen.*


### PR DESCRIPTION
Fixes the four findings from the Make It Buildable review of `hardware/orange-pi-5.md`:

- "Picos" expanded to "Raspberry Pi Picos" on first mention (no earlier definition existed)
- The fps claims (30/camera, 100 total) now cite the source: the sustained 3-worker NPU benchmark on the [Object Detection Research](https://docs.basically.website/lab/object-detection/) page, which is where those exact numbers come from
- The fan recommendation is now concrete (small 5V, 30-40mm, USB or GPIO-powered) instead of unspecified
- The driver-support note now uses the same `.notice` box treatment as the page's top callout, instead of a plain blockquote

Two more findings from the same review, added after barthel flagged that the first pass missed them:

- No way to visually tell the Standard M.2 PCIe (M-key) slot apart from the E-key slot, and no install procedure for the WiFi module itself — added a plain-English "notch position" identification note and a short install steps list
- No mention of where in the build sequence the board gets installed — added a sentence pointing to Electronics assembly

Also folds in the one useful addition from the now-closed duplicate PR #463 (a different session worked the same M.2 finding independently): an OS-verification step (`ip link` / `nmcli device wifi list`) at the end of the install procedure.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543603413898760202): "Review: Orange Pi 5 (hardware/orange-pi-5.md) Collecting all review findings regarding Orange Pi 5 (hardware/orange-pi-5.md) from here [link] and let's start to work on those findings."

barthel (@uwe_barthel) again [from Discord](https://discord.com/channels/1430279849171222682/1543603413898760202/1543605571750469692): "Did ypu notice this review findings for the orange pi [link] too?"

barthel (@uwe_barthel) again [from Discord](https://discord.com/channels/1430279849171222682/1543603413898760202/1543608748126375956): "Merge #462 and #463. Both on orange pi page and review findings, right?"

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543603413898760202
request: https://discord.com/channels/1430279849171222682/1543603413898760202/1543605571750469692
request: https://discord.com/channels/1430279849171222682/1543603413898760202/1543608748126375956
preview: /hardware/orange-pi-5/
-->
