### PR TITLE
parts-calculator: a second US source for the NEMA 23, from StepperOnline

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -4382,6 +4382,15 @@
             "affiliate_url": "https://www.amazon.com/dp/B091C37FJ2?tag=sorterv2-20"
           },
           {
+            "region": "US",
+            "vendor": "StepperOnline",
+            "url": "https://www.omc-stepperonline.com/nema-23-stepper-motor-2-4nm-339-79oz-in-4a-57x57x82mm-8mm-shaft-4-wires-23hs32-4004s",
+            "price": 18.92,
+            "pack_qty": 1,
+            "as_of": "2026-08-31",
+            "note": "23HS32-4004S: 2.4 Nm, 4 A, 82 mm body, 8 mm shaft — the bore the 20T timing pulley wants. Ships from StepperOnline's US warehouse; pick United States at checkout."
+          },
+          {
             "region": "EU",
             "vendor": "StepperOnline",
             "url": "https://www.omc-stepperonline.com/nema-23-bipolar-1-8deg-0-6nm-85oz-in-0-88a-6-6v-57x57x41mm-4-wires-23hs16-0884s"

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -3158,7 +3158,7 @@
 			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 7209,
+			"print_seconds": 7210,
 			"color": {
 				"by_section": {
 					"feeder": {
@@ -4192,7 +4192,7 @@
 			"support_grams": 9.29,
 			"support_used": true,
 			"support_intentional": false,
-			"print_seconds": 23973,
+			"print_seconds": 23959,
 			"color": {
 				"role": "chute-core"
 			},
@@ -5154,7 +5154,7 @@
 			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 7438,
+			"print_seconds": 7443,
 			"color": {
 				"role": "frame"
 			},
@@ -7538,7 +7538,7 @@
 			],
 			"attributes": [],
 			"grams": 29.01,
-			"support_grams": 0,
+			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
 			"print_seconds": 2334,
@@ -7669,7 +7669,7 @@
 			],
 			"attributes": [],
 			"grams": 52.99,
-			"support_grams": 0,
+			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
 			"print_seconds": 3798,
@@ -10101,10 +10101,10 @@
 			],
 			"attributes": [],
 			"grams": 13.96,
-			"support_grams": 5.52,
+			"support_grams": 5.55,
 			"support_used": true,
 			"support_intentional": false,
-			"print_seconds": 2724,
+			"print_seconds": 2727,
 			"color": {
 				"role": "chute-core"
 			},
@@ -14066,7 +14066,7 @@
 			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 15132,
+			"print_seconds": 15131,
 			"color": {
 				"role": "frame"
 			},
@@ -17332,6 +17332,15 @@
 						"pack_qty": 1,
 						"as_of": "2026-04-16",
 						"affiliate_url": "https://www.amazon.com/dp/B091C37FJ2?tag=sorterv2-20"
+					},
+					{
+						"region": "US",
+						"vendor": "StepperOnline",
+						"url": "https://www.omc-stepperonline.com/nema-23-stepper-motor-2-4nm-339-79oz-in-4a-57x57x82mm-8mm-shaft-4-wires-23hs32-4004s",
+						"price": 18.92,
+						"pack_qty": 1,
+						"as_of": "2026-08-31",
+						"note": "23HS32-4004S: 2.4 Nm, 4 A, 82 mm body, 8 mm shaft \u2014 the bore the 20T timing pulley wants. Ships from StepperOnline's US warehouse; pick United States at checkout."
 					},
 					{
 						"region": "EU",


### PR DESCRIPTION
Stacked on #504 — review that one first; this branch's base is `hex-frame-restructure`.

Adds StepperOnline's **23HS32-4004S** as a second US vendor for the chute stepper (`motor-nema23`). They ship it from a US warehouse, so the motor no longer has to come from Amazon.

- **$18.92** single, in stock, as of 2026-08-31.
- 2.4 Nm (339.87 oz-in), 4 A, 57 × 57 × 82 mm, 4 wires.
- **8 mm shaft** — the bore the 20T timing pulley already wants. Worth noting the EU listing we already carry (23HS16-0884S) is a 6.35 mm shaft, so of the two StepperOnline options this is the one that matches the pulley.

### One behaviour change worth knowing

`bestUsVendor` picks the cheapest priced US vendor, and $18.92 beats the Amazon listing's $25.99. So on this branch:

- the machine total prices the NEMA 23 at $18.92 rather than $25.99;
- the Amazon cart moves it into **"can't be added automatically"**, labelled *sold by StepperOnline, not Amazon* — there is no ASIN to add.

That is the app's designed behaviour for a non-Amazon cheapest source (the same path `tnut-m5-2020` would take if Zyltech ever undercut Amazon), not a regression. Say the word if you'd rather the motor stay in the cart and I'll drop the price off the StepperOnline entry so Amazon keeps the pick.

### Checks

All four parts checks pass locally against this base: `check_generated_pins.py`, `check_versioning.py`, `check_connections.py`, `check_asset_urls.py`.

The generated data is `catalog/generate.py`'s own output, committed alongside the source per the directory's rule. A few `print_seconds` / `support_grams` lines moved with it — that is slicer re-run jitter on unchanged geometry, not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)