### PR TITLE
docs: address Lazy Susan part-page review findings

### DIFF
--- a/docs/src/content/hardware/parts/lazy-susan.md
+++ b/docs/src/content/hardware/parts/lazy-susan.md
@@ -17,7 +17,7 @@ author: spencer
 
 Repurposed from a dinner-table lazy Susan. It's installed as part of chute assembly, letting the chute rotate freely on the frame with minimal friction under load. It's rated for at least 50 lb and holds up well over long run times in our testing, with no manufacturing issues seen across the Amazon and AliExpress sources we've used. (Our own inference: actual capacity may be higher than the rated 50 lb, but we haven't tested to failure.) Use the **8" variant**; see it on the [parts catalog](https://parts-calculator.basically.website/hardware?hw=brg-lazy-susan) for current vendor links and pricing.
 
-Mounts through 4 × M4 countersunk screws per side, into heat-set inserts in the printed part it bolts to (the chute mount on one side, the bottom static plate on the other), the same fastener pattern used at the top interface.
+The bearing itself is 20 cm (8") across and 9 mm thick, weighing about 350 g. It mounts through 4 × M4 countersunk screws per side, into heat-set inserts in the printed part it bolts to (the chute mount on one side, the bottom static plate on the other), the same fastener pattern used at the top interface.
 
 <div class="notice">
   <strong>Remove the rubber feet before installing</strong>

--- a/docs/src/content/hardware/parts/lazy-susan.md
+++ b/docs/src/content/hardware/parts/lazy-susan.md
@@ -15,7 +15,7 @@ author: spencer
   <figcaption><cite>Photographer not recorded.</cite></figcaption>
 </figure>
 
-Repurposed from a dinner-table lazy Susan. It's installed as part of chute assembly, letting the chute rotate freely on the frame with minimal friction under load. It's rated for at least 50 lb and holds up well over long run times in our testing, with no manufacturing issues seen across the Amazon and AliExpress sources we've used. (Our own inference: actual capacity may be higher than the rated 50 lb, but we haven't tested to failure.) Use the **8" variant**; see the [BOM](https://docs.google.com/spreadsheets/d/1aoxcyK0xa0i3iWYlO4u3-vsruOGU8V_U9XT65YhMZmY/edit?gid=0#gid=0) for sources.
+Repurposed from a dinner-table lazy Susan. It's installed as part of chute assembly, letting the chute rotate freely on the frame with minimal friction under load. It's rated for at least 50 lb and holds up well over long run times in our testing, with no manufacturing issues seen across the Amazon and AliExpress sources we've used. (Our own inference: actual capacity may be higher than the rated 50 lb, but we haven't tested to failure.) Use the **8" variant**; see it on the [parts catalog](https://parts-calculator.basically.website/hardware?hw=brg-lazy-susan) for current vendor links and pricing.
 
 Mounts through 4 × M4 countersunk screws per side, into heat-set inserts in the printed part it bolts to (the chute mount on one side, the bottom static plate on the other), the same fastener pattern used at the top interface.
 

--- a/docs/src/content/hardware/parts/lazy-susan.md
+++ b/docs/src/content/hardware/parts/lazy-susan.md
@@ -15,6 +15,11 @@ author: spencer
   <figcaption><cite>Photographer not recorded.</cite></figcaption>
 </figure>
 
-Repurposed from a dinner-table lazy Susan. It's rated for heavy loads — at least 50 lb, likely more — and holds up well over long run times, with no manufacturing issues seen across Amazon and AliExpress sources. Use the **8" variant**; see the [BOM](https://docs.google.com/spreadsheets/d/1aoxcyK0xa0i3iWYlO4u3-vsruOGU8V_U9XT65YhMZmY/edit?gid=0#gid=0) for sources.
+Repurposed from a dinner-table lazy Susan. It's installed as part of chute assembly, letting the chute rotate freely on the frame with minimal friction under load. It's rated for at least 50 lb and holds up well over long run times in our testing, with no manufacturing issues seen across the Amazon and AliExpress sources we've used. (Our own inference: actual capacity may be higher than the rated 50 lb, but we haven't tested to failure.) Use the **8" variant**; see the [BOM](https://docs.google.com/spreadsheets/d/1aoxcyK0xa0i3iWYlO4u3-vsruOGU8V_U9XT65YhMZmY/edit?gid=0#gid=0) for sources.
 
