### PR TITLE
docs: fix Distribution landing page per editorial review findings

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/index.md
+++ b/docs/src/content/hardware/assembly/distribution/index.md
@@ -5,13 +5,15 @@ type: landing
 section: hardware
 slug: assembly-distribution
 kicker: Assembly — Distribution
-lede: The bin tower and the chute that steers parts into it. Build in this order.
+lede: The bin tower, the interface that connects it to the feeder, and the chute that steers parts into it. Build in this order.
 permalink: /hardware/assembly/distribution/
 author: spencer
 ---
 
-Distribution and the interface layer are assembled as one unit.
+Distribution and the interface layer are assembled as one unit. It comes first in the [overall build order]({{ '/hardware/assembly/' | relative_url }}) and does not depend on the feeder: the feeder is built and added afterward, once the bin tower, interface, and chutes are already standing.
+
+Parts arrive from the feeder already identified; the interface's rotating chute aims each one down the hex-framed bin tower into the correct layer, and it is only fixed in place once the bin frame beneath it is built, which is why bin frame is built first even though the interface is where sorting decisions become physical.
 
 1. **[Bin frame]({{ '/hardware/assembly/distribution/bin-frame/' | relative_url }})** — the stacked layers of bins.
-2. **[Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})** — the interface between the feeder and the bin tower.
+2. **[Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})** — the interface between the feeder and the bin tower: brackets, the rotating-chute mount, gearing, and cable routing.
 3. **[Chute]({{ '/hardware/assembly/distribution/chute/' | relative_url }})** — the rotating chute that aims parts at the correct bin, including the per-layer door module.


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543621818194329693
preview: /hardware/assembly/distribution/
-->

Fixes the three findings from the "Make It Buildable" editorial review's [Distribution review post](https://discord.com/channels/1430279849171222682/1543523992437137518/1543529648187777106) and its [purpose/structure follow-up](https://discord.com/channels/1430279849171222682/1543523992437137518/1543540877035569163):

- The lede only named two of the three linked pages (dropped "top interface" entirely, even though it's the biggest of the three). Now names all three.
- The "Top interface" list item just restated the page's own lede, with no sense of what's actually in it. Now says what's inside: brackets, the rotating-chute mount, gearing, cable routing.
- The page never said whether Distribution depends on the feeder being built first, or explained why the mechanism works the way it does. Added a sentence noting Distribution comes first in the build order and doesn't depend on the feeder, plus the purpose/structure follow-up's suggested explanation of why bin frame is built before the interface even though the interface is where sorting decisions happen.

Left the missing tools-list/scope/image alone — checked the sibling Bin frame and Chute landing pages and neither has one either, so it's house style for a landing page, not an oversight.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543621818194329693): "Review: Distribution
Collecting all review findings regarding
Distribution
from here
https://discord.com/channels/1430279849171222682/1543523992437137518
and let's start to work on those findings."
