### PR TITLE
docs: fix Bottom interface review findings

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -34,7 +34,10 @@ parts_needed:
     qty: 9
   - part: tnut-m5-2020
     qty: 6
+tools_needed: [Hex key, Drill or electric screwdriver]
 ---
+
+The bottom interface is the Lazy Susan bearing assembly the chute rests and spins on, sitting between the chute and the bottom two layers of the frame.
 
 <div class="prep-item">
   <div class="prep-item-body">
@@ -62,7 +65,7 @@ The parts list above is only the Lazy Susan bearing stack and the extrusion moun
   <figcaption><cite>Video: Basically's own YouTube channel. Who filmed it isn't recorded.</cite></figcaption>
 </figure>
 
-The bottom interface stacks the chute mount, the Lazy Susan washer, the Lazy Susan bearing, and the bottom static part. Here it is exploded into its components:
+The bottom interface stacks the chute mount, the Lazy Susan washer, the Lazy Susan bearing, and the bottom static part. The Lazy Susan itself is two discs, inner and outer, that spin independently: the chute mount screws to one disc and the bottom static part to the other. Here it is exploded into its components:
 
 <div class="img-row">
   <figure>
@@ -112,7 +115,7 @@ Printed parts elsewhere in the machine take inserts too. Each assembly page list
 
 {% include step.html n="2" title="Mount the Lazy Susan to the chute mount" %}
 
-The Lazy Susan is two discs, inner and outer, that spin independently. The chute mount screws to one disc and the bottom static part to the other, so this step and the next work on opposite faces of the same bearing.
+This step and the next work on opposite faces of the same bearing.
 
 Remove the Lazy Susan's rubber tabs first (see [Preparing Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})). **The washer goes on before the bearing**: set the Lazy Susan washer on the chute mount, then the [Lazy Susan]({{ '/hardware/parts/lazy-susan/' | relative_url }}) on top of that.
 
@@ -207,7 +210,7 @@ The bearing stack is now complete:
 
 {% include step.html n="4" title="Prepare the frame" %}
 
-The bottom interface's frame is an ordinary [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}), built exactly as that page describes with no changes. Once it's built, a Lazy Susan extrusion mount pair bolts directly onto 3 of its spokes, alternating around the ring, on top of the spoke's existing Frame 90° bracket and crossbeam rather than replacing anything.
+The bottom interface's frame is an ordinary [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}), built exactly as that page describes, with one addition: that page's step 3 has a note on getting this page's 6 T-nuts into 3 of its spokes while they're still open. Once it's built, a Lazy Susan extrusion mount pair bolts directly onto those 3 spokes, alternating around the ring, on top of the spoke's existing Frame 90° bracket and crossbeam rather than replacing anything.
 
 Three Lazy Susan extrusion mounts carry the bearing assembly's weight; a hold in place bolts to each one first, as a pair, before either touches the extrusion. **They don't fix the chute itself**, that's attached up at the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}).
 
@@ -216,11 +219,11 @@ Three Lazy Susan extrusion mounts carry the bearing assembly's weight; a hold in
   <figcaption>Mount and hold in place, bolted together. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
-The screw between the extrusion mount and the hold in place is an {% include fastener.html size="M5" variant="socket" length="16" %}.
+The screw between the extrusion mount and the hold in place is an {% include fastener.html size="M5" variant="socket-button" length="16" %}.
 
 Each mount then bolts directly onto the B/H spoke (158mm) already in place in the hex frame, through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion.
 
-That's two {% include fastener.html size="M5" variant="socket" length="16" %} screws per mount, 6 more on top of the 3 between mount and hold in place.
+That's two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws per mount, 6 more on top of the 3 between mount and hold in place.
 
 <div class="img-row">
   <figure>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -108,6 +108,11 @@ Slide a B/H spoke (158mm) and a Frame crossbeam together. For easy assembly, sta
 
 Repeat step 2 around the hexagon until you have used **6 Frame crossbeams and 5 B/H spokes (158mm)**. Deliberately hold the 6th spoke back — it closes the loop later, in step 7.
 
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Building this frame for the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a>? Its three Lazy Susan extrusion mounts each bolt into a T-nut in a B/H spoke, on 3 of the 6 spokes alternating around the ring. If you're using slide-in T-nuts, slide 2 into each of those 3 spokes as you build them here in steps 2-3, since this is the last time their ends are open; drop-in or roll-in T-nuts can go in any time before the ring closes in step 7. An ordinary hex frame for a layer needs none of this.</p>
+</div>
+
 {% include step.html n="4" title="Fit 10 of the 12 Frame 90° brackets" %}
 
 <div class="img-row">


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543621297425223801
preview: /hardware/assembly/distribution/bin-frame/bottom-interface/
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543621297425223801): "Review: Bottom interface Collecting all review findings regarding Bottom interface from here https://discord.com/channels/1430279849171222682/1543523992437137518 and let's start to work on those findings."

## What this fixes

From the editorial review of `bottom-interface.md`:

- **Page opened with no description of what a bottom interface is.** It went straight from front matter into the "build a hex frame first" prep box, unlike the other how-to pages in this set. Added a lead sentence: "The bottom interface is the Lazy Susan bearing assembly the chute rests and spins on, sitting between the chute and the bottom two layers of the frame."
- **Wrong fastener variant on the extrusion-mount M5x16 screws.** Both were labeled plain "M5 socket, length 16"; every other M5x16 in this page set (hex-frame, regular-layers, bottom-two-layers) uses "socket-button," the same catalog part (`scr-m5-16-shcs`, socket-or-button-head interchangeable). Fixed both instances in step 4.
- **The 6 T-nuts this page's parts list needs had nowhere to go in.** Step 4 says to build the hex frame "exactly as that page describes with no changes," but `hex-frame.md` never has a step for getting T-nuts into the B/H spokes its own extrusion mounts bolt into. Added a callout to `hex-frame.md` step 3 telling a builder assembling a frame for the bottom interface to slide 2 T-nuts into each of the 3 spokes that will take a mount, before the ring closes in step 7 (hedged the same way that page's own step 1 already hedges slide-in vs. drop-in/roll-in T-nuts, since the catalog's `tnut-m5-2020` is roll-in but the existing text accounts for either). Reworded bottom-interface.md step 4 to point at that note instead of claiming "no changes."
- **Mechanism explanation buried in step 2 instead of the intro (minor, flagged "already adequate" by the follow-up pass).** Moved "the Lazy Susan is two discs, inner and outer, that spin independently" up into the intro paragraph above the exploded-view figures, and trimmed the now-duplicate sentence out of step 2.
- **No tools-needed list**, despite step 2's callout requiring a hex key (and implying a drill/driver first, since "a drill or electric screwdriver will not get them there"). Added `tools_needed: [Hex key, Drill or electric screwdriver]`.

Left the cross-page "bottom-two-layers.md step 6 doesn't resolve how the bottom interface physically joins that frame" item alone — that's `bottom-two-layers.md`'s own placeholder, already being tracked in PR #468.

Verified with a full local `npm run build` (Node 20, clean) plus `validate_frontmatter.py`/`validate_images.py` (pre-existing errors elsewhere, none on these two pages), and read the rendered page HTML directly to confirm the new lead sentence, fastener labels, and hex-frame callout all come out as intended.