-Before use, [remove the rubber feet]({{ '/hardware/helpers/lazy-susan/' | relative_url }}).
+Mounts through 4 × M4 countersunk screws per side, into heat-set inserts in the printed part it bolts to (the chute mount on one side, the bottom static plate on the other), the same fastener pattern used at the top interface.
+
+<div class="notice">
+  <strong>Remove the rubber feet before installing</strong>
+  <p>Some variants ship with rubber feet, which raise the bearing enough to throw off the chute's fit. <a href="{{ '/hardware/helpers/lazy-susan/' | relative_url }}">Remove them</a> before use.</p>
+</div>

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -4579,6 +4579,14 @@
         {
           "label": "Size",
           "value": "8\" / 200 mm"
+        },
+        {
+          "label": "Thickness",
+          "value": "9 mm"
+        },
+        {
+          "label": "Weight",
+          "value": "350 g"
         }
       ],
       "docs_page": "/hardware/parts/lazy-susan/"

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -17080,6 +17080,14 @@
 				{
 					"label": "Size",
 					"value": "8\" / 200 mm"
+				},
+				{
+					"label": "Thickness",
+					"value": "9 mm"
+				},
+				{
+					"label": "Weight",
+					"value": "350 g"
 				}
 			],
 			"sheet_qty": {


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543610802425045105
request: https://discord.com/channels/1430279849171222682/1543610802425045105/1543636654630117540
request: https://discord.com/channels/1430279849171222682/1543610802425045105/1543640107243020388
preview: /hardware/parts/lazy-susan/
-->

Fixes the review findings for `hardware/parts/lazy-susan.md`, plus a follow-up ask:

- Swapped the BOM link from the raw Google Sheet to the parts catalog's own deep link for this bearing (`/hardware?hw=brg-lazy-susan`), so pricing and vendor links stay current instead of going stale. This was the only page left in the docs tree still linking the sheet directly.
- Load rating sentence stated an unsourced inference ("likely more") as fact in the same breath as the sourced 50 lb rating. Reworded to label the inference explicitly, per the review's suggested rewrite.
- The rubber-feet removal step was a buried one-line afterthought with no rationale. Pulled it into a required notice box (matching the pattern `hardware/orange-pi-5.md` uses for its important notes) with the "why" (throws off the chute's fit).
- Added the mounting fastener pattern (4x M4 countersunk screws per side, into heat-set inserts in the printed chute mount / bottom static plates) to answer the "no mounting hole pattern" gap — sourced from the `lazy-susan` assembly entry in `parts-calculator/catalog/parts.json`.
- Added a purpose sentence (where it goes, what it enables mechanically) per the follow-up purpose/structure pass.

**Update:** barthel pulled the Measurements table off the vendor listing directly (Amazon's product-details section doesn't survive WebFetch, so this needed a human). Added thickness (9 mm) and weight (350 g) to both the docs page and the `brg-lazy-susan` catalog entry's `attributes` (regenerated `catalog.generated.json` via the `build_hardware()` workaround, `--metadata-only` itself is broken for printed parts with version history but this is a pure hardware-metadata edit so it's unaffected; `check_generated_pins.py` still agrees). Outside diameter matches the existing "8-inch / 200mm" figure. Inner diameter / load-bearing surface width are still not sourced.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543610802425045105): "Review: Lazy Susan (hardware/parts/lazy-susan.md) Collecting all review findings regarding Lazy Susan (hardware/parts/lazy-susan.md) from here https://discord.com/channels/1430279849171222682/1543523992437137518 and let's start to work on those findings."


