### PR TITLE
docs: fix Chute review findings

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -35,17 +35,17 @@ One chute is the chute core plus four things that bolt onto it:
 - **Door module**, one per chute: the door, the bearing assembly, the servo adapter and the servo in its bracket, built as a unit. See [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}).
 - **Funnel bracket (left)** and **Funnel bracket (right)**, one of each. See [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
 - **Layer connector A** and **Layer connector B**, one of each. See [Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
-- **Layer adapter board**, one per chute. See [PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}).
+- **Layer adapter board**, one per chute. See [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}).
 
 Every screw on this page lands in one of the chute core's own M3 heat inserts. Nothing here taps into bare plastic.
 
 {% include step.html n="1" title="Preparation" %}
 
-Press the heat inserts into the chute core before anything is mounted to it. Once the funnel brackets and the door module are on, several of the insert positions are hard to reach with an iron. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+Press the heat inserts into the chute core before you mount anything else onto it. Once the funnel brackets and the door module are on, several of the insert positions are hard to reach with an iron. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page. 2 for the servo bracket arms, 4 for the layer adapter board, and the rest for the funnel brackets, the bearing assembly and the layer connectors.</p>
+    <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page: 4 for the funnel brackets, 6 for the door module (4 for its two bearing covers, 2 for the servo bracket arms), 4 for the layer connectors, and 4 for the layer adapter board. This is separate from the bearing assembly's own 10 inserts, which live in the bearing race and holders themselves.</p>
     <p>All 18 are the same pocket, Ø4.2 mm and blind, 5.7 mm deep, split <strong>8 + 6 + 4</strong> across three faces. The views are rendered from the chute core STL, turned slightly off each face so the pockets shade as holes, and circle only the pockets visible in that view.</p>
   </div>
   <div class="prep-item-figure prep-item-figure-split">
@@ -69,12 +69,12 @@ Press the heat inserts into the chute core before anything is mounted to it. Onc
 Fit them in this order: the funnel brackets, the door module, the layer connectors, then the layer adapter board. Each has its own page for the procedure. What follows is the one thing those pages do not repeat, which screw goes into which insert, worked out from the STLs by comparing each mating part's wall thickness at its screw hole against the core's blind 5.70 mm pockets.
 
 - **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**, left and right: 4 × {% include fastener.html size="M3" variant="countersunk" length="12" %}, 2 per bracket. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the insert and an 8 mm one would not reach it at all.
-- **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**, bolted on as a unit: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, 2 per cover into 5.00 mm of wall, plus 2 × {% include fastener.html size="M3" variant="countersunk" length="12" %} for the servo bracket arms.
+- **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**, bolted on as a unit: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, 2 per cover into 5.00 mm of wall, plus 2 × {% include fastener.html size="M3" variant="countersunk" length="12" %} for the servo bracket arms. (The 12 mm figure is inferred by elimination, not measured: no STL exists for that joint, so check fit before committing.)
 - **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** A and B: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %}, 2 per connector. The strap is 3.78 mm thick, so an 8 mm screw reaches 4.22 mm in and stops 1.5 mm short of the pocket bottom, while a 12 mm screw would bottom out before the head seated.
 - **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**: 4 × {% include fastener.html size="M3" variant="socket-button" length="6" %} on the four inserts in the rear face, the only ones of this head type on the chute. They are in that page's parts list, not this one.
 
-That accounts for all 14 countersunk screws in the list above, 6 twelves and 8 eights. The servo-bracket row is the only one nothing published confirms: no STL sits on those two inserts, so 12 mm is by elimination from the other three rather than measured.
+That accounts for all 14 countersunk screws in the list above, 6 twelves and 8 eights.
 
-<div class="img-placeholder">Image coming</div>
+<div class="img-placeholder">Photo of a finished chute core with all four sub-assemblies bolted on: funnel brackets, door module, layer connectors and layer adapter board.</div>
 
 The chute is complete when all four are on. Repeat for every layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -55,7 +55,11 @@ parts_needed:
     qty: 16
 ---
 
