### PR TITLE
parts-calculator: the breaking bit and the assembly stamp rule

### DIFF
--- a/.github/workflows/check-parts.yml
+++ b/.github/workflows/check-parts.yml
@@ -13,6 +13,9 @@ name: Check part data
 #                               (assets are content-addressed, so a wrong URL
 #                               is a 200 with the wrong bytes, not a 404), and
 #                               nothing names the retired image domain
+#  - check_versioning.py      : revisions follow VERSIONING.md -- new version
+#                               entries declare their breaking bit, assembly
+#                               line changes are stamped as assembly versions
 #
 # Both are pure checks, a minute end to end. regen-parts.yml -- the old
 # CI-canonical slicer that committed back onto PR branches -- is deleted; its
@@ -43,3 +46,4 @@ jobs:
           python-version: '3.11'
       - run: python parts-calculator/scripts/check_generated_pins.py
       - run: python parts-calculator/scripts/check_asset_urls.py
+      - run: python parts-calculator/scripts/check_versioning.py

--- a/parts-calculator/CLAUDE.md
+++ b/parts-calculator/CLAUDE.md
@@ -17,9 +17,13 @@ for where this is heading (unified registry across this repo, the docs, and
 the BOM spreadsheet).
 
 `VERSIONING.md` is the succinct, citable statement of how parts are
-identified, revised, and removed (uids, versions, candidates, retire-in-place).
-When someone asks to delete or change a part, answer from — and link — that
-page.
+identified, revised, and removed (uids, versions, candidates, retire-in-place,
+the `breaking` bit, assembly version stamps). When someone asks to delete or
+change a part — or revises anything — answer from, follow, and link that
+page. In short: every new version entry declares `breaking: true|false`
+("can an old physical instance of this node still be used in its place?"),
+and a structural change to an assembly's lines must be stamped as a new
+assembly version. `scripts/check_versioning.py` enforces both in CI.
 
 ## What this is
 
@@ -37,9 +41,11 @@ build. Two halves:
   profile. So no machine needs OrcaSlicer to change parts data, and a branch
   preview is correct from the first push, because the data rode in with it.
   `.github/workflows/check-parts.yml` guards every PR and push: the generated
-  data must agree with the source pins (`check_generated_pins.py`) and every
-  URL the site ships must serve real bytes (`check_asset_urls.py`). Pure
-  checks, about a minute; nothing commits onto your branch.
+  data must agree with the source pins (`check_generated_pins.py`), every
+  URL the site ships must serve real bytes (`check_asset_urls.py`), and
+  revisions must follow the versioning discipline — breaking bits declared,
+  assembly line changes stamped (`check_versioning.py`, per `VERSIONING.md`).
+  Pure checks, about a minute; nothing commits onto your branch.
 - **`src/`** — the app. Reads generated JSON, does all math in the browser.
   Fully static.
 
@@ -275,6 +281,10 @@ assembly version is an authored structural change; its superseded entries
 snapshot the lines with each member's uid of the day (`stamp_versions.py`),
 and a candidate is an alternative bill of materials under test, optionally
 carrying the `name` the slot takes if it is adopted. Same minting, same
-retention rule. A part that exists only inside a candidate assembly has
+retention rule. A structural change to an assembly's `lines` (member
+removed/replaced, qty changed) MUST be stamped as a new assembly version
+with its `breaking` bit — `check_versioning.py` refuses it otherwise; the
+one exemption is purely additive completion of a `stub`/`partial` assembly.
+See `VERSIONING.md`. A part that exists only inside a candidate assembly has
 empty `quantities`: it is in no section, counts toward nothing, and is left
 out of the all-parts bundle.

--- a/parts-calculator/VERSIONING.md
+++ b/parts-calculator/VERSIONING.md
@@ -29,12 +29,71 @@ A revision is an **addition**, never an edit-in-place:
    design into the part's `versions[]` with its uid and `stl_hash` (the sha256
    of its final bytes). Historical geometry is fetched by that pin — never
    reconstructed from git history.
-3. Regenerate (`catalog/generate.py`) and commit source and generated data
+3. The new `versions[]` entry declares its **`breaking` bit** (next section).
+4. Regenerate (`catalog/generate.py`) and commit source and generated data
    together in the same change.
 
 A **candidate** is a revision under test for a part's slot: its own uid and
 `stl_hash`, no version number until adopted. Candidates are never deleted,
 only marked `superseded_by` / `rejected_at`.
