### PR TITLE
parts-calculator: the feeder becomes its four physical units

### DIFF
--- a/.github/workflows/check-parts.yml
+++ b/.github/workflows/check-parts.yml
@@ -18,6 +18,11 @@ name: Check part data
 #                               line changes are stamped as assembly versions
 #  - check_connections.py     : connection edges reference real members and
 #                               real fastener lines, methods from the enum
+#  - check_docs_refs.py       : warn-only — annotates the PR when a docs
+#                               page references a part the catalog no longer
+#                               uses, or documents an assembly the change
+#                               revises (stale docs allowed, silent staleness
+#                               not)
 #
 # Both are pure checks, a minute end to end. regen-parts.yml -- the old
 # CI-canonical slicer that committed back onto PR branches -- is deleted; its
@@ -29,10 +34,12 @@ on:
   pull_request:
     paths:
       - 'parts-calculator/**'
+      - 'docs/src/content/**'
   push:
     branches: [main]
     paths:
       - 'parts-calculator/**'
+      - 'docs/src/content/**'
 
 jobs:
   check:
@@ -50,3 +57,8 @@ jobs:
       - run: python parts-calculator/scripts/check_asset_urls.py
       - run: python parts-calculator/scripts/check_versioning.py
       - run: python parts-calculator/scripts/check_connections.py
+      # Warnings only, never fails: annotates the PR when a docs page
+      # references a part the catalog no longer uses, or documents an
+      # assembly this change revises. Stale docs are allowed — unflagged
+      # stale docs are not.
+      - run: python parts-calculator/scripts/check_docs_refs.py

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -38,9 +38,9 @@ parts_needed:
     qty: 4
   - part: scr-m3-12-cs
     qty: 40
-  - part: scr-m3-16-shcs
+  - part: scr-m3-16-cs
     qty: 12
-  - part: scr-m3-8-shcs
+  - part: scr-m3-8-cs
     qty: 4
 ---
 
