### PR TITLE
parts-calculator: hex frame restructured as inner + outer, and the first stable tags

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1006,7 +1006,8 @@
       "stl_hash": "313397afb08fc1943f045905b96131f73f1dc70c05d59fd2583c77da38318c36",
       "source": "1_printed_crossbeams - bottom_vertical_bracket.stl",
       "quantities": {
-        "layer": 6
+        "layer": 6,
+        "interface": 6
       },
       "assembly": "external-bracket",
       "color": {
@@ -6275,8 +6276,8 @@
     },
     {
       "id": "interface",
-      "uid": "bkgq",
-      "version": "2",
+      "uid": "uelo",
+      "version": "3",
       "name": "Top interface",
       "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
@@ -6289,14 +6290,6 @@
         {
           "assembly": "hex-frame",
           "qty": 1
-        },
-        {
-          "part": "ext-bracket-cover",
-          "qty": 6
-        },
-        {
-          "part": "scr-m5-16-shcs",
-          "qty": 12
         },
         {
           "assembly": "fixed-upper-section",
@@ -6510,7 +6503,117 @@
           "version": "2",
           "date": "2026-08-29",
           "message": "Consumes the new hex-frame assembly instead of duplicating its ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline. Dropped the stray top-level tnut-m5-2020 qty 8, now superseded by interface-bracket-mount's and limit-switch's own per-step T-nut lines.",
-          "commit": "a2c66436"
+          "commit": "a2c66436",
+          "uid": "bkgq",
+          "lines": [
+            {
+              "assembly": "interface-bracket-mount",
+              "qty": 6,
+              "uid": "pnl9"
+            },
+            {
+              "assembly": "hex-frame",
+              "qty": 1,
+              "uid": "l0xa"
+            },
+            {
+              "part": "ext-bracket-cover",
+              "qty": 6,
+              "uid": "1r5i"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 12,
+              "uid": "2e0s"
+            },
+            {
+              "assembly": "fixed-upper-section",
+              "qty": 1,
+              "uid": "99af"
+            },
+            {
+              "assembly": "cable-cage",
+              "qty": 1,
+              "uid": "nam6"
+            },
+            {
+              "part": "scr-m5-30-shcs",
+              "qty": 6,
+              "uid": "92kv"
+            },
+            {
+              "assembly": "cable-clamp",
+              "qty": 1,
+              "uid": "e0p9"
+            },
+            {
+              "part": "scr-m3-12-bhcs",
+              "qty": 2,
+              "uid": "izrb"
+            },
+            {
+              "assembly": "limit-switch",
+              "qty": 1,
+              "uid": "xzje"
+            },
+            {
+              "part": "scr-m5-20-shcs",
+              "qty": 2,
+              "uid": "e4hi"
+            },
+            {
+              "assembly": "chute-stepper-gearing",
+              "qty": 1,
+              "uid": "cwji"
+            },
+            {
+              "assembly": "interface-chute-drive",
+              "qty": 1,
+              "uid": "8cjj"
+            },
+            {
+              "part": "top-interface-split-spur-gear-2",
+              "qty": 1,
+              "uid": "izz5"
+            },
+            {
+              "assembly": "layer-connector",
+              "qty": 1,
+              "uid": "6m38"
+            },
+            {
+              "part": "brg-lazy-susan",
+              "qty": 1,
+              "uid": "wrxu"
+            },
+            {
+              "part": "scr-m4-12-cs",
+              "qty": 8,
+              "uid": "h8h4"
+            },
+            {
+              "part": "top-plate",
+              "qty": 1,
+              "uid": "1g22"
+            },
+            {
+              "part": "scr-m5-35-fhcs",
+              "qty": 6,
+              "uid": "xkl4"
+            },
+            {
+              "part": "scr-m5-8-cs",
+              "qty": 6,
+              "uid": "mqh4"
+            }
+          ]
+        },
+        {
+          "version": "3",
+          "date": "2026-08-31",
+          "message": "The six External bracket covers and 12 bracket screws move inside the hex frame's new External bracket with support segments. No physical change.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },
@@ -7013,28 +7116,77 @@
       ]
     },
     {
-      "id": "hex-frame",
-      "uid": "8z0e",
+      "id": "external-bracket-with-support",
+      "uid": "kiag",
       "version": "1",
-      "name": "Hex frame",
-      "description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket — side, with six B/H spokes and Frame crossbeams held inside by the Frame 90° brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
-      "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
-      "status": "partial",
-      "joining": [
-        {
-          "method": "friction",
-          "note": "The Frame 90° bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
-        }
-      ],
+      "name": "External bracket with support",
+      "description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, the snap-on cover, and one A/G outer extrusion screwed into the side bracket.",
       "lines": [
         {
-          "part": "ext-2020-ag",
-          "qty": 6
+          "part": "ext-bracket-left",
+          "qty": 1
         },
         {
-          "part": "ext-bracket-left",
-          "qty": 6
+          "part": "ext-bracket-bottom-vertical",
+          "qty": 1
         },
+        {
+          "part": "ext-bracket-cover",
+          "qty": 1
+        },
+        {
+          "part": "ext-2020-ag",
+          "qty": 1
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 3
+        }
+      ],
+      "connections": [
+        {
+          "from": "ext-bracket-left",
+          "to": "ext-bracket-bottom-vertical",
+          "via": "scr-m5-16-shcs",
+          "qty": 1,
+          "method": "self-tap"
+        },
+        {
+          "from": "ext-bracket-cover",
+          "to": "ext-bracket-left",
+          "qty": 1,
+          "method": "clip"
+        },
+        {
+          "from": "ext-bracket-left",
+          "to": "ext-2020-ag",
+          "via": "scr-m5-16-shcs",
+          "qty": 2,
+          "method": "thread",
+          "note": "Into the extrusion's M5 core -- no T-nuts."
+        }
+      ]
+    },
+    {
+      "id": "outer-hex-frame",
+      "uid": "jvp9",
+      "version": "1",
+      "name": "Outer hex frame",
+      "description": "Six External bracket with support segments closed into the outer hexagon.",
+      "lines": [
+        {
+          "assembly": "external-bracket-with-support",
+          "qty": 6
+        }
+      ]
+    },
+    {
+      "id": "inner-hex-frame",
+      "uid": "ltdo",
+      "version": "1",
+      "name": "Inner hex frame",
+      "description": "The inner hexagon: six B/H spokes with six crossbeams and twelve 90-degree brackets.",
+      "lines": [
         {
           "part": "ext-2020-bh",
           "qty": 6
@@ -7046,41 +7198,117 @@
         {
           "part": "frame-90deg-bracket",
           "qty": 12
+        }
+      ],
+      "connections": [
+        {
+          "from": "frame-crossbeam",
+          "to": "ext-2020-bh",
+          "qty": 6,
+          "method": "friction",
+          "note": "No hardware -- held by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
         },
         {
-          "part": "scr-m5-16-shcs",
-          "qty": 8
+          "from": "frame-90deg-bracket",
+          "to": "ext-2020-bh",
+          "qty": 12,
+          "method": "friction",
+          "note": "Two per spoke, same friction fit."
+        }
+      ]
+    },
+    {
+      "id": "hex-frame",
+      "uid": "l0xa",
+      "version": "2",
+      "name": "Hex frame",
+      "description": "The hexagonal frame shared by every layer and both interfaces: the inner hex seated in the outer hex.",
+      "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
+      "lines": [
+        {
+          "assembly": "inner-hex-frame",
+          "qty": 1
         },
         {
-          "part": "tnut-m5-2020",
-          "qty": 24
+          "assembly": "outer-hex-frame",
+          "qty": 1
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "uid": "8z0e",
+          "date": "2026-08-29",
+          "commit": "a2c66436",
+          "message": "Original version: one flat parts list -- brackets, extrusions, spokes, crossbeams, screws and 24 T-nuts inline, with no sub-structure and no joints recorded.",
+          "lines": [
+            {
+              "part": "ext-2020-ag",
+              "qty": 6,
+              "uid": "lnvw"
+            },
+            {
+              "part": "ext-bracket-left",
+              "qty": 6,
+              "uid": "0b4g"
+            },
+            {
+              "part": "ext-2020-bh",
+              "qty": 6,
+              "uid": "tuer"
+            },
+            {
+              "part": "frame-crossbeam",
+              "qty": 6,
+              "uid": "cdeg"
+            },
+            {
+              "part": "frame-90deg-bracket",
+              "qty": 12,
+              "uid": "3l20"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 8,
+              "uid": "2e0s"
+            },
+            {
+              "part": "tnut-m5-2020",
+              "qty": 24,
+              "uid": "bpwm"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-08-31",
+          "message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) and each segment's A/G extrusion become External bracket with support units; the 24 T-nuts are dropped -- the bracket screws go into the extrusions' M5 cores, not the slots. No physical change.",
+          "breaking": false,
+          "commit": null
+        }
+      ],
+      "connections": [
+        {
+          "from": "inner-hex-frame",
+          "to": "outer-hex-frame",
+          "qty": 1,
+          "method": "gravity",
+          "note": "The inner hex sits in the outer ring under its own weight."
         }
       ]
     },
     {
       "id": "layer-frame",
-      "uid": "22ck",
-      "version": "2",
+      "uid": "yq92",
+      "version": "3",
       "name": "Distribution frame",
-      "description": "The frame of one distribution layer: a hex frame plus the External bracket — cover and — bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
+      "description": "The frame of one distribution layer: one hex frame, whose bracket segments form the collars for piece C.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "status": "partial",
       "lines": [
         {
           "assembly": "hex-frame",
           "qty": 1
-        },
-        {
-          "part": "ext-bracket-bottom-vertical",
-          "qty": 6
-        },
-        {
-          "part": "ext-bracket-cover",
-          "qty": 6
-        },
-        {
-          "part": "scr-m5-16-shcs",
-          "qty": 24
         }
       ],
       "versions": [
@@ -7110,7 +7338,37 @@
           "version": "2",
           "date": "2026-08-29",
           "message": "Split the hex frame (outer ring, spokes, crossbeams, 90° brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
-          "commit": "a2c66436"
+          "commit": "a2c66436",
+          "uid": "22ck",
+          "lines": [
+            {
+              "assembly": "hex-frame",
+              "qty": 1,
+              "uid": "l0xa"
+            },
+            {
+              "part": "ext-bracket-bottom-vertical",
+              "qty": 6,
+              "uid": "xgzj"
+            },
+            {
+              "part": "ext-bracket-cover",
+              "qty": 6,
+              "uid": "1r5i"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 24,
+              "uid": "2e0s"
+            }
+          ]
+        },
+        {
+          "version": "3",
+          "date": "2026-08-31",
+          "message": "The bottom verticals, covers and their 24 screws move inside the hex frame's External bracket with support segments. No physical change.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },
@@ -7560,5 +7818,54 @@
       "note": "Unified the docs parts.yml catalog and this manifest into one source of truth. Conflicts referencing this merge were NOT hashed out at merge time: each records both catalogs' claims and is a TODO to resolve against the physical machine."
     }
   ],
-  "tags": []
+  "tags": [
+    {
+      "name": "hex-frame-v2",
+      "node": "hex-frame",
+      "stability": "stable",
+      "date": "2026-08-31",
+      "commit": null,
+      "message": "First stable tag: the hex frame restructured into inner and outer hexes with connection edges. Friction fits bench-confirmed 2026-08-26."
+    },
+    {
+      "name": "ext-bracket-left-v1",
+      "node": "ext-bracket-left",
+      "stability": "stable",
+      "date": "2026-08-31",
+      "commit": null,
+      "message": "Blessed stable with hex-frame-v2."
+    },
+    {
+      "name": "ext-bracket-bottom-vertical-v1",
+      "node": "ext-bracket-bottom-vertical",
+      "stability": "stable",
+      "date": "2026-08-31",
+      "commit": null,
+      "message": "Blessed stable with hex-frame-v2."
+    },
+    {
+      "name": "ext-bracket-cover-v1",
+      "node": "ext-bracket-cover",
+      "stability": "stable",
+      "date": "2026-08-31",
+      "commit": null,
+      "message": "Blessed stable with hex-frame-v2."
+    },
+    {
+      "name": "frame-crossbeam-v1",
+      "node": "frame-crossbeam",
+      "stability": "stable",
+      "date": "2026-08-31",
+      "commit": null,
+      "message": "Blessed stable with hex-frame-v2."
+    },
+    {
+      "name": "frame-90deg-bracket-v1",
+      "node": "frame-90deg-bracket",
+      "stability": "stable",
+      "date": "2026-08-31",
+      "commit": null,
+      "message": "Blessed stable with hex-frame-v2."
+    }
+  ]
 }

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7879,6 +7879,22 @@
       "date": "2026-08-31",
       "commit": null,
       "message": "Blessed stable with hex-frame-v2."
+    },
+    {
+      "name": "ext-2020-ag-v1",
+      "node": "ext-2020-ag",
+      "stability": "stable",
+      "date": "2026-08-31",
+      "commit": null,
+      "message": "Blessed stable with hex-frame-v2."
+    },
+    {
+      "name": "ext-2020-bh-v1",
+      "node": "ext-2020-bh",
+      "stability": "stable",
+      "date": "2026-08-31",
+      "commit": null,
+      "message": "Blessed stable with hex-frame-v2."
     }
   ]
 }

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7120,7 +7120,7 @@
       "uid": "kiag",
       "version": "1",
       "name": "External bracket with support",