-The door module is the moving half of the chute. It is built on the bench as one unit and then bolted to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}). One per chute, so one per layer.
+The door module is the moving half of the chute. Build it on the bench as one unit, then bolt it to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}). One per chute, so one per layer.
+
+The door pivots on two bearings held in the bearing assembly. The MG995 servo, coupled through the two-piece servo adapter, swings it between its open and closed positions, and the layer's [layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) controls when it opens, releasing the part only once the right bin has rotated underneath the funnel.
+
+Three of the four sub-assemblies below have no assembly steps written yet: the door, the bearing assembly and the servo adapter. Only the servo bracket (steps 2 and 3) comes from a real build. Build the other three from the parts themselves, and correct this page as you go. The fastener counts below are accurate even though the order of operations for those three isn't written down.
 
 The fasteners and quantities are in the parts list above and are called out inline at each step.
 
@@ -64,13 +68,13 @@ The fasteners and quantities are in the parts list above and are called out inli
 Four things make it up:
 
 1. **Chute door**. The flap itself, one printed part.
-2. **Bearing assembly**. What the door swings on: the Bearing race, a Bearing holder (left) and a Bearing holder (right), a Bearing cover (covered side) and a Bearing cover (servo side), and two 6704-2RS bearings.
+2. **Bearing assembly**. What the door swings on: the bearing race, a bearing holder (left) and a bearing holder (right), a bearing cover (covered side) and a bearing cover (servo side), and two 6704-2RS bearings.
 3. **Servo adapter**. Two printed parts, a servo side and a flap side, that couple the servo's output to the door. The MG995 Servo Horn that comes with the servo is clasped between the two halves, then the halves are screwed together around it: 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws, driven through the flap side (it's the half with the visible screw holes) into the servo side. No heat inserts, the screws thread directly into the printed plastic.
 4. **MG995 servo** in its four-part bracket: a housing, a lower arm, a side arm and a cover. Built on the bench, in the steps below.
 
 **What each fastener is for.** The list above gives totals for the whole module; this is the split:
 
-- **Bearing assembly, its own:** 10 {% include fastener.html size="M3" variant="heat-insert" %} (4 in the race, 3 in each holder) and 10 {% include fastener.html size="M3" variant="countersunk" length="8" %}. Six hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each.
+- **Bearing assembly, its own:** 10 {% include fastener.html size="M3" variant="heat-insert" %} (4 in the race, 3 in each holder) and 10 {% include fastener.html size="M3" variant="countersunk" length="8" %}. Six hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each. The two 6704-2RS bearings are sealed on both sides (that's what "2RS" means), so they're symmetric: there's no wrong way round to seat them. The covers are thin printed plastic, so snug their screws down evenly rather than fully tightening one before the others.
 - **Servo adapter, its own:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %}, no heat inserts. They hold the servo-side and flap-side halves together with the MG995 Servo Horn clasped between them.
 - **Servo bracket, its own:** 6 {% include fastener.html size="M3" variant="heat-insert" %} in the housing, 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} for the arms, and 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the servo's mounting ears.
 - **Holding the finished module to the chute core:** not in the list above at all. Those screws come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s own set and are counted on that page.
@@ -145,13 +149,11 @@ The servo adapter takes no inserts, but assemble it here anyway, before the brac
 
 The views are rendered from each part's STL, turned slightly off the face so the pockets shade as holes, and circle only the pockets visible from that angle. The counts match what the [parts calculator](https://parts-calculator.basically.website/assembly?focus=flap-module) asks for: 6 + 4 + 3 + 3.
 
-**Steps 2 and 3 build the servo bracket on the bench.** The bearing assembly, the door and the servo adapter have no steps written yet, so build those from the parts themselves and correct this page as you go.
-
 {% include step.html n="2" title="Seat the servo in its bracket housing" %}
 
 Drop the MG995 into the housing and fasten it with 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the servo's own mounting ears.
 