+
+## The `breaking` bit
+
+From 2026-08-31, every new `versions[]` entry — part or assembly — declares
+`breaking: true | false`. It answers exactly one question about exactly one
+node:
+
+> **Can an old physical instance of THIS node still be used in its place?**
+
+For a part an instance is a print; for an assembly it is an assembled unit.
+`false`: old instances stay interchangeable with the new revision. `true`:
+old instances don't fit or function in the current design — scrap for
+current builds (still valid for building the archived old structure they
+came from).
+
+The rules that keep the bit meaningful:
+
+- **Each node speaks only for itself.** An assembly can be reworked inside —
+  parts merged, members swapped — and still be `breaking: false` if it mates
+  outward the same way; whoever holds the old assembled unit keeps using it.
+- **Bits are set bottom-up at authoring time, on the nodes the change
+  touched.** A change is recorded on the node that owns what changed:
+  geometry → the part; membership or quantities → the assembly that owns
+  the lines. Then ask the same question one level up, and stop as soon as
+  the answer is false. There is never a search for "what broke" after the
+  fact — the causal chain and the edit are the same thing.
+- **First versions and new identities carry no bit.** Nothing older exists
+  to break. A replacement design is a *new* part or assembly (new uid, v1),
+  not a revision of the thing it replaces — the replaced one is retired from
+  the lines that used it, unrevised.
+- **Unused ≠ breaking.** A part whose slot disappeared is removed from
+  lines (see below); its geometry didn't stop fitting anything. Never use
+  `breaking` to express removal.
+- **Candidates carry no bit.** A candidate is a parallel experiment, not a
+  revision; the judgment happens on the version minted if it is adopted.
+
+Why: whether any old print fits today's machine becomes *computable* from
+the chain of bits — never reconstructed from memory or CAD archaeology.
+`scripts/check_versioning.py` (CI) refuses a new revision without its bit.
+
+## Revising an assembly
+
+A structural change to an assembly's `lines` — a member removed or replaced,
+a quantity changed — is a revision and must be **stamped** in the same
+change:
+
+1. Bump the assembly's `version`.
+2. Append a `versions[]` entry: new version number, `date`, `message`, its
+   `breaking` bit, `"commit": null` (pending).
+3. After committing, run `catalog/stamp_versions.py`: it ties the entry to
+   its commit and snapshots the superseded lines with each member's uid of
+   the day, so the box as built then reads back part by part.
+
+One exemption: purely *adding* lines to a `stub`/`partial` assembly is
+completing the record of what was always physically there, not changing the
+design — no stamp needed. The moment a line is removed or altered, or the
+assembly is no longer partial, the full rule applies. CI enforces both
+halves (`scripts/check_versioning.py`).
 
 ## Removing a part from the machine
 
@@ -61,3 +120,9 @@ Worked example: `washer-m3-15`, retired in
   the same design is a new hash under the same uid).
 - Deleting or overwriting an asset (the service cannot).
 - Hand-editing `src/lib/data/catalog.generated.json` (it is an output).
