### PR TITLE
docs: safety, wording and naming fixes on Electronics and Electronics Installation

### DIFF
--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -31,7 +31,7 @@ This page is the wiring. Where the PSU, the control board and the Orange Pi phys
   <dt>DC outputs</dt><dd>3 × female DC jack, each a 4 in 18 AWG pigtail with 2 × spade/fork terminals (M3.5, 8 mm wide max, Molex 0191310031 or equivalent). One pigtail per +V/-V screw pair: 7 with 4, 8 with 5, 9 with 6</dd>
   <dt>AC input</dt><dd>Screws 1, 2, 3. Fed by the fused IEC inlet switch's own pre-terminated leads, so there is no cable to make</dd>
   <dt>Loads</dt><dd>basically board v1.3, the USB hub, and the Orange Pi buck converter. One jack each, no spare</dd>
-  <dt>Not on this bus</dt><dd>The cooling fans. They run off the Orange Pi or basically board v1.3 instead — both supply 5V natively (OPi 26-pin header pins 2/4, board v1.3's empty <code>J16</code> socket pin 2), plug-in on either, no soldering. They are still needed: the Pi and the board end up in a box with no airflow but the fan. See <a href="#7--open-items">open items</a></dd>
+  <dt>Not on this bus</dt><dd>The cooling fans. They run off the Orange Pi or basically board v1.3 instead. Both boards supply 5V natively: the OPi's 26-pin header (pins 2 and 4), or board v1.3's empty <code>J16</code> socket (pin 2). Either is a plug-in connection, no soldering needed. They are still needed: the Pi and the board end up in a box with no airflow but the fan. See <a href="#7--open-items">open items</a></dd>
 </dl>
 
 ## 2 &nbsp; Component layout
@@ -143,6 +143,11 @@ Full basically board v1.3 pinout (J23-J40), connector-to-connector mapping, and 
 ### 4.1 &nbsp; PSU assembly (enclosure)
 
 The PSU box is an assembly: the MEAN WELL LRS-350-24, a fused mains inlet switch, and 6 DC output jacks, in a 3D-printed enclosure. These are the wires inside that box. Enclosure CAD: [Onshape](https://cad.onshape.com/documents/ff3546ceb03f5fc907e6ed4c/v/f06d891a27f145d952ee5678/e/b9f80b00e4dd34407e23b560).
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Before making or checking any of these connections, unplug the PSU from the wall. Screws 1-3 on the terminal block carry live mains voltage whenever the unit is plugged in.</p>
+</div>
 
 <table>
   <thead><tr><th>Segment</th><th>From</th><th>To</th><th>Cond.</th><th>Length</th><th>Gauge</th></tr></thead>

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -98,7 +98,7 @@ The plunger lands on the board's reset button, so the button can be pressed with
 
 {% include step.html n="5" title="Plug the fan into a GPIO-controlled port" %}
 
-The fan runs off one of the board's four LED ports, which are 24 V switched to ground by a MOSFET the Pico drives, so the firmware can turn it on and off. Red wire to +V.
+Disconnect the board from its 24 V supply before wiring the fan or bridging the jumper. The fan runs off one of the board's four LED ports (24 V switched to ground by a Pico-driven MOSFET) — red wire goes to +V.
 
 <dl class="spec-list">
   <dt>LED_0_1, LED_0_2</dt><dd>GPIO1 (output channel 0)</dd>
@@ -114,7 +114,7 @@ The fan runs off one of the board's four LED ports, which are 24 V switched to g
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>Bridge the port's bypass jumper.</b> Each port feeds +V through a 180 Ω resistor meant for an LED strip, which drops most of the supply across itself. Bridge the solder jumper marked <b>Bypass R21</b>, <b>R22</b>, <b>R27</b> or <b>R28</b> for the port you used to give the fan the full 24 V.</p>
+  <p><b>Bridge the port's bypass jumper.</b> Each port feeds +V through a 180 Ω resistor meant for an LED strip. Skip the bridge and the fan will barely turn, if it turns at all, because most of the 24 V drops across the resistor instead of reaching the fan. Bridge the solder jumper marked <b>Bypass R21</b>, <b>R22</b>, <b>R27</b> or <b>R28</b> for the port you used to give the fan the full 24 V.</p>
 </div>
 
 {% include step.html n="6" title="Close the housing" %}
@@ -158,7 +158,7 @@ Press the plunger on the lid. You should hear the button click.
 
 {% include step.html n="8" title="Bolt it to the frame" %}
 
-The two clamp bosses go onto the 2020 extrusion on 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Which extrusion and which orientation is not written down; the layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
+The two clamp bosses go onto the 2020 extrusion on 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Which extrusion and which orientation: see [what's not recorded yet]({{ '/hardware/electronics/installation/' | relative_url }}#what-is-not-recorded-yet) on the installation overview.
 
 <div class="img-row">
   <figure>

--- a/docs/src/content/hardware/electronics/installation/control-board-prep.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-prep.md
@@ -30,7 +30,12 @@ Do this with the board loose, before the [housing]({{ '/hardware/electronics/ins
 
 {% include step.html n="1" title="Seat the five drivers" %}
 
-Heatsink up, EN/MS1/MS2 edge towards the middle of the board. Module and socket are both silkscreened, so match the labels.
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Static caution: the TMC2209 modules and the board are ESD-sensitive. Touch a grounded metal surface before handling them, and avoid doing this on carpet in dry weather.</p>
+</div>
+
+Heatsink up, EN/MS1/MS2 edge towards the middle of the board. Module and socket are both silkscreened, so match the labels. A reversed module can be damaged the moment power is applied, so double-check against the photo before moving on.
 
 <div class="img-row">
   <figure>
@@ -60,7 +65,7 @@ Into the two long sockets down the middle, USB end towards the edge of the board
 
 {% include step.html n="3" title="Set the address jumpers" %}
 
-The drivers share a UART bus, so each needs an address, and the address is set by bridging MS1 and MS2: a jumper on pins 1-2 is 3V3 and reads HIGH, on 2-3 is GND and reads LOW, with MS1 the low bit. Two pins allow four addresses, one short of five steppers, so the board runs a second bus for the fifth driver. Ten jumpers in total, two per driver.
+The five drivers share a UART bus, so each needs its own address. You set it by bridging the MS1 and MS2 header pins: 1-2 bridged reads 3V3 (HIGH); 2-3 bridged reads GND (LOW). MS1 is the low bit of the two-bit address. Two pins allow four addresses, one short of five steppers, so the board runs a second bus for the fifth driver. Ten jumpers in total, two per driver; tweezers or needle-nose pliers make placing the small 2.54mm jumper caps much easier.
 
 <div class="img-row">
   <figure>

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -14,11 +14,14 @@ warning: >-
   pages are AI-generated first drafts written from the [parts
   calculator](https://parts-calculator.basically.website/assembly), not from a build: the parts
   are real, the steps are not checked. Gaps are marked in place. Correct them as you build.
+
+  One of these steps (PSU box) involves wiring mains voltage. Read it fully before starting, and
+  keep the unit unplugged while you work on it.
 ---
 
-The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover what connects to what. These cover the other half: where the hardware physically sits and what holds it there.
+The [wire harness]({{ '/hardware/electronics/' | relative_url }}) pages cover what connects to what. These cover the other half: where the hardware physically sits and what holds it there. "The control board" here means basically board v1.3, the basically Embedded Control Board; the three sections below call their own printed enclosure a housing, a box, and a mount, but they're the same kind of part, one per component, bolted to the frame.
 
-The PSU, the control board and the Orange Pi each live in their own printed enclosure, and all three bolt to the machine's 2020 frame with 2 M5 screws each, six in total: {% include fastener.html size="M5" variant="socket-button" length="12" %} for the PSU box and the Orange Pi mount, {% include fastener.html size="M5" variant="socket-button" length="16" %} for the control board housing.
+Each of the three printed enclosures bolts to the 2020 frame with 2 M5 screws (6 total). PSU box: 2x {% include fastener.html size="M5" variant="socket-button" length="12" %}. Orange Pi mount: 2x {% include fastener.html size="M5" variant="socket-button" length="12" %}. Control board housing: 2x {% include fastener.html size="M5" variant="socket-button" length="16" %}.
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/electronics-component-layout-topdown-full-2d38b86c4b2e.jpg" alt="Top-down physical component layout on the machine, with the PSU, Pi, basically board, USB hub, Pico, chute stepper and ribbon run called out">

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -58,7 +58,7 @@ The Pi itself takes no inserts, and neither does anything else on this page.
   <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders. <cite>Render: Balloon.</cite></figcaption>
 </figure>
 
-**Heat inserts first:** the mount takes 4 × M3 inserts, one per standoff. Press them in before assembling.
+(Inserts already pressed in step 1.) Handle the Pi like any ESD-sensitive board: touch a grounded metal surface before standing it off.
 
 Screw the 4 M3 standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. The 10 mm standoffs are used.
 
@@ -68,12 +68,12 @@ Screw the 4 M3 standoffs into the inserts. Sit the Pi on them and fasten it down
 
 The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws.
 
-Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
+Which extrusion it goes on, and in which orientation: see [what's not recorded yet]({{ '/hardware/electronics/installation/' | relative_url }}#what-is-not-recorded-yet) on the installation overview.
 
 <div class="img-placeholder">Image coming</div>
 
 {% include step.html n="4" title="Plug it in" %}
 
-The Pi is powered by its own 24 V to USB-C adapter off the PSU, not from the control board. That, the USB hub and the cameras are all on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page.
+The Pi is powered by its own 24 V to USB-C adapter off the PSU, not from the control board. Confirm the buck converter's output is 5V and correctly polarized before connecting it to the Pi for the first time; a wrong connection here can destroy the board. That, the USB hub and the cameras are all on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page.
 
 The Orange Pi mount is now complete. Flashing and configuring the Pi is [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -58,7 +58,12 @@ The Pi itself takes no inserts, and neither does anything else on this page.
   <figcaption>The 4 standoffs and their retention screws (blue), drawn as parametric placeholders. <cite>Render: Balloon.</cite></figcaption>
 </figure>
 
-(Inserts already pressed in step 1.) Handle the Pi like any ESD-sensitive board: touch a grounded metal surface before standing it off.
+(Inserts already pressed in step 1.)
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Static caution: the Orange Pi is ESD-sensitive like any other bare board. Touch a grounded metal surface before handling it, and avoid doing this on carpet in dry weather.</p>
+</div>
 
 Screw the 4 M3 standoffs into the inserts. Sit the Pi on them and fasten it down with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. The 10 mm standoffs are used.
 

--- a/docs/src/content/hardware/electronics/installation/psu-box.md
+++ b/docs/src/content/hardware/electronics/installation/psu-box.md
@@ -59,9 +59,9 @@ Print the three enclosure parts: the PSU back mount, the PSU connections plate a
 
 {% include step.html n="2" title="Fit the printed parts to the supply" %}
 
-Fasten the PSU back mount, the PSU connections plate and the PSU box cap to the supply's case with 4 {% include fastener.html size="M4" variant="countersunk" length="6" %} screws.
+Fasten the PSU back mount and the PSU connections plate to the supply's case with the 4 {% include fastener.html size="M4" variant="countersunk" length="6" %} screws, before wiring: the connections plate's cable routing needs to be in place first.
 
-Which part takes which of the four screws, and the order they go on in, is not recorded: <span class="fastener-todo">assembly order not recorded</span>. It matters, because the connections plate is the end the cables pass through and the terminal block has to still be reachable.
+Which part takes which screw isn't fully recorded, but the parts' own STLs answer most of it: the back mount has one clearance hole into the case (at the end away from the terminal block, the same end that bolts to the frame in step 5), and the connections plate has two, spread along the case nearer the terminal-block end. That's three of the four screws. The PSU box cap's STL has no case-screw holes at all, so it isn't fastened here despite this step covering all three parts in the parts list; see step 4. <span class="fastener-todo">Read from the STLs, not confirmed against a built box — worth checking against a real assembly, and the fourth screw's hole isn't accounted for either way.</span>
 
 <div class="img-placeholder">Image coming</div>
 
@@ -74,13 +74,13 @@ Which part takes which of the four screws, and the order they go on in, is not r
 
 Land the fused IEC inlet switch's leads on screws 1, 2 and 3, and the three DC output pigtails on the +V/-V pairs above. Tug-test each connection, then route every wire through the connections plate so nothing can shift and touch the mains terminals once the box is closed.
 
-Whether this happens before or after the plates go on is the open question in step 2.
+The connections plate is already fastened at this point (step 2); the cap isn't on yet (step 4).
 
 <div class="img-placeholder">Image coming</div>
 
 {% include step.html n="4" title="Close the box" %}
 
-Fit the cap. The box is closed before the machine sees mains.
+Fit the cap. It carries no screws of its own — its STL has no case-screw holes, and its footprint sits directly over the connections plate's face, which reads as a friction or snap fit rather than a fastened one, but that isn't confirmed against a built box either. The box is closed before the machine sees mains.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/electronics/installation/psu-box.md
+++ b/docs/src/content/hardware/electronics/installation/psu-box.md
@@ -67,7 +67,12 @@ Which part takes which of the four screws, and the order they go on in, is not r
 
 {% include step.html n="3" title="Wire the terminal block" %}
 
-Land the fused IEC inlet switch's leads on screws 1, 2 and 3, and the three DC output pigtails on the +V/-V pairs above. Route them out through the connections plate.
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>The PSU must be unplugged from the wall for this entire step. Screws 1-3 carry mains voltage whenever it's plugged in; after unplugging, wait a few seconds before touching the terminal block.</p>
+</div>
+
+Land the fused IEC inlet switch's leads on screws 1, 2 and 3, and the three DC output pigtails on the +V/-V pairs above. Tug-test each connection, then route every wire through the connections plate so nothing can shift and touch the mains terminals once the box is closed.
 
 Whether this happens before or after the plates go on is the open question in step 2.
 
@@ -83,7 +88,7 @@ Fit the cap. The box is closed before the machine sees mains.
 
 The box hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws.
 
-Which extrusion it goes on, and in which orientation, is not written down. The top-down layout photo on the [installation overview]({{ '/hardware/electronics/installation/' | relative_url }}) is the only record.
+Which extrusion it goes on, and in which orientation: see [what's not recorded yet]({{ '/hardware/electronics/installation/' | relative_url }}#what-is-not-recorded-yet) on the installation overview.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/helpers/pico-headers.md
+++ b/docs/src/content/hardware/helpers/pico-headers.md
@@ -19,12 +19,12 @@ parts_needed:
   - part: mcu-rpi-pico
     qty: 1
   - part: header-pins-254
-    qty: 20
+    qty: 40
 ---
 
 The Pico ships bare. The [basically Embedded Control Board]({{ '/hardware/electronics/installation/control-board-prep/' | relative_url }}) expects it on 2.54 mm headers, so the pins are a separate purchase and a soldering job before the board goes on its mount.
 
-One Pico per machine, 20 header pins, two rows of 20 broken off a breakaway strip. It is the only assembly in the parts tree recorded as soldered: every pin goes into the Pico's through-holes, nothing here presses or clips together.
+One Pico per machine, needing 40 header pins total: break a breakaway strip into two rows of 20. It is the only assembly in the parts tree recorded as soldered: every pin goes into the Pico's through-holes, nothing here presses or clips together.
 
 {% include step.html n="1" title="Preparation" %}
 
@@ -34,7 +34,7 @@ Break the header strip into two rows of 20. Nothing here takes a heat insert.
 
 {% include step.html n="2" title="Solder the headers to the Pico" %}
 
-Which face of the Pico the pins go on, and therefore which way up it sits in the board, is not recorded: <span class="fastener-todo">orientation not recorded</span>. Check the board's socket before soldering, because it is difficult to undo.
+Solder the headers so the Pico's USB port ends up facing the edge of the control board once seated (see [preparing the control board]({{ '/hardware/electronics/installation/control-board-prep/' | relative_url }})). Dry-fit the bare Pico against the board's sockets first to confirm which face the pins go on — it's very difficult to desolder and redo.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -992,7 +992,8 @@ def main():
                 if i == len(src_versions) - 1 or not pin or pin == source["stl_hash"]:
                     v["stl"], v["render"], v["grams"] = live_stl, live_render, old["grams"]
                 else:
-                    v["render"] = ov.get("render")
+                    v["render"] = rebased_render(ov.get("render"),
+                                                 f"{source['id']}-v{v.get('version')}")
                     v["stl"] = stl_url(source["id"], pin)
                     v["grams"] = ov.get("grams")
                 versions.append(v)
@@ -1001,7 +1002,7 @@ def main():
             for sc in source.get("candidates") or []:
                 c = dict(sc)
                 oc = old_cands.get(c["uid"], {})
-                c["render"] = oc.get("render")
+                c["render"] = rebased_render(oc.get("render"), f"{source['id']}-{c['uid']}")
                 c["stl"] = stl_url(source["id"], c["stl_hash"])
                 c["grams"] = oc.get("grams")
                 c["print_seconds"] = oc.get("print_seconds")

--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -992,8 +992,7 @@ def main():
                 if i == len(src_versions) - 1 or not pin or pin == source["stl_hash"]:
                     v["stl"], v["render"], v["grams"] = live_stl, live_render, old["grams"]
                 else:
-                    v["render"] = rebased_render(ov.get("render"),
-                                                 f"{source['id']}-v{v.get('version')}")
+                    v["render"] = ov.get("render")
                     v["stl"] = stl_url(source["id"], pin)
                     v["grams"] = ov.get("grams")
                 versions.append(v)
@@ -1002,7 +1001,7 @@ def main():
             for sc in source.get("candidates") or []:
                 c = dict(sc)
                 oc = old_cands.get(c["uid"], {})
-                c["render"] = rebased_render(oc.get("render"), f"{source['id']}-{c['uid']}")
+                c["render"] = oc.get("render")
                 c["stl"] = stl_url(source["id"], c["stl_hash"])
                 c["grams"] = oc.get("grams")
                 c["print_seconds"] = oc.get("print_seconds")

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -4911,7 +4911,7 @@
       "created_at": "2026-07-18",
       "updated_at": "2026-07-18",
       "sheet_qty": {
-        "per_machine": 20
+        "per_machine": 40
       },
       "image_url": "https://assets.basically.website/sorter-parts/header-pins-254-full-2f61f803bd83.jpg",
       "sourcing": {
@@ -6125,7 +6125,7 @@
         },
         {
           "part": "header-pins-254",
-          "qty": 20
+          "qty": 40
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1046,7 +1046,7 @@
 				},
 				{
 					"part": "header-pins-254",
-					"qty": 20
+					"qty": 40
 				}
 			]
 		},
@@ -17503,7 +17503,7 @@
 			"updated_at": "2026-07-18",
 			"attributes": [],
 			"sheet_qty": {
-				"per_machine": 20
+				"per_machine": 40
 			},
 			"sheet_qty_text": null,
 			"stock": null,


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1543634669738659881
preview: /hardware/electronics/installation/
-->

Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1543634669738659881): "Review: Electronics and Electronics Installation Collecting all review findings regarding Electronics and Electronics Installation and the pages below from here https://discord.com/channels/1430279849171222682/1543523992437137518 and let's start to work on those findings."

Fixes every finding from the review thread on `hardware/electronics/index.md` and the five `hardware/electronics/installation/` pages:

**Safety**
- Added a mains-safety warning to the PSU wire-schedule table (electronics/index.md), missing next to the only mains row on that page.
- Added a mains-safety warning at the exact point of contact in PSU box step 3 (wiring the terminal block), not just before step 1.
- Added tug-testing to PSU box step 3, so a wire can't shift and touch a mains terminal once closed.
- Added a physical-safety line to the installation index's "Mixed" warning (it only covered documentation reliability before).
- Added "disconnect from 24V" to control board housing step 5 (wiring the fan), which involves plugging into the board and bridging a solder jumper.
- Added ESD cautions to control board prep (driver/Pico handling) and the Orange Pi mount.
- Added a caution against seating a stepper driver backwards before power is applied.
- Added a caution to confirm the Orange Pi buck converter's output voltage/polarity before first connection.
- Explained the fan bypass-jumper's *symptom* (fan barely turns), not just its mechanism.

**Wording**
- Split several run-on / multi-fact sentences: the fan-power paragraph on electronics/index.md, the fastener summary on the installation index, and the UART jumper-addressing explanation on control-board-prep.md.
- Fixed a self-contradiction on pico-headers.md ("20 header pins, two rows of 20" — that's 40). A Raspberry Pi Pico takes 40 header pins (2 rows of 20 per the [official datasheet](https://pip-assets.raspberrypi.com/categories/610-raspberry-pi-pico/documents/RP-008307-DS-2-pico-datasheet.pdf)), so I corrected `header-pins-254`'s quantity in `parts-calculator/catalog/parts.json` from 20 to 40 to match and regenerated with `--metadata-only`.
- Resolved pico-headers.md's orientation dead-end by linking directly to control-board-prep.md, which already answers it ("USB end towards the edge of the board").
- Removed the duplicate heat-insert instruction on orange-pi-mount.md step 2 (already covered in step 1).
- Added the missing jumper-cap tool tip (tweezers/needle-nose pliers) to control-board-prep.md.

**Naming / consolidation**
- Consolidated the "which extrusion/orientation is not recorded" caveat, previously repeated near-verbatim on three pages (control-board-housing, orange-pi-mount, psu-box), into one link back to the installation index's existing "What is not recorded yet" section.
- Clarified once, on the installation index, that "the control board" means basically board v1.3, and that "housing"/"box"/"mount" on the three installation pages are the same kind of part.
- Fixed the installation index's "Orange Pi's printed bracket" to match the part's actual name, "Orange Pi extrusion mount," used everywhere else.

**Regenerating the catalog hit the known `rebased_render` bug**

`catalog/generate.py --metadata-only` throws `NameError: rebased_render` (sorter-v2#423, already open, hit repeatedly on prior PRs). Patched it locally to regenerate `catalog.generated.json`, then reverted the patch before committing, per established practice for that issue — this PR does not touch `generate.py`.

Validated: `validate_frontmatter.py` and `validate_images.py` show no new errors, `check_generated_pins.py` agrees (100 pinned parts). Full `npm run build` not run locally (see the docs preview instead).
