### PR TITLE
parts-calculator: note that washer-m3-15 is unused

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3639,9 +3639,10 @@
       },
       "name": "M3 × 15 mm washer",
       "category": "Washers",
-      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
+      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md).",
       "created_at": "2026-08-18",
-      "updated_at": "2026-08-25",
+      "updated_at": "2026-08-30",
+      "note": "Unused as of 2026-08-30. Do not add a new joint to this washer — the idler gear joint it was meant for uses the printed chute stepper idler bearing retainers instead.",
       "attributes": [
         {
           "label": "Thread",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -15994,10 +15994,10 @@
 			},
 			"name": "M3 \u00d7 15 mm washer",
 			"category": "Washers",
-			"description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine.",
-			"note": null,
+			"description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md).",
+			"note": "Unused as of 2026-08-30. Do not add a new joint to this washer \u2014 the idler gear joint it was meant for uses the printed chute stepper idler bearing retainers instead.",
 			"created_at": "2026-08-18",
-			"updated_at": "2026-08-25",
+			"updated_at": "2026-08-30",
 			"attributes": [
 				{
 					"label": "Thread",


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1543649360905244752/1543650309958537376
preview: /u/phwe
-->

Requested by Uwe Barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543649360905244752/1543650309958537376): "Create a new pull request for adding the same note on the washer in the catalog as we did for the unused m3 screws."

## What

`washer-m3-15` was already flagged unused in its `description` (from PR #420), but it didn't carry the `note` field or the "kept because a minted uid has to stay resolvable" explanation that `scr-m3-tbd` (#453) and `scr-m3-shcs-tbd` (#454) got. This adds both, same wording pattern as those two, and bumps `updated_at`.

Tracked for deletion in #478.

- `parts-calculator/catalog/parts.json`: `washer-m3-15` gets a `note` field and an added sentence in `description`.
- `parts-calculator/src/lib/data/catalog.generated.json`: regenerated with `catalog/generate.py --metadata-only`.

## Aside

`generate.py --metadata-only` still throws `NameError: name 'rebased_render' is not defined` on main, same pre-existing bug flagged in PR #420 (a leftover from the #418 asset-service refactor). Patched it locally to produce this regeneration, then reverted the source change, since `catalog/generate.py` isn't mine to open a PR against. Still worth a real fix from someone with access: the two dead calls are `v["render"] = rebased_render(...)` and `c["render"] = rebased_render(...)`, both should become `= ov.get("render")` / `= oc.get("render")` the way the third call site above them already was.

