### PR TITLE
parts-calculator: connection edges, the rotor units, and versions in the tree

### DIFF
--- a/.github/workflows/check-parts.yml
+++ b/.github/workflows/check-parts.yml
@@ -16,6 +16,8 @@ name: Check part data
 #  - check_versioning.py      : revisions follow VERSIONING.md -- new version
 #                               entries declare their breaking bit, assembly
 #                               line changes are stamped as assembly versions
+#  - check_connections.py     : connection edges reference real members and
+#                               real fastener lines, methods from the enum
 #
 # Both are pure checks, a minute end to end. regen-parts.yml -- the old
 # CI-canonical slicer that committed back onto PR branches -- is deleted; its
@@ -47,3 +49,4 @@ jobs:
       - run: python parts-calculator/scripts/check_generated_pins.py
       - run: python parts-calculator/scripts/check_asset_urls.py
       - run: python parts-calculator/scripts/check_versioning.py
+      - run: python parts-calculator/scripts/check_connections.py

--- a/parts-calculator/CLAUDE.md
+++ b/parts-calculator/CLAUDE.md
@@ -296,6 +296,21 @@ retention rule. A structural change to an assembly's `lines` (member
 removed/replaced, qty changed) MUST be stamped as a new assembly version
 with its `breaking` bit — `check_versioning.py` refuses it otherwise; the
 one exemption is purely additive completion of a `stub`/`partial` assembly.