@@ -91,7 +91,7 @@ Bolt the Output gear onto the underside of the rotor with 6 {% include fastener.
 
 {% include step.html n="3" title="Fit the input gear to the motor shaft" %}
 
-The Input gear (12T, screw) has a hole through its boss, parallel to the shaft, for the {% include fastener.html size="M3" variant="socket-button" length="8" %} screw that clamps it on. The bore is plain and round, so there is nothing to key it: turn the gear until that screw lines up with the flat on the NEMA 17's shaft, push the gear all the way on, then tighten the screw down onto the flat.
+The Input gear (12T, screw) has a hole through its boss, parallel to the shaft, for the {% include fastener.html size="M3" variant="countersunk" length="8" %} screw that clamps it on. The bore is plain and round, so there is nothing to key it: turn the gear until that screw lines up with the flat on the NEMA 17's shaft, push the gear all the way on, then tighten the screw down onto the flat.
 
 The head drops into a counterbore in the boss. Tighten until the head is seated and the gear does not turn on the shaft, and no further, it is threading into plastic.
 
@@ -104,7 +104,7 @@ The head drops into a counterbore in the boss. Tighten until the head is seated 
 
 Drop the Idler gear (24T) onto its post on the NEMA bracket **with the bearing facing up**.
 
-Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3" variant="socket-button" length="16" %} screws. Three, not four: one corner of the motor face is left free. The input gear meshes with the idler as the motor goes down.
+Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3" variant="countersunk" length="16" %} screws. Three, not four: one corner of the motor face is left free. The input gear meshes with the idler as the motor goes down.
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-idler-gear-and-motor-on-nema-bracket-w1600-dfefb06e2166.jpg" alt="The three-armed grey NEMA bracket seen from above, with the 24-tooth idler gear sitting on its post with the 608 bearing uppermost, the stepper motor bolted to the outer end of the bracket, and the raised hub at the centre of the bracket">

--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -817,9 +817,18 @@ def build_hardware(manifest):
 def build_lasercut(manifest):
     """Laser-cut sheet parts (kind: 'lasercut'): passed through verbatim -- the
     fields ARE the app's LaserCutPart shape, and the docs site reads the same
-    generated records."""
-    return [{k: v for k, v in p.items() if k != "kind"}
-            for p in manifest["parts"] if p.get("kind") == "lasercut"]
+    generated records. One derived field: an entry pinning an `stl_hash` (a
+    published solid model of the cut part -- never printed or sliced, just
+    viewable) gets its served `stl` URL from the pin, like every upload."""
+    out = []
+    for p in manifest["parts"]:
+        if p.get("kind") != "lasercut":
+            continue
+        e = {k: v for k, v in p.items() if k != "kind"}
+        if e.get("stl_hash"):
+            e["stl"] = stl_url(e["id"], e["stl_hash"])
+        out.append(e)
+    return out
 
 
 def build_families(manifest):

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5920,6 +5920,10 @@
           "qty": 2
         },
         {
+          "part": "cam-ov9732",
+          "qty": 1
+        },
+        {
           "part": "scr-m3-12-cs",
           "qty": 3
         },
@@ -6352,10 +6356,6 @@
         {
           "assembly": "classification-chamber",
           "qty": 1
-        },
-        {
-          "assembly": "camera-mount",
-          "qty": 2
         }
       ]
     },
@@ -6531,6 +6531,10 @@
         {
           "assembly": "light-post-assembly",
           "qty": 1
+        },
+        {
+          "assembly": "camera-mount",
+          "qty": 1
         }
       ],
       "connections": [
@@ -6569,6 +6573,10 @@
         },
         {
           "assembly": "light-post-assembly",
+          "qty": 1
+        },
+        {
+          "assembly": "camera-mount",
           "qty": 1
         }
       ],

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6254,8 +6254,8 @@
     },
     {
       "id": "machine",
-      "uid": "e4k9",
-      "version": "1",
+      "uid": "dlmn",
+      "version": "2",
       "name": "Sorter V2",
       "description": "The whole machine: feeder on top, interface, the distribution layers between the interfaces, and the bottom interface.",
       "docs": "/hardware/assembly/",
@@ -6265,6 +6265,66 @@
           "assembly": "feeder",
           "qty": 1
         },
+        {
+          "assembly": "superstructure",
+          "qty": 1
+        },
+        {
+          "assembly": "electronics",
+          "qty": 1
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "uid": "e4k9",
+          "commit": null,
+          "message": "Original recording: the interfaces, layers, feeder and electronics all sat flat at the root.",
+          "lines": [
+            {
+              "assembly": "feeder",
+              "qty": 1,
+              "uid": "y5ws"
+            },
+            {
+              "assembly": "interface",
+              "qty": 1,
+              "uid": "uelo"
+            },
+            {
+              "assembly": "layer",
+              "qty": "middle-layers",
+              "uid": "jog7"
+            },
+            {
+              "assembly": "bottom-interface",
+              "qty": 1,
+              "uid": "67uq"
+            },
+            {
+              "assembly": "electronics",
+              "qty": 1,
+              "uid": "lbrp"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-09-01",
+          "message": "The machine splits into what it physically is: the feeder, the superstructure it mounts onto — top interface, distribution layers, bottom interface — and the electronics. No physical change.",
+          "breaking": false,
+          "commit": null
+        }
+      ]
+    },
+    {
+      "id": "superstructure",
+      "uid": "ywb3",
+      "version": "1",
+      "name": "Superstructure",
+      "description": "What the feeder and the electronics mount onto: the top interface, the distribution layers between the interfaces, and the bottom interface.",
+      "status": "partial",
+      "lines": [
         {
           "assembly": "interface",
           "qty": 1
@@ -6276,12 +6336,9 @@
         {
           "assembly": "bottom-interface",
           "qty": 1
-        },
-        {
-          "assembly": "electronics",
-          "qty": 1
         }
-      ]
+      ],
+      "connections": []
     },
     {
       "id": "feeder",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3185,7 +3185,7 @@
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png",
-      "description": "Retired, no longer used anywhere. Was recorded as the C-channel stepper screw, but those are countersunk (scr-m3-16-cs).",
+      "description": "No longer the C-channel stepper screw — those are countersunk (scr-m3-16-cs). The top-interface docs call for 2 to mount the roller-lever limit switch into its housing's inserts, though the limit-switch assembly records M3 × 12 button heads for that joint — one of the two is wrong; settle it at the bench.",
       "created_at": "2026-07-18",
       "updated_at": "2026-09-01",
       "attributes": [
@@ -3201,8 +3201,7 @@
           "label": "Head",
           "value": "Socket or button head, interchangeable (both flat-bottomed, so either just clamps; socket is the default)"
         }
-      ],
-      "note": "Unused as of 2026-09-01. Do not re-add: the C-channel calls for the countersunk M3 × 16."
+      ]
     },
     {
       "id": "scr-m3-16-cs",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6341,9 +6341,25 @@
         {
           "assembly": "bottom-interface",
           "qty": 1
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 6
         }
       ],
-      "connections": []
+      "connections": [
+        {
+          "from": "top-plate",
+          "to": "interface",
+          "via": "scr-m5-16-shcs",
+          "qty": 6,
+          "method": "insert",
+          "through_mm": 9,
+          "thread_mm": 9,
+          "note": "Through the plate into the top interface's M5 heat-set inserts. The 16 mm length is assumed, not yet confirmed.",
+          "draft": true
+        }
+      ]
     },
     {
       "id": "feeder",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5592,7 +5592,7 @@
       "widthMm": 672,
       "heightMm": 770,
       "qty": 1,
-      "onshape": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/v/3b8fafc8cab54b09332e14d2/e/e6605a6f604d25617d91b7bc",
+      "onshape": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/v/f845b960415692451f2903b1/e/e6605a6f604d25617d91b7bc",
       "dxf": "/dxf/top-plate.dxf",
       "preview": "/dxf-previews/top-plate.svg",
       "updated": "2026-07-10",
@@ -5601,7 +5601,8 @@
         "blurb": "This plate is a regular hexagon — it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8″) drill holes.",
         "stock": "672.4 × 776.4 mm rectangle (26 15/32″ × 30 9/16″)",
         "tools": "jigsaw · drill · tape measure"
-      }
+      },
+      "stl_hash": "1f2d0ece017e38c09a6fa4258a407dcd85c07d844537017675a734647e74a067"
     }
   ],
   "assemblies": [

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -4156,9 +4156,9 @@
       },
       "name": "IMX415 4K camera module",
       "category": "Cameras",
-      "description": "Classification top camera",
+      "description": "Classification top camera — the ENOMAKER IMX415 4K USB module.",
       "created_at": "2026-07-18",
-      "updated_at": "2026-07-18",
+      "updated_at": "2026-09-01",
       "sheet_qty": {
         "per_machine": 1
       },
@@ -5769,7 +5769,19 @@
       ],
       "lines": [
         {
+          "assembly": "c-channel",
+          "qty": 1
+        },
+        {
           "assembly": "rotor-unit-finned",
+          "qty": 1
+        },
+        {
+          "part": "classification-dome",
+          "qty": 1
+        },
+        {
+          "assembly": "camera-led-insert-assembly",
           "qty": 1
         }
       ]
@@ -6232,10 +6244,10 @@
     },
     {
       "id": "feeder",
-      "uid": "pye7",
-      "version": "2",
+      "uid": "y5ws",
+      "version": "3",
       "name": "Feeder",
-      "description": "Feeder + classification channel. Everything above the interface.",
+      "description": "Everything above the top interface: the bulk bucket, C-channels 2 and 3, and the classification chamber.",
       "docs": "/hardware/assembly/feeder/",
       "status": "partial",
       "versions": [
@@ -6281,35 +6293,313 @@
           "date": "2026-08-31",
           "message": "The 3 faceted rotors become 3 Rotor unit (faceted) — rotor + bolted-on Output gear (130T) as one bench unit. No physical change.",
           "breaking": false,
+          "commit": null,
+          "uid": "pye7",
+          "lines": [
+            {
+              "assembly": "c-channel",
+              "qty": 4,
+              "uid": "4tvc"
+            },
+            {
+              "assembly": "rotor-unit-faceted",
+              "qty": 3,
+              "uid": "ylvv"
+            },
+            {
+              "assembly": "classification-chamber",
+              "qty": 1,
+              "uid": "fyqw"
+            },
+            {
+              "assembly": "camera-extension-assembly",
+              "qty": 1,
+              "uid": "dc2i"
+            },
+            {
+              "assembly": "light-post-assembly",
+              "qty": 2,
+              "uid": "v06x"
+            },
+            {
+              "assembly": "camera-mount",
+              "qty": 2,
+              "uid": "b3zx"
+            }
+          ]
+        },
+        {
+          "version": "3",
+          "date": "2026-09-01",
+          "message": "Restructured into the four physical units — the bulk bucket, C-channels 2 and 3, and the classification chamber — each carrying its own C-channel drive, rotor, supports, guide or cap, and lighting. No physical change.",
+          "breaking": false,
           "commit": null
         }
       ],
       "lines": [
         {
-          "assembly": "c-channel",
-          "qty": 4
+          "assembly": "bulk-bucket",
+          "qty": 1
         },
         {
-          "assembly": "rotor-unit-faceted",
-          "qty": 3
+          "assembly": "channel-two",
+          "qty": 1
+        },
+        {
+          "assembly": "channel-three",
+          "qty": 1
         },
         {
           "assembly": "classification-chamber",
           "qty": 1
         },
         {
-          "assembly": "camera-extension-assembly",
-          "qty": 1
-        },
-        {
-          "assembly": "light-post-assembly",
-          "qty": 2
-        },
-        {
           "assembly": "camera-mount",
           "qty": 2
         }
       ]
+    },
+    {
+      "id": "channel-three-support",
+      "uid": "r6ar",
+      "version": "1",
+      "name": "Channel 3 support",
+      "description": "One of C-channel 3's three standoffs: a foot and the leg the channel dovetails onto.",
+      "status": "partial",
+      "lines": [
+        {
+          "part": "foot",
+          "qty": 1
+        },
+        {
+          "part": "leg",
+          "qty": 1
+        }
+      ],
+      "connections": [
+        {
+          "from": "foot",
+          "to": "leg",
+          "qty": 1,
+          "method": "friction",
+          "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+        }
+      ]
+    },
+    {
+      "id": "channel-two-support",
+      "uid": "dp63",
+      "version": "1",
+      "name": "Channel 2 support",
+      "description": "One of C-channel 2's three standoffs: a foot, one leg extension, and the leg the channel dovetails onto.",
+      "status": "partial",
+      "lines": [
+        {
+          "part": "foot",
+          "qty": 1
+        },
+        {
+          "part": "leg-extension",
+          "qty": 1
+        },
+        {
+          "part": "leg",
+          "qty": 1
+        }
+      ],
+      "connections": [
+        {
+          "from": "foot",
+          "to": "leg-extension",
+          "qty": 1,
+          "method": "friction",
+          "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+        },
+        {
+          "from": "leg-extension",
+          "to": "leg",
+          "qty": 1,
+          "method": "friction",
+          "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+        }
+      ]
+    },
+    {
+      "id": "bulk-bucket-support",
+      "uid": "xo6j",
+      "version": "1",
+      "name": "Bulk bucket support",
+      "description": "One of the bulk bucket's three standoffs — the tallest stack: a foot, two leg extensions, and the leg.",
+      "status": "partial",
+      "lines": [
+        {
+          "part": "foot",
+          "qty": 1
+        },
+        {
+          "part": "leg-extension",
+          "qty": 2
+        },
+        {
+          "part": "leg",
+          "qty": 1
+        }
+      ],
+      "connections": [
+        {
+          "from": "foot",
+          "to": "leg-extension",
+          "qty": 1,
+          "method": "friction",
+          "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+        },
+        {
+          "from": "leg-extension",
+          "to": "leg-extension",
+          "qty": 1,
+          "method": "friction",
+          "note": "The two extensions stack tail-into-slot. Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+        },
+        {
+          "from": "leg-extension",
+          "to": "leg",
+          "qty": 1,
+          "method": "friction",
+          "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+        }
+      ]
+    },
+    {
+      "id": "bulk-bucket",
+      "uid": "1sej",
+      "version": "1",
+      "name": "Bulk bucket C-channel",
+      "description": "The top feeder unit: a C-channel drive with a white faceted rotor, capped by the Bulk cap instead of an output guide and with no light post, standing on the tallest supports.",
+      "status": "partial",
+      "lines": [
+        {
+          "assembly": "bulk-bucket-support",
+          "qty": 3
+        },
+        {
+          "assembly": "c-channel",
+          "qty": 1
+        },
+        {
+          "assembly": "rotor-unit-faceted",
+          "qty": 1
+        },
+        {
+          "part": "bulk-cap",
+          "qty": 1
+        }
+      ],
+      "connections": [
+        {
+          "from": "bulk-bucket-support",
+          "to": "c-channel",
+          "qty": 3,
+          "method": "friction",
+          "note": "Dovetail: each support's leg slides into the C-channel drive from below."
+        }
+      ]
+    },
+    {
+      "id": "channel-two",
+      "uid": "hi96",
+      "version": "1",
+      "name": "C-channel 2",
+      "description": "The middle feeder channel: a C-channel drive with a white faceted rotor, an output guide and a light post, standing on three supports with one leg extension each.",
+      "status": "partial",
+      "lines": [
+        {
+          "assembly": "channel-two-support",
+          "qty": 3
+        },
+        {
+          "assembly": "c-channel",
+          "qty": 1
+        },
+        {
+          "assembly": "rotor-unit-faceted",
+          "qty": 1
+        },
+        {
+          "part": "output-guide",
+          "qty": 1
+        },
+        {
+          "assembly": "light-post-assembly",
+          "qty": 1
+        }
+      ],
+      "connections": [
+        {
+          "from": "channel-two-support",
+          "to": "c-channel",
+          "qty": 3,
+          "method": "friction",
+          "note": "Dovetail: each support's leg slides into the C-channel drive from below."
+        }
+      ]
+    },
+    {
+      "id": "channel-three",
+      "uid": "xlak",
+      "version": "1",
+      "name": "C-channel 3",
+      "description": "The lowest feeder channel, just above the classification chamber: a C-channel drive with the gray faceted rotor, an output guide and a light post, on three foot-and-leg supports.",
+      "status": "partial",
+      "lines": [
+        {
+          "assembly": "channel-three-support",
+          "qty": 3
+        },
+        {
+          "assembly": "c-channel",
+          "qty": 1
+        },
+        {
+          "assembly": "rotor-unit-faceted",
+          "qty": 1
+        },
+        {
+          "part": "output-guide",
+          "qty": 1
+        },
+        {
+          "assembly": "light-post-assembly",
+          "qty": 1
+        }
+      ],
+      "connections": [
+        {
+          "from": "channel-three-support",
+          "to": "c-channel",
+          "qty": 3,
+          "method": "friction",
+          "note": "Dovetail: each support's leg slides into the C-channel drive from below."
+        }
+      ]
+    },
+    {
+      "id": "camera-led-insert-assembly",
+      "uid": "434r",
+      "version": "1",
+      "name": "Camera & LED insert assembly",
+      "description": "The Camera & LED insert print with the camera extension assembled into it; the loaded insert drops into the classification dome.",
+      "status": "partial",
+      "lines": [
+        {
+          "part": "camera-led-insert",
+          "qty": 1
+        },
+        {
+          "assembly": "camera-extension-assembly",
+          "qty": 1
+        }
+      ],
+      "connections": []
     },
     {
       "id": "interface",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3281,9 +3281,9 @@
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-12-bhcs-full-26e52d7d5bcd.png",
-      "description": "Mounts the cable clamp to the interface, and the limit switch to its housing.",
+      "description": "Mounts the cable clamp to the interface, the limit switch to its housing, and fastens the camera extension into the Camera & LED insert.",
       "created_at": "2026-07-18",
-      "updated_at": "2026-08-18",
+      "updated_at": "2026-09-01",
       "attributes": [
         {
           "label": "Thread",
@@ -6162,8 +6162,8 @@
     },
     {
       "id": "camera-extension-assembly",
-      "uid": "dc2i",
-      "version": "1",
+      "uid": "q2re",
+      "version": "2",
       "name": "Camera extension",
       "description": "Classification-channel camera extension for the 4K camera module: the 50 mm extension tube, its mount, and the camera. 1 per machine.",
       "status": "partial",
@@ -6183,10 +6183,48 @@
         {
           "part": "scr-m2-8-shcs",
           "qty": 4
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "uid": "dc2i",
+          "commit": null,
+          "message": "Original version: carried the 4 × M3 × 12 that fasten this assembly into the Camera & LED insert, even though the insert is the parent's line.",
+          "lines": [
+            {
+              "part": "camera-extension",
+              "qty": 1,
+              "uid": "v684"
+            },
+            {
+              "part": "camera-extension-mount",
+              "qty": 1,
+              "uid": "wt9t"
+            },
+            {
+              "part": "cam-imx415",
+              "qty": 1,
+              "uid": "1lze"
+            },
+            {
+              "part": "scr-m2-8-shcs",
+              "qty": 4,
+              "uid": "iwk6"
+            },
+            {
+              "part": "scr-m3-12-bhcs",
+              "qty": 4,
+              "uid": "izrb"
+            }
+          ]
         },
         {
-          "part": "scr-m3-12-bhcs",
-          "qty": 4
+          "version": "2",
+          "date": "2026-09-01",
+          "message": "The 4 × M3 × 12 moved out to the Camera & LED insert assembly: they fasten this whole assembly into the insert, so the joint and its screws belong to the node that holds both. No physical change.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },
@@ -6605,9 +6643,21 @@
         {
           "assembly": "camera-extension-assembly",
           "qty": 1
+        },
+        {
+          "part": "scr-m3-12-bhcs",
+          "qty": 4
         }
       ],
-      "connections": []
+      "connections": [
+        {
+          "from": "camera-extension-assembly",
+          "to": "camera-led-insert",
+          "via": "scr-m3-12-bhcs",
+          "qty": 4,
+          "method": "self-tap"
+        }
+      ]
     },
     {
       "id": "interface",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6312,7 +6312,7 @@
         {
           "version": "2",
           "date": "2026-09-01",
-          "message": "The machine splits into what it physically is: the feeder, the superstructure it mounts onto — top interface, distribution layers, bottom interface — and the electronics. No physical change.",
+          "message": "The machine splits into what it physically is: the feeder, the superstructure it mounts onto — top plate, top interface, distribution layers, bottom interface — and the electronics. No physical change.",
           "breaking": false,
           "commit": null
         }
@@ -6323,9 +6323,13 @@
       "uid": "ywb3",
       "version": "1",
       "name": "Superstructure",
-      "description": "What the feeder and the electronics mount onto: the top interface, the distribution layers between the interfaces, and the bottom interface.",
+      "description": "What the feeder and the electronics mount onto: the top plate, the top interface, the distribution layers between the interfaces, and the bottom interface.",
       "status": "partial",
       "lines": [
+        {
+          "part": "top-plate",
+          "qty": 1
+        },
         {
           "assembly": "interface",
           "qty": 1
@@ -6718,8 +6722,8 @@
     },
     {
       "id": "interface",
-      "uid": "uelo",
-      "version": "3",
+      "uid": "vhrk",
+      "version": "4",
       "name": "Top interface",
       "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
@@ -6784,10 +6788,6 @@
         {
           "part": "scr-m4-12-cs",
           "qty": 8
-        },
-        {
-          "part": "top-plate",
-          "qty": 1
         },
         {
           "part": "scr-m5-35-fhcs",
@@ -7054,6 +7054,106 @@
           "version": "3",
           "date": "2026-08-31",
           "message": "The six External bracket covers and 12 bracket screws move inside the hex frame's new External bracket with support segments. No physical change.",
+          "breaking": false,
+          "commit": null,
+          "uid": "uelo",
+          "lines": [
+            {
+              "assembly": "interface-bracket-mount",
+              "qty": 6,
+              "uid": "pnl9"
+            },
+            {
+              "assembly": "hex-frame",
+              "qty": 1,
+              "uid": "l0xa"
+            },
+            {
+              "assembly": "fixed-upper-section",
+              "qty": 1,
+              "uid": "99af"
+            },
+            {
+              "assembly": "cable-cage",
+              "qty": 1,
+              "uid": "nam6"
+            },
+            {
+              "part": "scr-m5-30-shcs",
+              "qty": 6,
+              "uid": "92kv"
+            },
+            {
+              "assembly": "cable-clamp",
+              "qty": 1,
+              "uid": "e0p9"
+            },
+            {
+              "part": "scr-m3-12-bhcs",
+              "qty": 2,
+              "uid": "izrb"
+            },
+            {
+              "assembly": "limit-switch",
+              "qty": 1,
+              "uid": "xzje"
+            },
+            {
+              "part": "scr-m5-20-shcs",
+              "qty": 2,
+              "uid": "e4hi"
+            },
+            {
+              "assembly": "chute-stepper-gearing",
+              "qty": 1,
+              "uid": "cwji"
+            },
+            {
+              "assembly": "interface-chute-drive",
+              "qty": 1,
+              "uid": "8cjj"
+            },
+            {
+              "part": "top-interface-split-spur-gear-2",
+              "qty": 1,
+              "uid": "izz5"
+            },
+            {
+              "assembly": "layer-connector",
+              "qty": 1,
+              "uid": "6m38"
+            },
+            {
+              "part": "brg-lazy-susan",
+              "qty": 1,
+              "uid": "wrxu"
+            },
+            {
+              "part": "scr-m4-12-cs",
+              "qty": 8,
+              "uid": "h8h4"
+            },
+            {
+              "part": "top-plate",
+              "qty": 1,
+              "uid": "1g22"
+            },
+            {
+              "part": "scr-m5-35-fhcs",
+              "qty": 6,
+              "uid": "xkl4"
+            },
+            {
+              "part": "scr-m5-8-cs",
+              "qty": 6,
+              "uid": "mqh4"
+            }
+          ]
+        },
+        {
+          "version": "4",
+          "date": "2026-09-01",
+          "message": "The top plate moved up to the superstructure: it sits on top of the machine at this assembly's level, not inside it. No physical change.",
           "breaking": false,
           "commit": null
         }

--- a/parts-calculator/scripts/check_docs_refs.py
+++ b/parts-calculator/scripts/check_docs_refs.py
@@ -1,0 +1,136 @@
+"""Alert when a catalog change is about to leave the docs stale.
+
+The docs site reads the same catalog this directory generates, and its pages
+reference parts two ways: a `- part: <id>` list in a page's frontmatter (the
+page's own bill of materials), and, for an assembly's write-up, the
+assembly's `docs` route in parts.json pointing at the page. Neither link is
+enforced anywhere else -- an id can be retired out of every assembly, or an
+assembly restamped into a new shape, and the page naming it keeps building
+happily (uids never die, so nothing 404s). This check makes the drift
+visible at PR time.
+
+Warnings, not failures: docs describing an older state of the machine are
+allowed to exist. Every finding prints as a GitHub Actions ::warning
+annotation and the script always exits 0 -- the alert is the product.
+
+  W1  a docs page names a part id the catalog doesn't have (typo)
+  W2  a docs page names a part the catalog no longer uses anywhere
+      (no assembly line, no `requires`, no connection `via`)
+  W3  an assembly with a docs page was revised in this change (its
+      version differs from the --base ref), so the page may now
+      describe the old structure
+
+    python scripts/check_docs_refs.py [--base HEAD~1]
+
+--base follows check_versioning.py: HEAD~1 is the previous main commit on a
+push and the base branch on a PR's merge ref.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+REPO = HERE.parent
+DOCS = REPO / "docs" / "src" / "content"
+
+PART_REF = re.compile(r"^\s*-\s*part:\s*(\S+)\s*$", re.M)
+
+
+def frontmatter_refs(md: Path):
+    text = md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return []
+    end = text.find("\n---", 3)
+    if end < 0:
+        return []
+    return PART_REF.findall(text[:end])
+
+
+def used_ids(d):
+    used = set()
+    for a in d.get("assemblies", []):
+        for line in a.get("lines") or []:
+            if line.get("part"):
+                used.add(line["part"])
+        for c in a.get("connections") or []:
+            if c.get("via"):
+                used.add(c["via"])
+    for p in d["parts"]:
+        for req in p.get("requires") or []:
+            used.add(req["part"])
+    return used
+
+
+def docs_file(route):
+    """The markdown file serving a docs route, if it exists."""
+    rel = route.strip("/")
+    for cand in (DOCS / f"{rel}.md", DOCS / rel / "index.md"):
+        if cand.is_file():
+            return cand
+    return None
+
+
+def baseline(ref):
+    r = subprocess.run(
+        ["git", "-C", str(REPO), "show", f"{ref}:parts-calculator/catalog/parts.json"],
+        capture_output=True, text=True)
+    return json.loads(r.stdout) if r.returncode == 0 else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="HEAD~1",
+                    help="baseline ref for the revised-assembly check")
+    args = ap.parse_args()
+
+    d = json.loads((HERE / "catalog" / "parts.json").read_text())
+    known = {p["id"] for p in d["parts"]}
+    used = used_ids(d)
+
+    warnings = []
+
+    if DOCS.is_dir():
+        for md in sorted(DOCS.rglob("*.md")):
+            rel = md.relative_to(REPO)
+            for pid in frontmatter_refs(md):
+                if pid not in known:
+                    warnings.append((rel, f"references part {pid!r}, which is "
+                                          f"not in the catalog"))
+                elif pid not in used:
+                    warnings.append((rel, f"references part {pid!r}, which the "
+                                          f"catalog no longer uses anywhere -- "
+                                          f"the page may be stale, or the "
+                                          f"catalog record incomplete"))
+
+    base = baseline(args.base)
+    if base is None:
+        print(f"note: no parts.json at {args.base}; skipping the "
+              f"revised-assembly check")
+    else:
+        base_ver = {a["id"]: a.get("version") for a in base.get("assemblies", [])}
+        for a in d.get("assemblies", []):
+            route = a.get("docs")
+            if not route or a["id"] not in base_ver:
+                continue
+            if a.get("version") != base_ver[a["id"]]:
+                md = docs_file(route)
+                if md:
+                    rel = md.relative_to(REPO)
+                    warnings.append((rel, f"assembly {a['id']!r} was revised in "
+                                          f"this change (v{base_ver[a['id']]} -> "
+                                          f"v{a['version']}); this page may "
+                                          f"describe the old structure"))
+
+    for rel, msg in warnings:
+        print(f"::warning file={rel}::{msg}")
+    n = len(warnings)
+    print(f"{n} docs-staleness warning(s)" if n else
+          "docs references agree with the catalog")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/parts-calculator/src/lib/components/ConnectionBraces.svelte
+++ b/parts-calculator/src/lib/components/ConnectionBraces.svelte
@@ -116,7 +116,9 @@
 	const hueOf = (i: number) =>
 		((METHOD_HUE[groups[i]?.method] ?? 0) + (hueShift[i] ?? 0)) % 360;
 	const colorOf = (i: number) => `hsl(${hueOf(i)} 60% 38%)`;