-      "description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, the snap-on cover, and one A/G outer extrusion screwed into the side bracket.",
+      "description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, with the snap-on cover.",
       "lines": [
         {
           "part": "ext-bracket-left",
@@ -7135,12 +7135,8 @@
           "qty": 1
         },
         {
-          "part": "ext-2020-ag",
-          "qty": 1
-        },
-        {
           "part": "scr-m5-16-shcs",
-          "qty": 3
+          "qty": 1
         }
       ],
       "connections": [
@@ -7156,14 +7152,6 @@
           "to": "ext-bracket-left",
           "qty": 1,
           "method": "clip"
-        },
-        {
-          "from": "ext-bracket-left",
-          "to": "ext-2020-ag",
-          "via": "scr-m5-16-shcs",
-          "qty": 2,
-          "method": "thread",
-          "note": "Into the extrusion's M5 core -- no T-nuts."
         }
       ]
     },
@@ -7172,11 +7160,36 @@
       "uid": "jvp9",
       "version": "1",
       "name": "Outer hex frame",
-      "description": "Six External bracket with support segments closed into the outer hexagon.",
+      "description": "Six External bracket with support corners with six A/G extrusions slid between them, closing the hexagon.",
       "lines": [
         {
           "assembly": "external-bracket-with-support",
           "qty": 6
+        },
+        {
+          "part": "ext-2020-ag",
+          "qty": 6
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 12
+        }
+      ],
+      "connections": [
+        {
+          "from": "ext-2020-ag",
+          "to": "external-bracket-with-support",
+          "qty": 12,
+          "method": "friction",
+          "note": "Each extrusion slides onto a bracket segment at either end -- one on either side of each bracket. These 12 fits hold the ring together."
+        },
+        {
+          "from": "external-bracket-with-support",
+          "to": "ext-2020-ag",
+          "via": "scr-m5-16-shcs",
+          "qty": 12,
+          "method": "thread",
+          "note": "Two per bracket, into the extrusions' M5 cores -- no T-nuts."
         }
       ]
     },