-See `VERSIONING.md`. A part that exists only inside a candidate assembly has
+See `VERSIONING.md`.
+
+**An assembly's `connections` are its joints as a graph over its members.**
+One edge per joint: `{from, to, via, qty, method, note?, draft?}`. `from`/`to`
+name the two members held together (`to` is the anchor side — where the
+fastener ends); `via` names the fastener, which must be one of the
+assembly's own hardware lines (omitted for fastenerless joints); `qty` is
+fasteners per assembly instance; `method` is one of `self-tap | thread |
+insert | nut | tnut | press | friction | clip | glue | solder | crimp`.
+`draft: true` marks an edge extracted from prose and not yet confirmed at
+the bench — remove the flag when the assembly is validated.
+`check_connections.py` enforces the shape in CI. Once a joint is an edge,
+take its sentence OUT of the description: joint knowledge lives in
+`connections`, and descriptions state what the assembly is, in a sentence
+or two — never enumerate screws and never argue why a value is what it is
+(that goes in the version message or `internal_notes`). A part that exists only inside a candidate assembly has
 empty `quantities`: it is in no section, counts toward nothing, and is left
 out of the all-parts bundle.

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5712,11 +5712,33 @@
     },
     {
       "id": "classification-chamber",
-      "uid": "umxp",
-      "version": "1",
+      "uid": "fyqw",
+      "version": "2",
       "name": "Classification chamber",
       "description": "The classification chamber: the dome, the finned rotor, and the camera & LED insert. All three print white, so the chamber bounces light onto the part instead of absorbing it.",
-      "docs": "/hardware/assembly/feeder/classification-chamber/"
+      "docs": "/hardware/assembly/feeder/classification-chamber/",
+      "status": "partial",
+      "versions": [
+        {
+          "version": "1",
+          "uid": "umxp",
+          "message": "Original version: a description-only node with no recorded lines.",
+          "lines": []
+        },
+        {
+          "version": "2",
+          "date": "2026-08-31",
+          "message": "First recorded line: the finned rotor unit (rotor + bolted-on Output gear (130T)). Marked partial — the dome and the camera & LED insert are still unrecorded.",
+          "breaking": false,
+          "commit": null
+        }
+      ],
+      "lines": [
+        {
+          "assembly": "rotor-unit-finned",
+          "qty": 1
+        }
+      ]
     },
     {
       "id": "chute-bearing",
@@ -6172,19 +6194,65 @@
     },
     {
       "id": "feeder",
-      "uid": "4swk",
-      "version": "1",
+      "uid": "pye7",
+      "version": "2",
       "name": "Feeder",
       "description": "Feeder + classification channel. Everything above the interface.",
       "docs": "/hardware/assembly/feeder/",
       "status": "partial",
+      "versions": [
+        {
+          "version": "1",
+          "uid": "4swk",
+          "message": "Original version: carried the 3 faceted rotors as bare parts; their bolted-on output gears were inside the C-channel drive.",
+          "lines": [
+            {
+              "assembly": "c-channel",
+              "qty": 4,
+              "uid": "mttx"
+            },
+            {
+              "part": "rotor-faceted",
+              "qty": 3,
+              "uid": "9v9q"
+            },
+            {
+              "assembly": "classification-chamber",
+              "qty": 1,
+              "uid": "umxp"
+            },
+            {
+              "assembly": "camera-extension-assembly",
+              "qty": 1,
+              "uid": "dc2i"
+            },
+            {
+              "assembly": "light-post-assembly",
+              "qty": 2,
+              "uid": "v06x"
+            },
+            {
+              "assembly": "camera-mount",
+              "qty": 2,
+              "uid": "b3zx"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-08-31",
+          "message": "The 3 faceted rotors become 3 Rotor unit (faceted) — rotor + bolted-on Output gear (130T) as one bench unit. No physical change.",
+          "breaking": false,
+          "commit": null
+        }
+      ],
       "lines": [
         {
           "assembly": "c-channel",
           "qty": 4
         },
         {
-          "part": "rotor-faceted",
+          "assembly": "rotor-unit-faceted",
           "qty": 3
         },
         {
@@ -6640,12 +6708,73 @@
     },
     {
       "id": "c-channel",
-      "uid": "mttx",
-      "version": "1",
+      "uid": "sbwe",
+      "version": "2",
       "name": "C-channel drive",
-      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+      "description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
       "status": "partial",
+      "versions": [
+        {
+          "version": "1",
+          "uid": "mttx",
+          "message": "Original version: carried the Output gear (130T) and the 6 × M3 × 12 that bolt it to the rotor inline, even though the rotor itself was the parent's line.",
+          "lines": [
+            {
+              "part": "stator",
+              "qty": 1,
+              "uid": "n6bm"
+            },
+            {
+              "part": "nema-bracket",
+              "qty": 1,
+              "uid": "x09t"
+            },
+            {
+              "part": "output-gear",
+              "qty": 1,
+              "uid": "26ek"
+            },
+            {
+              "part": "idler-gear",
+              "qty": 1,
+              "uid": "7bv7"
+            },
+            {
+              "part": "input-gear",
+              "qty": 1,
+              "uid": "70ul"
+            },
+            {
+              "part": "motor-nema17",
+              "qty": 1,
+              "uid": "w7pq"
+            },
+            {
+              "part": "scr-m3-16-shcs",
+              "qty": 3,
+              "uid": "e0ud"
+            },
+            {
+              "part": "scr-m3-12-cs",
+              "qty": 10,
+              "uid": "0a9x"
+            },
+            {
+              "part": "scr-m3-8-shcs",
+              "qty": 1,
+              "uid": "ql35"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-08-31",
+          "message": "Moved the Output gear (130T) and its 6 × M3 × 12 out to the new rotor units: the gear bolts to the rotor, so the joint and its screws belong to the node that holds both. No physical change.",
+          "breaking": false,
+          "commit": null
+        }
+      ],
       "lines": [
         {
           "part": "stator",
@@ -6653,10 +6782,6 @@
         },
         {
           "part": "nema-bracket",
-          "qty": 1
-        },
-        {
-          "part": "output-gear",
           "qty": 1
         },
         {
@@ -6677,7 +6802,7 @@
         },
         {
           "part": "scr-m3-12-cs",
-          "qty": 10
+          "qty": 4
         },
         {
           "part": "scr-m3-8-shcs",
@@ -6710,15 +6835,68 @@
           "method": "self-tap",
           "note": "Threads through the gear hub and bears on the motor shaft flat.",
           "draft": true
+        }
+      ]
+    },
+    {
+      "id": "rotor-unit-faceted",
+      "uid": "df0i",
+      "version": "1",
+      "name": "Rotor unit (faceted)",
+      "description": "The faceted rotor with the Output gear (130T) bolted on. Assembled once as a unit; a C-channel drive spins it.",
+      "lines": [
+        {
+          "part": "rotor-faceted",
+          "qty": 1
         },
+        {
+          "part": "output-gear",
+          "qty": 1
+        },
+        {
+          "part": "scr-m3-12-cs",
+          "qty": 6
+        }
+      ],
+      "connections": [
         {
           "from": "output-gear",
           "to": "rotor-faceted",
           "via": "scr-m3-12-cs",
           "qty": 6,
           "method": "self-tap",
-          "note": "One per spoke. The rotor is the parent's line (finned instead of faceted in the classification chamber). Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing.",
-          "draft": true
+          "note": "One per spoke. Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing."
+        }
+      ]
+    },
+    {
+      "id": "rotor-unit-finned",
+      "uid": "iau5",
+      "version": "1",
+      "name": "Rotor unit (finned)",
+      "description": "The finned rotor with the Output gear (130T) bolted on. Assembled once as a unit; the classification channel's C-channel drive spins it.",
+      "lines": [
+        {
+          "part": "rotor-finned",
+          "qty": 1
+        },
+        {
+          "part": "output-gear",
+          "qty": 1
+        },
+        {
+          "part": "scr-m3-12-cs",
+          "qty": 6
+        }
+      ],
+      "connections": [
+        {
+          "from": "output-gear",
+          "to": "rotor-finned",
+          "via": "scr-m3-12-cs",
+          "qty": 6,
+          "method": "self-tap",
+          "note": "One per spoke. Same joint as the faceted rotor unit."
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6643,7 +6643,7 @@
       "uid": "mttx",
       "version": "1",
       "name": "C-channel drive",
-      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Screw joints: 4 × [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 × [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 × [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 × [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke — the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing (the light post's 2 × [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+      "description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
       "status": "partial",
       "lines": [
@@ -6682,6 +6682,43 @@
         {
           "part": "scr-m3-8-shcs",
           "qty": 1
+        }
+      ],
+      "connections": [
+        {
+          "from": "nema-bracket",
+          "to": "stator",
+          "via": "scr-m3-12-cs",
+          "qty": 4,
+          "method": "self-tap",
+          "draft": true
+        },
+        {
+          "from": "nema-bracket",
+          "to": "motor-nema17",
+          "via": "scr-m3-16-shcs",
+          "qty": 3,
+          "method": "thread",
+          "note": "Into the NEMA 17's tapped face holes.",
+          "draft": true
+        },
+        {
+          "from": "input-gear",
+          "to": "motor-nema17",
+          "via": "scr-m3-8-shcs",
+          "qty": 1,
+          "method": "self-tap",
+          "note": "Threads through the gear hub and bears on the motor shaft flat.",
+          "draft": true
+        },
+        {
+          "from": "output-gear",
+          "to": "rotor-faceted",
+          "via": "scr-m3-12-cs",
+          "qty": 6,
+          "method": "self-tap",
+          "note": "One per spoke. The rotor is the parent's line (finned instead of faceted in the classification chamber). Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing.",
+          "draft": true
         }
       ]
     },

--- a/parts-calculator/scripts/check_connections.py
+++ b/parts-calculator/scripts/check_connections.py
@@ -5,12 +5,14 @@ An assembly's `connections` record its joints as a graph over its members:
     { "from": "nema-bracket", "to": "stator", "via": "scr-m3-12-cs",
       "qty": 4, "method": "self-tap", "note": "...", "draft": true }
 
-- `from` / `to`: the two members the joint holds together, by catalog id.
-  `to` is the anchor side when the joint has one -- where the fastener ends
-  (the thread, insert, nut or T-nut). Normally both are direct members of
-  the assembly; a joint whose far side is the parent's member names that
-  part with a note (the C-channel's output gear bolts to the rotor, which
-  is a feeder line because it differs by location).
+- `from` / `to`: the two members the joint holds together. Both MUST be
+  direct members of the assembly (named in its `lines`): a joint belongs to
+  the node where both sides are present, which is also where it is made on
+  the bench. When a joint seems to span levels, the structure is wrong, not
+  the rule -- restructure so both sides share a node (the C-channel's
+  output gear bolted to the rotor became the rotor units). `to` is the
+  anchor side when the joint has one -- where the fastener ends (the
+  thread, insert, nut or T-nut).
 - `via`: the fastener, which must be a hardware line of this assembly.
   Fastenerless joints (press, friction, clip, glue) omit it.
 - `qty`: fasteners in this joint per one instance of the assembly. Across
@@ -48,12 +50,18 @@ def main():
             if line.get("part"):
                 lines[line["part"]] = lines.get(line["part"], 0) + (
                     line["qty"] if isinstance(line["qty"], int) else 0)
+        members = {line.get("part") or line.get("assembly")
+                   for line in a.get("lines") or []}
         used = {}
         for i, c in enumerate(a.get("connections") or []):
             tag = f"{a['id']} connection {i} ({c.get('from')} -> {c.get('to')})"
             for end in ("from", "to"):
                 if c.get(end) not in known:
                     bad.append(f"{tag}: {end} {c.get(end)!r} is not in the catalog")
+                elif c.get(end) not in members:
+                    bad.append(f"{tag}: {end} {c.get(end)!r} is not a member of "
+                               f"{a['id']} -- a joint lives where both sides are "
+                               f"lines; restructure rather than reach across levels")
             method = c.get("method")
             if method not in METHODS:
                 bad.append(f"{tag}: method {method!r} is not one of "

--- a/parts-calculator/scripts/check_connections.py
+++ b/parts-calculator/scripts/check_connections.py
@@ -1,0 +1,88 @@
+"""Validate the connection edges in catalog/parts.json.
+
+An assembly's `connections` record its joints as a graph over its members:
+
+    { "from": "nema-bracket", "to": "stator", "via": "scr-m3-12-cs",
+      "qty": 4, "method": "self-tap", "note": "...", "draft": true }
+
+- `from` / `to`: the two members the joint holds together, by catalog id.
+  `to` is the anchor side when the joint has one -- where the fastener ends
+  (the thread, insert, nut or T-nut). Normally both are direct members of
+  the assembly; a joint whose far side is the parent's member names that
+  part with a note (the C-channel's output gear bolts to the rotor, which
+  is a feeder line because it differs by location).
+- `via`: the fastener, which must be a hardware line of this assembly.
+  Fastenerless joints (press, friction, clip, glue) omit it.
+- `qty`: fasteners in this joint per one instance of the assembly. Across
+  edges, a fastener's qtys must not exceed its line qty.
+- `method`: how the joint holds. Extends the JoinMethod enum with the
+  anchor kinds: `insert` is a heat-set insert in the `to` part (pairs with
+  its `requires`), `thread` a machine thread in the `to` member, `tnut` an
+  extrusion T-nut, `nut` a through-bolt with a nut.
+- `draft: true`: extracted from prose, not yet confirmed at the bench.
+  Removed when the assembly is validated.
+
+    python scripts/check_connections.py
+
+Pure JSON, exits non-zero listing every violation.
+"""
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+
+METHODS = {"self-tap", "thread", "insert", "nut", "tnut",
+           "press", "friction", "clip", "glue", "solder", "crimp"}
+FASTENERLESS = {"press", "friction", "clip", "glue", "solder", "crimp"}
+
+
+def main():
+    d = json.loads((HERE / "catalog" / "parts.json").read_text())
+    known = {p["id"] for p in d["parts"]} | {a["id"] for a in d.get("assemblies", [])}
+
+    bad = []
+    for a in d.get("assemblies", []):
+        lines = {}
+        for line in a.get("lines") or []:
+            if line.get("part"):
+                lines[line["part"]] = lines.get(line["part"], 0) + (
+                    line["qty"] if isinstance(line["qty"], int) else 0)
+        used = {}
+        for i, c in enumerate(a.get("connections") or []):
+            tag = f"{a['id']} connection {i} ({c.get('from')} -> {c.get('to')})"
+            for end in ("from", "to"):
+                if c.get(end) not in known:
+                    bad.append(f"{tag}: {end} {c.get(end)!r} is not in the catalog")
+            method = c.get("method")
+            if method not in METHODS:
+                bad.append(f"{tag}: method {method!r} is not one of "
+                           f"{sorted(METHODS)}")
+            via = c.get("via")
+            if via is None:
+                if method in METHODS - FASTENERLESS:
+                    bad.append(f"{tag}: method {method!r} needs a fastener -- "
+                               f"name it in `via`")
+            else:
+                if via not in lines:
+                    bad.append(f"{tag}: via {via!r} is not a line of {a['id']}")
+                used[via] = used.get(via, 0) + (c.get("qty") or 0)
+            if not isinstance(c.get("qty"), int) or c["qty"] < 1:
+                bad.append(f"{tag}: qty must be a positive integer, "
+                           f"got {c.get('qty')!r}")
+        for via, n in used.items():
+            if lines.get(via, 0) and n > lines[via]:
+                bad.append(f"{a['id']}: connections use {n} x {via} but the "
+                           f"assembly's lines carry only {lines[via]}")
+
+    if bad:
+        print(f"{len(bad)} connection violation(s) in parts.json:")
+        for b in bad:
+            print(f"  {b}")
+        sys.exit(1)
+    n = sum(len(a.get("connections") or []) for a in d.get("assemblies", []))
+    print(f"connections are consistent ({n} edge(s))")
+
+
+if __name__ == "__main__":
+    main()

--- a/parts-calculator/src/lib/components/DropdownMenu.svelte
+++ b/parts-calculator/src/lib/components/DropdownMenu.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	// Click-to-open menu in the site style. Unlike Popover (hover-to-peek
+	// context help), this is a control: it opens on click only, and the content
+	// snippet gets `close` so picking an item can dismiss it.
+	let {
+		label,
+		align = 'right',
+		menuClass = 'w-56',
+		trigger,
+		children
+	}: {
+		label: string;
+		align?: 'left' | 'right';
+		menuClass?: string;
+		trigger: Snippet<[{ toggle: () => void; open: boolean }]>;
+		children: Snippet<[{ close: () => void }]>;
+	} = $props();
+
+	let open = $state(false);
+	let root: HTMLElement;
+	const toggle = () => (open = !open);
+	const close = () => (open = false);
+
+	function onWindowClick(e: MouseEvent) {
+		if (open && root && !root.contains(e.target as Node)) open = false;
+	}
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') open = false;
+	}
+</script>
+
+<svelte:window onclick={onWindowClick} onkeydown={onKey} />
+
+<span bind:this={root} class="relative inline-flex align-middle">
+	{@render trigger({ toggle, open })}
+	{#if open}
+		<div
+			class="setup-panel absolute top-full z-30 mt-1 {menuClass} py-1 {align === 'right'
+				? 'right-0'
+				: 'left-0'}"
+			role="menu"
+			aria-label={label}
+		>
+			{@render children({ close })}
+		</div>
+	{/if}
+</span>

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -626,11 +626,34 @@
 		},
 		{
 			"id": "classification-chamber",
-			"uid": "umxp",
-			"version": "1",
+			"uid": "fyqw",
+			"version": "2",
 			"name": "Classification chamber",
 			"description": "The classification chamber: the dome, the finned rotor, and the camera & LED insert. All three print white, so the chamber bounces light onto the part instead of absorbing it.",
-			"docs": "/hardware/assembly/feeder/classification-chamber/"
+			"docs": "/hardware/assembly/feeder/classification-chamber/",
+			"status": "partial",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "umxp",
+					"message": "Original version: a description-only node with no recorded lines.",
+					"lines": []
+				},
+				{
+					"version": "2",
+					"uid": "fyqw",
+					"date": "2026-08-31",
+					"message": "First recorded line: the finned rotor unit (rotor + bolted-on Output gear (130T)). Marked partial \u2014 the dome and the camera & LED insert are still unrecorded.",
+					"breaking": false,
+					"commit": null
+				}
+			],
+			"lines": [
+				{
+					"assembly": "rotor-unit-finned",
+					"qty": 1
+				}
+			]
 		},
 		{
 			"id": "chute-bearing",
@@ -1087,19 +1110,66 @@
 		},
 		{
 			"id": "feeder",
-			"uid": "4swk",
-			"version": "1",
+			"uid": "pye7",
+			"version": "2",
 			"name": "Feeder",
 			"description": "Feeder + classification channel. Everything above the interface.",
 			"docs": "/hardware/assembly/feeder/",
 			"status": "partial",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "4swk",
+					"message": "Original version: carried the 3 faceted rotors as bare parts; their bolted-on output gears were inside the C-channel drive.",
+					"lines": [
+						{
+							"assembly": "c-channel",
+							"qty": 4,
+							"uid": "mttx"
+						},
+						{
+							"part": "rotor-faceted",
+							"qty": 3,
+							"uid": "9v9q"
+						},
+						{
+							"assembly": "classification-chamber",
+							"qty": 1,
+							"uid": "umxp"
+						},
+						{
+							"assembly": "camera-extension-assembly",
+							"qty": 1,
+							"uid": "dc2i"
+						},
+						{
+							"assembly": "light-post-assembly",
+							"qty": 2,
+							"uid": "v06x"
+						},
+						{
+							"assembly": "camera-mount",
+							"qty": 2,
+							"uid": "b3zx"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "pye7",
+					"date": "2026-08-31",
+					"message": "The 3 faceted rotors become 3 Rotor unit (faceted) \u2014 rotor + bolted-on Output gear (130T) as one bench unit. No physical change.",
+					"breaking": false,
+					"commit": null
+				}
+			],
 			"lines": [
 				{
 					"assembly": "c-channel",
 					"qty": 4
 				},
 				{
-					"part": "rotor-faceted",
+					"assembly": "rotor-unit-faceted",
 					"qty": 3
 				},
 				{
@@ -1557,12 +1627,74 @@
 		},
 		{
 			"id": "c-channel",
-			"uid": "mttx",
-			"version": "1",
+			"uid": "sbwe",
+			"version": "2",
 			"name": "C-channel drive",
-			"description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+			"description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
 			"docs": "/hardware/assembly/feeder/c-channel/",
 			"status": "partial",
+			"versions": [
+				{
+					"version": "1",
+					"uid": "mttx",
+					"message": "Original version: carried the Output gear (130T) and the 6 \u00d7 M3 \u00d7 12 that bolt it to the rotor inline, even though the rotor itself was the parent's line.",
+					"lines": [
+						{
+							"part": "stator",
+							"qty": 1,
+							"uid": "n6bm"
+						},
+						{
+							"part": "nema-bracket",
+							"qty": 1,
+							"uid": "x09t"
+						},
+						{
+							"part": "output-gear",
+							"qty": 1,
+							"uid": "26ek"
+						},
+						{
+							"part": "idler-gear",
+							"qty": 1,
+							"uid": "7bv7"
+						},
+						{
+							"part": "input-gear",
+							"qty": 1,
+							"uid": "70ul"
+						},
+						{
+							"part": "motor-nema17",
+							"qty": 1,
+							"uid": "w7pq"
+						},
+						{
+							"part": "scr-m3-16-shcs",
+							"qty": 3,
+							"uid": "e0ud"
+						},
+						{
+							"part": "scr-m3-12-cs",
+							"qty": 10,
+							"uid": "0a9x"
+						},
+						{
+							"part": "scr-m3-8-shcs",
+							"qty": 1,
+							"uid": "ql35"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "sbwe",
+					"date": "2026-08-31",
+					"message": "Moved the Output gear (130T) and its 6 \u00d7 M3 \u00d7 12 out to the new rotor units: the gear bolts to the rotor, so the joint and its screws belong to the node that holds both. No physical change.",
+					"breaking": false,
+					"commit": null
+				}
+			],
 			"lines": [
 				{
 					"part": "stator",
@@ -1570,10 +1702,6 @@
 				},
 				{
 					"part": "nema-bracket",
-					"qty": 1
-				},
-				{
-					"part": "output-gear",
 					"qty": 1
 				},
 				{
@@ -1594,7 +1722,7 @@
 				},
 				{
 					"part": "scr-m3-12-cs",
-					"qty": 10
+					"qty": 4
 				},
 				{
 					"part": "scr-m3-8-shcs",
@@ -1627,15 +1755,68 @@
 					"method": "self-tap",
 					"note": "Threads through the gear hub and bears on the motor shaft flat.",
 					"draft": true
+				}
+			]
+		},
+		{
+			"id": "rotor-unit-faceted",
+			"uid": "df0i",
+			"version": "1",
+			"name": "Rotor unit (faceted)",
+			"description": "The faceted rotor with the Output gear (130T) bolted on. Assembled once as a unit; a C-channel drive spins it.",
+			"lines": [
+				{
+					"part": "rotor-faceted",
+					"qty": 1
 				},
+				{
+					"part": "output-gear",
+					"qty": 1
+				},
+				{
+					"part": "scr-m3-12-cs",
+					"qty": 6
+				}
+			],
+			"connections": [
 				{
 					"from": "output-gear",
 					"to": "rotor-faceted",
 					"via": "scr-m3-12-cs",
 					"qty": 6,
 					"method": "self-tap",
-					"note": "One per spoke. The rotor is the parent's line (finned instead of faceted in the classification chamber). Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing.",
-					"draft": true
+					"note": "One per spoke. Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing."
+				}
+			]
+		},
+		{
+			"id": "rotor-unit-finned",
+			"uid": "iau5",
+			"version": "1",
+			"name": "Rotor unit (finned)",
+			"description": "The finned rotor with the Output gear (130T) bolted on. Assembled once as a unit; the classification channel's C-channel drive spins it.",
+			"lines": [
+				{
+					"part": "rotor-finned",
+					"qty": 1
+				},
+				{
+					"part": "output-gear",
+					"qty": 1
+				},
+				{
+					"part": "scr-m3-12-cs",
+					"qty": 6
+				}
+			],
+			"connections": [
+				{
+					"from": "output-gear",
+					"to": "rotor-finned",
+					"via": "scr-m3-12-cs",
+					"qty": 6,
+					"method": "self-tap",
+					"note": "One per spoke. Same joint as the faceted rotor unit."
 				}
 			]
 		},

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1560,7 +1560,7 @@
 			"uid": "mttx",
 			"version": "1",
 			"name": "C-channel drive",
-			"description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Screw joints: 4 \u00d7 [[hw:scr-m3-12-cs]] hold the NEMA bracket to the stator; 3 \u00d7 [[hw:scr-m3-16-shcs]] hold the stepper to the NEMA bracket; 1 \u00d7 [[hw:scr-m3-8-shcs]] clamps the input gear to the motor shaft flat; 6 \u00d7 [[hw:scr-m3-12-cs]] attach the output gear to the rotor, one per spoke \u2014 the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing (the light post's 2 \u00d7 [[hw:scr-m3-20-cs]] into the NEMA bracket live on the light-post assembly). The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
+			"description": "One C-channel drive unit: stator, NEMA bracket, output gear, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. The rotor differs by location (faceted in the feeder, finned in the classification chamber), so it is not part of this node.",
 			"docs": "/hardware/assembly/feeder/c-channel/",
 			"status": "partial",
 			"lines": [
@@ -1599,6 +1599,43 @@
 				{
 					"part": "scr-m3-8-shcs",
 					"qty": 1
+				}
+			],
+			"connections": [
+				{
+					"from": "nema-bracket",
+					"to": "stator",
+					"via": "scr-m3-12-cs",
+					"qty": 4,
+					"method": "self-tap",
+					"draft": true
+				},
+				{
+					"from": "nema-bracket",
+					"to": "motor-nema17",
+					"via": "scr-m3-16-shcs",
+					"qty": 3,
+					"method": "thread",
+					"note": "Into the NEMA 17's tapped face holes.",
+					"draft": true
+				},
+				{
+					"from": "input-gear",
+					"to": "motor-nema17",
+					"via": "scr-m3-8-shcs",
+					"qty": 1,
+					"method": "self-tap",
+					"note": "Threads through the gear hub and bears on the motor shaft flat.",
+					"draft": true
+				},
+				{
+					"from": "output-gear",
+					"to": "rotor-faceted",
+					"via": "scr-m3-12-cs",
+					"qty": 6,
+					"method": "self-tap",
+					"note": "One per spoke. The rotor is the parent's line (finned instead of faceted in the classification chamber). Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing.",
+					"draft": true
 				}
 			]
 		},

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -36,7 +36,9 @@
 		lineQty,
 		plainDescription,
 		primaryColorId,
+		type Assembly,
 		type AssemblyLine,
+		type AssemblySnapshotLine,
 		type Hardware,
 		type Joining,
 		type Part,
@@ -216,6 +218,75 @@
 		partial: 'Some of this assembly is recorded, but not all of it. The parts and hardware shown are real; the list is known to be missing pieces, and the data does not say which.'
 	};
 
+	// ---- assembly versions: view any revision, diff any two ------------------
+	// versions[] ends with the current revision; superseded entries carry the
+	// lines as they were, each pinned to the member's uid of the day. Viewing an
+	// old version swaps the node's line rows for that snapshot; picking a diff
+	// base marks what changed between the two.
+	let shownVersion = $state<Record<string, string>>({});
+	let diffBase = $state<Record<string, string>>({});
+
+	const currentVersion = (asm: Assembly) => String(asm.version ?? '1');
+
+	function memberOf(id: string) {
+		return getPart(id) ?? getHardware(id) ?? getLasercut(id) ?? getAssembly(id);
+	}
+	function memberName(id: string): string {
+		return memberOf(id)?.name ?? id;
+	}
+	/** Which revision of the member a pinned uid names: its version number, or
+	 *  null when the uid predates the member's recorded history. */
+	function memberRev(id: string, uid?: string): string | null {
+		if (!uid) return null;
+		const m = getPart(id) ?? getAssembly(id);
+		if (!m) return null;
+		if (m.uid === uid) return String(m.version ?? '1');
+		return m.versions?.find((v) => v.uid === uid)?.version ?? null;
+	}
+
+	/** The line snapshot at one version: the live lines for the current one
+	 *  (pinned to each member's current uid, which is what a snapshot taken now
+	 *  would say), a versions[] entry's snapshot otherwise. */
+	function linesAt(asm: Assembly, v: string): AssemblySnapshotLine[] | null {
+		if (v === currentVersion(asm))
+			return (asm.lines ?? []).map((l) => ({ ...l, uid: memberOf(l.part ?? l.assembly ?? '')?.uid }));
+		return asm.versions?.find((e) => e.version === v)?.lines ?? null;
+	}
+
+	type DiffRow = {
+		id: string;
+		kind: 'same' | 'added' | 'removed' | 'qty' | 'rev';
+		old?: AssemblySnapshotLine;
+		now?: AssemblySnapshotLine;
+	};
+	const sumQty = (a: AssemblyLine['qty'], b: AssemblyLine['qty']) =>
+		typeof a === 'number' && typeof b === 'number' ? a + b : (`${a} + ${b}` as const);
+	/** Line-level diff between two snapshots, keyed by member id. A member
+	 *  listed twice is aggregated first, so it can't diff against itself. */
+	function diffLines(oldL: AssemblySnapshotLine[], newL: AssemblySnapshotLine[]): DiffRow[] {
+		const gather = (ls: AssemblySnapshotLine[]) => {
+			const m = new Map<string, AssemblySnapshotLine>();
+			for (const l of ls) {
+				const k = l.part ?? l.assembly ?? '';
+				const g = m.get(k);
+				m.set(k, g ? { ...g, qty: sumQty(g.qty, l.qty) as AssemblyLine['qty'] } : { ...l });
+			}
+			return m;
+		};
+		const om = gather(oldL);
+		const nm = gather(newL);
+		const rows: DiffRow[] = [];
+		for (const [k, o] of om) {
+			const n = nm.get(k);
+			if (!n) rows.push({ id: k, kind: 'removed', old: o });
+			else if (String(o.qty) !== String(n.qty)) rows.push({ id: k, kind: 'qty', old: o, now: n });
+			else if (o.uid && n.uid && o.uid !== n.uid) rows.push({ id: k, kind: 'rev', old: o, now: n });
+			else rows.push({ id: k, kind: 'same', old: o, now: n });
+		}
+		for (const [k, n] of nm) if (!om.has(k)) rows.push({ id: k, kind: 'added', now: n });
+		return rows;
+	}
+
 	// Clicking a thumbnail in the tree opens the same detail view the other tabs use:
 	// printed parts get the parts-dashboard modal (3D viewer, versions, plates);
 	// off-the-shelf items get the hardware modal (specs, where it goes, sourcing).
@@ -376,6 +447,102 @@
 	{/each}
 {/snippet}
 
+<!-- One member of a version snapshot or diff row: name, kind, pinned uid and
+     the member revision that uid names. -->
+{#snippet memberCell(id: string, uid: string | undefined, struck: boolean)}
+	{@const render = getPart(id)?.render}
+	{#if render}<img src={render} alt="" class="h-7 w-7 shrink-0 object-contain {struck ? 'opacity-50' : ''}" />{/if}
+	<span class="min-w-0 flex-1">
+		<span class="font-semibold text-text {struck ? 'line-through opacity-60' : ''}">{memberName(id)}</span>
+		{#if getAssembly(id)}<span class="ml-1 border border-border px-1 py-px text-[9px] font-semibold uppercase tracking-wider text-text-muted">assembly</span>{/if}
+		{#if uid}
+			<span class="ml-1.5 font-mono text-[11px] text-text-muted">{uid}</span>
+			{#if memberRev(id, uid)}<span class="text-[11px] text-text-muted"> · v{memberRev(id, uid)}</span>{/if}
+		{/if}
+	</span>
+{/snippet}
+
+{#snippet snapshotRow(l: AssemblySnapshotLine)}
+	<li class="flex items-center gap-2.5 border border-border bg-surface px-2 py-1.5 text-xs">
+		{@render memberCell(l.part ?? l.assembly ?? '', l.uid, false)}
+		<span class="shrink-0 font-semibold tabular-nums">×{l.qty}</span>
+	</li>
+{/snippet}
+
+{#snippet diffRow(r: DiffRow)}
+	{@const l = r.now ?? r.old}
+	<li
+		class="flex items-center gap-2.5 border px-2 py-1.5 text-xs {r.kind === 'added'
+			? 'border-primary/60 bg-primary/[0.05]'
+			: r.kind === 'removed'
+				? 'border-border bg-surface opacity-75'
+				: 'border-border bg-surface'}"
+	>
+		<span
+			class="w-8 shrink-0 text-center font-mono text-[10px] font-semibold uppercase {r.kind === 'added'
+				? 'text-primary'
+				: r.kind === 'removed'
+					? 'text-warning-dark'
+					: r.kind === 'same'
+						? 'text-text-muted'
+						: 'text-warning-dark'}"
+			title={r.kind === 'added' ? 'Added in the newer version' : r.kind === 'removed' ? 'Removed in the newer version' : r.kind === 'qty' ? 'Quantity changed' : r.kind === 'rev' ? 'Member revised (new uid)' : 'Unchanged'}
+		>{r.kind === 'added' ? '+' : r.kind === 'removed' ? '−' : r.kind === 'qty' ? 'qty' : r.kind === 'rev' ? 'rev' : '·'}</span>
+		{@render memberCell(r.id, l?.uid, r.kind === 'removed')}
+		<span class="shrink-0 tabular-nums {r.kind === 'same' ? 'text-text-muted' : 'font-semibold'}">
+			{#if r.kind === 'qty'}×{r.old?.qty} → ×{r.now?.qty}
+			{:else if r.kind === 'rev'}<span class="font-mono text-[11px]">{r.old?.uid} → {r.now?.uid}</span>
+			{:else}×{l?.qty}{/if}
+		</span>
+	</li>
+{/snippet}
+
+<!-- A node's line rows, routed by the header's version controls: the live
+     lines, one version's snapshot, or the diff between two versions. -->
+{#snippet versionSwitch(asm: Assembly, mult: number, depth: number)}
+	{@const cur = currentVersion(asm)}
+	{@const shown = filtering ? cur : (shownVersion[asm.id] ?? cur)}
+	{@const base = filtering ? undefined : diffBase[asm.id]}
+	{#if base && base !== shown}
+		{@const [lo, hi] = Number(base) <= Number(shown) ? [base, shown] : [shown, base]}
+		<div class="ml-1.5 mt-2 sm:ml-4">
+			<div class="flex flex-wrap items-center gap-x-2 gap-y-1 border border-warning/50 bg-warning/[0.08] px-2 py-1.5 text-xs text-warning-dark">
+				<History size={11} /> Changes v{lo} → v{hi}
+				<button type="button" class="ml-auto font-medium underline underline-offset-2" onclick={() => delete diffBase[asm.id]}>close diff</button>
+			</div>
+			<ul class="mt-1.5 space-y-1">
+				{#each diffLines(linesAt(asm, lo) ?? [], linesAt(asm, hi) ?? []) as r (r.id)}
+					{@render diffRow(r)}
+				{/each}
+			</ul>
+		</div>
+	{:else if shown !== cur}
+		{@const entry = asm.versions?.find((e) => e.version === shown)}
+		<div class="ml-1.5 mt-2 sm:ml-4">
+			<div class="flex flex-wrap items-center gap-x-2 gap-y-1 border border-warning/50 bg-warning/[0.08] px-2 py-1.5 text-xs text-warning-dark">
+				<History size={11} /> v{shown}, superseded{entry?.date ? ` ${fmtDate(entry.date)}` : ''}
+				{#if entry?.uid}<span class="font-mono">{entry.uid}</span>{/if}
+				<button type="button" class="ml-auto font-medium underline underline-offset-2" onclick={() => delete shownVersion[asm.id]}>back to v{cur}</button>
+			</div>
+			{#if entry?.message}<AssemblyDescription text={entry.message} class="mt-1 max-w-2xl text-xs text-text-muted" />{/if}
+			{#if entry?.lines?.length}
+				<ul class="mt-1.5 space-y-1">
+					{#each entry.lines as l, i (`${l.part ?? l.assembly}-${i}`)}
+						{@render snapshotRow(l)}
+					{/each}
+				</ul>
+			{:else if entry?.lines}
+				<p class="mt-1.5 text-xs italic text-text-muted">Nothing was recorded in this version.</p>
+			{:else}
+				<p class="mt-1.5 text-xs italic text-text-muted">This version's lines were not snapshotted.</p>
+			{/if}
+		</div>
+	{:else}
+		{@render joiningRows(asm.joining)}
+		{@render lines(asm.lines ?? [], mult, depth)}
+	{/if}
+{/snippet}
+
 {#snippet node(id: string, qty: AssemblyLine['qty'], mult: number, depth: number)}
 	{@const asm = getAssembly(id)}
 	{#if asm && (!filtering || keep.assemblies.has(asm.id))}
@@ -436,6 +603,37 @@
 					{:else if qty === 'middle-layers'}×{Math.max(0, layers - 2)} (layers between the interfaces)
 					{:else if qty !== 1}×{qty}{/if}
 				</span>
+				{#if !filtering && (asm.versions?.length ?? 0) > 1}
+					<select
+						class="asm-ver"
+						value={shownVersion[asm.id] ?? currentVersion(asm)}
+						onchange={(e) => (shownVersion[asm.id] = e.currentTarget.value)}
+						aria-label="{asm.name}: version to display"
+					>
+						{#each [...(asm.versions ?? [])].reverse() as v (v.version)}
+							<option value={v.version}>v{v.version}{v.version === currentVersion(asm) ? '' : ' (superseded)'}</option>
+						{/each}
+					</select>
+					<select
+						class="asm-ver"
+						value={diffBase[asm.id] ?? ''}
+						onchange={(e) => {
+							const val = e.currentTarget.value;
+							if (val) diffBase[asm.id] = val;
+							else delete diffBase[asm.id];
+						}}
+						aria-label="{asm.name}: version to diff against"
+					>
+						<option value="">diff…</option>
+						{#each [...(asm.versions ?? [])].reverse() as v (v.version)}
+							{#if v.version !== (shownVersion[asm.id] ?? currentVersion(asm))}
+								<option value={v.version}>vs v{v.version}</option>
+							{/if}
+						{/each}
+					</select>
+				{:else}
+					<span class="font-mono text-[11px] text-text-muted">v{currentVersion(asm)}</span>
+				{/if}
 				{#if asm.status === 'stub'}
 					<span
 						class="cursor-help border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
@@ -484,8 +682,7 @@
 			<div class="tree-branch relative pl-2 sm:pl-4">
 				<button type="button" class="tree-line" onclick={() => toggle(asm.id)} aria-label="Collapse {asm.name}"></button>
 			{#if asm.images?.length}<div class="mt-2"><ImageStrip images={asm.images} /></div>{/if}
-			{@render joiningRows(asm.joining)}
-			{@render lines(asm.lines ?? [], mult, depth)}
+			{@render versionSwitch(asm, mult, depth)}
 			<!-- Alternative bills of materials under test, rendered with the same
 			     line rows. -->
 			{#each (filtering ? [] : (asm.candidates ?? [])) as c (c.uid)}
@@ -505,29 +702,6 @@
 					{@render lines(c.lines, mult, depth)}
 				</div>
 			{/each}
-			<!-- Superseded structures, each line pinned to the member's uid of the day. -->
-			{#if !filtering && (asm.versions?.length ?? 0) > 1}
-				<details class="ml-1.5 mt-3 sm:ml-4">
-					<summary class="inline-flex cursor-pointer items-center gap-1 text-xs font-semibold uppercase tracking-wider text-text-muted hover:text-text"><History size={11} /> Previous revisions · {(asm.versions?.length ?? 1) - 1}</summary>
-					{#each [...(asm.versions ?? [])].slice(0, -1).reverse() as v (v.version)}
-						<div class="mt-2 border border-border bg-surface p-2 text-xs sm:p-3">
-							<div class="flex flex-wrap items-baseline gap-x-2">
-								<b class="text-text">v{v.version}</b>
-								{#if v.uid}<span class="font-mono text-text-muted">{v.uid}</span>{/if}
-								<span class="text-text-muted">· {fmtDate(v.date)}</span>
-							</div>
-							<AssemblyDescription text={v.message} class="mt-0.5 max-w-2xl text-text-muted" />
-							{#if v.images?.length}<div class="mt-2"><ImageStrip images={v.images} /></div>{/if}
-							<ul class="mt-1.5 space-y-0.5 text-text-muted">
-								{#each v.lines ?? [] as l, i (`${l.part ?? l.assembly}-${i}`)}
-									{@const name = (l.part && (getPart(l.part)?.name ?? getHardware(l.part)?.name ?? getLasercut(l.part)?.name)) ?? (l.assembly && getAssembly(l.assembly)?.name) ?? l.part ?? l.assembly}
-									<li><span class="tabular-nums">×{l.qty}</span> {name}{#if l.uid} <span class="font-mono">{l.uid}</span>{/if}</li>
-								{/each}
-							</ul>
-						</div>
-					{/each}
-				</details>
-			{/if}
 			</div>
 			{/if}
 		</div>
@@ -614,5 +788,21 @@
 	.tree-line:hover::before,
 	.tree-line:focus-visible::before {
 		background: var(--color-primary);
+	}
+	/* The version dropdowns in a node's header row. Native selects, sized to
+	   read as chips beside the name. */
+	.asm-ver {
+		border: 1px solid var(--color-border);
+		background: var(--color-surface);
+		color: var(--color-text);
+		font-size: 11px;
+		font-family: var(--font-mono, monospace);
+		padding: 1px 2px;
+		cursor: pointer;
+	}
+	.asm-ver:hover,
+	.asm-ver:focus-visible {
+		outline: none;
+		border-color: var(--color-primary);
 	}
 </style>

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -488,7 +488,7 @@
 						<span class="border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
 							>{part ? '3D printed' : 'assembly'}</span>
 						{#if l.uid}
-							<span class="font-mono text-xs text-text-muted">{l.uid}{rev ? ` · v${rev}` : ''}</span>
+							<span class="font-mono text-xs text-text-muted">{l.uid}</span>{#if rev}<span class="text-xs text-text-muted">· v{rev}</span>{/if}
 						{/if}
 					</div>
 					{#if part && typeof (pv?.grams ?? part.grams) === 'number'}
@@ -548,11 +548,11 @@
 		<div class="ml-1.5 mt-2 sm:ml-4">
 			<div class="grid grid-cols-2 gap-x-1.5 gap-y-1">
 				<div class="flex items-baseline gap-1.5 border-b border-danger/60 px-2 pb-1 text-xs">
-					<span class="font-mono font-semibold text-danger">v{lo}</span>
+					<span class="font-semibold text-danger">v{lo}</span>
 					<span class="text-text-muted">{lo === cur ? 'current' : `superseded${loEntry?.date ? ` ${fmtDate(loEntry.date)}` : ''}`}</span>
 				</div>
 				<div class="flex items-baseline gap-1.5 border-b border-success/60 px-2 pb-1 text-xs">
-					<span class="font-mono font-semibold text-success">v{hi}</span>
+					<span class="font-semibold text-success">v{hi}</span>
 					<span class="text-text-muted">{hi === cur ? 'current' : 'superseded'}</span>
 				</div>
 				{#each diffLines(linesAt(asm, lo) ?? [], linesAt(asm, hi) ?? []) as r (r.id)}
@@ -672,7 +672,7 @@
 						{#if diffBase[asm.id]}
 							<button
 								type="button"
-								class="inline-flex items-center gap-1 border border-border bg-surface px-1.5 py-0.5 text-[11px] font-medium text-text hover:border-primary"
+								class="inline-flex items-center gap-1 border border-border bg-surface px-1.5 py-0.5 text-xs text-text hover:border-primary"
 								onclick={() => delete diffBase[asm.id]}
 								title="Close the diff"
 							>
@@ -683,7 +683,7 @@
 								{#snippet trigger({ toggle, open })}
 									<button
 										type="button"
-										class="inline-flex items-center gap-0.5 text-[11px] font-medium text-text-muted hover:text-text"
+										class="inline-flex items-center gap-0.5 text-xs text-text-muted hover:text-text"
 										onclick={toggle}
 										aria-expanded={open}
 									>
@@ -701,7 +701,7 @@
 													close();
 												}}
 											>
-												<span class="font-mono">v{v.version}</span>
+												<span>v{v.version}</span>
 												<span class="text-text-muted">{v.version === currentVersion(asm) ? 'current' : `superseded${v.date ? ` ${fmtDate(v.date)}` : ''}`}</span>
 											</button>
 										{/if}
@@ -714,7 +714,7 @@
 								{@const viewingOld = !!shownVersion[asm.id] && shownVersion[asm.id] !== currentVersion(asm)}
 								<button
 									type="button"
-									class="inline-flex items-center gap-1 border px-1.5 py-0.5 font-mono text-[11px] {viewingOld
+									class="inline-flex items-center gap-1 border px-1.5 py-0.5 text-xs {viewingOld
 										? 'border-warning/50 bg-warning/[0.08] text-warning-dark hover:border-warning'
 										: 'border-border bg-surface text-text hover:border-primary'}"
 									onclick={toggle}
@@ -737,7 +737,7 @@
 											close();
 										}}
 									>
-										<span class="font-mono">v{v.version}</span>
+										<span>v{v.version}</span>
 										<span class="text-text-muted">{v.version === currentVersion(asm) ? 'current' : `superseded${v.date ? ` ${fmtDate(v.date)}` : ''}`}</span>
 										{#if active}<Check size={12} class="ml-auto text-primary" />{/if}
 									</button>
@@ -745,7 +745,7 @@
 							{/snippet}
 						</DropdownMenu>
 					{:else}
-						<span class="font-mono text-[11px] text-text-muted">v{currentVersion(asm)}</span>
+						<span class="text-xs text-text-muted">v{currentVersion(asm)}</span>
 					{/if}
 					{#if hasContent}
 						<button

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import {
+		Check,
 		ChevronDown,
 		ChevronRight,
 		Download,
@@ -8,8 +9,10 @@
 		FlaskConical,
 		History,
 		Info,
+		X,
 		Zap
 	} from 'lucide-svelte';
+	import DropdownMenu from '$lib/components/DropdownMenu.svelte';
 	import AlternativeBadge from '$lib/components/AlternativeBadge.svelte';
 	import ConflictBadge from '$lib/components/ConflictBadge.svelte';
 	import AssemblyDescription from '$lib/components/AssemblyDescription.svelte';
@@ -469,32 +472,23 @@
 	</li>
 {/snippet}
 
-{#snippet diffRow(r: DiffRow)}
-	{@const l = r.now ?? r.old}
-	<li
-		class="flex items-center gap-2.5 border px-2 py-1.5 text-xs {r.kind === 'added'
-			? 'border-primary/60 bg-primary/[0.05]'
-			: r.kind === 'removed'
-				? 'border-border bg-surface opacity-75'
-				: 'border-border bg-surface'}"
-	>
-		<span
-			class="w-8 shrink-0 text-center font-mono text-[10px] font-semibold uppercase {r.kind === 'added'
-				? 'text-primary'
-				: r.kind === 'removed'
-					? 'text-warning-dark'
-					: r.kind === 'same'
-						? 'text-text-muted'
-						: 'text-warning-dark'}"
-			title={r.kind === 'added' ? 'Added in the newer version' : r.kind === 'removed' ? 'Removed in the newer version' : r.kind === 'qty' ? 'Quantity changed' : r.kind === 'rev' ? 'Member revised (new uid)' : 'Unchanged'}
-		>{r.kind === 'added' ? '+' : r.kind === 'removed' ? '−' : r.kind === 'qty' ? 'qty' : r.kind === 'rev' ? 'rev' : '·'}</span>
-		{@render memberCell(r.id, l?.uid, r.kind === 'removed')}
-		<span class="shrink-0 tabular-nums {r.kind === 'same' ? 'text-text-muted' : 'font-semibold'}">
-			{#if r.kind === 'qty'}×{r.old?.qty} → ×{r.now?.qty}
-			{:else if r.kind === 'rev'}<span class="font-mono text-[11px]">{r.old?.uid} → {r.now?.uid}</span>
-			{:else}×{l?.qty}{/if}
-		</span>
-	</li>
+<!-- One side of a diff row. Absent = the member doesn't exist in this
+     version; a dashed placeholder keeps the two columns aligned. -->
+{#snippet diffCell(l: AssemblySnapshotLine | undefined, tone: 'plain' | 'danger' | 'success')}
+	{#if l}
+		<div
+			class="flex items-center gap-2 border px-2 py-1.5 text-xs {tone === 'danger'
+				? 'border-danger/50 bg-danger/[0.06]'
+				: tone === 'success'
+					? 'border-success/50 bg-success/[0.07]'
+					: 'border-border bg-surface'}"
+		>
+			{@render memberCell(l.part ?? l.assembly ?? '', l.uid, false)}
+			<span class="shrink-0 tabular-nums {tone === 'plain' ? 'text-text-muted' : 'font-semibold'} {tone === 'danger' ? 'text-danger-dark' : tone === 'success' ? 'text-success-dark' : ''}">×{l.qty}</span>
+		</div>
+	{:else}
+		<div class="border border-dashed border-border/70"></div>
+	{/if}
 {/snippet}
 
 <!-- A node's line rows, routed by the header's version controls: the live
@@ -505,16 +499,22 @@
 	{@const base = filtering ? undefined : diffBase[asm.id]}
 	{#if base && base !== shown}
 		{@const [lo, hi] = Number(base) <= Number(shown) ? [base, shown] : [shown, base]}
+		{@const loEntry = asm.versions?.find((e) => e.version === lo)}
 		<div class="ml-1.5 mt-2 sm:ml-4">
-			<div class="flex flex-wrap items-center gap-x-2 gap-y-1 border border-warning/50 bg-warning/[0.08] px-2 py-1.5 text-xs text-warning-dark">
-				<History size={11} /> Changes v{lo} → v{hi}
-				<button type="button" class="ml-auto font-medium underline underline-offset-2" onclick={() => delete diffBase[asm.id]}>close diff</button>
-			</div>
-			<ul class="mt-1.5 space-y-1">
+			<div class="grid grid-cols-2 gap-x-1.5 gap-y-1">
+				<div class="flex items-baseline gap-1.5 border-b border-danger/60 px-2 pb-1 text-xs">
+					<span class="font-mono font-semibold text-danger">v{lo}</span>
+					<span class="text-text-muted">{lo === cur ? 'current' : `superseded${loEntry?.date ? ` ${fmtDate(loEntry.date)}` : ''}`}</span>
+				</div>
+				<div class="flex items-baseline gap-1.5 border-b border-success/60 px-2 pb-1 text-xs">
+					<span class="font-mono font-semibold text-success">v{hi}</span>
+					<span class="text-text-muted">{hi === cur ? 'current' : 'superseded'}</span>
+				</div>
 				{#each diffLines(linesAt(asm, lo) ?? [], linesAt(asm, hi) ?? []) as r (r.id)}
-					{@render diffRow(r)}
+					{@render diffCell(r.kind === 'added' ? undefined : r.old, r.kind === 'same' ? 'plain' : 'danger')}
+					{@render diffCell(r.kind === 'removed' ? undefined : r.now, r.kind === 'same' ? 'plain' : 'success')}
 				{/each}
-			</ul>
+			</div>
 		</div>
 	{:else if shown !== cur}
 		{@const entry = asm.versions?.find((e) => e.version === shown)}
@@ -603,37 +603,6 @@
 					{:else if qty === 'middle-layers'}×{Math.max(0, layers - 2)} (layers between the interfaces)
 					{:else if qty !== 1}×{qty}{/if}
 				</span>
-				{#if !filtering && (asm.versions?.length ?? 0) > 1}
-					<select
-						class="asm-ver"
-						value={shownVersion[asm.id] ?? currentVersion(asm)}
-						onchange={(e) => (shownVersion[asm.id] = e.currentTarget.value)}
-						aria-label="{asm.name}: version to display"
-					>
-						{#each [...(asm.versions ?? [])].reverse() as v (v.version)}
-							<option value={v.version}>v{v.version}{v.version === currentVersion(asm) ? '' : ' (superseded)'}</option>
-						{/each}
-					</select>
-					<select
-						class="asm-ver"
-						value={diffBase[asm.id] ?? ''}
-						onchange={(e) => {
-							const val = e.currentTarget.value;
-							if (val) diffBase[asm.id] = val;
-							else delete diffBase[asm.id];
-						}}
-						aria-label="{asm.name}: version to diff against"
-					>
-						<option value="">diff…</option>
-						{#each [...(asm.versions ?? [])].reverse() as v (v.version)}
-							{#if v.version !== (shownVersion[asm.id] ?? currentVersion(asm))}
-								<option value={v.version}>vs v{v.version}</option>
-							{/if}
-						{/each}
-					</select>
-				{:else}
-					<span class="font-mono text-[11px] text-text-muted">v{currentVersion(asm)}</span>
-				{/if}
 				{#if asm.status === 'stub'}
 					<span
 						class="cursor-help border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
@@ -655,6 +624,80 @@
 						>
 							In Docs <ExternalLink size={10} />
 						</a>
+					{/if}
+					{#if !filtering && (asm.versions?.length ?? 0) > 1}
+						{#if diffBase[asm.id]}
+							<button
+								type="button"
+								class="inline-flex items-center gap-1 border border-border bg-surface px-1.5 py-0.5 text-[11px] font-medium text-text hover:border-primary"
+								onclick={() => delete diffBase[asm.id]}
+								title="Close the diff"
+							>
+								diff v{diffBase[asm.id]} <X size={11} />
+							</button>
+						{:else}
+							<DropdownMenu label="{asm.name}: diff against a version" menuClass="w-48">
+								{#snippet trigger({ toggle, open })}
+									<button
+										type="button"
+										class="inline-flex items-center gap-0.5 text-[11px] font-medium text-text-muted hover:text-text"
+										onclick={toggle}
+										aria-expanded={open}
+									>
+										Diff against <ChevronDown size={11} />
+									</button>
+								{/snippet}
+								{#snippet children({ close })}
+									{#each [...(asm.versions ?? [])].reverse() as v (v.version)}
+										{#if v.version !== (shownVersion[asm.id] ?? currentVersion(asm))}
+											<button
+												type="button"
+												class="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-[var(--color-bg)]"
+												onclick={() => {
+													diffBase[asm.id] = v.version;
+													close();
+												}}
+											>
+												<span class="font-mono">v{v.version}</span>
+												<span class="text-text-muted">{v.version === currentVersion(asm) ? 'current' : `superseded${v.date ? ` ${fmtDate(v.date)}` : ''}`}</span>
+											</button>
+										{/if}
+									{/each}
+								{/snippet}
+							</DropdownMenu>
+						{/if}
+						<DropdownMenu label="{asm.name}: version to display" menuClass="w-52">
+							{#snippet trigger({ toggle, open })}
+								<button
+									type="button"
+									class="inline-flex items-center gap-1 border border-border bg-surface px-1.5 py-0.5 font-mono text-[11px] text-text hover:border-primary"
+									onclick={toggle}
+									aria-expanded={open}
+								>
+									v{shownVersion[asm.id] ?? currentVersion(asm)} <ChevronDown size={11} />
+								</button>
+							{/snippet}
+							{#snippet children({ close })}
+								{#each [...(asm.versions ?? [])].reverse() as v (v.version)}
+									{@const active = v.version === (shownVersion[asm.id] ?? currentVersion(asm))}
+									<button
+										type="button"
+										class="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-[var(--color-bg)]"
+										onclick={() => {
+											if (v.version === currentVersion(asm)) delete shownVersion[asm.id];
+											else shownVersion[asm.id] = v.version;
+											close();
+										}}
+									>
+										<span class="font-mono">v{v.version}</span>
+										<span class="text-text-muted">{v.version === currentVersion(asm) ? 'current' : `superseded${v.date ? ` ${fmtDate(v.date)}` : ''}`}</span>
+										{#if active}<Check size={12} class="ml-auto text-primary" />{/if}
+									</button>
+								{/each}
+							{/snippet}
+						</DropdownMenu>
+					{:else}
+						<span class="font-mono text-[11px] text-text-muted">v{currentVersion(asm)}</span>
 					{/if}
 					{#if hasContent}
 						<button
@@ -788,21 +831,5 @@
 	.tree-line:hover::before,
 	.tree-line:focus-visible::before {
 		background: var(--color-primary);
-	}
-	/* The version dropdowns in a node's header row. Native selects, sized to
-	   read as chips beside the name. */
-	.asm-ver {
-		border: 1px solid var(--color-border);
-		background: var(--color-surface);
-		color: var(--color-text);
-		font-size: 11px;
-		font-family: var(--font-mono, monospace);
-		padding: 1px 2px;
-		cursor: pointer;
-	}
-	.asm-ver:hover,
-	.asm-ver:focus-visible {
-		outline: none;
-		border-color: var(--color-primary);
 	}
 </style>

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -465,11 +465,56 @@
 	</span>
 {/snippet}
 
-{#snippet snapshotRow(l: AssemblySnapshotLine)}
-	<li class="flex items-center gap-2.5 border border-border bg-surface px-2 py-1.5 text-xs">
-		{@render memberCell(l.part ?? l.assembly ?? '', l.uid, false)}
-		<span class="shrink-0 font-semibold tabular-nums">×{l.qty}</span>
-	</li>
+<!-- A snapshot line rendered in the same style as the live rows, so an old
+     version reads like the assembly did then — down to the archived render
+     and grams of the pinned revision, when they were recorded. -->
+{#snippet snapshotRow(l: AssemblySnapshotLine, mult: number)}
+	{@const id = l.part ?? l.assembly ?? ''}
+	{@const part = getPart(id)}
+	{@const hw = getHardware(id)}
+	{@const qtyN = typeof l.qty === 'number' ? l.qty : null}
+	{@const total = qtyN === null ? null : qtyN * mult}
+	{@const rev = memberRev(id, l.uid)}
+	{@const pv = part?.versions?.find((v) => v.uid === l.uid)}
+	{#if part || getAssembly(id)}
+		<div class="ml-1.5 mt-2 border border-border bg-surface p-2 sm:ml-4 sm:p-3">
+			<div class="flex items-center gap-3">
+				{#if part}
+					<img src={pv?.render ?? part.render} alt={part.name} class="h-12 w-12 shrink-0 object-contain" />
+				{/if}
+				<div class="min-w-0 flex-1">
+					<div class="flex flex-wrap items-baseline gap-x-2">
+						<span class="text-sm font-semibold text-text">{memberName(id)}</span>
+						<span class="border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
+							>{part ? '3D printed' : 'assembly'}</span>
+						{#if l.uid}
+							<span class="font-mono text-xs text-text-muted">{l.uid}{rev ? ` · v${rev}` : ''}</span>
+						{/if}
+					</div>
+					{#if part && typeof (pv?.grams ?? part.grams) === 'number'}
+						<div class="text-xs text-text-muted">{(pv?.grams ?? part.grams).toFixed(0)} g each</div>
+					{/if}
+				</div>
+				<div class="text-right text-xs tabular-nums text-text">
+					<div class="font-semibold">×{l.qty}</div>
+					{#if total !== null && total !== qtyN}<div class="text-text-muted">{total} total</div>{/if}
+				</div>
+			</div>
+		</div>
+	{:else}
+		{@const img = hw ? hardwareImage(hw) : null}
+		<div class="ml-1.5 mt-2 flex items-center gap-3 border border-border bg-[var(--color-bg)] p-2 sm:ml-4">
+			{#if img}<img src={img.src} alt={hw?.name} class="h-8 w-8 shrink-0 object-contain" />{/if}
+			<div class="flex min-w-0 flex-1 items-center gap-1.5 text-xs font-semibold text-text">
+				{#if hw}<HardwareIcon {hw} size={14} />{/if}<span class="truncate">{memberName(id)}</span>
+				{#if l.uid}<span class="font-mono font-normal text-text-muted">{l.uid}</span>{/if}
+			</div>
+			<div class="text-right text-xs tabular-nums text-text">
+				<div class="font-semibold">×{l.qty}</div>
+				{#if total !== null && total !== qtyN}<div class="text-text-muted">{total} total</div>{/if}
+			</div>
+		</div>
+	{/if}
 {/snippet}
 
 <!-- One side of a diff row. Absent = the member doesn't exist in this
@@ -526,11 +571,9 @@
 			</div>
 			{#if entry?.message}<AssemblyDescription text={entry.message} class="mt-1 max-w-2xl text-xs text-text-muted" />{/if}
 			{#if entry?.lines?.length}
-				<ul class="mt-1.5 space-y-1">
-					{#each entry.lines as l, i (`${l.part ?? l.assembly}-${i}`)}
-						{@render snapshotRow(l)}
-					{/each}
-				</ul>
+				{#each entry.lines as l, i (`${l.part ?? l.assembly}-${i}`)}
+					{@render snapshotRow(l, mult)}
+				{/each}
 			{:else if entry?.lines}
 				<p class="mt-1.5 text-xs italic text-text-muted">Nothing was recorded in this version.</p>
 			{:else}
@@ -668,13 +711,16 @@
 						{/if}
 						<DropdownMenu label="{asm.name}: version to display" menuClass="w-52">
 							{#snippet trigger({ toggle, open })}
+								{@const viewingOld = !!shownVersion[asm.id] && shownVersion[asm.id] !== currentVersion(asm)}
 								<button
 									type="button"
-									class="inline-flex items-center gap-1 border border-border bg-surface px-1.5 py-0.5 font-mono text-[11px] text-text hover:border-primary"
+									class="inline-flex items-center gap-1 border px-1.5 py-0.5 font-mono text-[11px] {viewingOld
+										? 'border-warning/50 bg-warning/[0.08] text-warning-dark hover:border-warning'
+										: 'border-border bg-surface text-text hover:border-primary'}"
 									onclick={toggle}
 									aria-expanded={open}
 								>
-									v{shownVersion[asm.id] ?? currentVersion(asm)} <ChevronDown size={11} />
+									{viewingOld ? `Viewing v${shownVersion[asm.id]}` : `v${currentVersion(asm)}`} <ChevronDown size={11} />
 								</button>
 							{/snippet}
 							{#snippet children({ close })}

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -720,7 +720,9 @@
 									onclick={toggle}
 									aria-expanded={open}
 								>
-									{viewingOld ? `Viewing v${shownVersion[asm.id]}` : `v${currentVersion(asm)}`} <ChevronDown size={11} />
+									{viewingOld
+									? `Viewing v${shownVersion[asm.id]} (superseded)`
+									: `Viewing v${currentVersion(asm)} (current)`} <ChevronDown size={11} />
 								</button>
 							{/snippet}
 							{#snippet children({ close })}


### PR DESCRIPTION
Three related pieces on top of #496/#498:

## Connection edges
An assembly's `connections` record its joints as a graph over its members: `{from, to, via, qty, method, note?, draft?}`. `to` is the anchor side (where the fastener ends — thread, insert, nut, T-nut); `via` must be one of the assembly's own hardware lines; `method` extends the joining enum with the anchor kinds; `draft: true` marks an edge extracted from prose, cleared when confirmed at the bench. `check_connections.py` enforces the shape in CI, **including strict member-scoping**: an edge whose endpoint is not one of the assembly's lines is an error — the fix is restructuring, not reaching across levels. Documented in CLAUDE.md.

## The rotor units
The first restructure that rule forced, and Spencer confirmed the physical truth: the Output gear (130T) bolts to the rotor with 6 × M3 × 12, so the joint belongs to a node holding both. New `Rotor unit (faceted)` / `Rotor unit (finned)` assemblies carry rotor + gear + screws with the joint as an edge. C-channel drive (v2) drops the gear and its 6 screws; the feeder's three bare rotors become rotor units (v2); the classification chamber gets its first recorded line and an honest `partial` (v2). All three stamped per VERSIONING.md with `breaking: false` — no physical change — and the superseded uids archived with line snapshots.

## Versions in the tree
Every assembly node shows a version control on the right of its header: **"Viewing v2 (current)"** dropdown to display any revision (snapshot rows render in the live-row style, each line pinned to the member's uid of the day with the revision it resolves to, using the archived render/grams where recorded), and a **"Diff against"** menu that renders two aligned columns — older under a red hairline, newer under green: removed red beside an empty slot, added green, quantity changes red-old vs green-new. Replaces the unreadable previous-revisions disclosure. New `DropdownMenu` component (click-to-open, closes on select); one type treatment across the controls; hairline rule respected.

`svelte-check` clean; `check_connections.py`, `check_versioning.py`, `check_generated_pins.py` all green; verified in the browser through the folded tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)