+- A new revision without its `breaking` bit, or a structural change to an
+  assembly's lines without a version stamp (CI refuses both, from
+  2026-08-31; `scripts/check_versioning.py`).
+- Compatibility claims between arbitrary version pairs. Compatibility is
+  computed from the chain of `breaking` bits; anything the chain can't
+  derive is honestly unknown.

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -502,6 +502,14 @@
       "version": "2",
       "created_at": "2026-06-27",
       "updated_at": "2026-06-27",
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-06-27",
+          "message": "Initial catalog entry, imported 2026-06-27 at the design's second iteration ('v2' in the source export, 01_c_channel (5).zip). v1 predates the catalog: never published, no uid, no pinned geometry. The commit is where this entry first exists in this repository's history; the import itself predates it.",
+          "commit": "954f181e"
+        }
+      ],
       "quantities": {
         "feeder": 3,
         "classification-channel": 1

--- a/parts-calculator/catalog/stamp_versions.py
+++ b/parts-calculator/catalog/stamp_versions.py
@@ -15,7 +15,9 @@ uid at the time, so the box as built then reads back part by part.
 The workflow the version system assumes:
   1. Mint a uid (`python catalog/mint_uid.py`), put it on the part, bump
      `version`, and author a new version entry with `"commit": null`
-     (pending). Then publish the new STL (`python scripts/publish_assets.py
+     (pending) and its `breaking` bit (can an old print still be used in its
+     place? -- see VERSIONING.md; check_versioning.py refuses entries
+     without it). Then publish the new STL (`python scripts/publish_assets.py
      --upload part.stl`) and set the printed stl_hash.
   2. Commit ONLY that part's change, with a clear message (the version's
      changelog).

--- a/parts-calculator/scripts/check_versioning.py
+++ b/parts-calculator/scripts/check_versioning.py
@@ -1,0 +1,166 @@
+"""Guard the revision-tracking discipline in catalog/parts.json.
+
+VERSIONING.md defines the model this enforces. Two rules, both pure JSON plus
+one git read (the same HEAD~1 baseline check_generated_pins.py uses: the
+previous main commit on a push, the base branch on a PR's merge ref):
+
+1. **The breaking bit.** Every revision authored on or after 2026-08-31 must
+   declare `breaking: true|false` on its versions[] entry, answering one
+   question about one node: can an old physical instance of THIS node — a
+   print of the part, an assembled unit of the assembly — still be used in
+   its place? A first version never carries the bit (nothing older exists to
+   break), and neither does a candidate (a candidate is a parallel
+   experiment, not a revision; the bit belongs to the version minted if it
+   is adopted). Revisions predating adoption are exempt, not failed.
+
+2. **The stamp rule.** A structural change to an assembly's `lines` — a
+   member removed, replaced, or a quantity changed — must be stamped: the
+   assembly's `version` bumped and a new versions[] entry authored with a
+   date, a message, and its breaking bit. Exception: purely ADDING lines to
+   a `stub`/`partial` assembly is completing the record of what was always
+   physically there, not changing the design, and needs no stamp. A part
+   whose `uid` changed is a new revision by definition and must bump its
+   `version` with a new entry the same way.
+
+    python scripts/check_versioning.py [--base <ref>]
+
+Exits non-zero listing every violation.
+"""
+import argparse
+import collections
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+
+# Revisions from this date on must carry `breaking`; older history is exempt.
+ADOPTION_DATE = "2026-08-31"
+
+
+def previous_manifest(base):
+    """parts.json at the baseline ref, or None when history isn't there
+    (a depth-1 clone), in which case the diff-based checks are skipped."""
+    r = subprocess.run(["git", "-C", str(HERE), "show",
+                        f"{base}:parts-calculator/catalog/parts.json"],
+                       capture_output=True)
+    if r.returncode != 0:
+        print(f"note: no parts.json at {base}, skipping the change-stamp checks")
+        return None
+    return json.loads(r.stdout)
+
+
+def is_initial(entry):
+    """The first version of a node: nothing older exists for it to break."""
+    return str(entry.get("version")) == "1"
+
+
+def check_breaking_bits(manifest):
+    bad = []
+    for kind in ("parts", "assemblies"):
+        for item in manifest.get(kind, []):
+            where = f"{kind[:-1]} {item['id']}"
+            for v in item.get("versions") or []:
+                tag = f"{where} v{v.get('version')}"
+                if "breaking" in v and not isinstance(v["breaking"], bool):
+                    bad.append(f"{tag}: breaking must be true or false, "
+                               f"got {v['breaking']!r}")
+                elif is_initial(v):
+                    if "breaking" in v:
+                        bad.append(f"{tag}: a first version cannot carry "
+                                   f"`breaking` -- nothing older exists to break")
+                elif "breaking" not in v and (v.get("date") or "") >= ADOPTION_DATE:
+                    bad.append(f"{tag} (dated {v.get('date')}): missing `breaking` "
+                               f"-- can an old instance still be used in its "
+                               f"place? true/false, see VERSIONING.md")
+            for c in item.get("candidates") or []:
+                if "breaking" in c:
+                    bad.append(f"{where} candidate {c.get('uid')}: a candidate "
+                               f"is not a revision and cannot carry `breaking`; "
+                               f"the bit belongs to the version minted if it "
+                               f"is adopted")
+            # a bumped version with no versions[] history is a revision that
+            # left no record at all
+            if str(item.get("version", "1")) != "1" and not item.get("versions"):
+                bad.append(f"{where}: version is {item['version']} but there is "
+                           f"no versions[] history recording the revisions")
+    return bad
+
+
+def stamp_missing(item, prev, what_changed):
+    """A structural change must land with a bumped `version` and a new
+    versions[] entry carrying date, message and the breaking bit. Returns the
+    problems with this item's stamp, empty when the stamp is complete."""
+    tag = f"{item['id']}: {what_changed}"
+    if str(item.get("version", "1")) == str(prev.get("version", "1")):
+        return [f"{tag}, but `version` was not bumped -- stamp the revision "
+                f"(bump version, append a versions[] entry with date, message "
+                f"and breaking; see VERSIONING.md)"]
+    newest = (item.get("versions") or [{}])[-1]
+    out = []
+    if str(newest.get("version")) != str(item.get("version")):
+        out.append(f"{tag} and version bumped to {item.get('version')}, but the "
+                   f"newest versions[] entry is v{newest.get('version')} -- "
+                   f"append an entry for the new version")
+        return out
+    for field in ("date", "message"):
+        if not newest.get(field):
+            out.append(f"{tag}: new version entry has no {field}")
+    if "breaking" not in newest:
+        out.append(f"{tag}: new version entry does not declare `breaking`")
+    return out
+
+
+def check_change_stamps(manifest, prev):
+    bad = []
+    prev_parts = {p["id"]: p for p in prev.get("parts", [])}
+    for p in manifest.get("parts", []):
+        q = prev_parts.get(p["id"])
+        if q and p.get("uid") != q.get("uid"):
+            bad += [f"part {b}" for b in
+                    stamp_missing(p, q, f"uid changed {q.get('uid')} -> {p.get('uid')} (a new revision)")]
+
+    prev_asms = {a["id"]: a for a in prev.get("assemblies", [])}
+    for a in manifest.get("assemblies", []):
+        q = prev_asms.get(a["id"])
+        if not q:
+            continue
+        cur = [json.dumps(line, sort_keys=True) for line in a.get("lines") or []]
+        old = [json.dumps(line, sort_keys=True) for line in q.get("lines") or []]
+        if collections.Counter(cur) == collections.Counter(old):
+            continue
+        # Filling in a stub/partial assembly -- only adding lines, every old
+        # line untouched -- records what was always physically there and is
+        # not a design change. Anything removed or altered is one.
+        additive = not (collections.Counter(old) - collections.Counter(cur))
+        if additive and q.get("status") in ("stub", "partial"):
+            continue
+        bad += [f"assembly {b}" for b in stamp_missing(a, q, "lines changed")]
+    return bad
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="HEAD~1",
+                    help="baseline ref for the change-stamp checks (default HEAD~1; "
+                         "use origin/main when checking a dirty tree locally)")
+    args = ap.parse_args()
+
+    manifest = json.loads((HERE / "catalog" / "parts.json").read_text())
+    bad = check_breaking_bits(manifest)
+    prev = previous_manifest(args.base)
+    if prev is not None:
+        bad += check_change_stamps(manifest, prev)
+
+    if bad:
+        print(f"{len(bad)} versioning violation(s) in parts.json:")
+        for b in bad:
+            print(f"  {b}")
+        print("\nThe model is defined in parts-calculator/VERSIONING.md.")
+        sys.exit(1)
+    print("versioning discipline holds (breaking bits + change stamps)")
+
+
+if __name__ == "__main__":
+    main()

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2643,8 +2643,8 @@
 					"version": "2",
 					"uid": "x09t",
 					"date": "2026-06-27",
-					"message": "Initial version.",
-					"commit": null,
+					"message": "Initial catalog entry, imported 2026-06-27 at the design's second iteration ('v2' in the source export, 01_c_channel (5).zip). v1 predates the catalog: never published, no uid, no pinned geometry. The commit is where this entry first exists in this repository's history; the import itself predates it.",
+					"commit": "954f181e",
 					"stl": "https://assets.basically.website/sorter-parts/nema-bracket-8b2bea87360e.stl",
 					"render": "https://assets.basically.website/sorter-parts/nema-bracket-full-91f60f914ef2.png",
 					"grams": 72.45


### PR DESCRIPTION
Lays the compatibility foundation on top of the existing revision records. The model is documented in VERSIONING.md's two new sections; CI now enforces it.

## The model

- **`breaking: true|false` on every new version entry** (part or assembly, from 2026-08-31). One question about one node: *can an old physical instance of this node — a print of the part, an assembled unit of the assembly — still be used in its place?* Each node speaks only for itself: an assembly reworked inside can be `breaking: false` if it still mates outward the same way. Bits are set bottom-up at authoring time on the nodes the change touched, and propagation up stops as soon as the answer goes false. First versions and candidates never carry the bit (nothing older exists to break; a candidate is a parallel experiment, not a revision). Unused ≠ breaking: removal is expressed by lines, never by the bit.
- **The stamp rule.** A structural change to an assembly's `lines` (member removed/replaced, qty changed) must be stamped: version bumped, new entry with date, message, and its breaking bit. Exemption: purely *additive* completion of a `stub`/`partial` assembly records what was always physically there and needs no stamp.
- **No pairwise compatibility claims.** Whether an old print fits today's catalog is computed from the chain of bits; anything the chain can't derive is honestly unknown.

## What's in the change

- `scripts/check_versioning.py` — enforces both rules, pure JSON plus the same HEAD~1 baseline `check_generated_pins.py` uses; wired into `check-parts.yml`. Pre-adoption history is exempt, not failed.
- `VERSIONING.md` — "The `breaking` bit" and "Revising an assembly" sections; "What never happens" extended.
- `CLAUDE.md` + `stamp_versions.py` docstring — the agent-facing workflow now includes the bit and the stamp rule.
- **One real catch on the first run:** `nema-bracket` claimed version 2 with no recorded history — it was imported at its second CAD iteration in June, before the catalog versioned anything. That history is now recorded honestly, pinned to the first commit where the entry exists in this repository.

The check was verified against 16 synthetic cases (bits on first versions, missing bits on new revisions, unstamped qty changes, proper stamps passing, reorder-only ignored, additive-on-partial exempt, uid change without a bump, …) plus a clean run over the real catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)