@@ -7282,7 +7295,7 @@
         {
           "version": "2",
           "date": "2026-08-31",
-          "message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) and each segment's A/G extrusion become External bracket with support units; the 24 T-nuts are dropped -- the bracket screws go into the extrusions' M5 cores, not the slots. No physical change.",
+          "message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) become External bracket with support units; the A/G extrusions slide between them in the outer hex, held by 12 friction fits and secured by screws into their M5 cores; the 24 T-nuts are dropped. No physical change.",
           "breaking": false,
           "commit": null
         }

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7188,8 +7188,8 @@
           "to": "ext-2020-ag",
           "via": "scr-m5-16-shcs",
           "qty": 12,
-          "method": "thread",
-          "note": "Two per bracket, into the extrusions' M5 cores -- no T-nuts."
+          "method": "self-tap",
+          "note": "Two per bracket: self-taps through the bracket print and the tip rams against the extrusion, jamming the fit. No T-nuts."
         }
       ]
     },
@@ -7295,7 +7295,7 @@
         {
           "version": "2",
           "date": "2026-08-31",
-          "message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) become External bracket with support units; the A/G extrusions slide between them in the outer hex, held by 12 friction fits and secured by screws into their M5 cores; the 24 T-nuts are dropped. No physical change.",
+          "message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) become External bracket with support units; the A/G extrusions slide between them in the outer hex, held by 12 friction fits and jammed by screws that self-tap through the brackets and ram against the extrusions; the 24 T-nuts are dropped. No physical change.",
           "breaking": false,
           "commit": null
         }

--- a/parts-calculator/scripts/check_connections.py
+++ b/parts-calculator/scripts/check_connections.py
@@ -20,7 +20,8 @@ An assembly's `connections` record its joints as a graph over its members:
 - `method`: how the joint holds. Extends the JoinMethod enum with the
   anchor kinds: `insert` is a heat-set insert in the `to` part (pairs with
   its `requires`), `thread` a machine thread in the `to` member, `tnut` an
-  extrusion T-nut, `nut` a through-bolt with a nut.
+  extrusion T-nut, `nut` a through-bolt with a nut. `gravity` is a part
+  that just sits in place under its own weight.
 - `draft: true`: extracted from prose, not yet confirmed at the bench.
   Removed when the assembly is validated.
 
@@ -35,8 +36,8 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent.parent
 
 METHODS = {"self-tap", "thread", "insert", "nut", "tnut",
-           "press", "friction", "clip", "glue", "solder", "crimp"}
-FASTENERLESS = {"press", "friction", "clip", "glue", "solder", "crimp"}
+           "press", "friction", "clip", "glue", "solder", "crimp", "gravity"}
+FASTENERLESS = {"press", "friction", "clip", "glue", "solder", "crimp", "gravity"}
 
 
 def main():

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2039,7 +2039,7 @@
 			"uid": "kiag",
 			"version": "1",
 			"name": "External bracket with support",
-			"description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, the snap-on cover, and one A/G outer extrusion screwed into the side bracket.",
+			"description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, with the snap-on cover.",
 			"lines": [
 				{
 					"part": "ext-bracket-left",
@@ -2054,12 +2054,8 @@
 					"qty": 1
 				},
 				{
-					"part": "ext-2020-ag",
-					"qty": 1
-				},
-				{
 					"part": "scr-m5-16-shcs",
-					"qty": 3
+					"qty": 1
 				}
 			],
 			"connections": [
@@ -2075,14 +2071,6 @@
 					"to": "ext-bracket-left",
 					"qty": 1,
 					"method": "clip"
-				},
-				{
-					"from": "ext-bracket-left",
-					"to": "ext-2020-ag",
-					"via": "scr-m5-16-shcs",
-					"qty": 2,
-					"method": "thread",
-					"note": "Into the extrusion's M5 core -- no T-nuts."
 				}
 			]
 		},