-	const laneX = (i: number) => 12 + i * 16;
+	// The innermost lane keeps a real distance from the rows so every tick has
+	// a visible run — a 12px nub against a box border reads as no line at all.
+	const laneX = (i: number) => 24 + i * 16;
 
 	const groups = $derived(braceGroups(edges));
 

--- a/parts-calculator/src/lib/components/DetailPanes.svelte
+++ b/parts-calculator/src/lib/components/DetailPanes.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	// The detail views' shared frame — THE one layout for any detail that leads
+	// with a visual. In a modal the visual and the facts sit side by side once
+	// there's room: visual pinned left at 55%, facts scrolling on the right;
+	// stacked on narrow screens. On a standalone page everything just flows.
+	// PartDetail and LasercutDetail both render through this; a new visual-led
+	// detail view uses it rather than laying out its own panes.
+	let {
+		variant = 'modal',
+		visual,
+		facts
+	}: {
+		variant?: 'modal' | 'page';
+		visual: Snippet;
+		facts: Snippet;
+	} = $props();
+</script>
+
+<div class={variant === 'modal' ? 'flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row' : ''}>
+	<div class="relative {variant === 'modal' ? 'shrink-0 lg:w-[55%]' : ''}">
+		{@render visual()}
+	</div>
+	<!-- in the modal the facts scroll independently of the pinned visual (which
+	     owns wheel = zoom); on the page everything just flows -->
+	<div class="{variant === 'modal' ? 'min-h-0 flex-1 overflow-y-auto border-t lg:border-l lg:border-t-0' : 'border-t'} border-border">
+		{@render facts()}
+	</div>
+</div>