-Clock the horn before you commit to a position. The servo only rotates 180° and the door has to reach both of its positions inside that range; the video at the end of this page shows how it is set.
+Clock the horn before you commit to a position: center the servo (or let it settle at its power-on default), fit the horn at roughly the middle of the door's swing, then fine-tune once the module is mounted and you can check both open and closed by eye. The servo only rotates 180° and the door has to reach both of its positions inside that range; the video at the end of this page shows how it is set.
 
 <div class="img-placeholder">Photo of the MG995 seated in the bracket housing, held by its two mounting-ear screws, with the horn already clocked to a known position before the arms go on</div>
 
@@ -172,7 +174,7 @@ The servo output then couples to the door through the two-piece servo adapter, s
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>The MG995 only rotates 180°. Install the servo so the door can reach <strong>both</strong> its fully open and fully closed positions inside that range: clock the horn and set the mounting angle so neither extreme falls outside the servo's travel.</p>
+  <p>The MG995 only rotates 180°. Install the servo so the door can reach <strong>both</strong> its fully open and fully closed positions inside that range: clock the horn and set the mounting angle so neither extreme falls outside the servo's travel. Before you tighten anything down, cycle the door by hand through both positions to confirm it swings freely and doesn't bind on the bearings or the core.</p>
 </div>
 
 <figure class="video-figure">

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -57,7 +57,7 @@ parts_needed:
 
 The door module is the moving half of the chute. Build it on the bench as one unit, then bolt it to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}). One per chute, so one per layer.
 
-The door pivots on two bearings held in the bearing assembly. The MG995 servo, coupled through the two-piece servo adapter, swings it between its open and closed positions, and the layer's [layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) controls when it opens, releasing the part only once the right bin has rotated underneath the funnel.
+The door pivots on two bearings held in the bearing assembly. The MG995 servo, coupled through the two-piece servo adapter, swings it between its open and closed positions, and the layer's [layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) controls when it opens, releasing the part only once the chute stack has rotated the funnel into position over the right bin.
 
 Three of the four sub-assemblies below have no assembly steps written yet: the door, the bearing assembly and the servo adapter. Only the servo bracket (steps 2 and 3) comes from a real build. Build the other three from the parts themselves, and correct this page as you go. The fastener counts below are accurate even though the order of operations for those three isn't written down.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -40,7 +40,7 @@ The size is chosen per layer rather than once for the whole machine, and it sets
 - **Funnel (half size):** 12 bins on that layer, six Bin (half, left) and six Bin (half, right).
 - **Funnel (third size):** 18 bins on that layer, six each of Bin (third, left), Bin (third, center) and Bin (third, right-back).
 
-Decide before printing, since it changes both the funnel and the bin set. The [parts calculator](https://parts-calculator.basically.website/) takes a size per layer and totals the print for whatever mix you pick.
+Decide before printing: the funnel and its bin set are a matched pair. A half-size funnel needs the six-and-six half bins, a third-size funnel needs the three-way third bins, and picking one without the other leaves you short on prints or with bins that don't fit under that funnel. The [parts calculator](https://parts-calculator.basically.website/) takes a size per layer and totals the print for whatever mix you pick.
 
 {% include step.html n="2" title="Fit the funnel brackets to the chute core" %}
 
@@ -48,8 +48,8 @@ Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of
 
 Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. Why 12 mm and not 8 is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, along with the rest of the split.
 
-<div class="img-placeholder">Image coming</div>
+<div class="img-placeholder">Photo of both funnel brackets fitted to the chute core.</div>
 
 {% include step.html n="3" title="Hang the funnel" %}
 
-How the funnel itself attaches to the brackets is not recorded yet.
+The funnel's connection to the brackets isn't documented yet. There's no confirmed fastener or clip method. If you get this far, please share how yours attaches so this step can be filled in.

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -5,7 +5,7 @@ type: landing
 section: hardware
 slug: assembly-chute
 kicker: Distribution — Chute
-lede: The rotating chute that aims parts at the correct bin.
+lede: The chute that drops each part into the correct bin as the bin ring rotates underneath it.
 permalink: /hardware/assembly/distribution/chute/
 author: spencer
 contributors: [alex, brickcyclealice]
@@ -20,11 +20,13 @@ warning: >-
 
 The chute is one per layer. Build the core first, since everything else bolts into its heat inserts.
 
+The chute itself doesn't rotate: it's the bin ring below it that turns on the Lazy Susan. Each chute's door opens for a moment when the correct bin has rotated into position under its funnel, dropping the part in; see [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}) and [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) for how that opening is driven and timed.
+
 1. **[Chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})**. The printed body everything else mounts to, and the 18 heat inserts that hold it all together.
 2. **[Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**. The funnel that guides parts into the bin, and the two brackets it hangs from. Its size decides that layer's bin set, so pick it before printing.
 3. **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**. The door itself, the bearing assembly it swings on, the servo adapter, and the MG995 servo that drives it. Built as a unit, then bolted on.
 4. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})**. The pair that joins this layer's chute to the one below.
