### PR TITLE
parts-calculator: the open tab and the unfolded tree live in the URL

### DIFF
--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -57,7 +57,7 @@
 	import MissingImage from '$lib/components/MissingImage.svelte';
 	import { Download, Package, ZoomIn, Loader, Info, Plus, X, RotateCcw, Clock, Layers3, ExternalLink, AlertTriangle, History, ChevronRight, ChevronDown, ArrowUpRight, FlaskConical } from 'lucide-svelte';
 	import { page } from '$app/state';
-	import { replaceState } from '$app/navigation';
+	import { afterNavigate, replaceState } from '$app/navigation';
 	import { browser } from '$app/environment';
 
 	// ---- defaults (also used by "reset to default") -----------------------------
@@ -157,8 +157,18 @@
 		}
 		const aid = sp.get('assembly');
 		if (aid && getAssembly(aid)) openAssembly(aid);
-		urlReady = true;
+		// Which tab is showing is part of the view being shared, same as the open
+		// part is: a link to the build plates should arrive on the build plates.
+		if (sp.get('tab') === 'plates') activeTab = 'plates';
+		if (sp.get('view') === 'unique') listView = 'unique';
 	});
+
+	// The gate opens here rather than at the end of onMount: on a cold load the
+	// router is still initialising then, and a URL that needs tidying on arrival
+	// (`?tab=parts`, a colour that matches the default) would call replaceState
+	// before the router can take it, which throws. afterNavigate runs once the
+	// first navigation has landed, which is exactly late enough.
+	afterNavigate(() => (urlReady = true));
 
 	// Mirror the open part + its preview colour/version into the URL so the current
 	// view is a shareable link. Colour and version are only written when they differ
@@ -182,6 +192,11 @@
 		}
 		if (asmOpen && asmId) params.set('assembly', asmId);
 		else params.delete('assembly');
+		// Only the non-default tab is written, so the plain page keeps a bare URL.
+		if (activeTab === 'plates') params.set('tab', 'plates');
+		else params.delete('tab');
+		if (listView === 'unique') params.set('view', 'unique');
+		else params.delete('view');
 		const qs = params.toString();
 		const target = qs ? `${location.pathname}?${qs}` : location.pathname;
 		if (target !== location.pathname + location.search) replaceState(target, {});
@@ -228,8 +243,9 @@
 	// open; the modal binds and writes back to these.
 	let viewerColor = $state('ash-gray');
 	let viewerVersion = $state<PartVersion | null>(null);
-	// gate URL writes until the initial deep-link read has run (see onMount), so we
-	// never clobber ?part=… before we've had a chance to open it
+	// gate URL writes until the initial deep-link read has run and the router is up
+	// (see onMount and afterNavigate), so we never clobber ?part=… before we've had
+	// a chance to open it
 	let urlReady = $state(false);
 
 	// the per-layer size drives both the funnel and the bin set for that layer

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -56,6 +56,9 @@
 	import { layerStore } from '$lib/layers.svelte';
 	import changelog from '$lib/data/changelog.generated.json';
 	import { page } from '$app/state';
+	import { browser } from '$app/environment';
+	import { afterNavigate, replaceState } from '$app/navigation';
+	import { onMount } from 'svelte';
 	import { assemblyCsv } from '$lib/parts-csv';
 	import { download, exportSpec, filename } from '$lib/csv';
 
@@ -95,13 +98,17 @@
 	}
 
 	// First parent wins for a subtree shared by two branches — good enough for
-	// walking upward from a focus target.
+	// walking upward from a focus target. `treeOrder` is the same walk recorded
+	// as a list, so the ids written to the URL come out parents-first instead of
+	// in whatever order they happened to be unfolded.
 	const parentOf = new Map<string, string>();
