### PR TITLE
parts-calculator: connection edges render in the tree

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7132,15 +7132,15 @@
       "description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, with the snap-on cover.",
       "lines": [
         {
+          "part": "ext-bracket-cover",
+          "qty": 1
+        },
+        {
           "part": "ext-bracket-left",
           "qty": 1
         },
         {
           "part": "ext-bracket-bottom-vertical",
-          "qty": 1
-        },
-        {
-          "part": "ext-bracket-cover",
           "qty": 1
         },
         {

--- a/parts-calculator/src/lib/components/ConnectionBraces.svelte
+++ b/parts-calculator/src/lib/components/ConnectionBraces.svelte
@@ -1,30 +1,62 @@
 <!--
 	The line diagram for an assembly's connection edges: one brace per join
-	method, drawn in the right gutter of the open node, spanning the rows of
-	every member that method touches. The brace carries one word — the method —
-	and clicking it opens a panel with the specifics (from → to, fastener and
-	count, note, draft state). All-draft braces draw dashed.
+	method, drawn in a tight gutter just right of the node's own rows, spanning
+	the rows of every member that method touches. Each tick runs from the row's
+	actual right edge to the spine, so the brace visibly holds those rows. Each
+	lane gets its own hue, and a tick that crosses another brace's spine hops
+	over it, circuit-diagram style, so shared rows stay legible. The brace
+	carries one word — the method — and clicking it opens a panel with the
+	specifics (from → to, fastener and count, note, draft state). All-draft
+	braces draw dashed.
 
 	Renders as an absolutely-positioned overlay inside the node's branch
-	container (its parent element), which reserves right padding for it. Rows
+	container (its parent element), which reserves `gutter` px of right padding
+	for it — the page computes that number and passes the same value here. Rows
 	are found by the data-member attribute the tree sets on each direct line
-	row; positions re-measure on any size change of the branch.
+	row; everything re-measures on any size change of the branch, so nested
+	folds and window resizes keep ticks on their rows.
 -->
 <script lang="ts">
 	import type { Connection } from '$lib/filament';
 
 	let {
 		edges,
+		gutter,
 		labelOf,
 		nameOf
 	}: {
 		edges: Connection[];
+		gutter: number;
 		labelOf: (method: string) => string;
 		nameOf: (id: string) => string;
 	} = $props();
 
 	let host = $state<HTMLElement | null>(null);
 	let open = $state<number | null>(null);
+
+	// One hue per join method, the same everywhere — friction is always
+	// friction-colored. Pure red and the success green stay clear of the
+	// palette; the diff views own those. When two braces in one gutter land
+	// on close hues AND overlap vertically, the later one hue-shifts (below).
+	const METHOD_HUE: Record<string, number> = {
+		'self-tap': 35, // amber
+		thread: 215, // blue
+		friction: 170, // teal
+		clip: 260, // purple
+		gravity: 315, // magenta
+		press: 55, // olive
+		insert: 190, // cyan
+		nut: 240, // indigo
+		tnut: 285, // violet
+		glue: 20, // rust
+		solder: 100, // moss
+		crimp: 335 // pink
+	};
+	let hueShift = $state<number[]>([]);
+	const hueOf = (i: number) =>
+		((METHOD_HUE[groups[i]?.method] ?? 0) + (hueShift[i] ?? 0)) % 360;
+	const colorOf = (i: number) => `hsl(${hueOf(i)} 60% 38%)`;
+	const laneX = (i: number) => 12 + i * 16;
 
 	const groups = $derived.by(() => {
 		const m = new Map<string, Connection[]>();
@@ -37,25 +69,84 @@
 		}));
 	});
 
