### PR TITLE
docs: copy-link button beside every article heading

### DIFF
--- a/docs/src/routes/[...path]/+page.svelte
+++ b/docs/src/routes/[...path]/+page.svelte
@@ -24,6 +24,17 @@
 
 	let contentEl: HTMLElement | undefined = $state();
 
+	// One copy glyph for the whole article: the code-block button and the
+	// heading link button below are the same action, so they are the same icon.
+	const COPY_ICON =
+		'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" aria-hidden="true"><rect x="9" y="9" width="12" height="12"></rect><path d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1"></path></svg>';
+
+	// Copied-state feedback, shared by both buttons.
+	function flashCopied(btn: HTMLElement) {
+		btn.classList.add('is-copied');
+		setTimeout(() => btn.classList.remove('is-copied'), 1500);
+	}
+
 	// Copy buttons on code blocks (port of docs/assets/copy-code.js).
 	$effect(() => {
 		p.url; // rerun per page — {@html} replaces the DOM on navigation
@@ -38,14 +49,52 @@
 			btn.type = 'button';
 			btn.className = 'copy-code-button';
 			btn.setAttribute('aria-label', 'Copy code');
-			btn.innerHTML =
-				'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square"><rect x="9" y="9" width="12" height="12"></rect><path d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1"></path></svg>';
+			btn.innerHTML = COPY_ICON;
 			btn.addEventListener('click', async () => {
 				await navigator.clipboard.writeText(pre.innerText.replace(/\n$/, ''));
-				btn.classList.add('is-copied');
-				setTimeout(() => btn.classList.remove('is-copied'), 1500);
+				flashCopied(btn);
 			});
 			wrap.appendChild(btn);
+		}
+	});
+
+	// Copy-link buttons beside article headings, so a section can be linked to
+	// directly instead of "scroll down to the bit about heat inserts". Every
+	// heading already carries an id (rehype-slug, in src/lib/server/content.ts),
+	// so the id is the anchor, not something invented here.
+	$effect(() => {
+		p.url; // rerun per page — {@html} replaces the DOM on navigation
+		if (!contentEl) return;
+		for (const h of contentEl.querySelectorAll<HTMLElement>('h2[id], h3[id], h4[id]')) {
+			if (h.dataset.headingLink) continue;
+			h.dataset.headingLink = '1';
+			const btn = document.createElement('button');
+			btn.type = 'button';
+			btn.className = 'heading-link-button';
+			// A step heading (`{% include step.html %}`) is a column flex of "Step N"
+			// over the title, so the button goes inside the title span; appending it
+			// to the heading itself would stack it underneath as a third row.
+			const target = h.querySelector<HTMLElement>('.step-title') ?? h;
+			const label = target.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+			btn.setAttribute('aria-label', label ? `Copy link to "${label}"` : 'Copy link to this section');
+			btn.title = 'Copy link to this section';
+			btn.innerHTML = COPY_ICON;
+			btn.addEventListener('click', async () => {
+				// Absolute, and built from the current page rather than the address
+				// bar as it stands, so a link copied off a page you arrived at via
+				// another anchor still points at this heading and nothing else.
+				const url = `${location.origin}${location.pathname}#${h.id}`;
+				try {
+					await navigator.clipboard.writeText(url);
+				} catch {
+					// No clipboard (insecure context, or the user refused): put the
+					// anchor in the address bar instead so it can still be copied.
+					location.hash = h.id;
+					return;
+				}
+				flashCopied(btn);
+			});
+			target.appendChild(btn);
 		}
 	});
 

--- a/docs/src/routes/[...path]/+page.svelte
+++ b/docs/src/routes/[...path]/+page.svelte
@@ -24,10 +24,12 @@
 
 	let contentEl: HTMLElement | undefined = $state();
 