--- a/parts-calculator/src/lib/components/LasercutDetail.svelte
+++ b/parts-calculator/src/lib/components/LasercutDetail.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import StlViewer from '$lib/components/StlViewer.svelte';
+	import DownloadButton from '$lib/components/DownloadButton.svelte';
+	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
+	import { fmtDate } from '$lib/filament';
+	import type { LaserCutPart } from '$lib/lasercut';
+	import { ExternalLink } from 'lucide-svelte';
+
+	// The laser-cut part detail view: the solid model (or the DXF outline when
+	// none is published), then the facts, the downloads and the source link —
+	// the same one-thing-one-view treatment printed parts and hardware get.
+	let { part }: { part: LaserCutPart } = $props();
+
+	let view3d = $state(true);
+	$effect(() => {
+		part.id;
+		view3d = true;
+	});
+</script>
+
+<div class="relative border-b border-border bg-[var(--color-bg)]">
+	{#if part.stl && view3d}
+		<StlViewer url={part.stl} color="#b08d57" heightClass="h-[48vh]" />
+	{:else}
+		<div class="flex h-[48vh] items-center justify-center p-6">
+			<img src={part.preview} alt="{part.name} outline" class="max-h-full w-auto max-w-full" />
+		</div>
+	{/if}
+	{#if part.stl}
+		<button
+			type="button"
+			class="absolute left-3 top-3 border border-border bg-surface px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-text-muted hover:text-text"
+			onclick={() => (view3d = !view3d)}
+		>
+			{view3d ? 'Outline' : '3D'}
+		</button>
+	{/if}
+</div>
+
+<div class="px-5 py-4">
+	<div class="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
+		<div class="min-w-0 flex-1 space-y-2 text-sm">
+			<p class="text-text">{part.description}</p>
+			<ChangeStatus kind="lasercut" id={part.id} name={part.name} />
+		</div>
+		<div class="flex shrink-0 flex-col items-start gap-2 sm:items-end">
+			<DownloadButton href={part.dxf} size="md" label="Download DXF" />
+			{#if part.stl}
+				<DownloadButton href={part.stl} size="sm" label="STL" title="The solid model — for viewing or CAM, not for printing" />
+			{/if}
+			<a
+				href={part.onshape}
+				target="_blank"
+				rel="noopener"
+				class="inline-flex items-center gap-0.5 text-xs text-primary hover:text-primary-hover"
+				title="Open the pinned OnShape version">OnShape <ExternalLink size={11} /></a>
+		</div>
+	</div>
+
+	{#snippet tile(label: string, value: string)}
+		<div class="border border-border bg-[var(--color-bg)] px-3 py-2">
+			<dt class="text-[10px] font-semibold uppercase tracking-wider text-text-muted">{label}</dt>
+			<dd class="mt-0.5 text-sm font-medium text-text">{value}</dd>
+		</div>
+	{/snippet}
+	<dl class="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+		{@render tile('Material', `${part.thicknessIn} plywood (${part.thicknessMm} mm)`)}
+		{@render tile('Cut size', `${part.widthMm} × ${part.heightMm} mm`)}
+		{@render tile('Needed', `×${part.qty} per machine`)}
+		{@render tile('Updated', fmtDate(part.updated))}
+	</dl>
+
+	{#if part.handcut}
+		<p class="mt-3 text-xs text-text-muted">
+			No laser? This one can be laid out and cut by hand ({part.handcut.tools}) — the guide is on the
+			<a class="text-primary hover:text-primary-hover" href="/lasercut#laser-{part.id}">Laser cut parts</a> page.
+		</p>
+	{/if}
+</div>

--- a/parts-calculator/src/lib/components/LasercutDetail.svelte
+++ b/parts-calculator/src/lib/components/LasercutDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import DetailPanes from '$lib/components/DetailPanes.svelte';
 	import StlViewer from '$lib/components/StlViewer.svelte';
 	import DownloadButton from '$lib/components/DownloadButton.svelte';
 	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
@@ -18,11 +19,12 @@
 	});
 </script>
 
-<div class="relative border-b border-border bg-[var(--color-bg)]">
+<DetailPanes>
+	{#snippet visual()}
 	{#if part.stl && view3d}
-		<StlViewer url={part.stl} color="#b08d57" heightClass="h-[48vh]" />
+		<StlViewer url={part.stl} color="#b08d57" heightClass="h-[45vh] lg:h-[76vh]" />
 	{:else}
-		<div class="flex h-[48vh] items-center justify-center p-6">
+		<div class="flex h-[45vh] items-center justify-center bg-[var(--color-bg)] p-6 lg:h-[76vh]">
 			<img src={part.preview} alt="{part.name} outline" class="max-h-full w-auto max-w-full" />
 		</div>
 	{/if}
@@ -35,9 +37,10 @@
 			{view3d ? 'Outline' : '3D'}
 		</button>
 	{/if}
-</div>
+	{/snippet}
 
-<div class="px-5 py-4">
+	{#snippet facts()}
+	<div class="px-5 py-4">
 	<div class="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
 		<div class="min-w-0 flex-1 space-y-2 text-sm">
 			<p class="text-text">{part.description}</p>
@@ -76,4 +79,6 @@
 			<a class="text-primary hover:text-primary-hover" href="/lasercut#laser-{part.id}">Laser cut parts</a> page.
 		</p>
 	{/if}
-</div>
+	</div>
+	{/snippet}
+</DetailPanes>

--- a/parts-calculator/src/lib/components/LasercutDetailModal.svelte
+++ b/parts-calculator/src/lib/components/LasercutDetailModal.svelte
@@ -14,7 +14,7 @@
 	} = $props();
 </script>
 
-<Modal bind:open title={part?.name} maxW="max-w-4xl">
+<Modal bind:open title={part?.name} bodyScroll={false} maxW="max-w-[96rem]">
 	{#if part}
 		<LasercutDetail {part} />
 	{/if}

--- a/parts-calculator/src/lib/components/LasercutDetailModal.svelte
+++ b/parts-calculator/src/lib/components/LasercutDetailModal.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import Modal from '$lib/components/Modal.svelte';
+	import LasercutDetail from '$lib/components/LasercutDetail.svelte';
+	import type { LaserCutPart } from '$lib/lasercut';
+
+	// Thin modal wrapper around the shared LasercutDetail view, mirroring
+	// PartDetailModal / HardwareDetailModal.
+	let {
+		open = $bindable(false),
+		part
+	}: {
+		open?: boolean;
+		part: LaserCutPart | null;
+	} = $props();
+</script>
+
+<Modal bind:open title={part?.name} maxW="max-w-4xl">
+	{#if part}
+		<LasercutDetail {part} />
+	{/if}
+</Modal>

--- a/parts-calculator/src/lib/components/PartDetail.svelte
+++ b/parts-calculator/src/lib/components/PartDetail.svelte
@@ -8,6 +8,7 @@
 	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
 	import BuildPlates from '$lib/components/BuildPlates.svelte';
 	import Modal from '$lib/components/Modal.svelte';
+	import DetailPanes from '$lib/components/DetailPanes.svelte';
 	import ImageStrip from '$lib/components/ImageStrip.svelte';
 	import { getBambuColor } from '$lib/bambu-colors';
 	import { SITE_URL } from '$lib/seo';
@@ -111,21 +112,17 @@
 	{@const onshapeHref = candidate?.onshape_version ?? os.version}
 	{@const noteId = candidate?.note ?? active?.note ?? part.note}
 
-	<!-- In the modal the viewer and the facts sit side by side once there is
-	     room, each pane full height; stacked on narrow screens and on the page. -->
-	<div class={variant === 'modal' ? 'flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row' : ''}>
-	<!-- the preview, with the id-stamp controls and the colour picker laid over it -->
-	<div class="relative {variant === 'modal' ? 'shrink-0 lg:w-[55%]' : ''}">
+	<DetailPanes {variant}>
+		{#snippet visual()}
+		<!-- the preview, with the id-stamp controls and the colour picker laid over it -->
 		<StlViewer bind:this={viewer} url={activeStl} color={getBambuColor(colorId).hex} mark={stamp} heightClass={variant === 'modal' ? 'h-[45vh] lg:h-[76vh]' : 'h-[60vh]'} />
 		<div class="pointer-events-none absolute inset-x-3 top-3 flex flex-wrap items-start justify-between gap-2">
 			<IdStamp where="viewport" uid={candidate?.uid ?? part.uid} {stamps} bind:on={stampOn} bind:faceIdx onView={() => viewer?.viewMark()} onReset={() => viewer?.resetView()} />
 			<div class="pointer-events-auto ml-auto w-48 border border-border bg-[var(--color-surface)]/95 px-2.5 py-1.5 shadow-sm backdrop-blur"><ColorPicker bind:value={colorId} label="Preview color" /></div>
 		</div>
-	</div>
+		{/snippet}
 
-	<!-- in the modal the details scroll independently of the pinned viewer (which
-	     owns wheel = zoom); on the page everything just flows -->
-	<div class="{variant === 'modal' ? 'min-h-0 flex-1 overflow-y-auto border-t lg:border-l lg:border-t-0' : 'border-t'} border-border">
+		{#snippet facts()}
 		<div class="px-5 py-4">
 			<div class="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
 				<div class="min-w-0 flex-1 space-y-2 text-sm">
@@ -259,8 +256,8 @@
 				</div>
 			</div>
 		{/if}
-	</div>
-	</div>
+		{/snippet}
+	</DetailPanes>
 
 	<Modal bind:open={platesOpen} title="Build plates · {part.name}">
 		<div class="p-4">

--- a/parts-calculator/src/lib/components/PartDetailModal.svelte
+++ b/parts-calculator/src/lib/components/PartDetailModal.svelte
@@ -20,7 +20,7 @@
 	} = $props();
 </script>
 
-<Modal bind:open title={part?.name} bodyScroll={false} maxW="max-w-7xl">
+<Modal bind:open title={part?.name} bodyScroll={false} maxW="max-w-[96rem]">
 	{#if part}
 		<PartDetail {part} bind:colorId bind:version variant="modal" />
 	{/if}

--- a/parts-calculator/src/lib/components/StlViewer.svelte
+++ b/parts-calculator/src/lib/components/StlViewer.svelte
@@ -143,7 +143,11 @@
 		gazeBlend = null;
 	}
 	function homePose() {
-		const dist = (radius / Math.sin((camera.fov * Math.PI) / 360)) * 1.05;
+		// Fit the bounding sphere in BOTH directions: in a tall, narrow pane the
+		// horizontal fov is the binding constraint, not the vertical one.
+		const vHalf = (camera.fov * Math.PI) / 360;
+		const hHalf = Math.atan(Math.tan(vHalf) * camera.aspect);
+		const dist = (radius / Math.sin(Math.min(vHalf, hHalf))) * 1.05;
 		return new THREE.Vector3(1, 0.8, 1.3).normalize().multiplyScalar(dist);
 	}
 

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1044,8 +1044,8 @@
 		},
 		{
 			"id": "camera-extension-assembly",
-			"uid": "dc2i",
-			"version": "1",
+			"uid": "q2re",
+			"version": "2",
 			"name": "Camera extension",
 			"description": "Classification-channel camera extension for the 4K camera module: the 50 mm extension tube, its mount, and the camera. 1 per machine.",
 			"status": "partial",
@@ -1065,10 +1065,49 @@
 				{
 					"part": "scr-m2-8-shcs",
 					"qty": 4
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "dc2i",
+					"commit": null,
+					"message": "Original version: carried the 4 \u00d7 M3 \u00d7 12 that fasten this assembly into the Camera & LED insert, even though the insert is the parent's line.",
+					"lines": [
+						{
+							"part": "camera-extension",
+							"qty": 1,
+							"uid": "v684"
+						},
+						{
+							"part": "camera-extension-mount",
+							"qty": 1,
+							"uid": "wt9t"
+						},
+						{
+							"part": "cam-imx415",
+							"qty": 1,
+							"uid": "1lze"
+						},
+						{
+							"part": "scr-m2-8-shcs",
+							"qty": 4,
+							"uid": "iwk6"
+						},
+						{
+							"part": "scr-m3-12-bhcs",
+							"qty": 4,
+							"uid": "izrb"
+						}
+					]
 				},
 				{
-					"part": "scr-m3-12-bhcs",
-					"qty": 4
+					"version": "2",
+					"uid": "q2re",
+					"date": "2026-09-01",
+					"message": "The 4 \u00d7 M3 \u00d7 12 moved out to the Camera & LED insert assembly: they fasten this whole assembly into the insert, so the joint and its screws belong to the node that holds both. No physical change.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -1488,9 +1527,21 @@
 				{
 					"assembly": "camera-extension-assembly",
 					"qty": 1
+				},
+				{
+					"part": "scr-m3-12-bhcs",
+					"qty": 4
 				}
 			],
-			"connections": []
+			"connections": [
+				{
+					"from": "camera-extension-assembly",
+					"to": "camera-led-insert",
+					"via": "scr-m3-12-bhcs",
+					"qty": 4,
+					"method": "self-tap"
+				}
+			]
 		},
 		{
 			"id": "interface",
@@ -16536,10 +16587,10 @@
 			},
 			"name": "M3 \u00d7 12 mm socket/button head",
 			"category": "Screws",
-			"description": "Mounts the cable clamp to the interface, and the limit switch to its housing.",
+			"description": "Mounts the cable clamp to the interface, the limit switch to its housing, and fastens the camera extension into the Camera & LED insert.",
 			"note": null,
 			"created_at": "2026-07-18",
-			"updated_at": "2026-08-18",
+			"updated_at": "2026-09-01",
 			"attributes": [
 				{
 					"label": "Thread",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1225,9 +1225,25 @@
 				{
 					"assembly": "bottom-interface",
 					"qty": 1
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 6
 				}
 			],
-			"connections": []
+			"connections": [
+				{
+					"from": "top-plate",
+					"to": "interface",
+					"via": "scr-m5-16-shcs",
+					"qty": 6,
+					"method": "insert",
+					"through_mm": 9,
+					"thread_mm": 9,
+					"note": "Through the plate into the top interface's M5 heat-set inserts. The 16 mm length is assumed, not yet confirmed.",
+					"draft": true
+				}
+			]
 		},
 		{
 			"id": "feeder",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -16467,8 +16467,8 @@
 			},
 			"name": "M3 \u00d7 16 mm socket/button head",
 			"category": "Screws",
-			"description": "Retired, no longer used anywhere. Was recorded as the C-channel stepper screw, but those are countersunk (scr-m3-16-cs).",
-			"note": "Unused as of 2026-09-01. Do not re-add: the C-channel calls for the countersunk M3 \u00d7 16.",
+			"description": "No longer the C-channel stepper screw \u2014 those are countersunk (scr-m3-16-cs). The top-interface docs call for 2 to mount the roller-lever limit switch into its housing's inserts, though the limit-switch assembly records M3 \u00d7 12 button heads for that joint \u2014 one of the two is wrong; settle it at the bench.",
+			"note": null,
 			"created_at": "2026-07-18",
 			"updated_at": "2026-09-01",
 			"attributes": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -19433,7 +19433,7 @@
 			"widthMm": 672,
 			"heightMm": 770,
 			"qty": 1,
-			"onshape": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/v/3b8fafc8cab54b09332e14d2/e/e6605a6f604d25617d91b7bc",
+			"onshape": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/v/f845b960415692451f2903b1/e/e6605a6f604d25617d91b7bc",
 			"dxf": "/dxf/top-plate.dxf",
 			"preview": "/dxf-previews/top-plate.svg",
 			"updated": "2026-07-10",
@@ -19442,7 +19442,9 @@
 				"blurb": "This plate is a regular hexagon \u2014 it can be laid out with a tape measure and cut accurately with just a jigsaw and a drill. The five cable slots become single 22 mm (7/8\u2033) drill holes.",
 				"stock": "672.4 \u00d7 776.4 mm rectangle (26 15/32\u2033 \u00d7 30 9/16\u2033)",
 				"tools": "jigsaw \u00b7 drill \u00b7 tape measure"
-			}
+			},
+			"stl_hash": "1f2d0ece017e38c09a6fa4258a407dcd85c07d844537017675a734647e74a067",
+			"stl": "https://assets.basically.website/sorter-parts/top-plate-1f2d0ece017e.stl"
 		}
 	],
 	"merges": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -801,6 +801,10 @@
 					"qty": 2
 				},
 				{
+					"part": "cam-ov9732",
+					"qty": 1
+				},
+				{
 					"part": "scr-m3-12-cs",
 					"qty": 3
 				},
@@ -1235,10 +1239,6 @@
 				{
 					"assembly": "classification-chamber",
 					"qty": 1
-				},
-				{
-					"assembly": "camera-mount",
-					"qty": 2
 				}
 			]
 		},