-5. **[PCB]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**. The layer adapter board that drives the servo.
+5. **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**. The board that drives the servo.
 
 ## Installing the chutes in the machine
 
@@ -38,7 +40,9 @@ Building it upside down helps here: each layer's vertical screws can be driven *
 
 {% include step.html n="2" title="Add the chutes one at a time" %}
 
-Once the frame is finished, add the chutes one after another, not one per layer as you build the frame up. Each chute goes in as a complete unit, the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) with its own parts already attached. The [layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}) join each chute to the one below it, so add the chutes in order rather than skipping around.
+Once the frame is finished, add the chutes one at a time, in layer order. Each chute goes in as a complete unit, the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) with its own parts already attached. The [layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}) join each chute to the one below it, so working through the layers in order matters more than which direction you start from.
+
+Plug each chute's ribbon cable in before you slot it into the frame if the harness is easier to reach on the bench; see [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) for the connector.
 
 {% include step.html n="3" title="Leave the funnels off" %}
 
@@ -46,6 +50,6 @@ Add the chutes **without their funnels**. Nobody has said yet when the funnels s
 
 {% include step.html n="4" title="Bottom Lazy Susan, then the feeder" %}
 
-The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) and its Lazy Susan go on after the chutes. The [feeder]({{ '/hardware/assembly/feeder/' | relative_url }}) goes on last. This last part is based on how BrickCycleAlice and alex both built their machines.
+The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) and its Lazy Susan go on after the chutes, and the [feeder]({{ '/hardware/assembly/feeder/' | relative_url }}) goes on last. Both BrickCycleAlice and alex built their machines in this order.
 
 If you built yours in a different order, let us know. This is how one person built their machine, not an official method everyone has to follow.

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -5,7 +5,7 @@ type: landing
 section: hardware
 slug: assembly-chute
 kicker: Distribution — Chute
-lede: The chute that drops each part into the correct bin as the bin ring rotates underneath it.
+lede: The rotating chute that aims parts at the correct bin.
 permalink: /hardware/assembly/distribution/chute/
 author: spencer
 contributors: [alex, brickcyclealice]
@@ -20,7 +20,7 @@ warning: >-
 
 The chute is one per layer. Build the core first, since everything else bolts into its heat inserts.
 
-The chute itself doesn't rotate: it's the bin ring below it that turns on the Lazy Susan. Each chute's door opens for a moment when the correct bin has rotated into position under its funnel, dropping the part in; see [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}) and [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) for how that opening is driven and timed.
+The whole chute stack rotates as one unit, on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s Lazy Susan, driven by the stepper motor and gear train described there. The bins themselves don't move; each chute's door opens for a moment once it's rotated into position over the correct bin, dropping the part in. See [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}) and [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) for how that opening is driven and timed.
 
 1. **[Chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})**. The printed body everything else mounts to, and the 18 heat inserts that hold it all together.
 2. **[Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**. The funnel that guides parts into the bin, and the two brackets it hangs from. Its size decides that layer's bin set, so pick it before printing.

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -27,7 +27,7 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 {% include fastener-legend.html %}
 
-- **How many:** 1 of each per distribution layer, plus 1 of each for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) and 1 of each for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}).
+- **How many:** 1 of each per distribution layer, plus 1 of each for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) and 1 of each for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}). For an N-layer machine, that's N + 2 pairs total.
 - **Screws:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per connector, 4 for the pair. They come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s set of 8 and are not extra, so they are on that page's parts list rather than this one.
 - Both connectors go into the chute core's M3 heat inserts.
 