-	// One copy glyph for the whole article: the code-block button and the
-	// heading link button below are the same action, so they are the same icon.
-	const COPY_ICON =
-		'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square" aria-hidden="true"><rect x="9" y="9" width="12" height="12"></rect><path d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1"></path></svg>';
+	// A chain link, the conventional icon for "a link to this heading". Not the
+	// two-rectangle copy glyph the code blocks use: that one means "copy this
+	// text", which is a different thing, and zed0 said so when the first version
+	// of this reused it.
+	const LINK_ICON =
+		'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>';
 
 	// Copied-state feedback, shared by both buttons.
 	function flashCopied(btn: HTMLElement) {
@@ -49,7 +51,8 @@
 			btn.type = 'button';
 			btn.className = 'copy-code-button';
 			btn.setAttribute('aria-label', 'Copy code');
-			btn.innerHTML = COPY_ICON;
+			btn.innerHTML =
+				'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square"><rect x="9" y="9" width="12" height="12"></rect><path d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1"></path></svg>';
 			btn.addEventListener('click', async () => {
 				await navigator.clipboard.writeText(pre.innerText.replace(/\n$/, ''));
 				flashCopied(btn);
@@ -78,7 +81,7 @@
 			const label = target.textContent?.replace(/\s+/g, ' ').trim() ?? '';
 			btn.setAttribute('aria-label', label ? `Copy link to "${label}"` : 'Copy link to this section');
 			btn.title = 'Copy link to this section';
-			btn.innerHTML = COPY_ICON;
+			btn.innerHTML = LINK_ICON;
 			btn.addEventListener('click', async () => {
 				// Absolute, and built from the current page rather than the address
 				// bar as it stands, so a link copied off a page you arrived at via

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1520,10 +1520,11 @@ pre code {
 	border-color: rgba(0, 133, 43, 0.9);
 }
 
-/* The copy-link button beside article headings. Same glyph and same copied
-   flash as .copy-code-button above, sized down and recoloured for the light
-   article background. Faint until the heading is hovered or the button takes
-   focus, so a page of headings does not read as a column of icons. */
+/* The copy-link button beside article headings. A chain link, not the copy
+   glyph .copy-code-button uses, because copying a code block and linking to a
+   section are different actions. It shares the copied-state flash and nothing
+   else. Faint until the heading is hovered or the button takes focus, so a page
+   of headings does not read as a column of icons. */
 .heading-link-button {
 	display: inline-flex;
 	align-items: center;

--- a/docs/src/routes/layout.css
+++ b/docs/src/routes/layout.css
@@ -1520,6 +1520,61 @@ pre code {
 	border-color: rgba(0, 133, 43, 0.9);
 }
 
+/* The copy-link button beside article headings. Same glyph and same copied
+   flash as .copy-code-button above, sized down and recoloured for the light
+   article background. Faint until the heading is hovered or the button takes
+   focus, so a page of headings does not read as a column of icons. */
+.heading-link-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	margin-left: 8px;
+	padding: 0;
+	vertical-align: middle;
+	color: var(--muted);
+	background: transparent;
+	border: 1px solid transparent;
+	cursor: pointer;
+	opacity: 0.4;
+	transition:
+		opacity 0.12s ease,
+		color 0.12s ease,
+		background 0.12s ease,
+		border-color 0.12s ease;
+}
+
+.heading-link-button svg {
+	display: block;
+}
+
+h2:hover .heading-link-button,
+h3:hover .heading-link-button,
+h4:hover .heading-link-button,
+.heading-link-button:focus-visible {
+	opacity: 1;
+}
+
+.heading-link-button:hover {
+	color: var(--ink);
+	background: var(--bg);
+	border-color: var(--line);
+}
+
+.heading-link-button.is-copied {
+	opacity: 1;
+	color: #ffffff;
+	background: var(--ok);
+	border-color: var(--ok);
+}
+
+@media print {
+	.heading-link-button {
+		display: none;
+	}
+}
+
 blockquote {
 	margin: 1.2rem 0;
 	padding: 12px 16px;


### PR DESCRIPTION
Every heading in an article gets a small chain-link button beside it that puts a direct link to that section on your clipboard.

**Requested by zed0 (@zed0) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1544368367333281844):** "on the assembly guide can we provide a small icon beside the headings which copies the link for that heading? If we're doing something similar elsewhere then use the same icon".

## The icon

The first version of this reused the site's existing code-block copy glyph. zed0 [corrected that](https://discord.com/channels/1430279849171222682/1544368367333281844/1544372050037313557): "The copy button on code blocks is a different function though. I think the usual icon for this function is a chain link". So it is a chain link, drawn inline to match the site's other icons, and `.copy-code-button` is untouched. The two share the `is-copied` flash (green, 1.5s) and nothing else.

## What it does

- Sits on `h2`, `h3` and `h4` inside the article body. `rehype-slug` already gives every heading an id, and the assembly guide's step headings carry their own (`step-1`, `step-2`, from `_includes/step.html`), so the anchor is the id that is already there. Nothing new is invented.
- Copies an absolute URL built from the current page (`origin + pathname + #id`), not from the address bar as it stands, so a link copied off a page you arrived at via a different anchor still points at the heading you clicked.
- Faint at rest, full opacity when the heading is hovered or the button is focused. Hidden in print.
- If the clipboard is unavailable (insecure context, or the browser refuses), it falls back to putting the anchor in the address bar so the link can still be copied by hand.
- A step heading is a column flex of "Step N" over the title, so the button is appended inside the title span rather than to the heading itself, which would have stacked it underneath as a third row.

## Scope

zed0 asked for the assembly guide. The article renderer is shared by every page on the site, so this lands site-wide, which is where a section link is useful anyway. Restricting it to `/hardware/assembly/` would have meant a conditional with nothing behind it.

`npm run check` is clean (0 errors; the 4 warnings are pre-existing in `Requirements.svelte`) and `npm run build` passes.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1544368367333281844
request: https://discord.com/channels/1430279849171222682/1544368367333281844/1544372050037313557
preview: /hardware/assembly/distribution/chute/chute-core/
-->