@@ -2091,11 +2079,36 @@
 			"uid": "jvp9",
 			"version": "1",
 			"name": "Outer hex frame",
-			"description": "Six External bracket with support segments closed into the outer hexagon.",
+			"description": "Six External bracket with support corners with six A/G extrusions slid between them, closing the hexagon.",
 			"lines": [
 				{
 					"assembly": "external-bracket-with-support",
 					"qty": 6
+				},
+				{
+					"part": "ext-2020-ag",
+					"qty": 6
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 12
+				}
+			],
+			"connections": [
+				{
+					"from": "ext-2020-ag",
+					"to": "external-bracket-with-support",
+					"qty": 12,
+					"method": "friction",
+					"note": "Each extrusion slides onto a bracket segment at either end -- one on either side of each bracket. These 12 fits hold the ring together."
+				},
+				{
+					"from": "external-bracket-with-support",
+					"to": "ext-2020-ag",
+					"via": "scr-m5-16-shcs",
+					"qty": 12,
+					"method": "thread",
+					"note": "Two per bracket, into the extrusions' M5 cores -- no T-nuts."
 				}
 			]
 		},
@@ -2202,7 +2215,7 @@
 					"version": "2",
 					"uid": "l0xa",
 					"date": "2026-08-31",
-					"message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) and each segment's A/G extrusion become External bracket with support units; the 24 T-nuts are dropped -- the bracket screws go into the extrusions' M5 cores, not the slots. No physical change.",
+					"message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) become External bracket with support units; the A/G extrusions slide between them in the outer hex, held by 12 friction fits and secured by screws into their M5 cores; the 24 T-nuts are dropped. No physical change.",
 					"breaking": false,
 					"commit": null
 				}

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2107,8 +2107,8 @@
 					"to": "ext-2020-ag",
 					"via": "scr-m5-16-shcs",
 					"qty": 12,
-					"method": "thread",
-					"note": "Two per bracket, into the extrusions' M5 cores -- no T-nuts."
+					"method": "self-tap",
+					"note": "Two per bracket: self-taps through the bracket print and the tip rams against the extrusion, jamming the fit. No T-nuts."
 				}
 			]
 		},
@@ -2215,7 +2215,7 @@
 					"version": "2",
 					"uid": "l0xa",
 					"date": "2026-08-31",
-					"message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) become External bracket with support units; the A/G extrusions slide between them in the outer hex, held by 12 friction fits and secured by screws into their M5 cores; the 24 T-nuts are dropped. No physical change.",
+					"message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) become External bracket with support units; the A/G extrusions slide between them in the outer hex, held by 12 friction fits and jammed by screws that self-tap through the brackets and ram against the extrusions; the 24 T-nuts are dropped. No physical change.",
 					"breaking": false,
 					"commit": null
 				}

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -18838,6 +18838,22 @@
 			"date": "2026-08-31",
 			"commit": null,
 			"message": "Blessed stable with hex-frame-v2."
