### PR TITLE
parts-calculator: fix NameError in --metadata-only (rebased_render)

### DIFF
--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -992,8 +992,7 @@ def main():
                 if i == len(src_versions) - 1 or not pin or pin == source["stl_hash"]:
                     v["stl"], v["render"], v["grams"] = live_stl, live_render, old["grams"]
                 else:
-                    v["render"] = rebased_render(ov.get("render"),
-                                                 f"{source['id']}-v{v.get('version')}")
+                    v["render"] = ov.get("render")
                     v["stl"] = stl_url(source["id"], pin)
                     v["grams"] = ov.get("grams")
                 versions.append(v)
@@ -1002,7 +1001,7 @@ def main():
             for sc in source.get("candidates") or []:
                 c = dict(sc)
                 oc = old_cands.get(c["uid"], {})
-                c["render"] = rebased_render(oc.get("render"), f"{source['id']}-{c['uid']}")
+                c["render"] = oc.get("render")
                 c["stl"] = stl_url(source["id"], c["stl_hash"])
                 c["grams"] = oc.get("grams")
                 c["print_seconds"] = oc.get("print_seconds")


### PR DESCRIPTION
`catalog/generate.py --metadata-only` has crashed with `NameError: name 'rebased_render' is not defined` since #418, for any part with superseded versions or candidates. #418 deleted the nested `rebased_render` helper and converted one of its three call sites to use the stored render URL directly, but missed the other two.

This applies the same conversion to the remaining two call sites (versions and candidates), matching how `live_render` is already handled a few lines above — exactly the fix prescribed in #423.

Verified: `--metadata-only` now runs clean and leaves `catalog.generated.json` byte-identical (idempotent refresh, no data change), and `check_generated_pins.py` passes.

Fixes #423. Unblocks the patch-locally-and-revert workaround that #420, #422, #437, and #438 all had to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)