### PR TITLE
parts-calculator: finish the image-domain migration for the cable cage parts

### DIFF
--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -231,6 +231,10 @@ def render_url_for(stl_abs, hexcolor, out_png, force, prev_url=None):
     # itself. Fall through to the committed data, which does name the picture.
     if memo and not memo.startswith(ASSET_SERVICE + "/"):
         memo = None
+    # The committed data can name the retired store too (a branch generated
+    # before the migration, merged after it). Same rule: not an answer.
+    if prev_url and not prev_url.startswith(ASSET_SERVICE + "/"):
+        prev_url = None
     if not force and memo is None and prev_url:
         memo = prev_url
         os.makedirs(RENDER_META, exist_ok=True)

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -11,8 +11,8 @@
 		"density_g_cm3": 1.32,
 		"cost_per_kg": 24.99,
 		"commit_base_url": "https://github.com/basicallysource/sorter-v2/commit/",
-		"all_parts_zip": "https://assets.basically.website/sorter-parts/all-parts-3065dd935707.zip",
-		"all_parts_plain_zip": "https://assets.basically.website/sorter-parts/all-parts-plain-8b1c9c7ee9d3.zip"
+		"all_parts_zip": "https://assets.basically.website/sorter-parts/all-parts-4791476a8632.zip",
+		"all_parts_plain_zip": "https://assets.basically.website/sorter-parts/all-parts-plain-81b37b24d484.zip"
 	},
 	"sections": [
 		{
@@ -7004,6 +7004,269 @@
 					],
 					"cap": 3.5,
 					"depth": 0.6
+				}
+			]
+		},
+		{
+			"id": "cage-top-hex-corner",
+			"uid": "o732",
+			"name": "Cable cage hex corner (printed)",
+			"quantities": {},
+			"assembly": "cable-cage",
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "One corner segment of the 3D-printed cable cage hexagon. 6 build the bottom plate; 4 plus one cage motor piece build the top plate.",
+			"version": "1",
+			"created_at": "2026-08-24",
+			"updated_at": "2026-08-24",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "o732",
+					"date": "2026-08-24",
+					"message": "Initial version.",
+					"commit": null,
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-92c8342eaa28.stl",
+					"render": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-full-7d131e696c33.png",
+					"grams": 29.01
+				}
+			],
+			"attributes": [],
+			"grams": 29.01,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 2334,
+			"color": {
+				"role": "frame"
+			},
+			"optional": true,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-92c8342eaa28.stl",
+			"render": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-full-7d131e696c33.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-o732-stamped-bottom-fe5c140ba3e6.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						-1.0
+					],
+					"center": [
+						100.41,
+						68.36,
+						237.0
+					],
+					"size": [
+						12.33,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top",
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-o732-stamped-top-e43d095de58b.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						154.96,
+						10.19,
+						240.0
+					],
+					"size": [
+						12.33,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top 2",
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-o732-stamped-top-2-765b111edd67.stl",
+					"normal": [
+						-0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						95.8,
+						-3.81,
+						238.5
+					],
+					"size": [
+						12.33,
+						3.63
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				},
+				{
+					"face": "top 3",
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-o732-stamped-top-3-136bcce2a652.stl",
+					"normal": [
+						0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						48.51,
+						82.57,
+						238.5
+					],
+					"size": [
+						3.63,
+						12.33
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				}
+			]
+		},
+		{
+			"id": "cage-top-motor-piece",
+			"uid": "64tz",
+			"name": "Cable cage motor piece (printed)",
+			"quantities": {},
+			"assembly": "cable-cage",
+			"folder": null,
+			"variant_group": null,
+			"variant_name": null,
+			"description": "The chute-motor segment of the 3D-printed cable cage top plate. 1 needed, alongside 4 hex corner pieces.",
+			"version": "1",
+			"created_at": "2026-08-24",
+			"updated_at": "2026-08-24",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "64tz",
+					"date": "2026-08-24",
+					"message": "Initial version.",
+					"commit": null,
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-c4d97fa88f75.stl",
+					"render": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-full-8cf0441e55c6.png",
+					"grams": 52.99
+				}
+			],
+			"attributes": [],
+			"grams": 52.99,
+			"support_grams": 0,
+			"support_used": false,
+			"support_intentional": false,
+			"print_seconds": 3798,
+			"color": {
+				"role": "frame"
+			},
+			"optional": true,
+			"onshape": null,
+			"info": null,
+			"low_tolerance": false,
+			"low_tolerance_note": null,
+			"layer_scope": "all",
+			"requires": [],
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"stl": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-c4d97fa88f75.stl",
+			"render": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-full-8cf0441e55c6.png",
+			"stamped": [
+				{
+					"face": "bottom",
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-64tz-stamped-bottom-19ce45cc42b1.stl",
+					"normal": [
+						0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						-78.84,
+						-135.07,
+						237.0
+					],
+					"size": [
+						12.28,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				},
+				{
+					"face": "top",
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-64tz-stamped-top-e5877cf18935.stl",
+					"normal": [
+						0.0,
+						-0.0,
+						1.0
+					],
+					"center": [
+						-90.99,
+						-128.07,
+						240.0
+					],
+					"size": [
+						12.28,
+						3.56
+					],
+					"cap": 3.5,
+					"depth": 0.6
+				},
+				{
+					"face": "top 2",
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-64tz-stamped-top-2-c9da98b71c14.stl",
+					"normal": [
+						0.0,
+						0.0,
+						1.0
+					],
+					"center": [
+						-68.65,
+						-120.71,
+						238.5
+					],
+					"size": [
+						3.56,
+						12.28
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
+				},
+				{
+					"face": "bottom 2",
+					"stl": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-64tz-stamped-bottom-2-03059ab9d2c8.stl",
+					"normal": [
+						0.0,
+						0.0,
+						-1.0
+					],
+					"center": [
+						-48.48,
+						82.54,
+						238.5
+					],
+					"size": [
+						3.56,
+						12.28
+					],
+					"cap": 3.5,
+					"depth": 0.4,
+					"note": "shallow pocket"
 				}
 			]
 		},
@@ -14593,269 +14856,6 @@
 					"cap": 2.5,
 					"depth": 0.6,
 					"note": "smaller text"
-				}
-			]
-		},
-		{
-			"id": "cage-top-hex-corner",
-			"uid": "o732",
-			"name": "Cable cage hex corner (printed)",
-			"quantities": {},
-			"assembly": "cable-cage",
-			"folder": null,
-			"variant_group": null,
-			"variant_name": null,
-			"description": "One corner segment of the 3D-printed cable cage hexagon. 6 build the bottom plate; 4 plus one cage motor piece build the top plate.",
-			"version": "1",
-			"created_at": "2026-08-24",
-			"updated_at": "2026-08-24",
-			"versions": [
-				{
-					"version": "1",
-					"uid": "o732",
-					"date": "2026-08-24",
-					"message": "Initial version.",
-					"commit": null,
-					"stl": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-92c8342eaa28.stl",
-					"render": "https://img.basically.website/parts/render/cage-top-hex-corner-3a346d2e.png",
-					"grams": 29.01
-				}
-			],
-			"attributes": [],
-			"grams": 29.01,
-			"support_grams": 0,
-			"support_used": false,
-			"support_intentional": false,
-			"print_seconds": 2334,
-			"color": {
-				"role": "frame"
-			},
-			"optional": true,
-			"onshape": null,
-			"info": null,
-			"low_tolerance": false,
-			"low_tolerance_note": null,
-			"layer_scope": "all",
-			"requires": [],
-			"caption": null,
-			"docs_page": null,
-			"conflicts": null,
-			"stl": "https://assets.basically.website/sorter-parts/cage-top-hex-corner-92c8342eaa28.stl",
-			"render": "https://img.basically.website/parts/render/cage-top-hex-corner-3a346d2e.png",
-			"stamped": [
-				{
-					"face": "bottom",
-					"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-stamped-bottom-fcb66f29.stl",
-					"normal": [
-						0.0,
-						-0.0,
-						-1.0
-					],
-					"center": [
-						100.41,
-						68.36,
-						237.0
-					],
-					"size": [
-						12.33,
-						3.63
-					],
-					"cap": 3.5,
-					"depth": 0.6
-				},
-				{
-					"face": "top",
-					"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-stamped-top-84208af2.stl",
-					"normal": [
-						-0.0,
-						0.0,
-						1.0
-					],
-					"center": [
-						154.96,
-						10.19,
-						240.0
-					],
-					"size": [
-						12.33,
-						3.63
-					],
-					"cap": 3.5,
-					"depth": 0.6
-				},
-				{
-					"face": "top 2",
-					"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-stamped-top-2-d39f1122.stl",
-					"normal": [
-						-0.0,
-						0.0,
-						1.0
-					],
-					"center": [
-						95.8,
-						-3.81,
-						238.5
-					],
-					"size": [
-						12.33,
-						3.63
-					],
-					"cap": 3.5,
-					"depth": 0.4,
-					"note": "shallow pocket"
-				},
-				{
-					"face": "top 3",
-					"stl": "https://img.basically.website/parts/stl/cage-top-hex-corner-o732-stamped-top-3-5ef81bc5.stl",
-					"normal": [
-						0.0,
-						0.0,
-						1.0
-					],
-					"center": [
-						48.51,
-						82.57,
-						238.5
-					],
-					"size": [
-						3.63,
-						12.33
-					],
-					"cap": 3.5,
-					"depth": 0.4,
-					"note": "shallow pocket"
-				}
-			]
-		},
-		{
-			"id": "cage-top-motor-piece",
-			"uid": "64tz",
-			"name": "Cable cage motor piece (printed)",
-			"quantities": {},
-			"assembly": "cable-cage",
-			"folder": null,
-			"variant_group": null,
-			"variant_name": null,
-			"description": "The chute-motor segment of the 3D-printed cable cage top plate. 1 needed, alongside 4 hex corner pieces.",
-			"version": "1",
-			"created_at": "2026-08-24",
-			"updated_at": "2026-08-24",
-			"versions": [
-				{
-					"version": "1",
-					"uid": "64tz",
-					"date": "2026-08-24",
-					"message": "Initial version.",
-					"commit": null,
-					"stl": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-c4d97fa88f75.stl",
-					"render": "https://img.basically.website/parts/render/cage-top-motor-piece-fe7fc28a.png",
-					"grams": 52.99
-				}
-			],
-			"attributes": [],
-			"grams": 52.99,
-			"support_grams": 0,
-			"support_used": false,
-			"support_intentional": false,
-			"print_seconds": 3798,
-			"color": {
-				"role": "frame"
-			},
-			"optional": true,
-			"onshape": null,
-			"info": null,
-			"low_tolerance": false,
-			"low_tolerance_note": null,
-			"layer_scope": "all",
-			"requires": [],
-			"caption": null,
-			"docs_page": null,
-			"conflicts": null,
-			"stl": "https://assets.basically.website/sorter-parts/cage-top-motor-piece-c4d97fa88f75.stl",
-			"render": "https://img.basically.website/parts/render/cage-top-motor-piece-fe7fc28a.png",
-			"stamped": [
-				{
-					"face": "bottom",
-					"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-stamped-bottom-aff68d79.stl",
-					"normal": [
-						0.0,
-						0.0,
-						-1.0
-					],
-					"center": [
-						-78.84,
-						-135.07,
-						237.0
-					],
-					"size": [
-						12.28,
-						3.56
-					],
-					"cap": 3.5,
-					"depth": 0.4,
-					"note": "shallow pocket"
-				},
-				{
-					"face": "top",
-					"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-stamped-top-0f01b6da.stl",
-					"normal": [
-						0.0,
-						-0.0,
-						1.0
-					],
-					"center": [
-						-90.99,
-						-128.07,
-						240.0
-					],
-					"size": [
-						12.28,
-						3.56
-					],
-					"cap": 3.5,
-					"depth": 0.6
-				},
-				{
-					"face": "top 2",
-					"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-stamped-top-2-468a76f6.stl",
-					"normal": [
-						0.0,
-						0.0,
-						1.0
-					],
-					"center": [
-						-68.65,
-						-120.71,
-						238.5
-					],
-					"size": [
-						3.56,
-						12.28
-					],
-					"cap": 3.5,
-					"depth": 0.4,
-					"note": "shallow pocket"
-				},
-				{
-					"face": "bottom 2",
-					"stl": "https://img.basically.website/parts/stl/cage-top-motor-piece-64tz-stamped-bottom-2-a4896b9d.stl",
-					"normal": [
-						0.0,
-						0.0,
-						-1.0
-					],
-					"center": [
-						-48.48,
-						82.54,
-						238.5
-					],
-					"size": [
-						3.56,
-						12.28
-					],
-					"cap": 3.5,
-					"depth": 0.4,
-					"note": "shallow pocket"
 				}
 			]
 		}


### PR DESCRIPTION
`check-parts` has been red on every main push since Aug 25. Cause: a crossing-PR race — #417 (which introduced `cage-top-hex-corner` and `cage-top-motor-piece`) was generated before #418's migration but merged 7½ hours after it, re-introducing 12 `img.basically.website` render/stamped URLs onto a freshly-migrated main.

It could never self-heal: `--metadata-only` carries render/stamped URLs verbatim by design, and even a full run wouldn't have fixed it — `render_url_for()` rejects a *memo* naming the retired store but adopted the *committed data's* URL (`prev_url`) with no such guard.

Two changes:

- **`generate.py`**: apply the same "retired store is not an answer" rule to `prev_url`, so committed old-domain URLs force a re-render instead of riding through.
- **Regenerated** with a full run slicing via the asset service (stored reports, so no local-slicer grams drift). The diff is confined to the two cage-top parts — new `sorter-parts` renders and freshly re-cut stamped ladders (the re-cut found faces the old pipeline missed) — plus the two bundle zips, whose members include those parts' new stamped filenames.

Verified locally: `check_generated_pins.py` passes (100 pinned parts), and `check_asset_urls.py` passes — **652 URLs, all serve real bytes** — for the first time since the race.

Fixes #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)