### PR TITLE
parts-calculator: flag the servo adapter's M3S heat inserts as unconfirmed

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -346,6 +346,24 @@
           "scr-m3-shcs-tbd"
         ]
       }
+    },
+    {
+      "id": "unconfirmed-servo-adapter-heat-insert",
+      "name": "Servo adapter's 4x M3S heat inserts are unconfirmed against the current CAD",
+      "priority": "P2",
+      "description": "The catalog carries 4 x hsi-m3s per layer for the servo adapter from the original BOM spreadsheet, but that count was never placed in the assembly tree because the published STLs do not show an insert pocket: servo-adapter-flap-side has four 4.0 mm bores straight through a 5.0 mm wall with a countersink on the back, and servo-adapter-servo-side has four blind 2.8 mm holes only 4.0 mm deep, a self-tap pilot diameter, not ruthex's recommended 4.0 mm insert hole. That reads as a countersunk screw passing through the flap side and self-tapping into the servo side, no insert on either half, matching door-module.md's existing text that the two halves take no inserts. Neither STL has been revised since 2026-06-27. Buy the inserts only if you can confirm a pocket against a physical adapter or newer CAD; otherwise the self-tapping joint above is what the current model builds to.",
+      "targets": {
+        "hardware": [
+          "hsi-m3s"
+        ],
+        "parts": [
+          "servo-adapter-servo-side",
+          "servo-adapter-flap-side"
+        ],
+        "assemblies": [
+          "servo-adapter"
+        ]
+      }
     }
   ],
   "folders": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -360,6 +360,24 @@
 					"scr-m3-shcs-tbd"
 				]
 			}
+		},
+		{
+			"id": "unconfirmed-servo-adapter-heat-insert",
+			"name": "Servo adapter's 4x M3S heat inserts are unconfirmed against the current CAD",
+			"priority": "P2",
+			"description": "The catalog carries 4 x hsi-m3s per layer for the servo adapter from the original BOM spreadsheet, but that count was never placed in the assembly tree because the published STLs do not show an insert pocket: servo-adapter-flap-side has four 4.0 mm bores straight through a 5.0 mm wall with a countersink on the back, and servo-adapter-servo-side has four blind 2.8 mm holes only 4.0 mm deep, a self-tap pilot diameter, not ruthex's recommended 4.0 mm insert hole. That reads as a countersunk screw passing through the flap side and self-tapping into the servo side, no insert on either half, matching door-module.md's existing text that the two halves take no inserts. Neither STL has been revised since 2026-06-27. Buy the inserts only if you can confirm a pocket against a physical adapter or newer CAD; otherwise the self-tapping joint above is what the current model builds to.",
+			"targets": {
+				"hardware": [
+					"hsi-m3s"
+				],
+				"parts": [
+					"servo-adapter-servo-side",
+					"servo-adapter-flap-side"
+				],
+				"assemblies": [
+					"servo-adapter"
+				]
+			}
 		}
 	],
 	"folders": [


### PR DESCRIPTION
`hsi-m3s`'s own note has said since 2026-08-21 that the servo adapter's 4-per-layer BOM count for it is carried from the original spreadsheet, not placed in the assembly tree, because the published STLs read as a self-tapping joint:

- `servo-adapter-flap-side`: four straight 4.0mm bores through a 5.0mm wall, countersunk on the back, a clearance hole for a screw head, not a blind insert pocket.
- `servo-adapter-servo-side`: four blind 2.8mm holes, 4.0mm deep, a self-tap pilot diameter, not ruthex's recommended ~4.0mm insert hole.

That matches `door-module.md`'s existing text that the two adapter halves take no inserts. Neither STL has been revised since 2026-06-27.

Per this project's own part-problem-triage procedure (a part/spec ambiguity gets an entry on the changes page, not prose left in a note nobody sees rendered), added a P2 `changes` entry targeting `hsi-m3s`, both adapter halves and the `servo-adapter` assembly, so it shows up as a visible badge wherever those render (dashboard, part page, assembly row), not just in the part's internal note.

Not resolving the ambiguity itself, that needs a physical adapter or newer CAD to actually confirm, same caveat the original 2026-08-21 investigation left. Just making it visible instead of buried.

Second commit: barthel asked whether these were actually meant for the top interface's idler gear instead, since its insert holes read shallow to him. Checked: that joint's own insert count (4 per layer, chute-stepper-gearing's outer retainer) is already resolved and shipped separately as the standard `hsi-m3` (5.7mm), not this short M3S, measured off ~7mm-deep insert bores in the gear body back in PR #420. The BOM sheet's own row for this M3S is also labeled "Servo adapter only". Added a sentence to the changes entry ruling this out.

Asked by Senna (@senna03) in #balloon-general: "the catalog asks for 12x ruthex M3S for the servo adapter, with the note that the current STLs show a self-tapping connection, are the inserts needed or not?" Second commit asked by barthel (@uwe_barthel), same thread.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1544031363525775360/1544074075734016170
request: https://discord.com/channels/1430279849171222682/1544031363525775360/1544252340289146900
preview: /parts?part=hsi-m3s
-->