@@ -1414,6 +1414,10 @@
 				{
 					"assembly": "light-post-assembly",
 					"qty": 1
+				},
+				{
+					"assembly": "camera-mount",
+					"qty": 1
 				}
 			],
 			"connections": [
@@ -1452,6 +1456,10 @@
 				},
 				{
 					"assembly": "light-post-assembly",
+					"qty": 1
+				},
+				{
+					"assembly": "camera-mount",
 					"qty": 1
 				}
 			],

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1138,8 +1138,8 @@
 		},
 		{
 			"id": "machine",
-			"uid": "e4k9",
-			"version": "1",
+			"uid": "dlmn",
+			"version": "2",
 			"name": "Sorter V2",
 			"description": "The whole machine: feeder on top, interface, the distribution layers between the interfaces, and the bottom interface.",
 			"docs": "/hardware/assembly/",
@@ -1149,6 +1149,67 @@
 					"assembly": "feeder",
 					"qty": 1
 				},
+				{
+					"assembly": "superstructure",
+					"qty": 1
+				},
+				{
+					"assembly": "electronics",
+					"qty": 1
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "e4k9",
+					"commit": null,
+					"message": "Original recording: the interfaces, layers, feeder and electronics all sat flat at the root.",
+					"lines": [
+						{
+							"assembly": "feeder",
+							"qty": 1,
+							"uid": "y5ws"
+						},
+						{
+							"assembly": "interface",
+							"qty": 1,
+							"uid": "uelo"
+						},
+						{
+							"assembly": "layer",
+							"qty": "middle-layers",
+							"uid": "jog7"
+						},
+						{
+							"assembly": "bottom-interface",
+							"qty": 1,
+							"uid": "67uq"
+						},
+						{
+							"assembly": "electronics",
+							"qty": 1,
+							"uid": "lbrp"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "dlmn",
+					"date": "2026-09-01",
+					"message": "The machine splits into what it physically is: the feeder, the superstructure it mounts onto \u2014 top interface, distribution layers, bottom interface \u2014 and the electronics. No physical change.",
+					"breaking": false,
+					"commit": null
+				}
+			]
+		},
+		{
+			"id": "superstructure",
+			"uid": "ywb3",
+			"version": "1",
+			"name": "Superstructure",
+			"description": "What the feeder and the electronics mount onto: the top interface, the distribution layers between the interfaces, and the bottom interface.",
+			"status": "partial",
+			"lines": [
 				{
 					"assembly": "interface",
 					"qty": 1
@@ -1160,12 +1221,9 @@
 				{
 					"assembly": "bottom-interface",
 					"qty": 1
-				},
-				{
-					"assembly": "electronics",
-					"qty": 1
 				}
-			]
+			],
+			"connections": []
 		},
 		{
 			"id": "feeder",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1196,7 +1196,7 @@
 					"version": "2",
 					"uid": "dlmn",
 					"date": "2026-09-01",
-					"message": "The machine splits into what it physically is: the feeder, the superstructure it mounts onto \u2014 top interface, distribution layers, bottom interface \u2014 and the electronics. No physical change.",
+					"message": "The machine splits into what it physically is: the feeder, the superstructure it mounts onto \u2014 top plate, top interface, distribution layers, bottom interface \u2014 and the electronics. No physical change.",
 					"breaking": false,
 					"commit": null
 				}
