### PR TITLE
parts-calculator: rename Interface section to Top interface

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -13,7 +13,7 @@
     },
     {
       "id": "interface",
-      "name": "Interface",
+      "name": "Top interface",
       "scales_with_layers": false
     },
     {
@@ -6175,7 +6175,7 @@
       "id": "interface",
       "uid": "bkgq",
       "version": "2",
-      "name": "Interface",
+      "name": "Top interface",
       "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
       "status": "partial",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -27,7 +27,7 @@
 		},
 		{
 			"id": "interface",
-			"name": "Interface",
+			"name": "Top interface",
 			"scales_with_layers": false
 		},
 		{
@@ -1106,7 +1106,7 @@
 			"id": "interface",
 			"uid": "bkgq",
 			"version": "2",
-			"name": "Interface",
+			"name": "Top interface",
 			"description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
 			"status": "partial",


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543624727355068486
preview: /3d-printed
-->

## Summary

barthel flagged that the docs' recent bin-frame reorg (#449) split the old
single "interface" idea into distinct **Top interface** and **Bottom
interface** pages (plus a new shared **Hex frame** page used by both of
those and every regular layer), and asked whether the parts calculator's
own groupings still line up with that.

They don't, in one clear way: the calculator has a section called just
**"Interface"** (id `interface`), and it is not the general concept the
name implies — its own `docs:` field points at
`/hardware/assembly/distribution/top-interface/`, and everything counted
in it (Interface bracket, the top interface's own hex frame instance,
Fixed upper section, Cable cage, Chute stepper gearing, etc.) is top
interface only. There's no equivalent "Bottom interface" section — that
page's own parts are split across the existing "Distribution frame" and
"Bottom lazy Susan" sections instead. So a plain "Interface" label reads as
if it means the whole interface concept, when since the reorg it only ever
meant the top one.

This renames the section (`sections[].name`) and the top-level assembly's
own display name (`assemblies[].name` for `interface`) from "Interface" to
"Top interface", matching the docs page title exactly. Only the two `name`
strings changed — ids, uids, versions, quantities and every other field are
untouched (diffed before writing, see below).

**Not done here, flagged for a follow-up:** there's still no "Bottom
interface" section of its own in the calculator (its parts stay split
across "Distribution frame" / "Bottom lazy Susan"), and the new shared "Hex
frame" concept has no section either — it shows up as a nested line under
both "Top interface" and "Distribution frame" with no single place to see
what one hex frame costs. Fixing either of those means moving `quantities`
keys on the affected parts, not just a label, so it's a bigger change than
this one and needs a bit more thought about where hex-frame's own count
should live before touching it.

## How this was generated

`catalog/generate.py` can't run end to end in this environment right now —
`--metadata-only` hits a pre-existing `NameError: rebased_render` (open,
see sorter-v2#423) as soon as it refreshes any printed part carrying
version/candidate history, which is most of this catalog. `sections` and
`assemblies` are both pure passthroughs of `catalog/parts.json` in
`generate.py` (`data["sections"] = manifest["sections"]`;
`data["assemblies"] = normalize_assemblies(manifest)`, and
`normalize_assemblies` only touches uid-stamping on the newest version
entry) — no slicer involved — so I reproduced that exact logic directly
against the edited `parts.json` and replaced only those two keys in
`catalog.generated.json`, diffing old vs new first to confirm nothing but
the two `name` fields moved.

## Test plan

- [x] `python3 parts-calculator/scripts/check_generated_pins.py` — agrees,
      100 pinned parts
- [x] Diffed `sections`/`assemblies` before and after: only
      `interface`'s `name` field changed in each, nothing else
- [ ] `check_asset_urls.py` not run (no URL/image touched)
- [ ] Not rebuilt with the actual `npm run build` (no Node toolchain
      available this session) — the change is two JSON string fields, no
      code touched

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543624727355068486): "Because of the reorg of the frame/top and bottom interface documentation it's also worth checking the groupings in the parts calculator as they don't line up nicely with this."**