@@ -35,12 +35,12 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 Both connectors fasten to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}), into its M3 heat inserts.
 
-Each connector takes 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flat strap between its two end blocks.
+Each connector takes 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flat strap between its two end blocks, but don't fully tighten them yet: step 2 covers checking the alignment first.
 
 The strap is countersunk 90° on its outer face, so the head sits flush. Why 8 mm and not 12 is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page with the rest of the split.
 
-<div class="img-placeholder">Image coming</div>
+<div class="img-placeholder">Photo of both layer connectors screwed to the chute core.</div>
 
 {% include step.html n="2" title="Check the alignment against the layer below" %}
 
-Build the layers up first and check that A on one layer lines up with B on the layer below before tightening. Nothing here is adjustable once the tower is stacked.
+Build the layers up first and check that A on one layer sits flush against B on the layer below, with no visible gap or twist between the two straps, before tightening either one down. Nothing here is adjustable once the tower is stacked.

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -35,7 +35,12 @@ Nothing to press in here. The four inserts the board sits on are pressed into th
 
 {% include step.html n="2" title="Screw the board onto the chute core" %}
 
-Handle the board by its edges and avoid touching the connectors or components directly. Seat it over the four inserts and fasten it with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. Do not overtighten, the board is standing on printed plastic, not a metal standoff.
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Static caution: this is a bare board. Touch a grounded metal surface before handling it, and handle it by its edges, avoiding the connectors and components.</p>
+</div>
+
+Seat it over the four inserts and fasten it with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. Do not overtighten, the board is standing on printed plastic, not a metal standoff.
 
 <div class="img-placeholder">Photo of the layer adapter board seated on its four inserts and screwed to the chute core.</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: PCB
+title: Layer adapter board
 type: how-to
 section: hardware
 slug: assembly-pcb
-kicker: Chute — PCB
+kicker: Chute — Layer adapter board
 lede: The board that drives the servo.
 permalink: /hardware/assembly/distribution/chute/pcb/
 author: spencer
@@ -35,10 +35,10 @@ Nothing to press in here. The four inserts the board sits on are pressed into th
 
 {% include step.html n="2" title="Screw the board onto the chute core" %}
 
-Seat the board over the four inserts and fasten it with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. Do not overtighten, the board is standing on printed plastic.
+Handle the board by its edges and avoid touching the connectors or components directly. Seat it over the four inserts and fasten it with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. Do not overtighten, the board is standing on printed plastic, not a metal standoff.
 
-<div class="img-placeholder">Image coming</div>
+<div class="img-placeholder">Photo of the layer adapter board seated on its four inserts and screwed to the chute core.</div>
 
 {% include step.html n="3" title="Connect the ribbon cable" %}
 
-The board takes the ribbon connection that chains this layer to the control board. How the layers chain is covered under [electronics]({{ '/hardware/electronics/' | relative_url }}) and in the [WireViz drawings]({{ '/hardware/electronics/wireviz/' | relative_url }}).
+Plug the ribbon cable into the board's connector before you install the chute into the frame if the harness is easier to reach on the bench beforehand. Full harness routing is covered under [electronics]({{ '/hardware/electronics/' | relative_url }}) and in the [WireViz drawings]({{ '/hardware/electronics/wireviz/' | relative_url }}).

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -49,7 +49,7 @@ sections:
                     url: /hardware/assembly/distribution/chute/door-module/
                   - title: Layer connectors
                     url: /hardware/assembly/distribution/chute/layer-connectors/
-                  - title: PCB
+                  - title: Layer adapter board
                     url: /hardware/assembly/distribution/chute/pcb/
           - title: Feeder
             url: /hardware/assembly/feeder/