@@ -1207,9 +1207,13 @@
 			"uid": "ywb3",
 			"version": "1",
 			"name": "Superstructure",
-			"description": "What the feeder and the electronics mount onto: the top interface, the distribution layers between the interfaces, and the bottom interface.",
+			"description": "What the feeder and the electronics mount onto: the top plate, the top interface, the distribution layers between the interfaces, and the bottom interface.",
 			"status": "partial",
 			"lines": [
+				{
+					"part": "top-plate",
+					"qty": 1
+				},
 				{
 					"assembly": "interface",
 					"qty": 1
@@ -1603,8 +1607,8 @@
 		},
 		{
 			"id": "interface",
-			"uid": "uelo",
-			"version": "3",
+			"uid": "vhrk",
+			"version": "4",
 			"name": "Top interface",
 			"description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
@@ -1669,10 +1673,6 @@
 				{
 					"part": "scr-m4-12-cs",
 					"qty": 8
-				},
-				{
-					"part": "top-plate",
-					"qty": 1
 				},
 				{
 					"part": "scr-m5-35-fhcs",
@@ -1937,9 +1937,109 @@
 				},
 				{
 					"version": "3",
-					"uid": "uelo",
 					"date": "2026-08-31",
 					"message": "The six External bracket covers and 12 bracket screws move inside the hex frame's new External bracket with support segments. No physical change.",
+					"breaking": false,
+					"commit": null,
+					"uid": "uelo",
+					"lines": [
+						{
+							"assembly": "interface-bracket-mount",
+							"qty": 6,
+							"uid": "pnl9"
+						},
+						{
+							"assembly": "hex-frame",
+							"qty": 1,
+							"uid": "l0xa"
+						},
+						{
+							"assembly": "fixed-upper-section",
+							"qty": 1,
+							"uid": "99af"
+						},
+						{
+							"assembly": "cable-cage",
+							"qty": 1,
+							"uid": "nam6"
+						},
+						{
+							"part": "scr-m5-30-shcs",
+							"qty": 6,
+							"uid": "92kv"
+						},
+						{
+							"assembly": "cable-clamp",
+							"qty": 1,
+							"uid": "e0p9"
+						},
+						{
+							"part": "scr-m3-12-bhcs",
+							"qty": 2,
+							"uid": "izrb"
+						},
+						{
+							"assembly": "limit-switch",
+							"qty": 1,
+							"uid": "xzje"
+						},
+						{
+							"part": "scr-m5-20-shcs",
+							"qty": 2,
+							"uid": "e4hi"
+						},
+						{
+							"assembly": "chute-stepper-gearing",
+							"qty": 1,
+							"uid": "cwji"
+						},
+						{
+							"assembly": "interface-chute-drive",
+							"qty": 1,
+							"uid": "8cjj"
+						},
+						{
+							"part": "top-interface-split-spur-gear-2",
+							"qty": 1,
+							"uid": "izz5"
+						},
+						{
+							"assembly": "layer-connector",
+							"qty": 1,
+							"uid": "6m38"
+						},
+						{
+							"part": "brg-lazy-susan",
+							"qty": 1,
+							"uid": "wrxu"
+						},
+						{
+							"part": "scr-m4-12-cs",
+							"qty": 8,
+							"uid": "h8h4"
+						},
+						{
+							"part": "top-plate",
+							"qty": 1,
+							"uid": "1g22"
+						},
+						{
+							"part": "scr-m5-35-fhcs",
+							"qty": 6,
+							"uid": "xkl4"
+						},
+						{
+							"part": "scr-m5-8-cs",
+							"qty": 6,
+							"uid": "mqh4"
+						}
+					]
+				},
+				{
+					"version": "4",
+					"uid": "vhrk",
+					"date": "2026-09-01",
+					"message": "The top plate moved up to the superstructure: it sits on top of the machine at this assembly's level, not inside it. No physical change.",
 					"breaking": false,
 					"commit": null
 				}

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -650,7 +650,19 @@
 			],
 			"lines": [
 				{
+					"assembly": "c-channel",
+					"qty": 1
+				},
+				{
 					"assembly": "rotor-unit-finned",
+					"qty": 1
+				},
+				{
+					"part": "classification-dome",
+					"qty": 1
+				},
+				{
+					"assembly": "camera-led-insert-assembly",
 					"qty": 1
 				}
 			]
@@ -1114,10 +1126,10 @@
 		},
 		{
 			"id": "feeder",
-			"uid": "pye7",
-			"version": "2",
+			"uid": "y5ws",
+			"version": "3",
 			"name": "Feeder",
-			"description": "Feeder + classification channel. Everything above the interface.",
+			"description": "Everything above the top interface: the bulk bucket, C-channels 2 and 3, and the classification chamber.",
 			"docs": "/hardware/assembly/feeder/",
 			"status": "partial",
 			"versions": [
@@ -1160,39 +1172,317 @@
 				},
 				{
 					"version": "2",
-					"uid": "pye7",
 					"date": "2026-08-31",
 					"message": "The 3 faceted rotors become 3 Rotor unit (faceted) \u2014 rotor + bolted-on Output gear (130T) as one bench unit. No physical change.",
+					"breaking": false,
+					"commit": null,
+					"uid": "pye7",
+					"lines": [
+						{
+							"assembly": "c-channel",
+							"qty": 4,
+							"uid": "4tvc"
+						},
+						{
+							"assembly": "rotor-unit-faceted",
+							"qty": 3,
+							"uid": "ylvv"
+						},
+						{
+							"assembly": "classification-chamber",
+							"qty": 1,
+							"uid": "fyqw"
+						},
+						{
+							"assembly": "camera-extension-assembly",
+							"qty": 1,
+							"uid": "dc2i"
+						},
+						{
+							"assembly": "light-post-assembly",
+							"qty": 2,
+							"uid": "v06x"
+						},
+						{
+							"assembly": "camera-mount",
+							"qty": 2,
+							"uid": "b3zx"
+						}
+					]
+				},
+				{
+					"version": "3",
+					"uid": "y5ws",
+					"date": "2026-09-01",
+					"message": "Restructured into the four physical units \u2014 the bulk bucket, C-channels 2 and 3, and the classification chamber \u2014 each carrying its own C-channel drive, rotor, supports, guide or cap, and lighting. No physical change.",
 					"breaking": false,
 					"commit": null
 				}
 			],
 			"lines": [
 				{
-					"assembly": "c-channel",
-					"qty": 4
+					"assembly": "bulk-bucket",
+					"qty": 1
 				},
 				{
-					"assembly": "rotor-unit-faceted",
-					"qty": 3
+					"assembly": "channel-two",
+					"qty": 1
+				},
+				{
+					"assembly": "channel-three",
+					"qty": 1
 				},
 				{
 					"assembly": "classification-chamber",
 					"qty": 1
 				},
 				{
-					"assembly": "camera-extension-assembly",
-					"qty": 1
-				},
-				{
-					"assembly": "light-post-assembly",
-					"qty": 2
-				},
-				{
 					"assembly": "camera-mount",
 					"qty": 2
 				}
 			]
