### PR TITLE
docs: bin frame index — link Top interface, explain the bin frame

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
@@ -5,7 +5,7 @@ type: landing
 section: hardware
 slug: assembly-bin-frame
 kicker: Distribution — Bin frame
-lede: The stacked layers of bins. Layer count is N (however many bins your machine has); build in this order.
+lede: The stacked layers of bins. Layer count is N (however many bin layers your machine has, not the total number of bins); build in this order.
 permalink: /hardware/assembly/distribution/bin-frame/
 author: spencer
 ---

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
@@ -5,12 +5,15 @@ type: landing
 section: hardware
 slug: assembly-bin-frame
 kicker: Distribution — Bin frame
-lede: The stacked layers of bins. Layer count is N; build in this order.
+lede: The stacked layers of bins. Layer count is N (however many bins your machine has); build in this order.
 permalink: /hardware/assembly/distribution/bin-frame/
 author: spencer
 ---
+
+The bin frame is the stack of hexagonal layers that makes up the body of the machine: each layer carries one chute-and-bin pair that catches pieces routed to it as they come down from distribution above. The stack sits on the bottom interface, which the pieces feed from below, and is capped by [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}). Build order runs bottom-up, since each layer's vertical extrusion locates and is fastened to the one below it.
 
 1. **[Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})** — the shared hexagonal ring. Build N+1 of these first: one per planned layer, plus one each for the bottom and top interface.
 2. **[Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }})** — the base the frame builds up from.
 3. **[Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }})** — the paired base layers on the long vertical extrusions.
 4. **[Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }})** — build N−2 of these, one per remaining layer.
+5. **[Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})** — outside this section, but takes one of the hex frames from step 1 and caps the stack.


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543613015767777403
preview: /hardware/assembly/distribution/bin-frame/
-->

Fixes the two findings from the "Make It Buildable" review of `bin-frame/index.md`:

- **No link forward to Top interface.** `hex-frame.md` tells the reader to build N+1 hex frames, one for the bottom interface and one for the top interface, but the index never linked to Top interface — someone following only this page would build a spare hex frame with nowhere to send it. Added a link in the intro paragraph and as a fifth list item.
- **Page never explained what a "bin frame" is.** It was a one-line lede plus a bare four-item list. Added a short paragraph after the lede saying what the stack is for and how it relates to the bottom/top interface, and defined "N" in the lede itself (was undefined until hex-frame.md).

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543613015767777403): "Review: Bin frame (index)
Collecting all review findings regarding
Bin frame (index)
from here
https://discord.com/channels/1430279849171222682/1543523992437137518
and let's start to work on those findings."

Verified: `validate_frontmatter.py` and `validate_images.py` both clean (same pre-existing errors as `main`), full `npm run build` (Node 20) succeeded, and the built HTML for the page shows the new paragraph and both Top interface links.
