### PR TITLE
parts-calculator: retire the orphaned M5 TBD screws left after the support block's removal

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3609,9 +3609,9 @@
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m5-shcs-tbd-full-26e52d7d5bcd.png",
-      "description": "Placeholder for the three electronics mounts that bolt to the frame. The length has not been measured yet.",
+      "description": "Placeholder for an unmeasured M5 joint. Originally the three electronics mounts that bolt to the frame (resolved to scr-m5-12-shcs / scr-m5-16-shcs in PR #428) and, since then, the two screws fastening the Chute stepper support block. Unused as of 2026-08-31: that block was removed from the machine (sorter-v2#489, sorter-v2#483) after Spencer confirmed the NEMA 23 chute stepper mount works without it, so its two screws are gone from the interface assembly too. The length was never measured.",
       "created_at": "2026-07-18",
-      "updated_at": "2026-08-18",
+      "updated_at": "2026-08-31",
       "attributes": [
         {
           "label": "Thread",
@@ -3626,7 +3626,7 @@
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
       ],
-      "note": "Length unknown — measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount."
+      "note": "Unused as of 2026-08-31. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own VERSIONING.md). Do not re-add without a new joint to point it at, the chute stepper support block it was last used for is gone."
     },
     {
       "id": "washer-m3-15",
@@ -6243,10 +6243,6 @@
         {
           "part": "top-interface-split-spur-gear-2",
           "qty": 1
-        },
-        {
-          "part": "scr-m5-shcs-tbd",
-          "qty": 2
         },
         {
           "assembly": "layer-connector",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1168,10 +1168,6 @@
 					"qty": 1
 				},
 				{
-					"part": "scr-m5-shcs-tbd",
-					"qty": 2
-				},
-				{
 					"assembly": "layer-connector",
 					"qty": 1
 				},
@@ -15951,10 +15947,10 @@
 			},
 			"name": "M5 socket/button head, length TBD",
 			"category": "Screws",
-			"description": "Placeholder for the three electronics mounts that bolt to the frame. The length has not been measured yet.",
-			"note": "Length unknown \u2014 measure one on the machine before ordering. Six are used: PSU box, control board mount, Orange Pi mount.",
+			"description": "Placeholder for an unmeasured M5 joint. Originally the three electronics mounts that bolt to the frame (resolved to scr-m5-12-shcs / scr-m5-16-shcs in PR #428) and, since then, the two screws fastening the Chute stepper support block. Unused as of 2026-08-31: that block was removed from the machine (sorter-v2#489, sorter-v2#483) after Spencer confirmed the NEMA 23 chute stepper mount works without it, so its two screws are gone from the interface assembly too. The length was never measured.",
+			"note": "Unused as of 2026-08-31. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own VERSIONING.md). Do not re-add without a new joint to point it at, the chute stepper support block it was last used for is gone.",
 			"created_at": "2026-07-18",
-			"updated_at": "2026-08-18",
+			"updated_at": "2026-08-31",
 			"attributes": [
 				{
 					"label": "Thread",


### PR DESCRIPTION
`scr-m5-shcs-tbd`'s only remaining live use, 2x on the Top interface assembly, was for fastening the Chute stepper support block. sorter-v2#489 removed that block from the machine (Spencer confirmed the NEMA 23 chute stepper mount works without it, closing #483), but left the two placeholder screws behind in the assembly's `lines`: an orphaned BOM entry for a part that no longer exists.

- Removed the `scr-m5-shcs-tbd qty:2` line from the `interface` assembly.
- Retired `scr-m5-shcs-tbd` in place per `VERSIONING.md`: `description`/`note` updated to say it's unused as of today and why, with a "do not re-add" warning, same treatment `scr-m3-tbd` (#452) and `washer-m3-15` (#479) got. Not deleted, uid `wy04` keeps resolving.
- Regenerated with `generate.py --metadata-only`; `check_generated_pins.py` (100 pinned parts) and `check_asset_urls.py` (61 URLs) both pass.

Its length was never actually measured (it was already a placeholder, not a documented gap), and now there's nothing left to measure for.

Found while answering Senna (@senna03) in #balloon-general, who asked whether the length of the top interface's 2 remaining `scr-m5-shcs-tbd` screws was known yet.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1544031363525775360/1544072294249529475
preview: /parts?part=scr-m5-shcs-tbd
-->