### PR TITLE
docs: move Soldering Pico headers into Helpers

### DIFF
--- a/docs/src/content/hardware/electronics/installation/control-board-prep.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-prep.md
@@ -19,7 +19,7 @@ parts_needed:
     qty: 10
 ---
 
-Do this with the board loose, before the [housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}). Solder the [Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }}) first.
+Do this with the board loose, before the [housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}). Solder the [Pico headers]({{ '/hardware/helpers/pico-headers/' | relative_url }}) first.
 
 <div class="img-row">
   <figure>

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -10,8 +10,8 @@ permalink: /hardware/electronics/installation/
 author: barthel
 contributors: [spencer]
 warning: >-
-  **Mixed.** The two control board pages come from a real build. The PSU box, Orange Pi mount
-  and Soldering Pico headers pages are AI-generated first drafts written from the [parts
+  **Mixed.** The two control board pages come from a real build. The PSU box and Orange Pi mount
+  pages are AI-generated first drafts written from the [parts
   calculator](https://parts-calculator.basically.website/assembly), not from a build: the parts
   are real, the steps are not checked. Gaps are marked in place. Correct them as you build.
 ---
@@ -25,11 +25,12 @@ The PSU, the control board and the Orange Pi each live in their own mount, and a
   <figcaption>Where everything sits, top-down. This render is currently the only record of the placement. <cite>Render: Spencer.</cite></figcaption>
 </figure>
 
-1. **[Soldering Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**: soldering the header pins so the Pico can seat in the control board. First, while the board is still loose.
-2. **[PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }})**: the printed enclosure around the Mean Well LRS-350-24.
-3. **[Preparing the control board]({{ '/hardware/electronics/installation/control-board-prep/' | relative_url }})**: the five stepper drivers, the Pico, and the jumpers that address the drivers.
-4. **[Control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }})**: the printed housing the board closes into, with its fan.
-5. **[Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }})**: Orange Pi 5 on standoffs.
+Solder the [Pico headers]({{ '/hardware/helpers/pico-headers/' | relative_url }}) first, a one-time prep step under [Helpers]({{ '/hardware/helpers/' | relative_url }}); the Pico won't seat in the control board without it. Then:
+
+1. **[PSU box]({{ '/hardware/electronics/installation/psu-box/' | relative_url }})**: the printed enclosure around the Mean Well LRS-350-24.
+2. **[Preparing the control board]({{ '/hardware/electronics/installation/control-board-prep/' | relative_url }})**: the five stepper drivers, the Pico, and the jumpers that address the drivers.
+3. **[Control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }})**: the printed housing the board closes into, with its fan.
+4. **[Orange Pi mount]({{ '/hardware/electronics/installation/orange-pi-mount/' | relative_url }})**: Orange Pi 5 on standoffs.
 
 Wiring follows on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page, then [software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}).
 

--- a/docs/src/content/hardware/helpers/index.md
+++ b/docs/src/content/hardware/helpers/index.md
@@ -13,5 +13,5 @@ contributors: [barthel]
 
 - **[Preparing the Lazy Susan]({{ '/hardware/helpers/lazy-susan/' | relative_url }})**
 - **[Preparing the 20-tooth timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }})**
-- **[Soldering Pico headers]({{ '/hardware/electronics/installation/pico-headers/' | relative_url }})**
+- **[Soldering Pico headers]({{ '/hardware/helpers/pico-headers/' | relative_url }})**
 - **[Installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }})**

--- a/docs/src/content/hardware/helpers/pico-headers.md
+++ b/docs/src/content/hardware/helpers/pico-headers.md
@@ -3,10 +3,10 @@ layout: default
 title: Soldering Pico headers
 type: how-to
 section: hardware
-slug: electronics-pico-headers
+slug: helper-pico-headers
 kicker: Helpers — Soldering Pico headers
 lede: Soldering 2.54 mm header pins to the Raspberry Pi Pico so it can seat in the control board.
-permalink: /hardware/electronics/installation/pico-headers/
+permalink: /hardware/helpers/pico-headers/
 author: barthel
 contributors: [spencer]
 warning: >-

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -100,7 +100,7 @@ sections:
           - title: Prepare timing pulley 20 tooth
             url: /hardware/helpers/pulley-gear-mod/
           - title: Soldering Pico headers
-            url: /hardware/electronics/installation/pico-headers/
+            url: /hardware/helpers/pico-headers/
           - title: Installing heat inserts
             url: /hardware/helpers/heat-inserts/
       - title: Parts

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6110,7 +6110,7 @@
       "version": "1",
       "name": "Pico with headers",
       "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare — the pins are a separate purchase.",
-      "docs": "/hardware/electronics/installation/pico-headers/",
+      "docs": "/hardware/helpers/pico-headers/",
       "status": "partial",
       "joining": [
         {

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1031,7 +1031,7 @@
 			"version": "1",
 			"name": "Pico with headers",
 			"description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare \u2014 the pins are a separate purchase.",
-			"docs": "/hardware/electronics/installation/pico-headers/",
+			"docs": "/hardware/helpers/pico-headers/",
 			"status": "partial",
 			"joining": [
 				{


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1543866032165355561/1543868427368931348
preview: /hardware/helpers/pico-headers/
-->
Moves "Soldering Pico headers" from `hardware/electronics/installation/` to `hardware/helpers/`, where it fits the pattern: one-time prep for a part before it's used elsewhere (same shape as heat inserts, the Lazy Susan prep, or the timing pulley mod), not a step in the installation build sequence. The sidebar already filed it under Helpers while its URL and file still lived under electronics/installation; this makes them agree.

Also drops it from the installation index's numbered "build in this order" list (it's a prerequisite, not a build step) and keeps the reference to it as a link, same as control-board-prep.md already did. Updated the nav URL and the parts-calculator catalog's `docs` pointer, and regenerated `catalog.generated.json`.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1543866032165355561/1543868427368931348): "Shouldn't we move this page to "Helpers," where other components are also being prepared?"**