+	const treeOrder: string[] = ['machine'];
 	{
 		const walk = (id: string) => {
 			for (const line of getAssembly(id)?.lines ?? []) {
 				if (line.assembly && !parentOf.has(line.assembly)) {
 					parentOf.set(line.assembly, id);
+					treeOrder.push(line.assembly);
 					walk(line.assembly);
 				}
 			}
@@ -109,12 +116,29 @@
 		walk('machine');
 	}
 
-	// ?focus=<assembly id> — the hardware page links here to answer "where does
-	// this screw actually go?". Read in an effect rather than derived: the site is
-	// prerendered, so query params don't exist until the page is in a browser.
+	// ---- the open tree in the URL --------------------------------------------
+	// Which nodes are unfolded IS the view on this page, so it belongs in the
+	// address bar: the link you paste reopens the branch you were talking about.
+	// `open` lists the unfolded assemblies; `open=` with nothing after it means
+	// everything is folded, which is a different thing from no param at all (that
+	// one means "the authored default"), and `open=all` is the whole tree, spelled
+	// out because the id list for that runs past 500 characters. Query params only
+	// exist in the browser — the site is prerendered — so the URL is read on mount,
+	// once, and written back from an effect afterwards.
 	let focus = $state<string | null>(null);
-	$effect(() => {
-		const target = page.url.searchParams.get('focus');
+	let urlReady = $state(false);
+	onMount(() => {
+		const sp = page.url.searchParams;
+		const openParam = sp.get('open');
+		if (openParam !== null) {
+			expanded = {};
+			const ids = openParam === 'all' ? treeOrder : openParam.split(',');
+			for (const id of ids) if (getAssembly(id)) expanded[id] = true;
+		}
+
+		// ?focus=<assembly id> — the hardware page links here to answer "where does
+		// this screw actually go?".
+		const target = sp.get('focus');
 		focus = target;
 		if (!target) return;
 		// A collapsed ancestor would hide the thing being pointed at.
@@ -124,6 +148,26 @@
 		const aim = () => document.getElementById(`asm-${target}`)?.scrollIntoView({ block: 'center' });
 		const timers = [0, 120, 400, 900].map((t) => setTimeout(aim, t));
 		return () => timers.forEach(clearTimeout);
+	});
+
+	// Not onMount: on a cold load the router is still initialising then, and
+	// replaceState throws if it is called before that finishes. afterNavigate
+	// runs once the first navigation has landed, which is exactly late enough.
+	afterNavigate(() => (urlReady = true));
+
+	$effect(() => {
+		if (!browser || !urlReady) return;
+		const open = treeOrder.filter((id) => expanded[id]);
+		const params = new URLSearchParams(page.url.search);
+		// The default view writes no param, so the bare page keeps a bare URL.
+		if (open.length === 1 && open[0] === 'machine') params.delete('open');
+		else if (open.length === treeOrder.length) params.set('open', 'all');
+		else params.set('open', open.join(','));
+		// A comma is legal in a query string, and a list of ids is worth reading
+		// in the address bar; URLSearchParams escapes it anyway, so undo that.
+		const qs = params.toString().replaceAll('%2C', ',');
+		const target = qs ? `${location.pathname}?${qs}` : location.pathname;
+		if (target !== location.pathname + location.search) replaceState(target, {});
 	});
 
 	// ---- filtering the tree --------------------------------------------------


### PR DESCRIPTION
Stacked on #504.

Two views that could not be linked to now can be.

- **Parts page** writes which tab is showing: `?tab=plates` for the build plates, `?view=unique` for the by-unique-part list. Only the non-default is written, so the plain page keeps a bare URL.
- **Assembly page** writes which nodes are unfolded: `?open=machine,feeder,…`, read back on arrival. So "look at this branch" is a link instead of a paragraph of directions.

`open=` carries three cases on purpose: absent is the authored default (the machine alone), empty is everything folded, and `all` stands in for the whole tree — spelling out every id runs past 500 characters. Unknown ids are dropped on read, so a stale link degrades to the parts of it that still exist. `?focus=` still works and now records the branch it opened.

Both pages open their URL-writing gate in `afterNavigate` rather than at the end of `onMount`. On a cold load the router is still initialising during `onMount`, so any URL that needs tidying on arrival — `?tab=parts`, a colour matching the part's default — threw `Cannot call replaceState(...) before router is initialized` and killed the effect. That was already reachable on the parts page; the tree would have hit it on every shared link.

Verified in the browser: cold loads of `?open=all`, `?open=`, an id list and `?focus=camera-mount` all restore the right tree (47 / 1 / 12 / centred-and-highlighted nodes) with a clean console; toggling rows, expand-all and collapse-all write the URL back; `?tab=parts&view=assembly` tidies to `/`. `npm run check` is 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)