### PR DESCRIPTION
Fixes the editorial review findings for the Chute landing page and its five sub-pages (chute core, door module, funnel, layer connectors, PCB/layer adapter board).

## What changed

- **Chute (index)**: added the sorting mechanism explanation (the whole chute stack rotates as one unit on the top interface's Lazy Susan; bins are fixed), deduplicated the "don't build chutes into layers" instruction, clarified the "This last part" reference, and noted when to connect each chute's ribbon cable.
- **Chute core**: clarified that the core's 18 inserts are separate from the bearing assembly's own 10 (previously easy to read as the same set), moved the inferred 12mm servo-bracket screw length next to where it's first used instead of burying it at the end of the section, fixed passive phrasing, and gave the placeholder image a caption.
- **Door module**: added the door's mechanism up front (bearings, servo, PCB timing), moved the "no assembly steps written for 3 of 4 sub-assemblies" disclosure before the fastener breakdown instead of after (previously the reader hit detailed fastener counts first, implying steps existed), fixed inconsistent capitalization of part names in running prose, noted the 6704-2RS bearings are sealed on both sides so they're symmetric (no orientation to get wrong), added a snug-don't-overtighten note for the bearing covers, explained what "clock the horn" actually means instead of relying entirely on the embedded video, and added a dry-fit check for the door's swing before final tightening.
- **Funnel**: stated plainly that funnel size and bin set are a matched pair (previously just said it "changes both"), gave the placeholder image a caption, and reworded the unrecorded funnel-attachment step to ask builders to share how theirs attaches.
- **Layer connectors**: gave a concrete pass/fail for "lines up" (flush, no visible gap or twist), tied the "don't fully tighten yet" warning directly to the fastening step instead of leaving it to a separate step with no cross-reference, added the N+2 total connector pairs for an N-layer machine, and gave the placeholder image a caption.
- **PCB → Layer adapter board**: renamed the page's title/kicker from "PCB" to "Layer adapter board" to match how every other page on the site refers to it (and updated the two cross-page link labels plus the nav.yml sidebar entry to match), added handling guidance for the bare board, gave a concrete answer for ribbon-cable timing (connect it before installing the chute into the frame if the harness is easier to reach on the bench), and gave the placeholder image a caption.

## Two findings checked and left alone

The review flagged two things that don't actually hold up once checked against the rendered site, so I didn't touch them:

- `funnel-half`/`funnel-third` already have no `qty` and a catalog `caption` instead ("For a layer of 12 half bins" etc.) — that's the established fix for an either/or part from sorter-v2#409, and adding `qty: 1` back (as the review suggested) would misrepresent that both are needed.
- `layer-connector-1`/`layer-connector-2` already render as "Layer connector A"/"Layer connector B" on the page, via the catalog's own `name` field (`Requirements.svelte` shows `part.name`, not the raw id), matching the body prose. No mismatch a reader would actually see.

Verified with a full local `npm run build` (Node 20, clean), `validate_frontmatter.py`/`validate_images.py` (no new errors), and grepped the built HTML for each changed string.

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543523992437137518): "Review: Chute / Collecting all review findings regarding Chute and the pages below from here [...] and let's start to work on those findings."

## Correction (barthel caught this)

The first version of this PR had the rotation mechanism backwards: it said the chute is stationary and a "bin ring" rotates underneath it. That's wrong, and it came from an unverified purpose/structure suggestion in the review rather than checking the existing pages. `top-interface.md` and `bottom-interface.md` both already describe the real mechanism: the whole chute stack rotates as one unit, stepper-driven through a gear train, on the Lazy Susan at the top interface; there's no separate "bin ring." Restored the original "rotating chute" lede and fixed the two mechanism sentences (chute index.md and door-module.md) that had it backwards.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543626298956447756
request: https://discord.com/channels/1430279849171222682/1543626298956447756/1543630909046128701
request: https://discord.com/channels/1430279849171222682/1543626298956447756/1543835198158798908
preview: /hardware/assembly/distribution/chute/
-->