+		},
+		{
+			"name": "ext-2020-ag-v1",
+			"node": "ext-2020-ag",
+			"stability": "stable",
+			"date": "2026-08-31",
+			"commit": null,
+			"message": "Blessed stable with hex-frame-v2."
+		},
+		{
+			"name": "ext-2020-bh-v1",
+			"node": "ext-2020-bh",
+			"stability": "stable",
+			"date": "2026-08-31",
+			"commit": null,
+			"message": "Blessed stable with hex-frame-v2."
 		}
 	]
 }

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1192,8 +1192,8 @@
 		},
 		{
 			"id": "interface",
-			"uid": "bkgq",
-			"version": "2",
+			"uid": "uelo",
+			"version": "3",
 			"name": "Top interface",
 			"description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
@@ -1206,14 +1206,6 @@
 				{
 					"assembly": "hex-frame",
 					"qty": 1
-				},
-				{
-					"part": "ext-bracket-cover",
-					"qty": 6
-				},
-				{
-					"part": "scr-m5-16-shcs",
-					"qty": 12
 				},
 				{
 					"assembly": "fixed-upper-section",
@@ -1425,10 +1417,120 @@
 				},
 				{
 					"version": "2",
-					"uid": "bkgq",
 					"date": "2026-08-29",
 					"message": "Consumes the new hex-frame assembly instead of duplicating its ext-bracket-left/ext-2020-ag/ext-2020-bh/frame-90deg-bracket/frame-crossbeam lines inline. Dropped the stray top-level tnut-m5-2020 qty 8, now superseded by interface-bracket-mount's and limit-switch's own per-step T-nut lines.",
-					"commit": "a2c66436"
+					"commit": "a2c66436",
+					"uid": "bkgq",
+					"lines": [
+						{
+							"assembly": "interface-bracket-mount",
+							"qty": 6,
+							"uid": "pnl9"
+						},
+						{
+							"assembly": "hex-frame",
+							"qty": 1,
+							"uid": "l0xa"
+						},
+						{
+							"part": "ext-bracket-cover",
+							"qty": 6,
+							"uid": "1r5i"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 12,
+							"uid": "2e0s"
+						},
+						{
+							"assembly": "fixed-upper-section",
+							"qty": 1,
+							"uid": "99af"
+						},
+						{
+							"assembly": "cable-cage",
+							"qty": 1,
+							"uid": "nam6"
+						},
+						{
+							"part": "scr-m5-30-shcs",
+							"qty": 6,
+							"uid": "92kv"
+						},
+						{
+							"assembly": "cable-clamp",
+							"qty": 1,
+							"uid": "e0p9"
+						},
+						{
+							"part": "scr-m3-12-bhcs",
+							"qty": 2,
+							"uid": "izrb"
+						},
+						{
+							"assembly": "limit-switch",
+							"qty": 1,
+							"uid": "xzje"
+						},
+						{
+							"part": "scr-m5-20-shcs",
+							"qty": 2,
+							"uid": "e4hi"
+						},
+						{
+							"assembly": "chute-stepper-gearing",
+							"qty": 1,
+							"uid": "cwji"
+						},
+						{
+							"assembly": "interface-chute-drive",
+							"qty": 1,
+							"uid": "8cjj"
+						},
+						{
+							"part": "top-interface-split-spur-gear-2",
+							"qty": 1,
+							"uid": "izz5"
+						},
+						{
+							"assembly": "layer-connector",
+							"qty": 1,
+							"uid": "6m38"
+						},
+						{
+							"part": "brg-lazy-susan",
+							"qty": 1,
+							"uid": "wrxu"
+						},
+						{
+							"part": "scr-m4-12-cs",
+							"qty": 8,
+							"uid": "h8h4"
+						},
+						{
+							"part": "top-plate",
+							"qty": 1,
+							"uid": "1g22"
+						},
+						{
+							"part": "scr-m5-35-fhcs",
+							"qty": 6,
+							"uid": "xkl4"
+						},
+						{
+							"part": "scr-m5-8-cs",
+							"qty": 6,
+							"uid": "mqh4"
+						}
+					]
+				},
+				{
+					"version": "3",
+					"uid": "uelo",
+					"date": "2026-08-31",
+					"message": "The six External bracket covers and 12 bracket screws move inside the hex frame's new External bracket with support segments. No physical change.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -1933,28 +2035,77 @@
 			]
 		},
 		{
-			"id": "hex-frame",
-			"uid": "8z0e",
+			"id": "external-bracket-with-support",
+			"uid": "kiag",
 			"version": "1",
-			"name": "Hex frame",
-			"description": "The hexagonal aluminum-and-bracket ring shared by every layer, the bottom interface and the top interface. Six A/G outer-ring sections joined by six External bracket \u2014 side, with six B/H spokes and Frame crossbeams held inside by the Frame 90\u00b0 brackets, friction-fit with no hardware. The 24 T-nuts are pre-installed in the A/G extrusion for the bin retainers a layer attaches later; the top interface's own hex frame pre-installs the same 24 without using them, since it has no bin retainers.",
-			"docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
-			"status": "partial",
-			"joining": [
-				{
-					"method": "friction",
-					"note": "The Frame 90\u00b0 bracket and Frame crossbeam take no hardware at all -- they hold in place by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
-				}
-			],
+			"name": "External bracket with support",
+			"description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, the snap-on cover, and one A/G outer extrusion screwed into the side bracket.",
 			"lines": [
 				{
-					"part": "ext-2020-ag",
-					"qty": 6
+					"part": "ext-bracket-left",
+					"qty": 1
 				},
 				{
-					"part": "ext-bracket-left",
-					"qty": 6
+					"part": "ext-bracket-bottom-vertical",
+					"qty": 1
 				},
+				{
+					"part": "ext-bracket-cover",
+					"qty": 1
+				},
+				{
+					"part": "ext-2020-ag",
+					"qty": 1
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 3
+				}
+			],
+			"connections": [
+				{
+					"from": "ext-bracket-left",
+					"to": "ext-bracket-bottom-vertical",
+					"via": "scr-m5-16-shcs",
+					"qty": 1,
+					"method": "self-tap"
+				},
+				{
+					"from": "ext-bracket-cover",
+					"to": "ext-bracket-left",
+					"qty": 1,
+					"method": "clip"
+				},
+				{
+					"from": "ext-bracket-left",
+					"to": "ext-2020-ag",
+					"via": "scr-m5-16-shcs",
+					"qty": 2,
+					"method": "thread",
+					"note": "Into the extrusion's M5 core -- no T-nuts."
+				}
+			]
+		},
+		{
+			"id": "outer-hex-frame",
+			"uid": "jvp9",
+			"version": "1",
+			"name": "Outer hex frame",
+			"description": "Six External bracket with support segments closed into the outer hexagon.",
+			"lines": [
+				{
+					"assembly": "external-bracket-with-support",
+					"qty": 6
+				}
+			]
+		},
+		{
+			"id": "inner-hex-frame",
+			"uid": "ltdo",
+			"version": "1",
+			"name": "Inner hex frame",
+			"description": "The inner hexagon: six B/H spokes with six crossbeams and twelve 90-degree brackets.",
+			"lines": [
 				{
 					"part": "ext-2020-bh",
 					"qty": 6
@@ -1966,41 +2117,118 @@
 				{
 					"part": "frame-90deg-bracket",
 					"qty": 12
+				}
+			],
+			"connections": [
+				{
+					"from": "frame-crossbeam",
+					"to": "ext-2020-bh",
+					"qty": 6,
+					"method": "friction",
+					"note": "No hardware -- held by friction against alignment nubs in the extrusion. Confirmed by Spencer 2026-08-26, see the docs' Build the hex frame page."
 				},
 				{
-					"part": "scr-m5-16-shcs",
-					"qty": 8
+					"from": "frame-90deg-bracket",
+					"to": "ext-2020-bh",
+					"qty": 12,
+					"method": "friction",
+					"note": "Two per spoke, same friction fit."
+				}
+			]
+		},
+		{
+			"id": "hex-frame",
+			"uid": "l0xa",
+			"version": "2",
+			"name": "Hex frame",
+			"description": "The hexagonal frame shared by every layer and both interfaces: the inner hex seated in the outer hex.",
+			"docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
+			"lines": [
+				{
+					"assembly": "inner-hex-frame",
+					"qty": 1
 				},
 				{
-					"part": "tnut-m5-2020",
-					"qty": 24
+					"assembly": "outer-hex-frame",
+					"qty": 1
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "8z0e",
+					"date": "2026-08-29",
+					"commit": "a2c66436",
+					"message": "Original version: one flat parts list -- brackets, extrusions, spokes, crossbeams, screws and 24 T-nuts inline, with no sub-structure and no joints recorded.",
+					"lines": [
+						{
+							"part": "ext-2020-ag",
+							"qty": 6,
+							"uid": "lnvw"
+						},
+						{
+							"part": "ext-bracket-left",
+							"qty": 6,
+							"uid": "0b4g"
+						},
+						{
+							"part": "ext-2020-bh",
+							"qty": 6,
+							"uid": "tuer"
+						},
+						{
+							"part": "frame-crossbeam",
+							"qty": 6,
+							"uid": "cdeg"
+						},
+						{
+							"part": "frame-90deg-bracket",
+							"qty": 12,
+							"uid": "3l20"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 8,
+							"uid": "2e0s"
+						},
+						{
+							"part": "tnut-m5-2020",
+							"qty": 24,
+							"uid": "bpwm"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "l0xa",
+					"date": "2026-08-31",
+					"message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) and each segment's A/G extrusion become External bracket with support units; the 24 T-nuts are dropped -- the bracket screws go into the extrusions' M5 cores, not the slots. No physical change.",
+					"breaking": false,
+					"commit": null
+				}
+			],
+			"connections": [
+				{
+					"from": "inner-hex-frame",
+					"to": "outer-hex-frame",
+					"qty": 1,
+					"method": "gravity",
+					"note": "The inner hex sits in the outer ring under its own weight."
 				}
 			]
 		},
 		{
 			"id": "layer-frame",
-			"uid": "22ck",
-			"version": "2",
+			"uid": "yq92",
+			"version": "3",
 			"name": "Distribution frame",
-			"description": "The frame of one distribution layer: a hex frame plus the External bracket \u2014 cover and \u2014 bottom vertical that turn its side brackets into full collars for piece C. The aluminum extrusion it is built on is sized on the framing tab, not listed here.",
+			"description": "The frame of one distribution layer: one hex frame, whose bracket segments form the collars for piece C.",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
 			"status": "partial",
 			"lines": [
 				{
 					"assembly": "hex-frame",
 					"qty": 1
-				},
-				{
-					"part": "ext-bracket-bottom-vertical",
-					"qty": 6
-				},
-				{
-					"part": "ext-bracket-cover",
-					"qty": 6
-				},
-				{
-					"part": "scr-m5-16-shcs",
-					"qty": 24
 				}
 			],
 			"versions": [
@@ -2028,10 +2256,40 @@
 				},
 				{
 					"version": "2",
-					"uid": "22ck",
 					"date": "2026-08-29",
 					"message": "Split the hex frame (outer ring, spokes, crossbeams, 90\u00b0 brackets) out into its own hex-frame assembly, reused by layer, bottom-interface and interface, instead of duplicating it. This assembly is now just the collar delta on top of one hex frame.",
-					"commit": "a2c66436"
+					"commit": "a2c66436",
+					"uid": "22ck",
+					"lines": [
+						{
+							"assembly": "hex-frame",
+							"qty": 1,
+							"uid": "l0xa"
+						},
+						{
+							"part": "ext-bracket-bottom-vertical",
+							"qty": 6,
+							"uid": "xgzj"
+						},
+						{
+							"part": "ext-bracket-cover",
+							"qty": 6,
+							"uid": "1r5i"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 24,
+							"uid": "2e0s"
+						}
+					]
+				},
+				{
+					"version": "3",
+					"uid": "yq92",
+					"date": "2026-08-31",
+					"message": "The bottom verticals, covers and their 24 screws move inside the hex frame's External bracket with support segments. No physical change.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -5344,7 +5602,8 @@
 			"uid": "xgzj",
 			"name": "External bracket \u2014 bottom vertical",
 			"quantities": {
-				"layer": 6
+				"layer": 6,
+				"interface": 6
 			},
 			"assembly": "external-bracket",
 			"folder": null,
@@ -18518,5 +18777,54 @@
 			"note": "Unified the docs parts.yml catalog and this manifest into one source of truth. Conflicts referencing this merge were NOT hashed out at merge time: each records both catalogs' claims and is a TODO to resolve against the physical machine."
 		}
 	],
-	"tags": []
+	"tags": [
+		{
+			"name": "hex-frame-v2",
+			"node": "hex-frame",
+			"stability": "stable",
+			"date": "2026-08-31",
+			"commit": null,
+			"message": "First stable tag: the hex frame restructured into inner and outer hexes with connection edges. Friction fits bench-confirmed 2026-08-26."
+		},
+		{
+			"name": "ext-bracket-left-v1",
+			"node": "ext-bracket-left",
+			"stability": "stable",
+			"date": "2026-08-31",
+			"commit": null,
+			"message": "Blessed stable with hex-frame-v2."
+		},
+		{
+			"name": "ext-bracket-bottom-vertical-v1",
+			"node": "ext-bracket-bottom-vertical",
+			"stability": "stable",
+			"date": "2026-08-31",
+			"commit": null,
+			"message": "Blessed stable with hex-frame-v2."
+		},
+		{
+			"name": "ext-bracket-cover-v1",
+			"node": "ext-bracket-cover",
+			"stability": "stable",
+			"date": "2026-08-31",
+			"commit": null,
+			"message": "Blessed stable with hex-frame-v2."
+		},
+		{
+			"name": "frame-crossbeam-v1",
+			"node": "frame-crossbeam",
+			"stability": "stable",
+			"date": "2026-08-31",
+			"commit": null,
+			"message": "Blessed stable with hex-frame-v2."
+		},
+		{
+			"name": "frame-90deg-bracket-v1",
+			"node": "frame-90deg-bracket",
+			"stability": "stable",
+			"date": "2026-08-31",
+			"commit": null,
+			"message": "Blessed stable with hex-frame-v2."
+		}
+	]
 }

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -336,8 +336,10 @@
 	const eraThrough = changelog.through as string;
 	const ghostName = (id: string) => (changelog.ghosts as Record<string, string>)[id];
 	// Recorded revisions sit after every same-date reconstructed commit; the cap
-	// keeps them below NOW.
+	// keeps them below NOW. DAY_END is later still: the moment after everything
+	// recorded on a date, used when an event can't be placed more precisely.
 	const VSEQ = 10_000_000;
+	const DAY_END = VSEQ * 2;
 	const ALL_EVENTS: HistoryEvent[] = [
 		...(changelog.events as HistoryEvent[]),
 		...[...PARTS, ...ASSEMBLIES].flatMap((item) => {
@@ -429,7 +431,10 @@
 		const asm = getAssembly(id);
 		const vs = asm?.versions ?? [];
 		vs.forEach((v, i) => {
-			if (v.date && v.date > eraThrough)
+			// >= : a stamp dated the era's own horizon (same-day) must still
+			// resolve. When the era already recorded that change, the extra
+			// state carries identical lines, so resolution is unaffected.
+			if (v.date && v.date >= eraThrough)
 				st.push({ d: v.date, s: VSEQ + i, lines: i === vs.length - 1 ? (asm!.lines ?? []) : (v.lines ?? null) });
 		});
 		stateCache.set(id, st);
@@ -469,21 +474,36 @@
 	 *  their day. */
 	function viewEvent(e: HistoryEvent, mode: TimeMode) {
 		if (!e.date) return;
-		let s = e.seq;
-		let exact = s !== undefined && e.kind !== 'tag' && !(e.kind === 'revision' && e.date <= eraThrough);
-		if (!exact) {
+		let s: number;
+		let exact = true;
+		const sig = (ls: AssemblyLine[] | null | undefined) =>
+			JSON.stringify((ls ?? []).map((l) => `${l.part ?? l.assembly}|${l.qty}`).sort());
+		if (e.seq !== undefined && e.kind !== 'revision' && e.kind !== 'tag') {
+			s = e.seq; // reconstructed events carry their commit's seq
+		} else if (e.kind === 'revision' && e.seq !== undefined && e.date >= eraThrough) {
+			// The entry's state is in statesOf at its own seq. If the era's last
+			// recorded state for this node is the SAME state — the stamp merged
+			// before the artifact froze — stand at the era commit instead, so
+			// "before" lands just ahead of the change rather than after it.
+			s = e.seq;
+			const tl = eraAsm[e.node]?.timeline ?? [];
+			const last = tl[tl.length - 1];
+			if (last?.date === e.date && sig(last.lines) === sig(linesAtKey(e.node, { d: e.date, s }))) s = last.seq;
+		} else {
+			// A recorded revision from inside the era, or a tag: find its commit.
 			const hit =
 				(e.commit ? eraCommits[e.commit]?.seq : undefined) ??
 				eraAsm[e.node]?.timeline.find((t) => t.date === e.date)?.seq;
-			if (hit !== undefined) {
-				s = hit;
-				exact = true;
-			} else s = VSEQ - 1; // end of the day; "before" is then its start
+			if (hit !== undefined) s = hit;
+			else {
+				s = DAY_END; // end of the day; "before" is then its start
+				exact = false;
+			}
 		}
 		const ref = e.tag ? e.tag.name : e.pr ? `#${e.pr}` : (e.version ?? e.commit ?? '');
 		timeView = {
-			point: { d: e.date, s: s! },
-			before: exact ? { d: e.date, s: s! - 1 } : { d: e.date, s: -1 },
+			point: { d: e.date, s },
+			before: exact ? { d: e.date, s: s - 1 } : { d: e.date, s: -1 },
 			label: `${memberName(e.node)} ${ref} · ${fmtDate(e.date)}`,
 			mode
 		};

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -9,6 +9,7 @@
 		FlaskConical,
 		History,
 		Info,
+		SlidersHorizontal,
 		X,
 		Zap
 	} from 'lucide-svelte';
@@ -56,6 +57,7 @@
 	import { layerStore } from '$lib/layers.svelte';
 	import changelog from '$lib/data/changelog.generated.json';
 	import { page } from '$app/state';
+	import { replaceState } from '$app/navigation';
 	import { assemblyCsv } from '$lib/parts-csv';
 	import { download, exportSpec, filename } from '$lib/csv';
 
@@ -133,11 +135,31 @@
 	// matches or when anything beneath it does, and the path down to a match stays
 	// on screen. An assembly that matches by its own name keeps its whole subtree
 	// — you asked for the chute core, you want what is in it.
+	// Text search and the menu's predicate filters (stable-tagged) AND together;
+	// both use the same keep machinery. Order re-sorts each assembly's lines in
+	// place. Both menu choices live in the URL (?stable=1&order=name).
 	let filter = $state('');
-	const filtering = $derived(filter.trim().length > 0);
+	let onlyStable = $state(false);
+	let order = $state<'authored' | 'name'>('authored');
+	const textActive = $derived(filter.trim().length > 0);
+	const filtering = $derived(textActive || onlyStable);
+
+	/** The tags standing on a node's CURRENT version: a tag blesses a moment,
+	 *  so a revision after its date leaves it behind on the old version. */
+	function tagsFor(id: string): CatalogTag[] {
+		return TAGS.filter((t) => {
+			if (t.node !== id) return false;
+			const m = getPart(id) ?? getAssembly(id);
+			const last = m?.versions?.[m.versions.length - 1];
+			return !last?.date || last.date <= t.date;
+		});
+	}
+	const stableOk = (id: string) => !onlyStable || tagsFor(id).some((t) => t.stability === 'stable');
 
 	/** Does this member — printed part, bought part or laser-cut sheet — match? */
 	function memberMatches(id: string): boolean {
+		if (!stableOk(id)) return false;
+		if (!textActive) return true;
 		const p = getPart(id);
 		if (p) return !!scoreEntry(filter, { name: p.name, uid: p.uid, id: p.id, keywords: p.aliases, text: p.description });
 		const h = getHardware(id);
@@ -184,12 +206,15 @@
 			seen.set(id, false);
 			const asm = getAssembly(id);
 			if (!asm) return false;
-			let hit = !!scoreEntry(filter, {
-				name: asm.name,
-				uid: asm.uid,
-				id: asm.id,
-				text: plainDescription(asm.description)
-			});
+			let hit =
+				stableOk(id) &&
+				(!textActive ||
+					!!scoreEntry(filter, {
+						name: asm.name,
+						uid: asm.uid,
+						id: asm.id,
+						text: plainDescription(asm.description)
+					}));
 			if (hit) {
 				matched.add(id);
 				includeAll(id);
@@ -220,6 +245,35 @@
 		(line.assembly ? keep.assemblies.has(line.assembly) : !!line.part && keep.members.has(line.part));
 
 	const matchCount = $derived(keep.matched.size);
+
+	// The menu's choices are shareable state, so they live in the URL. Read once
+	// when the page is in a browser (it is prerendered), write back on change.
+	let urlReady = false;
+	$effect(() => {
+		if (urlReady) return;
+		urlReady = true;
+		const sp = new URL(location.href).searchParams;
+		onlyStable = sp.get('stable') === '1';
+		if (sp.get('order') === 'name') order = 'name';
+	});
+	$effect(() => {
+		const stable = onlyStable ? '1' : null;
+		const ord = order !== 'authored' ? order : null;
+		if (!urlReady) return;
+		const u = new URL(location.href);
+		// No-op when the URL already says this — which also keeps the mount run
+		// from calling replaceState before the router is initialized.
+		if (u.searchParams.get('stable') === stable && u.searchParams.get('order') === ord) return;
+		if (stable) u.searchParams.set('stable', stable);
+		else u.searchParams.delete('stable');
+		if (ord) u.searchParams.set('order', ord);
+		else u.searchParams.delete('order');
+		try {
+			replaceState(u.pathname + u.search + u.hash, {});
+		} catch {
+			history.replaceState(history.state, '', u);
+		}
+	});
 
 	// What the badge means. The tree records that a node is incomplete but not
 	// which pieces are missing, so the tooltip says exactly that much and no
@@ -593,6 +647,7 @@
 			<HardwareIcon {hw} size={14} /><span class="truncate">{hw.name}</span>
 			<AlternativeBadge value={hw.alternative} size={14} />
 						<ConflictBadge conflicts={hw.conflicts} size={14} />
+			{@render tagChips(hw.id)}
 		</div>
 		<div class="text-right text-xs tabular-nums text-text">
 			<div class="font-semibold">×{each}</div>
@@ -611,11 +666,25 @@
 	{/each}
 {/snippet}
 
+<!-- The tags standing on a node's current version, as badges: STABLE (green)
+     or EXPERIMENTAL, with a count when several. Hover names the tags. -->
+{#snippet tagChips(id: string)}
+	{@const tags = tagsFor(id)}
+	{#each [['stable', 'border-success/60 text-success-dark'], ['experimental', 'border-border text-text-muted']] as [st, cls] (st)}
+		{@const n = tags.filter((t) => t.stability === st)}
+		{#if n.length}
+			<span
+				class="border px-1 py-px text-[10px] font-semibold uppercase tracking-wider {cls}"
+				title={n.map((t) => t.name).join(', ')}>{st}{n.length > 1 ? ` ×${n.length}` : ''}</span>
+		{/if}
+	{/each}
+{/snippet}
+
 {#snippet lines(list: AssemblyLine[], mult: number, depth: number)}
 	<!-- Keyed by position as well as id: two lines can legitimately name the
 	     same part, and a bare id key makes that a duplicate-key error that
 	     blanks the whole page on hydration. -->
-	{#each list as line, i (`${line.part ?? line.assembly}-${i}`)}
+	{#each order === 'name' ? [...list].sort((a, b) => memberName(a.part ?? a.assembly ?? '').localeCompare(memberName(b.part ?? b.assembly ?? ''))) : list as line, i (`${line.part ?? line.assembly}-${i}`)}
 		{#if !lineShown(line)}
 			<!-- filtered out -->
 		{:else if line.assembly}
@@ -654,6 +723,7 @@
 								<span class="text-sm font-semibold text-text">{part.name}</span>
 								<span class="border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
 									>3D printed</span>
+								{#if line.part}{@render tagChips(line.part)}{/if}
 							</div>
 							<div class="text-xs text-text-muted">{part.grams.toFixed(0)} g each</div>
 						</div>
@@ -1017,6 +1087,7 @@
 					{:else if qty === 'middle-layers'}×{Math.max(0, layers - 2)} (layers between the interfaces)
 					{:else if qty !== 1}×{qty}{/if}
 				</span>
+				{@render tagChips(asm.id)}
 				{#if asm.status === 'stub'}
 					<span
 						class="cursor-help border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
@@ -1195,6 +1266,43 @@
 					wide
 					class="min-w-0 flex-1"
 				/>
+				<DropdownMenu label="Filter and order the tree" menuClass="w-52">
+					{#snippet trigger({ toggle, open })}
+						<button
+							type="button"
+							class="flex h-8 w-8 shrink-0 items-center justify-center border bg-surface {onlyStable || order !== 'authored'
+								? 'border-primary text-primary'
+								: 'border-border text-text-muted'} hover:border-primary hover:text-primary"
+							onclick={toggle}
+							aria-expanded={open}
+							title="Filter and order"
+						>
+							<SlidersHorizontal size={14} />
+						</button>
+					{/snippet}
+					{#snippet children({ close: _close })}
+						<div class="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Filter</div>
+						<button
+							type="button"
+							class="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs text-text hover:bg-[var(--color-bg)]"
+							onclick={() => (onlyStable = !onlyStable)}
+						>
+							<span>Stable only</span>
+							{#if onlyStable}<Check size={12} class="ml-auto text-primary" />{/if}
+						</button>
+						<div class="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Order</div>
+						{#each [['authored', 'As authored'], ['name', 'By name']] as [o, lbl] (o)}
+							<button
+								type="button"
+								class="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs text-text hover:bg-[var(--color-bg)]"
+								onclick={() => (order = o as typeof order)}
+							>
+								<span>{lbl}</span>
+								{#if order === o}<Check size={12} class="ml-auto text-primary" />{/if}
+							</button>
+						{/each}
+					{/snippet}
+				</DropdownMenu>
 				<button
 					class="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-primary hover:text-primary-hover"
 					onclick={downloadCsv}


### PR DESCRIPTION
The hex frame becomes what it physically is, per Spencer's walkthrough, with every joint an edge:

- **External bracket with support** — side bracket screwed to the bottom vertical (1 × M5×16, self-tap), snap-on cover (clip), one A/G outer extrusion screwed into the side bracket (2 × M5×16, `thread` into the extrusion's M5 core). The 24 T-nuts are gone — they were never part of these joints.
- **Outer hex frame** — six of those segments closed into the hexagon.
- **Inner hex frame** — six B/H spokes, six crossbeams, twelve 90° brackets, all `friction` against the alignment nubs. The bench-confirmed joining note (2026-08-26) moves out of prose into these edges.
- **Hex frame v2** — inner + outer, joined by `gravity` (new fastenerless method in the enum).

Stamped fallout, all `breaking: false` (no physical change): **Top interface v3** drops its duplicate covers + 12 bracket screws; **Distribution frame v3** drops the bottom verticals, covers and 24 screws — all of that now lives inside the hex's segments. Every hex position now carries the support brackets, so `ext-bracket-bottom-vertical` gains interface counts alongside its layer counts.

**First stable tags**: `hex-frame-v2` plus the five printed parts inside it (side, bottom vertical, cover, crossbeam, 90° bracket), per Spencer 2026-08-31. They render highlighted on the timeline; clicking the tag shows the blessed tree.

Two page fixes ride along so same-day stamps resolve: boundary-date `versions[]` states join the resolution set (identical content when the era already recorded them), and an event placed only by date stands at the end of its day.

Verified in the browser: the tag's tree shows the new structure, Top interface v2→v3 diffs to exactly the two departing lines, back-to-now restores the live tree. All four parts checks pass, svelte-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)