### PR TITLE
parts-calculator: assembly corrections from the bench

### DIFF
--- a/parts-calculator/CLAUDE.md
+++ b/parts-calculator/CLAUDE.md
@@ -313,14 +313,21 @@ one exemption is purely additive completion of a `stub`/`partial` assembly.
 See `VERSIONING.md`.
 
 **An assembly's `connections` are its joints as a graph over its members.**
-One edge per joint: `{from, to, via, qty, method, note?, draft?}`. `from`/`to`
+One edge per joint: `{from, to, via, qty, method, through_mm?, thread_mm?,
+note?, draft?}`. `from`/`to`
 name the two members held together (`to` is the anchor side — where the
 fastener ends); `via` names the fastener, which must be one of the
 assembly's own hardware lines (omitted for fastenerless joints); `qty` is
 fasteners per assembly instance; `method` is one of `self-tap | thread |
 insert | nut | tnut | press | friction | clip | glue | solder | crimp`.
 `draft: true` marks an edge extracted from prose and not yet confirmed at
-the bench — remove the flag when the assembly is validated.
+the bench — remove the flag when the assembly is validated. `through_mm` /
+`thread_mm` record measured screw-length geometry — the fastener's travel
+through the `from` side, and the thread length in the anchor — so
+compatible screw lengths are computed, not remembered. A component that
+installs into a part (a press-fit bearing) is a member and a `press` edge,
+never `requires`; `requires` is only for fastener anchors that become part
+of the print (heat-set inserts).
 `check_connections.py` enforces the shape in CI. Once a joint is an edge,
 take its sentence OUT of the description: joint knowledge lives in
 `connections`, and descriptions state what the assembly is, in a sentence

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1678,7 +1678,7 @@
       "internal_notes": "Idler gear (24 teeth). 1 per C-channel => 4. Feeder color. Takes a standard 608 skateboard bearing.",
       "version": "1",
       "created_at": "2026-06-27",
-      "updated_at": "2026-06-27",
+      "updated_at": "2026-09-01",
       "quantities": {
         "feeder": 4
       },
@@ -1688,13 +1688,7 @@
         "role": "feeder"
       },
       "optional": false,
-      "support": false,
-      "requires": [
-        {
-          "part": "brg-608-2rs",
-          "qty": 1
-        }
-      ]
+      "support": false
     },
     {
       "id": "input-gear",
@@ -3063,9 +3057,9 @@
       "name": "M3 × 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
-      "description": "Clamps the C-channel input gear (12T) to the flat of the NEMA 17 shaft. 1 per C-channel.",
+      "description": "Retired, no longer used anywhere. Was recorded as the screw clamping the C-channel input gear (12T) to the NEMA 17 shaft flat, but that screw is countersunk (scr-m3-8-cs).",
       "created_at": "2026-08-21",
-      "updated_at": "2026-08-21",
+      "updated_at": "2026-09-01",
       "attributes": [
         {
           "label": "Thread",
@@ -3080,7 +3074,7 @@
           "value": "Socket or button head, interchangeable (both bottom on the counterbore floor, so either just clamps)"
         }
       ],
-      "note": "Head type and length measured off the input-gear STL: the boss carries a Ø2.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the Ø4.87 mm bore; the head sits in a round Ø6.40 mm × 2.7 mm counterbore with a 90° cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (Ø5.5 × 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (Ø5.7 × 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic."
+      "note": "Head type and length measured off the input-gear STL: the boss carries a Ø2.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the Ø4.87 mm bore; the head sits in a round Ø6.40 mm × 2.7 mm counterbore with a 90° cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (Ø5.5 × 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (Ø5.7 × 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic. Unused as of 2026-09-01: the screw is the countersunk M3 × 8 (scr-m3-8-cs)."
     },
     {
       "id": "scr-m3-12-cs",
@@ -3193,9 +3187,9 @@
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png",
-      "description": "Bolts the NEMA 17 stepper to the NEMA bracket. 3 per C-channel.",
+      "description": "Retired, no longer used anywhere. Was recorded as the C-channel stepper screw, but those are countersunk — and 4, not 3 (scr-m3-16-cs).",
       "created_at": "2026-07-18",
-      "updated_at": "2026-08-18",
+      "updated_at": "2026-09-01",
       "attributes": [
         {
           "label": "Thread",
@@ -3209,7 +3203,39 @@
           "label": "Head",
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
-      ]
+      ],
+      "note": "Unused as of 2026-09-01. Do not re-add: the C-channel calls for the countersunk M3 × 16."
+    },
+    {
+      "id": "scr-m3-16-cs",
+      "uid": "bdi4",
+      "kind": "cots",
+      "cots": {
+        "type": "screw",
+        "size": "M3",
+        "variant": "countersunk",
+        "length_mm": 16
+      },
+      "name": "M3 × 16 mm countersunk",
+      "category": "Screws",
+      "description": "Bolts the NEMA 17 stepper to the NEMA bracket, into the stepper's tapped face holes. 4 per C-channel.",
+      "created_at": "2026-09-01",
+      "updated_at": "2026-09-01",
+      "attributes": [
+        {
+          "label": "Thread",
+          "value": "M3"
+        },
+        {
+          "label": "Length",
+          "value": "16 mm"
+        },
+        {
+          "label": "Head",
+          "value": "Countersunk (flat) socket"
+        }
+      ],
+      "image_url": "https://assets.basically.website/sorter-parts/hardware-screws-countersunk-full-faf0edbe3324.jpg"
     },
     {
       "id": "scr-m3-6-bhcs",
@@ -6825,7 +6851,7 @@
     {
       "id": "c-channel",
       "uid": "sbwe",
-      "version": "2",
+      "version": "3",
       "name": "C-channel drive",
       "description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
@@ -6889,11 +6915,22 @@
           "message": "Moved the Output gear (130T) and its 6 × M3 × 12 out to the new rotor units: the gear bolts to the rotor, so the joint and its screws belong to the node that holds both. No physical change.",
           "breaking": false,
           "commit": null
+        },
+        {
+          "version": "3",
+          "date": "2026-09-01",
+          "message": "The screws are all countersunk — socket/button was recorded wrong — and the stepper takes 4, not 3. The idler's 608 bearing moved from the gear's requires to a line of its own, with its press fit as a connection. Connections bench-confirmed and listed in assembly order.",
+          "breaking": false,
+          "commit": null
         }
       ],
       "lines": [
         {
-          "part": "stator",
+          "part": "idler-gear",
+          "qty": 1
+        },
+        {
+          "part": "brg-608-2rs",
           "qty": 1
         },
         {
@@ -6901,7 +6938,7 @@
           "qty": 1
         },
         {
-          "part": "idler-gear",
+          "part": "motor-nema17",
           "qty": 1
         },
         {
@@ -6909,48 +6946,51 @@
           "qty": 1
         },
         {
-          "part": "motor-nema17",
+          "part": "stator",
           "qty": 1
         },
         {
-          "part": "scr-m3-16-shcs",
-          "qty": 3
+          "part": "scr-m3-16-cs",
+          "qty": 4
+        },
+        {
+          "part": "scr-m3-8-cs",
+          "qty": 1
         },
         {
           "part": "scr-m3-12-cs",
           "qty": 4
-        },
-        {
-          "part": "scr-m3-8-shcs",
-          "qty": 1
         }
       ],
       "connections": [
+        {
+          "from": "brg-608-2rs",
+          "to": "idler-gear",
+          "qty": 1,
+          "method": "press"
+        },
+        {
+          "from": "nema-bracket",
+          "to": "motor-nema17",
+          "via": "scr-m3-16-cs",
+          "qty": 4,
+          "method": "thread",
+          "note": "Into the NEMA 17's tapped face holes."
+        },
+        {
+          "from": "input-gear",
+          "to": "motor-nema17",
+          "via": "scr-m3-8-cs",
+          "qty": 1,
+          "method": "self-tap",
+          "note": "Threads through the gear hub and bears on the motor shaft flat."
+        },
         {
           "from": "nema-bracket",
           "to": "stator",
           "via": "scr-m3-12-cs",
           "qty": 4,
-          "method": "self-tap",
-          "draft": true
-        },
-        {
-          "from": "nema-bracket",
-          "to": "motor-nema17",
-          "via": "scr-m3-16-shcs",
-          "qty": 3,
-          "method": "thread",
-          "note": "Into the NEMA 17's tapped face holes.",
-          "draft": true
-        },
-        {
-          "from": "input-gear",
-          "to": "motor-nema17",
-          "via": "scr-m3-8-shcs",
-          "qty": 1,
-          "method": "self-tap",
-          "note": "Threads through the gear hub and bears on the motor shaft flat.",
-          "draft": true
+          "method": "self-tap"
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -452,7 +452,16 @@
         }
       },
       "optional": false,
