### PR TITLE
parts-calculator: flag chute stepper support block for possible deletion

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -346,6 +346,20 @@
           "scr-m3-shcs-tbd"
         ]
       }
+    },
+    {
+      "id": "review-chute-stepper-support-block-for-deletion",
+      "name": "Chute stepper support block may be deleted to cut part count",
+      "priority": "P4",
+      "description": "Basically wants to use as few parts as possible, and this printed block's own catalog note already flags its quantity as an unconfirmed default. It has no documented install location, orientation, or screw length anywhere, and lives in its own standalone Onshape document rather than the shared Interface Layer one. Someone with CAD/mechanical context needs to confirm the NEMA 23 chute stepper mount works without it before it can actually be dropped from the assembly and deleted. Tracked as sorter-v2 issue #483.",
+      "targets": {
+        "parts": [
+          "chute-stepper-support-block"
+        ],
+        "assemblies": [
+          "interface"
+        ]
+      }
     }
   ],
   "folders": [
@@ -2283,11 +2297,11 @@
       "id": "chute-stepper-support-block",
       "uid": "loc0",
       "name": "Chute stepper support block",
-      "description": "Support block for the chute stepper.",
+      "description": "Support block for the chute stepper. Flagged for possible removal to cut part count; not yet confirmed whether the mount needs it.",
       "internal_notes": "Interface part. Frame colour. Qty 1/machine is a DEFAULT pending confirmation.",
       "version": "1",
       "created_at": "2026-07-03",
-      "updated_at": "2026-07-03",
+      "updated_at": "2026-08-31",
       "quantities": {
         "interface": 1
       },
@@ -2299,7 +2313,8 @@
         "role": "frame"
       },
       "optional": false,
-      "support": false
+      "support": false,
+      "note": "Under review for deletion (sorter-v2#483). Basically wants to minimize part count. Its own qty is already an unconfirmed default, and it is undocumented anywhere on the docs site. Kept in the catalog until someone with CAD context confirms the NEMA 23 mount works without it."
     },
     {
       "id": "funnel-third",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -360,6 +360,20 @@
 					"scr-m3-shcs-tbd"
 				]
 			}
+		},
+		{
+			"id": "review-chute-stepper-support-block-for-deletion",
+			"name": "Chute stepper support block may be deleted to cut part count",
+			"priority": "P4",
+			"description": "Basically wants to use as few parts as possible, and this printed block's own catalog note already flags its quantity as an unconfirmed default. It has no documented install location, orientation, or screw length anywhere, and lives in its own standalone Onshape document rather than the shared Interface Layer one. Someone with CAD/mechanical context needs to confirm the NEMA 23 chute stepper mount works without it before it can actually be dropped from the assembly and deleted. Tracked as sorter-v2 issue #483.",
+			"targets": {
+				"parts": [
+					"chute-stepper-support-block"
+				],
+				"assemblies": [
+					"interface"
+				]
+			}
 		}
 	],
 	"folders": [
@@ -11500,10 +11514,10 @@
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
-			"description": "Support block for the chute stepper.",
+			"description": "Support block for the chute stepper. Flagged for possible removal to cut part count; not yet confirmed whether the mount needs it.",
 			"version": "1",
 			"created_at": "2026-07-03",
-			"updated_at": "2026-07-03",
+			"updated_at": "2026-08-31",
 			"versions": [
 				{
 					"version": "1",
@@ -11511,6 +11525,7 @@
 					"date": "2026-07-03",
 					"message": "Initial version.",
 					"commit": null,
+					"note": "Under review for deletion (sorter-v2#483). Basically wants to minimize part count. Its own qty is already an unconfirmed default, and it is undocumented anywhere on the docs site. Kept in the catalog until someone with CAD context confirms the NEMA 23 mount works without it.",
 					"stl": "https://assets.basically.website/sorter-parts/chute-stepper-support-block-106dec95fef1.stl",
 					"render": "https://assets.basically.website/sorter-parts/chute-stepper-support-block-full-8225afc29021.png",
 					"grams": 26.1


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1541669609936003124/1543880339980812288
request: https://discord.com/channels/1430279849171222682/1541669609936003124/1543880475112767518
preview: /parts?part=chute-stepper-support-block
-->

Basically wants to use as few parts as possible. `chute-stepper-support-block` is a good candidate: its own `internal_notes` already flagged its qty-1 as an unconfirmed default, it is undocumented anywhere on the docs site (no install location, orientation, or screw length recorded), and it lives in its own standalone Onshape document rather than the shared Interface Layer one the rest of that assembly's parts share.

This does **not** remove it from the `interface` assembly yet, since nobody has confirmed whether the NEMA 23 chute stepper mount actually holds up without it. Instead, same mechanism as the other pending catalog deletions (`scr-m3-tbd` #453, `scr-m3-shcs-tbd` #454, `washer-m3-15` #478):

- `parts.json`: added a `note` and updated `description` on the part itself, and a `changes` entry (`review-chute-stepper-support-block-for-deletion`, P4) so it carries a visible notice wherever it renders (dashboard, part page, the Interface assembly).
- Regenerated `catalog.generated.json` with `generate.py --metadata-only`.
- Filed [sorter-v2#483](https://github.com/basicallysource/sorter-v2/issues/483), tagged `bom`, tracking the actual removal once someone with CAD context confirms it's safe to drop.

Closed sorter-v2 #419 in favor of this: that PR was going to document installing this part, which no longer makes sense for a part on its way out. Its only other content (photo/video credits on the top-interface page) had already landed on `main` separately since #419 was opened, so nothing there was lost.

## Aside

`generate.py --metadata-only` still throws `NameError: name 'rebased_render' is not defined` on `main`, same pre-existing bug noted in #479 (a leftover from the #418 asset-service refactor, two dead calls to `rebased_render` that should be `ov.get("render")` / `oc.get("render")`). Patched it locally to regenerate, then reverted the source change, since `catalog/generate.py` isn't mine to open a PR against.

Requested by Uwe Barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1541669609936003124/1543880475112767518): "Da wir so wenig wie möglich Teile verwenden wollen, entferne dieses Teil aus dem part calculator bzw. markiere es als 'to delete' o.ä. erstelle die notwendigen PRs (rejecte oder widme #419 um) und notwendige gthub issues (tagged with BOM)."