### PR TITLE
docs: link Orange Pi 5 from the parts overview page

### DIFF
--- a/docs/src/content/hardware/parts/index.md
+++ b/docs/src/content/hardware/parts/index.md
@@ -11,3 +11,4 @@ author: spencer
 ---
 
 - **[Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }})**
+- **[Orange Pi 5]({{ '/hardware/orange-pi-5/' | relative_url }})**


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1543606172311887952/1543608166997037220
preview: /hardware/parts
-->

The Orange Pi 5 is a part with its own reference page but wasn't linked from the Parts landing page, which only listed Lazy Susan.

- Added an Orange Pi 5 entry to `hardware/parts/index.md`, linking to the existing `hardware/orange-pi-5.md` page.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543606172311887952/1543608166997037220): "The orange pi is also a part and should linked in the parts overview page."