-      "support": true
+      "support": true,
+      "versions": [
+        {
+          "version": "1",
+          "date": "2026-06-27",
+          "message": "Initial catalog entry, imported 2026-06-27.",
+          "commit": null,
+          "onshape_version": "https://cad.onshape.com/documents/60aa51fc61d18f2155b99910/v/b76489d0ca46a1169a2a6081/e/66109ce96b305bf318354f93"
+        }
+      ]
     },
     {
       "id": "rotor-faceted",
@@ -492,7 +501,7 @@
       "internal_notes": "1 per C-channel => 4 total. Feeder color. Takes the 6806 (30 mm bore) bearing.",
       "version": "1",
       "created_at": "2026-06-27",
-      "updated_at": "2026-06-27",
+      "updated_at": "2026-09-01",
       "quantities": {
         "feeder": 3,
         "classification-channel": 1
@@ -503,13 +512,7 @@
         "role": "feeder"
       },
       "optional": false,
-      "support": false,
-      "requires": [
-        {
-          "part": "brg-6806-2rs",
-          "qty": 1
-        }
-      ]
+      "support": false
     },
     {
       "id": "nema-bracket",
@@ -525,7 +528,8 @@
           "version": "2",
           "date": "2026-06-27",
           "message": "Initial catalog entry, imported 2026-06-27 at the design's second iteration ('v2' in the source export, 01_c_channel (5).zip). v1 predates the catalog: never published, no uid, no pinned geometry. The commit is where this entry first exists in this repository's history; the import itself predates it.",
-          "commit": "954f181e"
+          "commit": "954f181e",
+          "onshape_version": "https://cad.onshape.com/documents/60aa51fc61d18f2155b99910/v/b76489d0ca46a1169a2a6081/e/66109ce96b305bf318354f93"
         }
       ],
       "quantities": {
@@ -3187,7 +3191,7 @@
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png",
-      "description": "Retired, no longer used anywhere. Was recorded as the C-channel stepper screw, but those are countersunk — and 4, not 3 (scr-m3-16-cs).",
+      "description": "Retired, no longer used anywhere. Was recorded as the C-channel stepper screw, but those are countersunk (scr-m3-16-cs).",
       "created_at": "2026-07-18",
       "updated_at": "2026-09-01",
       "attributes": [
@@ -3218,7 +3222,7 @@
       },
       "name": "M3 × 16 mm countersunk",
       "category": "Screws",
-      "description": "Bolts the NEMA 17 stepper to the NEMA bracket, into the stepper's tapped face holes. 4 per C-channel.",
+      "description": "Bolts the NEMA 17 stepper to the NEMA bracket, into the stepper's tapped face holes. 3 per C-channel.",
       "created_at": "2026-09-01",
       "updated_at": "2026-09-01",
       "attributes": [
@@ -6850,7 +6854,7 @@
     },
     {
       "id": "c-channel",
-      "uid": "sbwe",
+      "uid": "4tvc",
       "version": "3",
       "name": "C-channel drive",
       "description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
@@ -6914,12 +6918,55 @@
           "date": "2026-08-31",
           "message": "Moved the Output gear (130T) and its 6 × M3 × 12 out to the new rotor units: the gear bolts to the rotor, so the joint and its screws belong to the node that holds both. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": null,
+          "uid": "sbwe",
+          "lines": [
+            {
+              "part": "stator",
+              "qty": 1,
+              "uid": "n6bm"
+            },
+            {
+              "part": "nema-bracket",
+              "qty": 1,
+              "uid": "x09t"
+            },
+            {
+              "part": "idler-gear",
+              "qty": 1,
+              "uid": "7bv7"
+            },
+            {
+              "part": "input-gear",
+              "qty": 1,
+              "uid": "70ul"
+            },
+            {
+              "part": "motor-nema17",
+              "qty": 1,
+              "uid": "w7pq"
+            },
+            {
+              "part": "scr-m3-16-shcs",
+              "qty": 3,
+              "uid": "e0ud"
+            },
+            {
+              "part": "scr-m3-12-cs",
+              "qty": 4,
+              "uid": "0a9x"
+            },
+            {
+              "part": "scr-m3-8-shcs",
+              "qty": 1,
+              "uid": "ql35"
+            }
+          ]
         },
         {
           "version": "3",
           "date": "2026-09-01",
-          "message": "The screws are all countersunk — socket/button was recorded wrong — and the stepper takes 4, not 3. The idler's 608 bearing moved from the gear's requires to a line of its own, with its press fit as a connection. Connections bench-confirmed and listed in assembly order.",
+          "message": "The screws are all countersunk — socket/button was recorded wrong. The idler's 608 bearing is a line of its own with its press fit as a connection, and the screw joints carry measured pass-through and thread depths. Connections bench-confirmed and listed in assembly order.",
           "breaking": false,
           "commit": null
         }
@@ -6951,7 +6998,7 @@
         },
         {
           "part": "scr-m3-16-cs",
-          "qty": 4
+          "qty": 3
         },
         {
           "part": "scr-m3-8-cs",
@@ -6973,9 +7020,10 @@
           "from": "nema-bracket",
           "to": "motor-nema17",
           "via": "scr-m3-16-cs",
-          "qty": 4,
+          "qty": 3,
           "method": "thread",
-          "note": "Into the NEMA 17's tapped face holes."
+          "through_mm": 10.45,
+          "note": "Into the NEMA 17's tapped face holes; tapped depth not yet measured."
         },
         {
           "from": "input-gear",
@@ -6989,15 +7037,27 @@
           "from": "nema-bracket",
           "to": "stator",
           "via": "scr-m3-12-cs",
-          "qty": 4,
-          "method": "self-tap"
+          "qty": 2,
+          "method": "self-tap",
+          "through_mm": 6.45,
+          "thread_mm": 10
+        },
+        {
+          "from": "nema-bracket",
+          "to": "stator",
+          "via": "scr-m3-12-cs",
+          "qty": 2,
+          "method": "self-tap",
+          "through_mm": 8.45,
+          "thread_mm": 10,
+          "note": "The bracket's four stator holes come in two depths: two at 6.45 mm, two at 8.45 mm."
         }
       ]
     },
     {
       "id": "rotor-unit-faceted",
-      "uid": "df0i",
-      "version": "1",
+      "uid": "ylvv",
+      "version": "2",
       "name": "Rotor unit (faceted)",
       "description": "The faceted rotor with the Output gear (130T) bolted on. Assembled once as a unit; a C-channel drive spins it.",
       "lines": [
@@ -7010,25 +7070,70 @@
           "qty": 1
         },
         {
+          "part": "brg-6806-2rs",
+          "qty": 1
+        },
+        {
           "part": "scr-m3-12-cs",
           "qty": 6
         }
       ],
       "connections": [
         {
+          "from": "brg-6806-2rs",
+          "to": "output-gear",
+          "qty": 1,
+          "method": "press"
+        },
+        {
           "from": "output-gear",
           "to": "rotor-faceted",
           "via": "scr-m3-12-cs",
           "qty": 6,
           "method": "self-tap",
-          "note": "One per spoke. Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing."
+          "note": "One per spoke. Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing.",
+          "through_mm": 6.45,
+          "thread_mm": 5
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "uid": "df0i",
+          "date": "2026-08-31",
+          "commit": null,
+          "message": "Original recording: the 6806 bearing rode along as the output gear's requires rather than a line.",
+          "lines": [
+            {
+              "part": "rotor-faceted",
+              "qty": 1,
+              "uid": "9v9q"
+            },
+            {
+              "part": "output-gear",
+              "qty": 1,
+              "uid": "26ek"
+            },
+            {
+              "part": "scr-m3-12-cs",
+              "qty": 6,
+              "uid": "0a9x"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-09-01",
+          "message": "The output gear's 6806 bearing is a line of its own with its press fit as a connection (was the gear's requires).",
+          "breaking": false,
+          "commit": null
         }
       ]
     },
     {
       "id": "rotor-unit-finned",
-      "uid": "iau5",
-      "version": "1",
+      "uid": "7ol7",
+      "version": "2",
       "name": "Rotor unit (finned)",
       "description": "The finned rotor with the Output gear (130T) bolted on. Assembled once as a unit; the classification channel's C-channel drive spins it.",
       "lines": [
@@ -7041,11 +7146,21 @@
           "qty": 1
         },
         {
+          "part": "brg-6806-2rs",
+          "qty": 1
+        },
+        {
           "part": "scr-m3-12-cs",
           "qty": 6
         }
       ],
       "connections": [
+        {
+          "from": "brg-6806-2rs",
+          "to": "output-gear",
+          "qty": 1,
+          "method": "press"
+        },
         {
           "from": "output-gear",
           "to": "rotor-finned",
@@ -7053,6 +7168,39 @@
           "qty": 6,
           "method": "self-tap",
           "note": "One per spoke. Same joint as the faceted rotor unit."
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "uid": "iau5",
+          "date": "2026-08-31",
+          "commit": null,
+          "message": "Original recording: the 6806 bearing rode along as the output gear's requires rather than a line.",
+          "lines": [
+            {
+              "part": "rotor-finned",
+              "qty": 1,
+              "uid": "brsr"
+            },
+            {
+              "part": "output-gear",
+              "qty": 1,
+              "uid": "26ek"
+            },
+            {
+              "part": "scr-m3-12-cs",
+              "qty": 6,
+              "uid": "0a9x"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-09-01",
+          "message": "The output gear's 6806 bearing is a line of its own with its press fit as a connection (was the gear's requires).",
+          "breaking": false,
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1291,7 +1291,7 @@
       "internal_notes": "1 per interface. Frame color.",
       "version": "1",
       "created_at": "2026-06-27",
-      "updated_at": "2026-06-27",
+      "updated_at": "2026-09-01",
       "quantities": {
         "interface": 1
       },
@@ -1301,13 +1301,7 @@
         "role": "frame"
       },
       "optional": false,
-      "support": false,
-      "requires": [
-        {
-          "part": "brg-608-2rs",
-          "qty": 1
-        }
-      ]
+      "support": false
     },
     {
       "id": "interface-nema23-bracket",
@@ -7226,6 +7220,10 @@
           "qty": 1
         },
         {
+          "part": "brg-608-2rs",
+          "qty": 1
+        },
+        {
           "part": "scr-m3-35-bhcs",
           "qty": 1
         },
@@ -7244,6 +7242,14 @@
         {
           "part": "hsi-m3",
           "qty": 4
+        }
+      ],
+      "connections": [
+        {
+          "from": "brg-608-2rs",
+          "to": "interface-idler-gear",
+          "qty": 1,
+          "method": "press"
         }
       ]
     },

--- a/parts-calculator/scripts/check_connections.py
+++ b/parts-calculator/scripts/check_connections.py
@@ -24,10 +24,12 @@ An assembly's `connections` record its joints as a graph over its members:
   that just sits in place under its own weight.
 - `through_mm` / `thread_mm`: measured screw-length geometry. `through_mm`
   is the fastener's travel through the `from` side before it reaches the
-  anchor; `thread_mm` is the thread length waiting on the `to` side
-  (tapped plastic, insert, nut). Both optional, positive numbers -- record
-  them and compatible screw lengths become computable instead of
-  remembered.
+  anchor, measured over the plain bore only -- a countersink's cone is NOT
+  included, because a countersunk screw's nominal length includes its head
+  and the head rides in the cone (the site's fit math subtracts the head).
+  `thread_mm` is the thread length waiting on the `to` side (tapped
+  plastic, insert, nut). Both optional, positive numbers -- record them
+  and compatible screw lengths become computable instead of remembered.
 - `draft: true`: extracted from prose, not yet confirmed at the bench.
   Removed when the assembly is validated.
 

--- a/parts-calculator/scripts/check_connections.py
+++ b/parts-calculator/scripts/check_connections.py
@@ -22,6 +22,12 @@ An assembly's `connections` record its joints as a graph over its members:
   its `requires`), `thread` a machine thread in the `to` member, `tnut` an
   extrusion T-nut, `nut` a through-bolt with a nut. `gravity` is a part
   that just sits in place under its own weight.
+- `through_mm` / `thread_mm`: measured screw-length geometry. `through_mm`
+  is the fastener's travel through the `from` side before it reaches the
+  anchor; `thread_mm` is the thread length waiting on the `to` side
+  (tapped plastic, insert, nut). Both optional, positive numbers -- record
+  them and compatible screw lengths become computable instead of
+  remembered.
 - `draft: true`: extracted from prose, not yet confirmed at the bench.
   Removed when the assembly is validated.
 
@@ -79,6 +85,11 @@ def main():
             if not isinstance(c.get("qty"), int) or c["qty"] < 1:
                 bad.append(f"{tag}: qty must be a positive integer, "
                            f"got {c.get('qty')!r}")
+            for k in ("through_mm", "thread_mm"):
+                if k in c and not (isinstance(c[k], (int, float))
+                                   and not isinstance(c[k], bool) and c[k] > 0):
+                    bad.append(f"{tag}: {k} must be a positive number, "
+                               f"got {c[k]!r}")
         for via, n in used.items():
             if lines.get(via, 0) and n > lines[via]:
                 bad.append(f"{a['id']}: connections use {n} x {via} but the "

--- a/parts-calculator/src/lib/components/ConnectionBraces.svelte
+++ b/parts-calculator/src/lib/components/ConnectionBraces.svelte
@@ -57,13 +57,20 @@
 		edges,
 		gutter,
 		labelOf,
-		nameOf
+		nameOf,
+		lengthOf = () => null
 	}: {
 		edges: Connection[];
 		gutter: number;
 		labelOf: (method: string) => string;
 		nameOf: (id: string) => string;
+		/** Nominal length of a fastener line, for the screw-fit bar. */
+		lengthOf?: (id: string) => number | null;
 	} = $props();
+
+	// A screw needs at least this much thread engagement to count as holding.
+	const MIN_BITE_MM = 2;
+	const mm = (n: number) => (Math.round(n * 100) / 100).toString();
 
 	let host = $state<HTMLElement | null>(null);
 	let open = $state<number | null>(null);
@@ -236,9 +243,7 @@
 			     spine, its background masking the line behind it. -->
 			<button
 				type="button"
-				class="pointer-events-auto absolute z-10 whitespace-nowrap bg-surface py-1 text-[10px] font-semibold uppercase tracking-wider transition-opacity duration-150 {open === i
-					? 'underline'
-					: ''}"
+				class="pointer-events-auto absolute z-10 whitespace-nowrap bg-surface py-1 text-[10px] font-semibold uppercase tracking-wider transition-opacity duration-150"
 				style="left: {laneX(laneOf[i] ?? i)}px; top: {s.labelY}px; transform: translate(-50%, -50%); writing-mode: vertical-rl; color: {colorOf(i)}; opacity: {hot !== null && hot !== i ? 0.15 : 1};"
 				aria-expanded={open === i}
 				onmouseenter={() => (hover = i)}