+		},
+		{
+			"id": "channel-three-support",
+			"uid": "r6ar",
+			"version": "1",
+			"name": "Channel 3 support",
+			"description": "One of C-channel 3's three standoffs: a foot and the leg the channel dovetails onto.",
+			"status": "partial",
+			"lines": [
+				{
+					"part": "foot",
+					"qty": 1
+				},
+				{
+					"part": "leg",
+					"qty": 1
+				}
+			],
+			"connections": [
+				{
+					"from": "foot",
+					"to": "leg",
+					"qty": 1,
+					"method": "friction",
+					"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+				}
+			]
+		},
+		{
+			"id": "channel-two-support",
+			"uid": "dp63",
+			"version": "1",
+			"name": "Channel 2 support",
+			"description": "One of C-channel 2's three standoffs: a foot, one leg extension, and the leg the channel dovetails onto.",
+			"status": "partial",
+			"lines": [
+				{
+					"part": "foot",
+					"qty": 1
+				},
+				{
+					"part": "leg-extension",
+					"qty": 1
+				},
+				{
+					"part": "leg",
+					"qty": 1
+				}
+			],
+			"connections": [
+				{
+					"from": "foot",
+					"to": "leg-extension",
+					"qty": 1,
+					"method": "friction",
+					"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+				},
+				{
+					"from": "leg-extension",
+					"to": "leg",
+					"qty": 1,
+					"method": "friction",
+					"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+				}
+			]
+		},
+		{
+			"id": "bulk-bucket-support",
+			"uid": "xo6j",
+			"version": "1",
+			"name": "Bulk bucket support",
+			"description": "One of the bulk bucket's three standoffs \u2014 the tallest stack: a foot, two leg extensions, and the leg.",
+			"status": "partial",
+			"lines": [
+				{
+					"part": "foot",
+					"qty": 1
+				},
+				{
+					"part": "leg-extension",
+					"qty": 2
+				},
+				{
+					"part": "leg",
+					"qty": 1
+				}
+			],
+			"connections": [
+				{
+					"from": "foot",
+					"to": "leg-extension",
+					"qty": 1,
+					"method": "friction",
+					"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+				},
+				{
+					"from": "leg-extension",
+					"to": "leg-extension",
+					"qty": 1,
+					"method": "friction",
+					"note": "The two extensions stack tail-into-slot. Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+				},
+				{
+					"from": "leg-extension",
+					"to": "leg",
+					"qty": 1,
+					"method": "friction",
+					"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+				}
+			]
+		},
+		{
+			"id": "bulk-bucket",
+			"uid": "1sej",
+			"version": "1",
+			"name": "Bulk bucket C-channel",
+			"description": "The top feeder unit: a C-channel drive with a white faceted rotor, capped by the Bulk cap instead of an output guide and with no light post, standing on the tallest supports.",
+			"status": "partial",
+			"lines": [
+				{
+					"assembly": "bulk-bucket-support",
+					"qty": 3
+				},
+				{
+					"assembly": "c-channel",
+					"qty": 1
+				},
+				{
+					"assembly": "rotor-unit-faceted",
+					"qty": 1
+				},
+				{
+					"part": "bulk-cap",
+					"qty": 1
+				}
+			],
+			"connections": [
+				{
+					"from": "bulk-bucket-support",
+					"to": "c-channel",
+					"qty": 3,
+					"method": "friction",
+					"note": "Dovetail: each support's leg slides into the C-channel drive from below."
+				}
+			]
+		},
+		{
+			"id": "channel-two",
+			"uid": "hi96",
+			"version": "1",
+			"name": "C-channel 2",
+			"description": "The middle feeder channel: a C-channel drive with a white faceted rotor, an output guide and a light post, standing on three supports with one leg extension each.",
+			"status": "partial",
+			"lines": [
+				{
+					"assembly": "channel-two-support",
+					"qty": 3
+				},
+				{
+					"assembly": "c-channel",
+					"qty": 1
+				},
+				{
+					"assembly": "rotor-unit-faceted",
+					"qty": 1
+				},
+				{
+					"part": "output-guide",
+					"qty": 1
+				},
+				{
+					"assembly": "light-post-assembly",
+					"qty": 1
+				}
+			],
+			"connections": [
+				{
+					"from": "channel-two-support",
+					"to": "c-channel",
+					"qty": 3,
+					"method": "friction",
+					"note": "Dovetail: each support's leg slides into the C-channel drive from below."
+				}
+			]
+		},
+		{
+			"id": "channel-three",
+			"uid": "xlak",
+			"version": "1",
+			"name": "C-channel 3",
+			"description": "The lowest feeder channel, just above the classification chamber: a C-channel drive with the gray faceted rotor, an output guide and a light post, on three foot-and-leg supports.",
+			"status": "partial",
+			"lines": [
+				{
+					"assembly": "channel-three-support",
+					"qty": 3
+				},
+				{
+					"assembly": "c-channel",
+					"qty": 1
+				},
+				{
+					"assembly": "rotor-unit-faceted",
+					"qty": 1
+				},
+				{
+					"part": "output-guide",
+					"qty": 1
+				},
+				{
+					"assembly": "light-post-assembly",
+					"qty": 1
+				}
+			],
+			"connections": [
+				{
+					"from": "channel-three-support",
+					"to": "c-channel",
+					"qty": 3,
+					"method": "friction",
+					"note": "Dovetail: each support's leg slides into the C-channel drive from below."
+				}
+			]
+		},
+		{
+			"id": "camera-led-insert-assembly",
+			"uid": "434r",
+			"version": "1",
+			"name": "Camera & LED insert assembly",
+			"description": "The Camera & LED insert print with the camera extension assembled into it; the loaded insert drops into the classification dome.",
+			"status": "partial",
+			"lines": [
+				{
+					"part": "camera-led-insert",
+					"qty": 1
+				},
+				{
+					"assembly": "camera-extension-assembly",
+					"qty": 1
+				}
+			],
+			"connections": []
 		},
 		{
 			"id": "interface",
@@ -17285,10 +17575,10 @@
 			},
 			"name": "IMX415 4K camera module",
 			"category": "Cameras",
-			"description": "Classification top camera",
+			"description": "Classification top camera \u2014 the ENOMAKER IMX415 4K USB module.",
 			"note": null,
 			"created_at": "2026-07-18",
-			"updated_at": "2026-07-18",
+			"updated_at": "2026-09-01",
 			"attributes": [],
 			"sheet_qty": {
 				"per_machine": 1

--- a/parts-calculator/src/lib/lasercut.ts
+++ b/parts-calculator/src/lib/lasercut.ts
@@ -28,6 +28,10 @@ export type LaserCutPart = {
 	onshape: string; // pinned OnShape version this DXF was exported from
 	dxf: string; // download path
 	preview: string; // SVG outline preview path
+	// published solid model of the cut part — never printed or sliced, just a
+	// 3D view. Source pins `stl_hash`; the generator derives the served URL.
+	stl_hash?: string;
+	stl?: string;
 	updated: string; // date of the DXF export (ISO)
 	// optional "by hand" (jigsaw + drill) route for people without a laser
 	handcut?: {

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -1290,7 +1290,7 @@
 			{#if open}
 			{@const braceGutter =
 				asm.connections?.length && !filtering
-					? 32 + (braceGroups(asm.connections).length - 1) * 16
+					? 44 + (braceGroups(asm.connections).length - 1) * 16
 					: 0}
 			<div
 				class="tree-branch relative pl-2 sm:pl-4"

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -23,6 +23,8 @@
 	import PartDetailModal from '$lib/components/PartDetailModal.svelte';
 	import AssemblyDetailModal from '$lib/components/AssemblyDetailModal.svelte';
 	import HardwareDetailModal from '$lib/components/HardwareDetailModal.svelte';
+	import LasercutDetailModal from '$lib/components/LasercutDetailModal.svelte';
+	import type { LaserCutPart } from '$lib/lasercut';
 	import HardwareIcon from '$lib/components/HardwareIcon.svelte';
 	import ImageStrip from '$lib/components/ImageStrip.svelte';
 	import SearchField from '$lib/components/search/SearchField.svelte';
@@ -517,6 +519,8 @@
 		if (p) return openPart(p);
 		const h = getHardware(id);
 		if (h) return openHardware(h);
+		const lc = getLasercut(id);
+		if (lc) return openLasercut(lc);
 		if (getAssembly(id)) openAssembly(id);
 	}
 
@@ -649,6 +653,12 @@
 		hwModal = h;
 		hwOpen = true;
 	}
+	let lcOpen = $state(false);
+	let lcModal = $state<LaserCutPart | null>(null);
+	function openLasercut(lc: LaserCutPart) {
+		lcModal = lc;
+		lcOpen = true;
+	}
 	// A node's name pulls it out of the tree into the same one-box view the parts
 	// dashboard opens, which is the point of having the view at all: on this page
 	// an assembly is a branch among hundreds, and sometimes you want just the box.
@@ -759,10 +769,12 @@
 		{:else if line.part && getLasercut(line.part)}
 			{@const lc = getLasercut(line.part)!}
 			<div data-member={line.part} class="ml-1.5 mt-2 flex items-center gap-3 border border-border bg-surface p-2 sm:ml-4 sm:p-3">
-				<img src={lc.preview} alt={lc.name} class="h-12 w-12 shrink-0 object-contain" />
+				<button type="button" class="asm-thumb shrink-0" title="View {lc.name} details" onclick={() => openLasercut(lc)}>
+					<img src={lc.preview} alt={lc.name} class="h-12 w-12 object-contain" />
+				</button>
 				<div class="min-w-0 flex-1">
 					<div class="flex flex-wrap items-baseline gap-x-2">
-						<span class="text-sm font-semibold text-text">{lc.name}</span>
+						<button type="button" class="text-sm font-semibold text-text hover:text-primary" onclick={() => openLasercut(lc)}>{lc.name}</button>
 						<span class="border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
 							>laser cut</span>
 					</div>
@@ -1471,6 +1483,7 @@
 <AssemblyDetailModal bind:open={asmOpen} id={asmId} {layers} onPart={openPart} onHardware={openHardware} />
 <PartDetailModal bind:open={partOpen} part={partModal} bind:colorId={partColor} bind:version={partVersion} />
 <HardwareDetailModal bind:open={hwOpen} hardware={hwModal} {layers} />
+<LasercutDetailModal bind:open={lcOpen} part={lcModal} />
 
 <style>
 	/* Tree thumbnails open a detail view on click, so they carry the same click cue

--- a/parts-calculator/src/routes/lasercut/+page.svelte
+++ b/parts-calculator/src/routes/lasercut/+page.svelte
@@ -7,6 +7,7 @@
 	import HandCutCageGuide from '$lib/components/HandCutCageGuide.svelte';
 	import ChangeStatus from '$lib/components/ChangeStatus.svelte';
 	import PartDetailModal from '$lib/components/PartDetailModal.svelte';
+	import StlViewer from '$lib/components/StlViewer.svelte';
 	import { LASER_CUT_PARTS, type LaserCutPart } from '$lib/lasercut';
 	import { fmtDate, PARTS, primaryColorId, type Part, type PartVersion } from '$lib/filament';
 	import { colorStore } from '$lib/colors.svelte';
@@ -34,6 +35,8 @@
 	let mode = $state<Record<string, Mode>>(
 		Object.fromEntries(LASER_CUT_PARTS.map((p) => [p.id, 'laser' as Mode]))
 	);
+	// cards with a published solid model can swap the outline for a 3D view
+	let view3d = $state<Record<string, boolean>>({});
 	let guidePart = $state<LaserCutPart | null>(null);
 	let guideOpen = $state(false);
 	function openGuide(p: LaserCutPart) {
@@ -124,8 +127,21 @@
 			<div class="grid gap-4 sm:grid-cols-2">
 				{#each group.parts as p (p.id)}
 					<div class="setup-card-shell flex scroll-mt-6 flex-col border" id="laser-{p.id}">
-						<div class="relative flex items-center justify-center border-b border-border bg-[var(--color-bg)] p-4">
-							<img src={p.preview} alt="{p.name} outline" class="h-48 w-auto max-w-full" />
+						<div class="relative border-b border-border bg-[var(--color-bg)] {view3d[p.id] ? '' : 'flex items-center justify-center p-4'}">
+							{#if p.stl && view3d[p.id]}
+								<StlViewer url={p.stl} color="#b08d57" heightClass="h-[224px]" />
+							{:else}
+								<img src={p.preview} alt="{p.name} outline" class="h-48 w-auto max-w-full" />
+							{/if}
+							{#if p.stl}
+								<button
+									type="button"
+									class="absolute left-2 top-2 border border-border bg-surface px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted hover:text-text"
+									onclick={() => (view3d[p.id] = !view3d[p.id])}
+								>
+									{view3d[p.id] ? 'Outline' : '3D'}
+								</button>
+							{/if}
 							<ChangeStatus kind="lasercut" id={p.id} name={p.name} variant="marker" />
 						</div>
 						<div class="flex gap-1 border-b border-border px-2">
@@ -182,6 +198,7 @@
 								</dl>
 								<div class="mt-auto flex flex-wrap items-center gap-3 pt-1">
 									<DownloadButton href={p.dxf} size="md" label="Download DXF" />
+									{#if p.stl}<DownloadButton href={p.stl} size="sm" label="STL" title="The solid model — for viewing or CAM, not for printing" />{/if}
 									<a
 										href={p.onshape}
 										target="_blank"


### PR DESCRIPTION
Restructures the feeder per Spencer's walkthrough of the real machine:

- **Four units**: Bulk bucket C-channel, C-channel 2, C-channel 3, classification chamber — each with its own C-channel drive and rotor unit. Bulk bucket takes the bulk cap instead of an output guide and has no light post; channels 2 and 3 carry output guide + light post; channel 3 has the gray rotor.
- **Support stacks as assemblies**: Channel 3 support (foot + leg), Channel 2 support (+1 leg extension), Bulk bucket support (+2 extensions) — dovetail friction edges inside, and ×3 per unit dovetailing onto the drive. Part counts already agreed (9 feet, 9 legs, 9 extensions).
- **Classification chamber completed** (additive, no stamp): its C-channel drive, the finned rotor unit, the classification dome, and a new Camera & LED insert assembly (insert print + camera extension).
- Feeder stamped v3 with uid rotation; camera recorded as the ENOMAKER IMX415 4K module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)