-	let spans = $state<{ ys: number[] }[]>([]);
+	type Span = { ticks: { y: number; from: number }[]; top: number; bottom: number; labelY: number };
+	let spans = $state<Span[]>([]);
+	let laneOf = $state<number[]>([]);
+	let height = $state(0);
+
 	function measure() {
 		const parent = host?.parentElement;
 		if (!parent) return;
 		const pr = parent.getBoundingClientRect();
-		spans = groups.map((g) => {
-			const ys: number[] = [];
+		height = pr.height;
+		const hostLeft = pr.right - gutter;
+		const next: Span[] = groups.map((g) => {
+			const ticks: { y: number; from: number }[] = [];
 			for (const id of g.ids) {
 				const el = parent.querySelector(`:scope > [data-member="${CSS.escape(id)}"]`);
 				if (el) {
 					const r = el.getBoundingClientRect();
-					ys.push(r.top - pr.top + r.height / 2);
+					ticks.push({ y: r.top - pr.top + r.height / 2, from: r.right - hostLeft });
 				}
 			}
-			return { ys: ys.sort((a, b) => a - b) };
+			return { ticks, top: 0, bottom: 0, labelY: 0 };
 		});
+		// The brace spanning the fewest rows sits closest to them, so a wide
+		// brace never has to thread through a narrow one.
+		const heightOf = (s: Span) =>
+			s.ticks.length ? Math.max(...s.ticks.map((t) => t.y)) - Math.min(...s.ticks.map((t) => t.y)) : 0;
+		const rank = next
+			.map((s, i) => ({ h: heightOf(s), i }))
+			.sort((a, b) => a.h - b.h)
+			.map(({ i }) => i);
+		const lanes = next.map((_, i) => rank.indexOf(i));
+		// Braces ticking the same row must not overlap there: nudge each shared
+		// tick a few px toward the side the rest of its own brace lies on, so
+		// one brace visibly ends where the other begins.
+		const clusters = new Map<number, { t: { y: number; from: number }; s: Span }[]>();
+		for (const s of next)
+			for (const t of s.ticks) {
+				const key = Math.round(t.y);
+				clusters.set(key, [...(clusters.get(key) ?? []), { t, s }]);
+			}
+		for (const c of clusters.values()) {
+			if (c.length < 2) continue;
+			const side = (e: (typeof c)[number]) => {
+				const others = e.s.ticks.filter((o) => o !== e.t);
+				if (!others.length) return 0;
+				const mean = others.reduce((a, o) => a + o.y, 0) / others.length;
+				return Math.sign(mean - e.t.y);
+			};
+			c.sort((a, b) => side(a) - side(b));
+			c.forEach((e, k) => (e.t.y += (k - (c.length - 1) / 2) * 5));
+		}
+		for (const s of next) {
+			s.ticks.sort((a, b) => a.y - b.y);
+			s.top = s.ticks.length ? s.ticks[0].y : 0;
+			s.bottom = s.ticks.length ? s.ticks[s.ticks.length - 1].y : 0;
+			s.labelY = (s.top + s.bottom) / 2;
+		}
+		// Same-ish hue + overlapping spans would read as one brace: shift the
+		// later one around the wheel until they part.
+		const shifts = next.map(() => 0);
+		for (let i = 0; i < next.length; i++)
+			for (let j = i + 1; j < next.length; j++) {
+				const a = next[i];
+				const b = next[j];
+				if (!a.ticks.length || !b.ticks.length) continue;
+				if (a.bottom < b.top || b.bottom < a.top) continue;
+				const ha = (METHOD_HUE[groups[i].method] ?? 0) + shifts[i];
+				const hb = (METHOD_HUE[groups[j].method] ?? 0) + shifts[j];
+				const d = Math.abs(((ha - hb + 540) % 360) - 180);
+				if (d < 30) shifts[j] += 45;
+			}
+		hueShift = shifts;
+		laneOf = lanes;
+		spans = next;
 	}
 	$effect(() => {
 		void groups;
+		void gutter;
 		measure();
 		const parent = host?.parentElement;
 		if (!parent) return;
@@ -63,6 +154,7 @@
 		ro.observe(parent);
 		return () => ro.disconnect();
 	});
+
 	function onWinClick(e: MouseEvent) {
 		if (open !== null && !host?.contains(e.target as Node)) open = null;
 	}
@@ -70,27 +162,36 @@
 
 <svelte:window onclick={onWinClick} onkeydown={(e) => e.key === 'Escape' && (open = null)} />
 
-<div bind:this={host} class="pointer-events-none absolute inset-y-0 right-0 w-0">
+<div bind:this={host} class="pointer-events-none absolute inset-y-0 right-0" style="width: {gutter}px">
+	<svg class="absolute left-0 top-0 overflow-visible" width={gutter} {height} aria-hidden="true">
+		{#each groups as g, i (g.method)}
+			{@const s = spans[i]}
+			{#if s && s.ticks.length}
+				{@const x = laneX(laneOf[i] ?? i)}
+				<path
+					d="M {x} {s.top} V {s.bottom}"
+					stroke={colorOf(i)}
+					stroke-width="1"
+					fill="none"
+					stroke-dasharray={g.draft ? '3,3' : undefined}
+				/>
+				{#each s.ticks as t (t.y)}
+					<path d="M {t.from} {t.y} H {x}" stroke={colorOf(i)} stroke-width="1" fill="none" />
+				{/each}
+			{/if}
+		{/each}
+	</svg>
 	{#each groups as g, i (g.method)}
 		{@const s = spans[i]}
-		{#if s && s.ys.length >= 1}
-			{@const x = 14 + i * 12}
-			{@const top = s.ys[0]}
-			{@const bottom = s.ys[s.ys.length - 1]}
-			<!-- the spine (1px, per the hairline rule; dashed when all-draft) -->
-			<div
-				class="absolute {g.draft ? 'border-l border-dashed border-warning' : 'bg-warning'}"
-				style="right: {x}px; top: {top}px; height: {Math.max(1, bottom - top)}px; width: 1px;"
-			></div>
-			{#each s.ys as y (y)}
-				<div class="absolute bg-warning" style="right: {x}px; top: {y}px; width: 9px; height: 1px;"></div>
-			{/each}
+		{#if s && s.ticks.length}
+			<!-- The method name sits IN the wire: vertical text centered on the
+			     spine, its background masking the line behind it. -->
 			<button
 				type="button"
-				class="pointer-events-auto absolute z-10 -translate-y-1/2 border bg-surface px-1 py-px text-[10px] font-semibold uppercase tracking-wider {open === i
-					? 'border-warning text-warning-dark'
-					: 'border-warning/60 text-warning-dark hover:border-warning'}"
-				style="right: {x - 5}px; top: {(top + bottom) / 2}px;"
+				class="pointer-events-auto absolute z-10 whitespace-nowrap bg-surface py-1 text-[10px] font-semibold uppercase tracking-wider {open === i
+					? 'underline'
+					: 'hover:opacity-80'}"
+				style="left: {laneX(laneOf[i] ?? i)}px; top: {s.labelY}px; transform: translate(-50%, -50%); writing-mode: vertical-rl; color: {colorOf(i)};"
 				aria-expanded={open === i}
 				onclick={() => (open = open === i ? null : i)}
 			>
@@ -98,11 +199,11 @@
 			</button>
 			{#if open === i}
 				<div
-					class="setup-panel pointer-events-auto absolute z-30 w-72 p-2.5 text-xs"
-					style="right: {x + 8}px; top: {(top + bottom) / 2}px;"
+					class="setup-panel pointer-events-auto absolute right-0 z-30 w-72 p-2.5 text-xs"
+					style="top: {s.labelY + 12}px;"
 				>
 					{#each g.edges as e, j (j)}
-						<div class="{j > 0 ? 'mt-1.5 border-t border-border/60 pt-1.5' : ''}">
+						<div class={j > 0 ? 'mt-1.5 border-t border-border/60 pt-1.5' : ''}>
 							<div class="flex flex-wrap items-baseline gap-x-1.5">
 								<span class="font-semibold text-text">{nameOf(e.from)}</span>
 								<span class="text-text-muted">→</span>

--- a/parts-calculator/src/lib/components/ConnectionBraces.svelte
+++ b/parts-calculator/src/lib/components/ConnectionBraces.svelte
@@ -1,0 +1,126 @@
+<!--
+	The line diagram for an assembly's connection edges: one brace per join
+	method, drawn in the right gutter of the open node, spanning the rows of
+	every member that method touches. The brace carries one word — the method —
+	and clicking it opens a panel with the specifics (from → to, fastener and
+	count, note, draft state). All-draft braces draw dashed.
+
+	Renders as an absolutely-positioned overlay inside the node's branch
+	container (its parent element), which reserves right padding for it. Rows
+	are found by the data-member attribute the tree sets on each direct line
+	row; positions re-measure on any size change of the branch.
+-->
+<script lang="ts">
+	import type { Connection } from '$lib/filament';
+
+	let {
+		edges,
+		labelOf,
+		nameOf
+	}: {
+		edges: Connection[];
+		labelOf: (method: string) => string;
+		nameOf: (id: string) => string;
+	} = $props();
+
+	let host = $state<HTMLElement | null>(null);
+	let open = $state<number | null>(null);
+
+	const groups = $derived.by(() => {
+		const m = new Map<string, Connection[]>();
+		for (const e of edges) m.set(e.method, [...(m.get(e.method) ?? []), e]);
+		return [...m.entries()].map(([method, es]) => ({
+			method,
+			edges: es,
+			ids: [...new Set(es.flatMap((e) => [e.from, e.to, ...(e.via ? [e.via] : [])]))],
+			draft: es.every((e) => e.draft)
+		}));
+	});
+
+	let spans = $state<{ ys: number[] }[]>([]);
+	function measure() {
+		const parent = host?.parentElement;
+		if (!parent) return;
+		const pr = parent.getBoundingClientRect();
+		spans = groups.map((g) => {
+			const ys: number[] = [];
+			for (const id of g.ids) {
+				const el = parent.querySelector(`:scope > [data-member="${CSS.escape(id)}"]`);
+				if (el) {
+					const r = el.getBoundingClientRect();
+					ys.push(r.top - pr.top + r.height / 2);
+				}
+			}
+			return { ys: ys.sort((a, b) => a - b) };
+		});
+	}
+	$effect(() => {
+		void groups;
+		measure();
+		const parent = host?.parentElement;
+		if (!parent) return;
+		const ro = new ResizeObserver(measure);
+		ro.observe(parent);
+		return () => ro.disconnect();
+	});
+	function onWinClick(e: MouseEvent) {
+		if (open !== null && !host?.contains(e.target as Node)) open = null;
+	}
+</script>
+
+<svelte:window onclick={onWinClick} onkeydown={(e) => e.key === 'Escape' && (open = null)} />
+
+<div bind:this={host} class="pointer-events-none absolute inset-y-0 right-0 w-0">
+	{#each groups as g, i (g.method)}
+		{@const s = spans[i]}
+		{#if s && s.ys.length >= 1}
+			{@const x = 14 + i * 12}
+			{@const top = s.ys[0]}
+			{@const bottom = s.ys[s.ys.length - 1]}
+			<!-- the spine (1px, per the hairline rule; dashed when all-draft) -->
+			<div
+				class="absolute {g.draft ? 'border-l border-dashed border-warning' : 'bg-warning'}"
+				style="right: {x}px; top: {top}px; height: {Math.max(1, bottom - top)}px; width: 1px;"
+			></div>
+			{#each s.ys as y (y)}
+				<div class="absolute bg-warning" style="right: {x}px; top: {y}px; width: 9px; height: 1px;"></div>
+			{/each}
+			<button
+				type="button"
+				class="pointer-events-auto absolute z-10 -translate-y-1/2 border bg-surface px-1 py-px text-[10px] font-semibold uppercase tracking-wider {open === i
+					? 'border-warning text-warning-dark'
+					: 'border-warning/60 text-warning-dark hover:border-warning'}"
+				style="right: {x - 5}px; top: {(top + bottom) / 2}px;"
+				aria-expanded={open === i}
+				onclick={() => (open = open === i ? null : i)}
+			>
+				{labelOf(g.method)}
+			</button>
+			{#if open === i}
+				<div
+					class="setup-panel pointer-events-auto absolute z-30 w-72 p-2.5 text-xs"
+					style="right: {x + 8}px; top: {(top + bottom) / 2}px;"
+				>
+					{#each g.edges as e, j (j)}
+						<div class="{j > 0 ? 'mt-1.5 border-t border-border/60 pt-1.5' : ''}">
+							<div class="flex flex-wrap items-baseline gap-x-1.5">
+								<span class="font-semibold text-text">{nameOf(e.from)}</span>
+								<span class="text-text-muted">→</span>
+								<span class="font-semibold text-text">{nameOf(e.to)}</span>
+								{#if e.draft}
+									<span
+										class="border border-dashed border-warning/60 px-1 py-px text-[10px] font-semibold uppercase tracking-wider text-warning-dark"
+										title="Extracted from prose — not yet confirmed at the bench">draft</span>
+								{/if}
+							</div>
+							<div class="text-text-muted">
+								{#if e.via}{e.qty} × {nameOf(e.via)}{:else}{labelOf(e.method)}{e.qty > 1 ? ` — ${e.qty} places` : ''}{/if}
+							</div>
+							{#if e.note}<div class="mt-0.5 text-text-muted">{e.note}</div>{/if}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		{/if}
+	{/each}
+</div>

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2042,15 +2042,15 @@
 			"description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, with the snap-on cover.",
 			"lines": [
 				{
+					"part": "ext-bracket-cover",
+					"qty": 1
+				},
+				{
 					"part": "ext-bracket-left",
 					"qty": 1
 				},
 				{
 					"part": "ext-bracket-bottom-vertical",
-					"qty": 1
-				},
-				{
-					"part": "ext-bracket-cover",
 					"qty": 1
 				},
 				{

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -120,7 +120,29 @@ export type Assembly = {
 	status?: 'stub' | 'partial';
 	joining?: Joining[]; // work needed to make these lines into one unit
 	lines?: AssemblyLine[];
+	connections?: Connection[]; // the joints, as edges over this assembly's lines
 	images?: CatalogImage[]; // beyond the members' renders: a photo of it built, a section view
+};
+
+/** A joint recorded as an edge over the assembly's own lines. `to` is the
+ *  anchor side — where the fastener ends; `via` names the fastener line and
+ *  is absent for fastenerless methods; `draft` marks an edge extracted from
+ *  prose and not yet confirmed at the bench (scripts/check_connections.py). */
+export type ConnectionMethod =
+	| JoinMethod
+	| 'thread'
+	| 'insert'
+	| 'nut'
+	| 'tnut'
+	| 'gravity';
+export type Connection = {
+	from: string;
+	to: string;
+	via?: string;
+	qty: number;
+	method: ConnectionMethod;
+	note?: string;
+	draft?: boolean;
 };
 
 /** The documentation site. An assembly's `docs` is a path on it, never a full

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -49,6 +49,7 @@
 		type Assembly,
 		type AssemblyLine,
 		type AssemblySnapshotLine,
+		type Connection,
 		type Hardware,
 		type Joining,
 		type Part,
@@ -62,6 +63,17 @@
 	import { onMount } from 'svelte';
 	import { assemblyCsv } from '$lib/parts-csv';
 	import { download, exportSpec, filename } from '$lib/csv';
+
+	// The connection methods extend JoinMethod with the anchor kinds
+	// (check_connections.py is the authority on the enum).
+	const CONN_LABELS: Record<string, string> = {
+		...JOIN_LABELS,
+		thread: 'threaded',
+		insert: 'heat-set insert',
+		nut: 'nut',
+		tnut: 'T-nut',
+		gravity: 'gravity'
+	};
 
 	// Experimental view of the unified parts system (notes/UNIFIED-PARTS-SYSTEM.md):
 	// the machine as a recursive assembly tree whose lines reference printed parts,
@@ -718,6 +730,30 @@
 	{/each}
 {/snippet}
 
+<!-- The assembly's joints, one row per connection edge: what holds what and
+     via which fastener. `to` is the anchor side, so the arrow reads in the
+     direction the fastener goes. A dashed DRAFT chip marks an edge extracted
+     from prose and not yet confirmed at the bench. -->
+{#snippet connectionRows(list: Connection[] | undefined)}
+	{#each list ?? [] as c, i (i)}
+		<div class="mt-1 flex max-w-3xl flex-wrap items-baseline gap-x-2 gap-y-0.5">
+			<Badge variant="warning"><Zap size={10} />{CONN_LABELS[c.method] ?? c.method}</Badge>
+			<button type="button" class="text-xs font-medium text-text hover:text-primary" onclick={() => openNode(c.from)}>{memberName(c.from)}</button>
+			<span class="text-xs text-text-muted" aria-label="into">→</span>
+			<button type="button" class="text-xs font-medium text-text hover:text-primary" onclick={() => openNode(c.to)}>{memberName(c.to)}</button>
+			{#if c.via}
+				<span class="text-xs text-text-muted">· {c.qty} × {memberName(c.via)}</span>
+			{:else if c.qty > 1}
+				<span class="text-xs text-text-muted">· ×{c.qty}</span>
+			{/if}
+			{#if c.draft}
+				<span class="border border-dashed border-warning/60 px-1 py-px text-[10px] font-semibold uppercase tracking-wider text-warning-dark" title="Extracted from prose — not yet confirmed at the bench">draft</span>
+			{/if}
+			{#if c.note}<AssemblyDescription text={c.note} as="span" class="text-xs text-text-muted" />{/if}
+		</div>
+	{/each}
+{/snippet}
+
 <!-- The tags standing on a node's current version, as badges: STABLE (green)
      or EXPERIMENTAL, with a count when several. Hover names the tags. -->
 {#snippet tagChips(id: string)}
@@ -923,6 +959,7 @@
 		</div>
 	{:else}
 		{@render joiningRows(asm.joining)}
+		{@render connectionRows(asm.connections)}
 		{@render lines(asm.lines ?? [], mult, depth)}
 	{/if}
 {/snippet}

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -13,6 +13,7 @@
 		X,
 		Zap
 	} from 'lucide-svelte';
+	import ConnectionBraces from '$lib/components/ConnectionBraces.svelte';
 	import DropdownMenu from '$lib/components/DropdownMenu.svelte';
 	import AlternativeBadge from '$lib/components/AlternativeBadge.svelte';
 	import ConflictBadge from '$lib/components/ConflictBadge.svelte';
@@ -701,7 +702,7 @@
      that belong to the joint rather than to either part it holds together. -->
 {#snippet hardwareRow(hw: Hardware, each: number, total: number)}
 	{@const img = hardwareImage(hw)}
-	<div class="ml-1.5 mt-2 flex items-center gap-3 border border-border bg-[var(--color-bg)] p-2 sm:ml-4">
+	<div data-member={hw.id} class="ml-1.5 mt-2 flex items-center gap-3 border border-border bg-[var(--color-bg)] p-2 sm:ml-4">
 		{#if img}
 			<button type="button" class="asm-thumb shrink-0" title="View {hw.name} details" onclick={() => openHardware(hw)}>
 				<img src={img.src} alt={hw.name} class="h-8 w-8 object-contain" />
@@ -730,29 +731,6 @@
 	{/each}
 {/snippet}
 
-<!-- The assembly's joints, one row per connection edge: what holds what and
-     via which fastener. `to` is the anchor side, so the arrow reads in the
-     direction the fastener goes. A dashed DRAFT chip marks an edge extracted
-     from prose and not yet confirmed at the bench. -->
-{#snippet connectionRows(list: Connection[] | undefined)}
-	{#each list ?? [] as c, i (i)}
-		<div class="mt-1 flex max-w-3xl flex-wrap items-baseline gap-x-2 gap-y-0.5">
-			<Badge variant="warning"><Zap size={10} />{CONN_LABELS[c.method] ?? c.method}</Badge>
-			<button type="button" class="text-xs font-medium text-text hover:text-primary" onclick={() => openNode(c.from)}>{memberName(c.from)}</button>
-			<span class="text-xs text-text-muted" aria-label="into">→</span>
-			<button type="button" class="text-xs font-medium text-text hover:text-primary" onclick={() => openNode(c.to)}>{memberName(c.to)}</button>
-			{#if c.via}
-				<span class="text-xs text-text-muted">· {c.qty} × {memberName(c.via)}</span>
-			{:else if c.qty > 1}
-				<span class="text-xs text-text-muted">· ×{c.qty}</span>
-			{/if}
-			{#if c.draft}
-				<span class="border border-dashed border-warning/60 px-1 py-px text-[10px] font-semibold uppercase tracking-wider text-warning-dark" title="Extracted from prose — not yet confirmed at the bench">draft</span>
-			{/if}
-			{#if c.note}<AssemblyDescription text={c.note} as="span" class="text-xs text-text-muted" />{/if}
-		</div>
-	{/each}
-{/snippet}
 
 <!-- The tags standing on a node's current version, as badges: STABLE (green)
      or EXPERIMENTAL, with a count when several. Hover names the tags. -->
@@ -779,7 +757,7 @@
 			{@render node(line.assembly, line.qty, lineQty(line, layers) * mult, depth + 1)}
 		{:else if line.part && getLasercut(line.part)}
 			{@const lc = getLasercut(line.part)!}
-			<div class="ml-1.5 mt-2 flex items-center gap-3 border border-border bg-surface p-2 sm:ml-4 sm:p-3">
+			<div data-member={line.part} class="ml-1.5 mt-2 flex items-center gap-3 border border-border bg-surface p-2 sm:ml-4 sm:p-3">
 				<img src={lc.preview} alt={lc.name} class="h-12 w-12 shrink-0 object-contain" />
 				<div class="min-w-0 flex-1">
 					<div class="flex flex-wrap items-baseline gap-x-2">
@@ -801,7 +779,7 @@
 			{@const part = getPart(line.part)}
 			{#if part}
 				{@const total = lineQty(line, layers) * mult}
-				<div class="ml-1.5 mt-2 border border-border bg-surface p-2 sm:ml-4 sm:p-3">
+				<div data-member={line.part} class="ml-1.5 mt-2 border border-border bg-surface p-2 sm:ml-4 sm:p-3">
 					<div class="flex items-center gap-3">
 						<button type="button" class="asm-thumb shrink-0" title="View {part.name} details" onclick={() => openPart(part)}>
 							<img src={part.render} alt={part.name} class="h-12 w-12 object-contain" />
@@ -959,7 +937,6 @@
 		</div>
 	{:else}
 		{@render joiningRows(asm.joining)}
-		{@render connectionRows(asm.connections)}
 		{@render lines(asm.lines ?? [], mult, depth)}
 	{/if}
 {/snippet}
@@ -1128,6 +1105,7 @@
 		{@const open = hasContent && isOpen(asm.id)}
 		<div
 			id="asm-{asm.id}"
+			data-member={asm.id}
 			class="{depth > 0 ? 'ml-1.5 mt-2 sm:ml-4' : ''} py-1 {focus === asm.id ? 'bg-primary/[0.06]' : ''}"
 		>
 			<!-- The whole row is the expand/collapse target; anything interactive
@@ -1306,8 +1284,11 @@
 			     detail view the ⓘ opens. Inline it turns the tree into a wall of
 			     prose that restates the line rows below it. -->
 			{#if open}
-			<div class="tree-branch relative pl-2 sm:pl-4">
+			<div class="tree-branch relative pl-2 sm:pl-4 {asm.connections?.length && !filtering ? 'pr-20 sm:pr-28' : ''}">
 				<button type="button" class="tree-line" onclick={() => toggle(asm.id)} aria-label="Collapse {asm.name}"></button>
+				{#if asm.connections?.length && !filtering}
+					<ConnectionBraces edges={asm.connections} labelOf={(m) => CONN_LABELS[m] ?? m} nameOf={memberName} />
+				{/if}
 			{#if asm.images?.length}<div class="mt-2"><ImageStrip images={asm.images} /></div>{/if}
 			{#if historyFor[asm.id] && !filtering}{@render historyPanel(asm)}{/if}
 			{@render versionSwitch(asm, mult, depth)}

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -746,7 +746,7 @@
 	{/each}
 {/snippet}
 
-{#snippet lines(list: AssemblyLine[], mult: number, depth: number)}
+{#snippet lines(list: AssemblyLine[], mult: number, depth: number, endpoints: Set<string> | null = null)}
 	<!-- Keyed by position as well as id: two lines can legitimately name the
 	     same part, and a bare id key makes that a duplicate-key error that
 	     blanks the whole page on hydration. -->
@@ -754,7 +754,7 @@
 		{#if !lineShown(line)}
 			<!-- filtered out -->
 		{:else if line.assembly}
-			{@render node(line.assembly, line.qty, lineQty(line, layers) * mult, depth + 1)}
+			{@render node(line.assembly, line.qty, lineQty(line, layers) * mult, depth + 1, endpoints?.has(line.assembly) ?? false)}
 		{:else if line.part && getLasercut(line.part)}
 			{@const lc = getLasercut(line.part)!}
 			<div data-member={line.part} class="ml-1.5 mt-2 flex items-center gap-3 border border-border bg-surface p-2 sm:ml-4 sm:p-3">
@@ -937,7 +937,10 @@
 		</div>
 	{:else}
 		{@render joiningRows(asm.joining)}
-		{@render lines(asm.lines ?? [], mult, depth)}
+		<!-- assemblies a brace wires into get a box, so the tick lands on a
+		     visible container instead of ending in space -->
+		{@const eps = asm.connections?.length ? new Set(asm.connections.flatMap((c) => [c.from, c.to])) : null}
+		{@render lines(asm.lines ?? [], mult, depth, eps)}
 	{/if}
 {/snippet}
 
@@ -1093,7 +1096,7 @@
 	</div>
 {/snippet}
 
-{#snippet node(id: string, qty: AssemblyLine['qty'], mult: number, depth: number)}
+{#snippet node(id: string, qty: AssemblyLine['qty'], mult: number, depth: number, boxed: boolean = false)}
 	{@const asm = getAssembly(id)}
 	{#if asm && (!filtering || keep.assemblies.has(asm.id))}
 		{@const hasContent =
@@ -1106,7 +1109,7 @@
 		<div
 			id="asm-{asm.id}"
 			data-member={asm.id}
-			class="{depth > 0 ? 'ml-1.5 mt-2 sm:ml-4' : ''} py-1 {focus === asm.id ? 'bg-primary/[0.06]' : ''}"
+			class="{depth > 0 ? 'ml-1.5 mt-2 sm:ml-4' : ''} py-1 {boxed ? 'border border-border px-1.5' : ''} {focus === asm.id ? 'bg-primary/[0.06]' : ''}"
 		>
 			<!-- The whole row is the expand/collapse target; anything interactive
 			     inside it (details, guide link, ⋮ menu) is filtered out by the
@@ -1284,10 +1287,17 @@
 			     detail view the ⓘ opens. Inline it turns the tree into a wall of
 			     prose that restates the line rows below it. -->
 			{#if open}
-			<div class="tree-branch relative pl-2 sm:pl-4 {asm.connections?.length && !filtering ? 'pr-20 sm:pr-28' : ''}">
+			{@const braceGutter =
+				asm.connections?.length && !filtering
+					? 32 + (new Set(asm.connections.map((c) => c.method)).size - 1) * 16
+					: 0}
+			<div
+				class="tree-branch relative pl-2 sm:pl-4"
+				style={braceGutter ? `padding-right: ${braceGutter}px` : undefined}
+			>
 				<button type="button" class="tree-line" onclick={() => toggle(asm.id)} aria-label="Collapse {asm.name}"></button>
-				{#if asm.connections?.length && !filtering}
-					<ConnectionBraces edges={asm.connections} labelOf={(m) => CONN_LABELS[m] ?? m} nameOf={memberName} />
+				{#if braceGutter && asm.connections}
+					<ConnectionBraces edges={asm.connections} gutter={braceGutter} labelOf={(m) => CONN_LABELS[m] ?? m} nameOf={memberName} />
 				{/if}
 			{#if asm.images?.length}<div class="mt-2"><ImageStrip images={asm.images} /></div>{/if}
 			{#if historyFor[asm.id] && !filtering}{@render historyPanel(asm)}{/if}
@@ -1317,7 +1327,9 @@
 	{/if}
 {/snippet}
 
-<div class="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+<!-- Wider than the other tabs on purpose: nested nodes each reserve a right
+     gutter for their connection braces, and the rows need the room back. -->
+<div class="mx-auto max-w-screen-2xl px-4 py-8 sm:px-6">
 	<header class="mb-5">
 		<h1 class="text-2xl font-bold text-text">Machine assembly</h1>
 	</header>


### PR DESCRIPTION
The joints recorded as `connections` render as a line diagram, per Spencer's sketch — not prose:

- each open assembly draws **one brace per join method** in its right gutter: a 1px spine with ticks touching every involved member row (the two sides and the fastener line)
- the brace carries **one word** — the method (FRICTION, SELF-TAPPING, GRAVITY, …)
- clicking it opens a panel with the specifics: from → to, fastener × count, the note, and a DRAFT chip on unconfirmed edges; an all-draft brace draws dashed
- rows anchor via `data-member`; a ResizeObserver keeps ticks aligned when nested nodes fold or the window resizes

`Connection`/`ConnectionMethod` types land in filament.ts; `scripts/check_connections.py` remains the authority on the enum. All 12 recorded edges render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)