@@ -270,10 +275,33 @@
 								{#if e.via}{e.qty} × {nameOf(e.via)}{:else}{labelOf(e.method)}{e.qty > 1 ? ` — ${e.qty} places` : ''}{/if}
 							</div>
 							{#if e.through_mm || e.thread_mm}
-								<div class="text-text-muted">
-									{#if e.through_mm}{e.through_mm} mm through{/if}{#if e.through_mm && e.thread_mm}
-										·
-									{/if}{#if e.thread_mm}{e.thread_mm} mm of thread{/if}
+								<!-- The screw's journey to scale: pass-through, then the thread
+								     waiting for it, a marker at the actual screw's length. Both
+								     depths known = a computable valid-length range. -->
+								{@const th = e.through_mm ?? 0}
+								{@const tr = e.thread_mm ?? 0}
+								{@const len = e.via ? lengthOf(e.via) : null}
+								{@const span = Math.max(th + tr, len ?? 0)}
+								{@const lo = th + MIN_BITE_MM}
+								{@const hi = th + tr}
+								{@const fits = len != null && th > 0 && tr > 0 && len >= lo && len <= hi}
+								<div class="relative mt-1.5 h-3 w-full">
+									{#if th}
+										<div class="absolute inset-y-0 left-0 border border-border bg-[var(--color-bg)]" style="width: {(th / span) * 100}%"></div>
+									{/if}
+									{#if tr}
+										<div
+											class="absolute inset-y-0 border"
+											style="left: {(th / span) * 100}%; width: {(tr / span) * 100}%; border-color: {colorOf(i)}; background: color-mix(in srgb, {colorOf(i)} 22%, transparent)"
+										></div>
+									{/if}
+									{#if len != null}
+										<div class="absolute -inset-y-0.5 w-px bg-text" style="left: {(len / span) * 100}%" title="{mm(len)} mm screw"></div>
+									{/if}
+								</div>
+								<div class="text-[11px] text-text-muted">
+									{#if th}{mm(th)} mm through{/if}{#if th && tr}{' · '}{/if}{#if tr}{mm(tr)} mm thread{/if}{#if th && tr && hi > lo}{` · fits ${mm(lo)}–${mm(hi)} mm`}{/if}{#if len != null && th && tr}
+										<span class={fits ? 'text-success' : 'text-warning-dark'}>{` · ${mm(len)} mm ${fits ? 'fits' : 'out of range'}`}</span>{/if}
 								</div>
 							{/if}
 							{#if e.note}<div class="mt-0.5 text-text-muted">{e.note}</div>{/if}

--- a/parts-calculator/src/lib/components/ConnectionBraces.svelte
+++ b/parts-calculator/src/lib/components/ConnectionBraces.svelte
@@ -58,14 +58,15 @@
 		gutter,
 		labelOf,
 		nameOf,
-		lengthOf = () => null
+		travelOf = () => null
 	}: {
 		edges: Connection[];
 		gutter: number;
 		labelOf: (method: string) => string;
 		nameOf: (id: string) => string;
-		/** Nominal length of a fastener line, for the screw-fit bar. */
-		lengthOf?: (id: string) => number | null;
+		/** How far a fastener line reaches through a joint (nominal length,
+		 *  less the head for countersunk — see screwTravel in filament.ts). */
+		travelOf?: (id: string) => number | null;
 	} = $props();
 
 	// A screw needs at least this much thread engagement to count as holding.
@@ -280,7 +281,7 @@
 								     depths known = a computable valid-length range. -->
 								{@const th = e.through_mm ?? 0}
 								{@const tr = e.thread_mm ?? 0}
-								{@const len = e.via ? lengthOf(e.via) : null}
+								{@const len = e.via ? travelOf(e.via) : null}
 								{@const span = Math.max(th + tr, len ?? 0)}
 								{@const lo = th + MIN_BITE_MM}
 								{@const hi = th + tr}
@@ -296,12 +297,12 @@
 										></div>
 									{/if}
 									{#if len != null}
-										<div class="absolute -inset-y-0.5 w-px bg-text" style="left: {(len / span) * 100}%" title="{mm(len)} mm screw"></div>
+										<div class="absolute -inset-y-0.5 w-px bg-text" style="left: {(len / span) * 100}%" title="the screw reaches {mm(len)} mm"></div>
 									{/if}
 								</div>
 								<div class="text-[11px] text-text-muted">
 									{#if th}{mm(th)} mm through{/if}{#if th && tr}{' · '}{/if}{#if tr}{mm(tr)} mm thread{/if}{#if th && tr && hi > lo}{` · fits ${mm(lo)}–${mm(hi)} mm`}{/if}{#if len != null && th && tr}
-										<span class={fits ? 'text-success' : 'text-warning-dark'}>{` · ${mm(len)} mm ${fits ? 'fits' : 'out of range'}`}</span>{/if}
+										<span class={fits ? 'text-success' : 'text-warning-dark'}>{` · reaches ${mm(len)} mm — ${fits ? 'fits' : 'out of range'}`}</span>{/if}
 								</div>
 							{/if}
 							{#if e.note}<div class="mt-0.5 text-text-muted">{e.note}</div>{/if}

--- a/parts-calculator/src/lib/components/ConnectionBraces.svelte
+++ b/parts-calculator/src/lib/components/ConnectionBraces.svelte
@@ -16,9 +16,43 @@
 	row; everything re-measures on any size change of the branch, so nested
 	folds and window resizes keep ticks on their rows.
 -->
-<script lang="ts">
+<script lang="ts" module>
 	import type { Connection } from '$lib/filament';
 
+	/** One brace per independent joint: edges of one method split into connected
+	 *  components over shared members, so two unrelated self-tapped joints never
+	 *  merge into a single spine. Exported because the page sizes each branch's
+	 *  gutter off the same grouping. */
+	export function braceGroups(edges: Connection[]) {
+		const byMethod = new Map<string, Connection[]>();
+		for (const e of edges) byMethod.set(e.method, [...(byMethod.get(e.method) ?? []), e]);
+		const out: { key: string; method: string; edges: Connection[]; ids: string[]; draft: boolean }[] = [];
+		for (const [method, es] of byMethod) {
+			const comps: Connection[][] = [];
+			for (const e of es) {
+				const mine = new Set([e.from, e.to, ...(e.via ? [e.via] : [])]);
+				const touching = comps.filter((c) =>
+					c.some((o) => [o.from, o.to, o.via].some((x) => x && mine.has(x)))
+				);
+				for (const t of touching) comps.splice(comps.indexOf(t), 1);
+				comps.push([...touching.flat(), e]);
+			}
+			for (const c of comps) {
+				const ids = [...new Set(c.flatMap((e) => [e.from, e.to, ...(e.via ? [e.via] : [])]))];
+				out.push({
+					key: `${method}:${ids.join('+')}`,
+					method,
+					edges: c,
+					ids,
+					draft: c.every((e) => e.draft)
+				});
+			}
+		}
+		return out;
+	}
+</script>
+
+<script lang="ts">
 	let {
 		edges,
 		gutter,
@@ -58,16 +92,7 @@
 	const colorOf = (i: number) => `hsl(${hueOf(i)} 60% 38%)`;
 	const laneX = (i: number) => 12 + i * 16;
 
-	const groups = $derived.by(() => {
-		const m = new Map<string, Connection[]>();
-		for (const e of edges) m.set(e.method, [...(m.get(e.method) ?? []), e]);
-		return [...m.entries()].map(([method, es]) => ({
-			method,
-			edges: es,
-			ids: [...new Set(es.flatMap((e) => [e.from, e.to, ...(e.via ? [e.via] : [])]))],
-			draft: es.every((e) => e.draft)
-		}));
-	});
+	const groups = $derived(braceGroups(edges));
 
 	type Span = { ticks: { y: number; from: number }[]; top: number; bottom: number; labelY: number };
 	let spans = $state<Span[]>([]);
@@ -127,10 +152,13 @@
 			s.labelY = (s.top + s.bottom) / 2;
 		}
 		// Same-ish hue + overlapping spans would read as one brace: shift the
-		// later one around the wheel until they part.
+		// later one around the wheel until they part. Two braces of the SAME
+		// method keep their exact hue — the color is the method's identity, and
+		// their separate lanes and labels already tell them apart.
 		const shifts = next.map(() => 0);
 		for (let i = 0; i < next.length; i++)
 			for (let j = i + 1; j < next.length; j++) {
+				if (groups[i].method === groups[j].method) continue;
 				const a = next[i];
 				const b = next[j];
 				if (!a.ticks.length || !b.ticks.length) continue;
@@ -164,7 +192,7 @@
 
 <div bind:this={host} class="pointer-events-none absolute inset-y-0 right-0" style="width: {gutter}px">
 	<svg class="absolute left-0 top-0 overflow-visible" width={gutter} {height} aria-hidden="true">
-		{#each groups as g, i (g.method)}
+		{#each groups as g, i (g.key)}
 			{@const s = spans[i]}
 			{#if s && s.ticks.length}
 				{@const x = laneX(laneOf[i] ?? i)}
@@ -181,7 +209,7 @@
 			{/if}
 		{/each}
 	</svg>
-	{#each groups as g, i (g.method)}
+	{#each groups as g, i (g.key)}
 		{@const s = spans[i]}
 		{#if s && s.ticks.length}
 			<!-- The method name sits IN the wire: vertical text centered on the
@@ -217,6 +245,13 @@
 							<div class="text-text-muted">
 								{#if e.via}{e.qty} × {nameOf(e.via)}{:else}{labelOf(e.method)}{e.qty > 1 ? ` — ${e.qty} places` : ''}{/if}
 							</div>
+							{#if e.through_mm || e.thread_mm}
+								<div class="text-text-muted">
+									{#if e.through_mm}{e.through_mm} mm through{/if}{#if e.through_mm && e.thread_mm}
+										·
+									{/if}{#if e.thread_mm}{e.thread_mm} mm of thread{/if}
+								</div>
+							{/if}
 							{#if e.note}<div class="mt-0.5 text-text-muted">{e.note}</div>{/if}
 						</div>
 					{/each}

--- a/parts-calculator/src/lib/components/ConnectionBraces.svelte
+++ b/parts-calculator/src/lib/components/ConnectionBraces.svelte
@@ -67,6 +67,24 @@
 
 	let host = $state<HTMLElement | null>(null);
 	let open = $state<number | null>(null);
+	// Hovering a brace focuses it: the other braces fade and the rows this one
+	// holds get a hairline ring in its color. An open popover pins the focus.
+	let hover = $state<number | null>(null);
+	const hot = $derived(open ?? hover);
+	$effect(() => {
+		const parent = host?.parentElement;
+		if (!parent || hot === null) return;
+		const g = groups[hot];
+		if (!g) return;
+		const color = colorOf(hot);
+		const els = g.ids
+			.map((id) => parent.querySelector(`:scope > [data-member="${CSS.escape(id)}"]`))
+			.filter((el): el is HTMLElement => el instanceof HTMLElement);
+		for (const el of els) el.style.boxShadow = `inset 0 0 0 1px ${color}`;
+		return () => {
+			for (const el of els) el.style.boxShadow = '';
+		};
+	});
 
 	// One hue per join method, the same everywhere — friction is always
 	// friction-colored. Pure red and the success green stay clear of the
@@ -196,16 +214,18 @@
 			{@const s = spans[i]}
 			{#if s && s.ticks.length}
 				{@const x = laneX(laneOf[i] ?? i)}
-				<path
-					d="M {x} {s.top} V {s.bottom}"
-					stroke={colorOf(i)}
-					stroke-width="1"
-					fill="none"
-					stroke-dasharray={g.draft ? '3,3' : undefined}
-				/>
-				{#each s.ticks as t (t.y)}
-					<path d="M {t.from} {t.y} H {x}" stroke={colorOf(i)} stroke-width="1" fill="none" />
-				{/each}
+				<g class="transition-opacity duration-150" opacity={hot !== null && hot !== i ? 0.15 : 1}>
+					<path
+						d="M {x} {s.top} V {s.bottom}"
+						stroke={colorOf(i)}
+						stroke-width="1"
+						fill="none"
+						stroke-dasharray={g.draft ? '3,3' : undefined}
+					/>
+					{#each s.ticks as t (t.y)}
+						<path d="M {t.from} {t.y} H {x}" stroke={colorOf(i)} stroke-width="1" fill="none" />
+					{/each}
+				</g>
 			{/if}
 		{/each}
 	</svg>
@@ -216,11 +236,15 @@
 			     spine, its background masking the line behind it. -->
 			<button
 				type="button"
-				class="pointer-events-auto absolute z-10 whitespace-nowrap bg-surface py-1 text-[10px] font-semibold uppercase tracking-wider {open === i
+				class="pointer-events-auto absolute z-10 whitespace-nowrap bg-surface py-1 text-[10px] font-semibold uppercase tracking-wider transition-opacity duration-150 {open === i
 					? 'underline'
-					: 'hover:opacity-80'}"
-				style="left: {laneX(laneOf[i] ?? i)}px; top: {s.labelY}px; transform: translate(-50%, -50%); writing-mode: vertical-rl; color: {colorOf(i)};"
+					: ''}"
+				style="left: {laneX(laneOf[i] ?? i)}px; top: {s.labelY}px; transform: translate(-50%, -50%); writing-mode: vertical-rl; color: {colorOf(i)}; opacity: {hot !== null && hot !== i ? 0.15 : 1};"
 				aria-expanded={open === i}
+				onmouseenter={() => (hover = i)}
+				onmouseleave={() => (hover = null)}
+				onfocus={() => (hover = i)}
+				onblur={() => (hover = null)}
 				onclick={() => (open = open === i ? null : i)}
 			>
 				{labelOf(g.method)}

--- a/parts-calculator/src/lib/components/PartDetail.svelte
+++ b/parts-calculator/src/lib/components/PartDetail.svelte
@@ -111,9 +111,12 @@
 	{@const onshapeHref = candidate?.onshape_version ?? os.version}
 	{@const noteId = candidate?.note ?? active?.note ?? part.note}
 
+	<!-- In the modal the viewer and the facts sit side by side once there is
+	     room, each pane full height; stacked on narrow screens and on the page. -->
+	<div class={variant === 'modal' ? 'flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row' : ''}>
 	<!-- the preview, with the id-stamp controls and the colour picker laid over it -->
-	<div class="relative {variant === 'modal' ? 'shrink-0' : ''}">
-		<StlViewer bind:this={viewer} url={activeStl} color={getBambuColor(colorId).hex} mark={stamp} heightClass={variant === 'modal' ? 'h-[56vh]' : 'h-[60vh]'} />
+	<div class="relative {variant === 'modal' ? 'shrink-0 lg:w-[55%]' : ''}">
+		<StlViewer bind:this={viewer} url={activeStl} color={getBambuColor(colorId).hex} mark={stamp} heightClass={variant === 'modal' ? 'h-[45vh] lg:h-[76vh]' : 'h-[60vh]'} />
 		<div class="pointer-events-none absolute inset-x-3 top-3 flex flex-wrap items-start justify-between gap-2">
 			<IdStamp where="viewport" uid={candidate?.uid ?? part.uid} {stamps} bind:on={stampOn} bind:faceIdx onView={() => viewer?.viewMark()} onReset={() => viewer?.resetView()} />
 			<div class="pointer-events-auto ml-auto w-48 border border-border bg-[var(--color-surface)]/95 px-2.5 py-1.5 shadow-sm backdrop-blur"><ColorPicker bind:value={colorId} label="Preview color" /></div>
@@ -122,7 +125,7 @@
 
 	<!-- in the modal the details scroll independently of the pinned viewer (which
 	     owns wheel = zoom); on the page everything just flows -->
-	<div class="{variant === 'modal' ? 'min-h-0 flex-1 overflow-y-auto' : ''} border-t border-border">
+	<div class="{variant === 'modal' ? 'min-h-0 flex-1 overflow-y-auto border-t lg:border-l lg:border-t-0' : 'border-t'} border-border">
 		<div class="px-5 py-4">
 			<div class="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
 				<div class="min-w-0 flex-1 space-y-2 text-sm">
@@ -256,6 +259,7 @@
 				</div>
 			</div>
 		{/if}
+	</div>
 	</div>
 
 	<Modal bind:open={platesOpen} title="Build plates · {part.name}">

--- a/parts-calculator/src/lib/components/PartDetailModal.svelte
+++ b/parts-calculator/src/lib/components/PartDetailModal.svelte
@@ -20,7 +20,7 @@
 	} = $props();
 </script>
 
-<Modal bind:open title={part?.name} bodyScroll={false} maxW="max-w-5xl">
+<Modal bind:open title={part?.name} bodyScroll={false} maxW="max-w-7xl">
 	{#if part}
 		<PartDetail {part} bind:colorId bind:version variant="modal" />
 	{/if}

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1733,7 +1733,7 @@
 		},
 		{
 			"id": "c-channel",
-			"uid": "sbwe",
+			"uid": "4tvc",
 			"version": "3",
 			"name": "C-channel drive",
 			"description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
@@ -1797,13 +1797,56 @@
 					"date": "2026-08-31",
 					"message": "Moved the Output gear (130T) and its 6 \u00d7 M3 \u00d7 12 out to the new rotor units: the gear bolts to the rotor, so the joint and its screws belong to the node that holds both. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": null,
+					"uid": "sbwe",
+					"lines": [
+						{
+							"part": "stator",
+							"qty": 1,
+							"uid": "n6bm"
+						},
+						{
+							"part": "nema-bracket",
+							"qty": 1,
+							"uid": "x09t"
+						},
+						{
+							"part": "idler-gear",
+							"qty": 1,
+							"uid": "7bv7"
+						},
+						{
+							"part": "input-gear",
+							"qty": 1,
+							"uid": "70ul"
+						},
+						{
+							"part": "motor-nema17",
+							"qty": 1,
+							"uid": "w7pq"
+						},
+						{
+							"part": "scr-m3-16-shcs",
+							"qty": 3,
+							"uid": "e0ud"
+						},
+						{
+							"part": "scr-m3-12-cs",
+							"qty": 4,
+							"uid": "0a9x"
+						},
+						{
+							"part": "scr-m3-8-shcs",
+							"qty": 1,
+							"uid": "ql35"
+						}
+					]
 				},
 				{
 					"version": "3",
-					"uid": "sbwe",
+					"uid": "4tvc",
 					"date": "2026-09-01",
-					"message": "The screws are all countersunk \u2014 socket/button was recorded wrong \u2014 and the stepper takes 4, not 3. The idler's 608 bearing moved from the gear's requires to a line of its own, with its press fit as a connection. Connections bench-confirmed and listed in assembly order.",
+					"message": "The screws are all countersunk \u2014 socket/button was recorded wrong. The idler's 608 bearing is a line of its own with its press fit as a connection, and the screw joints carry measured pass-through and thread depths. Connections bench-confirmed and listed in assembly order.",
 					"breaking": false,
 					"commit": null
 				}
@@ -1835,7 +1878,7 @@
 				},
 				{
 					"part": "scr-m3-16-cs",
-					"qty": 4
+					"qty": 3
 				},
 				{
 					"part": "scr-m3-8-cs",
@@ -1857,9 +1900,10 @@
 					"from": "nema-bracket",
 					"to": "motor-nema17",
 					"via": "scr-m3-16-cs",
-					"qty": 4,
+					"qty": 3,
 					"method": "thread",
-					"note": "Into the NEMA 17's tapped face holes."
+					"through_mm": 10.45,
+					"note": "Into the NEMA 17's tapped face holes; tapped depth not yet measured."
 				},
 				{
 					"from": "input-gear",
@@ -1873,15 +1917,27 @@
 					"from": "nema-bracket",
 					"to": "stator",
 					"via": "scr-m3-12-cs",
-					"qty": 4,
-					"method": "self-tap"
+					"qty": 2,
+					"method": "self-tap",
+					"through_mm": 6.45,
+					"thread_mm": 10
+				},
+				{
+					"from": "nema-bracket",
+					"to": "stator",
+					"via": "scr-m3-12-cs",
+					"qty": 2,
+					"method": "self-tap",
+					"through_mm": 8.45,
+					"thread_mm": 10,
+					"note": "The bracket's four stator holes come in two depths: two at 6.45 mm, two at 8.45 mm."
 				}
 			]
 		},
 		{
 			"id": "rotor-unit-faceted",
-			"uid": "df0i",
-			"version": "1",
+			"uid": "ylvv",
+			"version": "2",
 			"name": "Rotor unit (faceted)",
 			"description": "The faceted rotor with the Output gear (130T) bolted on. Assembled once as a unit; a C-channel drive spins it.",
 			"lines": [
@@ -1894,25 +1950,71 @@
 					"qty": 1
 				},
 				{
+					"part": "brg-6806-2rs",
+					"qty": 1
+				},
+				{
 					"part": "scr-m3-12-cs",
 					"qty": 6
 				}
 			],
 			"connections": [
 				{
+					"from": "brg-6806-2rs",
+					"to": "output-gear",
+					"qty": 1,
+					"method": "press"
+				},
+				{
 					"from": "output-gear",
 					"to": "rotor-faceted",
 					"via": "scr-m3-12-cs",
 					"qty": 6,
 					"method": "self-tap",
-					"note": "One per spoke. Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing."
+					"note": "One per spoke. Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing.",
+					"through_mm": 6.45,
+					"thread_mm": 5
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "df0i",
+					"date": "2026-08-31",
+					"commit": null,
+					"message": "Original recording: the 6806 bearing rode along as the output gear's requires rather than a line.",
+					"lines": [
+						{
+							"part": "rotor-faceted",
+							"qty": 1,
+							"uid": "9v9q"
+						},
+						{
+							"part": "output-gear",
+							"qty": 1,
+							"uid": "26ek"
+						},
+						{
+							"part": "scr-m3-12-cs",
+							"qty": 6,
+							"uid": "0a9x"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "ylvv",
+					"date": "2026-09-01",
+					"message": "The output gear's 6806 bearing is a line of its own with its press fit as a connection (was the gear's requires).",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
 		{
 			"id": "rotor-unit-finned",
-			"uid": "iau5",
-			"version": "1",
+			"uid": "7ol7",
+			"version": "2",
 			"name": "Rotor unit (finned)",
 			"description": "The finned rotor with the Output gear (130T) bolted on. Assembled once as a unit; the classification channel's C-channel drive spins it.",
 			"lines": [
@@ -1925,11 +2027,21 @@
 					"qty": 1
 				},
 				{
+					"part": "brg-6806-2rs",
+					"qty": 1
+				},
+				{
 					"part": "scr-m3-12-cs",
 					"qty": 6
 				}
 			],
 			"connections": [
+				{
+					"from": "brg-6806-2rs",
+					"to": "output-gear",
+					"qty": 1,
+					"method": "press"
+				},
 				{
 					"from": "output-gear",
 					"to": "rotor-finned",
@@ -1937,6 +2049,40 @@
 					"qty": 6,
 					"method": "self-tap",
 					"note": "One per spoke. Same joint as the faceted rotor unit."
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "iau5",
+					"date": "2026-08-31",
+					"commit": null,
+					"message": "Original recording: the 6806 bearing rode along as the output gear's requires rather than a line.",
+					"lines": [
+						{
+							"part": "rotor-finned",
+							"qty": 1,
+							"uid": "brsr"
+						},
+						{
+							"part": "output-gear",
+							"qty": 1,
+							"uid": "26ek"
+						},
+						{
+							"part": "scr-m3-12-cs",
+							"qty": 6,
+							"uid": "0a9x"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "7ol7",
+					"date": "2026-09-01",
+					"message": "The output gear's 6806 bearing is a line of its own with its press fit as a connection (was the gear's requires).",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -2780,8 +2926,9 @@
 					"version": "1",
 					"uid": "n6bm",
 					"date": "2026-06-27",
-					"message": "Initial version.",
+					"message": "Initial catalog entry, imported 2026-06-27.",
 					"commit": null,
+					"onshape_version": "https://cad.onshape.com/documents/60aa51fc61d18f2155b99910/v/b76489d0ca46a1169a2a6081/e/66109ce96b305bf318354f93",
 					"stl": "https://assets.basically.website/sorter-parts/stator-323b2d1f94a5.stl",
 					"render": "https://assets.basically.website/sorter-parts/stator-full-8b6222d89d98.png",
 					"grams": 175.52
@@ -3068,7 +3215,7 @@
 			"description": "Output gear, 130 teeth. One per C-channel (4 total).",
 			"version": "1",
 			"created_at": "2026-06-27",
-			"updated_at": "2026-06-27",
+			"updated_at": "2026-09-01",
 			"versions": [
 				{
 					"version": "1",
@@ -3096,12 +3243,7 @@
 			"low_tolerance": false,
 			"low_tolerance_note": null,
 			"layer_scope": "all",
-			"requires": [
-				{
-					"part": "brg-6806-2rs",
-					"qty": 1
-				}
-			],
+			"requires": [],
 			"caption": null,
 			"docs_page": null,
 			"conflicts": null,
@@ -3213,6 +3355,7 @@
 					"date": "2026-06-27",
 					"message": "Initial catalog entry, imported 2026-06-27 at the design's second iteration ('v2' in the source export, 01_c_channel (5).zip). v1 predates the catalog: never published, no uid, no pinned geometry. The commit is where this entry first exists in this repository's history; the import itself predates it.",
 					"commit": "954f181e",
+					"onshape_version": "https://cad.onshape.com/documents/60aa51fc61d18f2155b99910/v/b76489d0ca46a1169a2a6081/e/66109ce96b305bf318354f93",
 					"stl": "https://assets.basically.website/sorter-parts/nema-bracket-8b2bea87360e.stl",
 					"render": "https://assets.basically.website/sorter-parts/nema-bracket-full-91f60f914ef2.png",
 					"grams": 72.45
@@ -15968,7 +16111,7 @@
 			},
 			"name": "M3 \u00d7 16 mm socket/button head",
 			"category": "Screws",
-			"description": "Retired, no longer used anywhere. Was recorded as the C-channel stepper screw, but those are countersunk \u2014 and 4, not 3 (scr-m3-16-cs).",
+			"description": "Retired, no longer used anywhere. Was recorded as the C-channel stepper screw, but those are countersunk (scr-m3-16-cs).",
 			"note": "Unused as of 2026-09-01. Do not re-add: the C-channel calls for the countersunk M3 \u00d7 16.",
 			"created_at": "2026-07-18",
 			"updated_at": "2026-09-01",
@@ -16008,7 +16151,7 @@
 			},
 			"name": "M3 \u00d7 16 mm countersunk",
 			"category": "Screws",
-			"description": "Bolts the NEMA 17 stepper to the NEMA bracket, into the stepper's tapped face holes. 4 per C-channel.",
+			"description": "Bolts the NEMA 17 stepper to the NEMA bracket, into the stepper's tapped face holes. 3 per C-channel.",
 			"note": null,
 			"created_at": "2026-09-01",
 			"updated_at": "2026-09-01",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2108,6 +2108,10 @@
 					"qty": 1
 				},
 				{
+					"part": "brg-608-2rs",
+					"qty": 1
+				},
+				{
 					"part": "scr-m3-35-bhcs",
 					"qty": 1
 				},
@@ -2126,6 +2130,14 @@
 				{
 					"part": "hsi-m3",
 					"qty": 4
+				}
+			],
+			"connections": [
+				{
+					"from": "brg-608-2rs",
+					"to": "interface-idler-gear",
+					"qty": 1,
+					"method": "press"
 				}
 			]
 		},
@@ -7139,7 +7151,7 @@
 			"description": "Idler gear for the chute stepper, 2M 25T. 1 needed.",
 			"version": "1",
 			"created_at": "2026-06-27",
-			"updated_at": "2026-06-27",
+			"updated_at": "2026-09-01",
 			"versions": [
 				{
 					"version": "1",
@@ -7167,12 +7179,7 @@
 			"low_tolerance": false,
 			"low_tolerance_note": null,
 			"layer_scope": "all",
-			"requires": [
-				{
-					"part": "brg-608-2rs",
-					"qty": 1
-				}
-			],
+			"requires": [],
 			"caption": null,
 			"docs_page": null,
 			"conflicts": null,

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1734,7 +1734,7 @@
 		{
 			"id": "c-channel",
 			"uid": "sbwe",
-			"version": "2",
+			"version": "3",
 			"name": "C-channel drive",
 			"description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
 			"docs": "/hardware/assembly/feeder/c-channel/",
@@ -1794,16 +1794,27 @@
 				},
 				{
 					"version": "2",
-					"uid": "sbwe",
 					"date": "2026-08-31",
 					"message": "Moved the Output gear (130T) and its 6 \u00d7 M3 \u00d7 12 out to the new rotor units: the gear bolts to the rotor, so the joint and its screws belong to the node that holds both. No physical change.",
+					"breaking": false,
+					"commit": null
+				},
+				{
+					"version": "3",
+					"uid": "sbwe",
+					"date": "2026-09-01",
+					"message": "The screws are all countersunk \u2014 socket/button was recorded wrong \u2014 and the stepper takes 4, not 3. The idler's 608 bearing moved from the gear's requires to a line of its own, with its press fit as a connection. Connections bench-confirmed and listed in assembly order.",
 					"breaking": false,
 					"commit": null
 				}
 			],
 			"lines": [
 				{
-					"part": "stator",
+					"part": "idler-gear",
+					"qty": 1
+				},
+				{
+					"part": "brg-608-2rs",
 					"qty": 1
 				},
 				{
@@ -1811,7 +1822,7 @@
 					"qty": 1
 				},
 				{
-					"part": "idler-gear",
+					"part": "motor-nema17",
 					"qty": 1
 				},
 				{
@@ -1819,48 +1830,51 @@
 					"qty": 1
 				},
 				{
-					"part": "motor-nema17",
+					"part": "stator",
 					"qty": 1
 				},
 				{
-					"part": "scr-m3-16-shcs",
-					"qty": 3
+					"part": "scr-m3-16-cs",
+					"qty": 4
+				},
+				{
+					"part": "scr-m3-8-cs",
+					"qty": 1
 				},
 				{
 					"part": "scr-m3-12-cs",
 					"qty": 4
-				},
-				{
-					"part": "scr-m3-8-shcs",
-					"qty": 1
 				}
 			],
 			"connections": [
+				{
+					"from": "brg-608-2rs",
+					"to": "idler-gear",
+					"qty": 1,
+					"method": "press"
+				},
+				{
+					"from": "nema-bracket",
+					"to": "motor-nema17",
+					"via": "scr-m3-16-cs",
+					"qty": 4,
+					"method": "thread",
+					"note": "Into the NEMA 17's tapped face holes."
+				},
+				{
+					"from": "input-gear",
+					"to": "motor-nema17",
+					"via": "scr-m3-8-cs",
+					"qty": 1,
+					"method": "self-tap",
+					"note": "Threads through the gear hub and bears on the motor shaft flat."
+				},
 				{
 					"from": "nema-bracket",
 					"to": "stator",
 					"via": "scr-m3-12-cs",
 					"qty": 4,
-					"method": "self-tap",
-					"draft": true
-				},
-				{
-					"from": "nema-bracket",
-					"to": "motor-nema17",
-					"via": "scr-m3-16-shcs",
-					"qty": 3,
-					"method": "thread",
-					"note": "Into the NEMA 17's tapped face holes.",
-					"draft": true
-				},
-				{
-					"from": "input-gear",
-					"to": "motor-nema17",
-					"via": "scr-m3-8-shcs",
-					"qty": 1,
-					"method": "self-tap",
-					"note": "Threads through the gear hub and bears on the motor shaft flat.",
-					"draft": true
+					"method": "self-tap"
 				}
 			]
 		},
@@ -3209,7 +3223,7 @@
 			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 7210,
+			"print_seconds": 7209,
 			"color": {
 				"by_section": {
 					"feeder": {
@@ -4243,7 +4257,7 @@
 			"support_grams": 9.29,
 			"support_used": true,
 			"support_intentional": false,
-			"print_seconds": 23959,
+			"print_seconds": 23973,
 			"color": {
 				"role": "chute-core"
 			},
@@ -5205,7 +5219,7 @@
 			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 7443,
+			"print_seconds": 7438,
 			"color": {
 				"role": "frame"
 			},
@@ -7589,7 +7603,7 @@
 			],
 			"attributes": [],
 			"grams": 29.01,
-			"support_grams": 0.0,
+			"support_grams": 0,
 			"support_used": false,
 			"support_intentional": false,
 			"print_seconds": 2334,
@@ -7720,7 +7734,7 @@
 			],
 			"attributes": [],
 			"grams": 52.99,
-			"support_grams": 0.0,
+			"support_grams": 0,
 			"support_used": false,
 			"support_intentional": false,
 			"print_seconds": 3798,
@@ -8753,7 +8767,7 @@
 			"description": "C-channel idler gear, 24 teeth. One per C-channel (4 total).",
 			"version": "1",
 			"created_at": "2026-06-27",
-			"updated_at": "2026-06-27",
+			"updated_at": "2026-09-01",
 			"versions": [
 				{
 					"version": "1",
@@ -8781,12 +8795,7 @@
 			"low_tolerance": false,
 			"low_tolerance_note": null,
 			"layer_scope": "all",
-			"requires": [
-				{
-					"part": "brg-608-2rs",
-					"qty": 1
-				}
-			],
+			"requires": [],
 			"caption": null,
 			"docs_page": null,
 			"conflicts": null,
@@ -10152,10 +10161,10 @@
 			],
 			"attributes": [],
 			"grams": 13.96,
-			"support_grams": 5.55,
+			"support_grams": 5.52,
 			"support_used": true,
 			"support_intentional": false,
-			"print_seconds": 2727,
+			"print_seconds": 2724,
 			"color": {
 				"role": "chute-core"
 			},
@@ -14117,7 +14126,7 @@
 			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
-			"print_seconds": 15131,
+			"print_seconds": 15132,
 			"color": {
 				"role": "frame"
 			},
@@ -15806,10 +15815,10 @@
 			},
 			"name": "M3 \u00d7 8 mm socket/button head",
 			"category": "Screws",
-			"description": "Clamps the C-channel input gear (12T) to the flat of the NEMA 17 shaft. 1 per C-channel.",
-			"note": "Head type and length measured off the input-gear STL: the boss carries a \u00d82.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the \u00d84.87 mm bore; the head sits in a round \u00d86.40 mm \u00d7 2.7 mm counterbore with a 90\u00b0 cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (\u00d85.5 \u00d7 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (\u00d85.7 \u00d7 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic.",
+			"description": "Retired, no longer used anywhere. Was recorded as the screw clamping the C-channel input gear (12T) to the NEMA 17 shaft flat, but that screw is countersunk (scr-m3-8-cs).",
+			"note": "Head type and length measured off the input-gear STL: the boss carries a \u00d82.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the \u00d84.87 mm bore; the head sits in a round \u00d86.40 mm \u00d7 2.7 mm counterbore with a 90\u00b0 cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (\u00d85.5 \u00d7 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (\u00d85.7 \u00d7 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic. Unused as of 2026-09-01: the screw is the countersunk M3 \u00d7 8 (scr-m3-8-cs).",
 			"created_at": "2026-08-21",
-			"updated_at": "2026-08-21",
+			"updated_at": "2026-09-01",
 			"attributes": [
 				{
 					"label": "Thread",
@@ -15959,10 +15968,10 @@
 			},
 			"name": "M3 \u00d7 16 mm socket/button head",
 			"category": "Screws",
-			"description": "Bolts the NEMA 17 stepper to the NEMA bracket. 3 per C-channel.",
-			"note": null,
+			"description": "Retired, no longer used anywhere. Was recorded as the C-channel stepper screw, but those are countersunk \u2014 and 4, not 3 (scr-m3-16-cs).",
+			"note": "Unused as of 2026-09-01. Do not re-add: the C-channel calls for the countersunk M3 \u00d7 16.",
 			"created_at": "2026-07-18",
-			"updated_at": "2026-08-18",
+			"updated_at": "2026-09-01",
 			"attributes": [
 				{
 					"label": "Thread",
@@ -15986,6 +15995,46 @@
 			"docs_page": null,
 			"conflicts": null,
 			"image": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png"
+		},
+		{
+			"id": "scr-m3-16-cs",
+			"uid": "bdi4",
+			"kind": "cots",
+			"cots": {
+				"type": "screw",
+				"size": "M3",
+				"variant": "countersunk",
+				"length_mm": 16
+			},
+			"name": "M3 \u00d7 16 mm countersunk",
+			"category": "Screws",
+			"description": "Bolts the NEMA 17 stepper to the NEMA bracket, into the stepper's tapped face holes. 4 per C-channel.",
+			"note": null,
+			"created_at": "2026-09-01",
+			"updated_at": "2026-09-01",
+			"attributes": [
+				{
+					"label": "Thread",
+					"value": "M3"
+				},
+				{
+					"label": "Length",
+					"value": "16 mm"
+				},
+				{
+					"label": "Head",
+					"value": "Countersunk (flat) socket"
+				}
+			],
+			"sheet_qty": null,
+			"sheet_qty_text": null,
+			"stock": null,
+			"sourcing": null,
+			"alternative": null,
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"image": "https://assets.basically.website/sorter-parts/hardware-screws-countersunk-full-faf0edbe3324.jpg"
 		},
 		{
 			"id": "scr-m3-6-bhcs",

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -141,6 +141,11 @@ export type Connection = {
 	via?: string;
 	qty: number;
 	method: ConnectionMethod;
+	/** The fastener's travel through the `from` side before it reaches the
+	 *  anchor, and the thread length waiting on the `to` side — measured, so
+	 *  compatible screw lengths are computable instead of remembered. */
+	through_mm?: number;
+	thread_mm?: number;
 	note?: string;
 	draft?: boolean;
 };
@@ -164,8 +169,11 @@ export function docsUrl(a: Assembly): string | null {
 	return a.docs ? DOCS_BASE + a.docs : null;
 }
 
-/** Hardware committed to a single physical part (heat inserts, press-fit
- *  bearings). Scales automatically with the part count. */
+/** Fastener anchors committed to a single physical part before it joins
+ *  anything — heat-set inserts, which a later joint's `insert` edge threads
+ *  into. Scales automatically with the part count. Components that merely
+ *  install into a part (a press-fit bearing) are NOT this: they are members
+ *  of the assembly where the joint happens, connected by a `press` edge. */
 export type Requirement = { part: string; qty: number };
 
 export type Vendor = {

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -135,6 +135,19 @@ export type ConnectionMethod =
 	| 'nut'
 	| 'tnut'
 	| 'gravity';
+/** ISO 10642 countersunk head heights by thread size. A countersunk screw's
+ *  nominal length is measured over the head, and the head rides inside the
+ *  countersink — so only nominal minus head actually travels the joint. */
+const CSK_HEAD_MM: Record<string, number> = { M3: 1.7, M4: 2.3, M5: 2.8, M6: 3.3 };
+
+/** How far a screw reaches through a joint: nominal length, less the head for
+ *  countersunk screws. Null when the length isn't recorded. */
+export function screwTravel(h: Hardware | null | undefined): number | null {
+	const len = h?.cots?.length_mm;
+	if (len == null) return null;
+	return h?.cots?.variant === 'countersunk' ? len - (CSK_HEAD_MM[h.cots.size ?? ''] ?? 0) : len;
+}
+
 export type Connection = {
 	from: string;
 	to: string;

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -13,7 +13,7 @@
 		X,
 		Zap
 	} from 'lucide-svelte';
-	import ConnectionBraces from '$lib/components/ConnectionBraces.svelte';
+	import ConnectionBraces, { braceGroups } from '$lib/components/ConnectionBraces.svelte';
 	import DropdownMenu from '$lib/components/DropdownMenu.svelte';
 	import AlternativeBadge from '$lib/components/AlternativeBadge.svelte';
 	import ConflictBadge from '$lib/components/ConflictBadge.svelte';
@@ -1289,7 +1289,7 @@
 			{#if open}
 			{@const braceGutter =
 				asm.connections?.length && !filtering
-					? 32 + (new Set(asm.connections.map((c) => c.method)).size - 1) * 16
+					? 32 + (braceGroups(asm.connections).length - 1) * 16
 					: 0}
 			<div
 				class="tree-branch relative pl-2 sm:pl-4"

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -44,6 +44,7 @@
 		PARTS,
 		plainDescription,
 		primaryColorId,
+		screwTravel,
 		SETTINGS,
 		TAGS,
 		type CatalogTag,
@@ -1297,7 +1298,7 @@
 			>
 				<button type="button" class="tree-line" onclick={() => toggle(asm.id)} aria-label="Collapse {asm.name}"></button>
 				{#if braceGutter && asm.connections}
-					<ConnectionBraces edges={asm.connections} gutter={braceGutter} labelOf={(m) => CONN_LABELS[m] ?? m} nameOf={memberName} lengthOf={(id) => getHardware(id)?.cots?.length_mm ?? null} />
+					<ConnectionBraces edges={asm.connections} gutter={braceGutter} labelOf={(m) => CONN_LABELS[m] ?? m} nameOf={memberName} travelOf={(id) => screwTravel(getHardware(id))} />
 				{/if}
 			{#if asm.images?.length}<div class="mt-2"><ImageStrip images={asm.images} /></div>{/if}
 			{#if historyFor[asm.id] && !filtering}{@render historyPanel(asm)}{/if}

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -1297,7 +1297,7 @@
 			>
 				<button type="button" class="tree-line" onclick={() => toggle(asm.id)} aria-label="Collapse {asm.name}"></button>
 				{#if braceGutter && asm.connections}
-					<ConnectionBraces edges={asm.connections} gutter={braceGutter} labelOf={(m) => CONN_LABELS[m] ?? m} nameOf={memberName} />
+					<ConnectionBraces edges={asm.connections} gutter={braceGutter} labelOf={(m) => CONN_LABELS[m] ?? m} nameOf={memberName} lengthOf={(id) => getHardware(id)?.cots?.length_mm ?? null} />
 				{/if}
 			{#if asm.images?.length}<div class="mt-2"><ImageStrip images={asm.images} /></div>{/if}
 			{#if historyFor[asm.id] && !filtering}{@render historyPanel(asm)}{/if}


### PR DESCRIPTION
Rolling corrections as Spencer reviews the assemblies against the real machine. First up, the C-channel drive:

- Every screw is countersunk — the socket/button entries were recorded wrong. New `scr-m3-16-cs` (×4 on the stepper, not ×3); both socket/button entries retired in place. Exact lengths still being double-checked at the bench.
- The 608 bearing is a part like any other: a C-channel line with a first-class `press` connection, not `requires` on the gear. `requires` narrows to fastener anchors (heat-set inserts).
- Connection edges gain optional `through_mm` / `thread_mm` — pass-through travel on the from side, thread length on the anchor — so compatible screw lengths become computable. Validated in CI, shown in the brace popover.
- The brace diagram splits a method's edges into connected components: independent joints get their own spines (the stator joint no longer shares a spine with the input-gear set screw). Same method keeps the same hue.
- C-channel stamped v3, non-breaking; lines and edges in assembly order; draft flags cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)