### PR TITLE
bottom interface: add the 2 M3 heat inserts the layer connector needs

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -109,7 +109,7 @@ Press the heat inserts into both printed parts while they are still loose. See [
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-render-full-4eb13edc375d.png" alt="Render of the Lazy Susan chute mount seen from one side, with a red circle around a small pocket on a raised tab partway up the side wall">
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-render2-full-73129c8af447.png" alt="Render of the Lazy Susan chute mount seen from one side, with a red circle around a small pocket on a raised tab partway up the side wall">
       <figcaption>Where it is: the pocket sits on the small raised tab on the side wall. The far side is a mirror of this one. <cite>Render: Balloon.</cite></figcaption>
     </figure>
     <figure>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -109,7 +109,7 @@ Press the heat inserts into both printed parts while they are still loose. See [
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-render3-full-bf44835e1437.png" alt="Render of the Lazy Susan chute mount seen from one side, with a red circle around a small pocket on a raised tab partway up the side wall">
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-render4-full-1fb455668c8e.png" alt="Render of the Lazy Susan chute mount's side face, with a red circle around the small pocket on the raised tab partway up the wall">
       <figcaption>The pocket on the near side face. The far side is a mirror of it. <cite>Render: Balloon.</cite></figcaption>
     </figure>
     <figure>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -107,10 +107,16 @@ Press the heat inserts into both printed parts while they are still loose. See [
   <div class="prep-item-body">
     <p><strong>Lazy Susan chute mount:</strong> 2 × M3, one on each of the two side faces, about halfway up. These are easy to miss because they are on a different face from the four M4 above, and they are what the <a href="{{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}">layer connectors</a> screw into when the chute goes on top. The pockets are measured off the published model rather than off a built machine, so if your print has nothing there, correct this page.</p>
   </div>
-  <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-prep-chute-mount-m3-pocket-full-912ab394cb68.png" alt="Two stacked views of the Lazy Susan chute mount: the whole part with a red circle around a small pocket partway up the near side wall, and below it a close-up of that pocket highlighted in red">
-    <figcaption>The M3 pocket on the near side face, and a close-up. The far side is a mirror of it. <cite>Render: Balloon.</cite></figcaption>
-  </figure>
+  <div class="prep-item-figure prep-item-figure-split">
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-render-full-4eb13edc375d.png" alt="Render of the Lazy Susan chute mount seen from one side, with a red circle around a small pocket on a raised tab partway up the side wall">
+      <figcaption>Where it is: the pocket sits on the small raised tab on the side wall. The far side is a mirror of this one. <cite>Render: Balloon.</cite></figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-photo-full-ea22d619b316.png" alt="Close photo of the same raised tab on a printed chute mount, with a red circle around the empty pocket in it">
+      <figcaption>The same tab on a printed part, circled. No insert is in it here. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+    </figure>
+  </div>
 </div>
 
 <div class="prep-item">

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -26,6 +26,8 @@ parts_needed:
     qty: 3
   - part: ls-hold-in-place
     qty: 3
+  - part: hsi-m3
+    qty: 2
   - part: hsi-m4
     qty: 8
   - part: scr-m4-12-cs
@@ -98,6 +100,16 @@ Press the heat inserts into both printed parts while they are still loose. See [
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-prep-chute-mount-inserts-1-full-70bcf9a84302.jpg" alt="Looking into the Lazy Susan chute mount's circular face: four brass M4 heat inserts around the rim, with the raised square socket for the chute in the middle and the pass-through hole between two of the inserts">
     <figcaption>All four M4 inserts, with the pass-through hole. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Lazy Susan chute mount:</strong> 2 × M3, one on each of the two side faces, about halfway up. These are easy to miss because they are on a different face from the four M4 above, and they are what the <a href="{{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}">layer connectors</a> screw into when the chute goes on top. The pockets are measured off the published model rather than off a built machine, so if your print has nothing there, correct this page.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-prep-chute-mount-m3-inserts-full-0822332eee5c.png" alt="Two views of the Lazy Susan chute mount: the whole part with a red circle around a small pocket partway up the near side wall, and a close-up of that pocket highlighted in red">
+    <figcaption>The M3 pocket on the near side face, and a close-up. The far side is a mirror of it. <cite>Render: Balloon.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -105,16 +105,16 @@ Press the heat inserts into both printed parts while they are still loose. See [
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Lazy Susan chute mount:</strong> 2 × M3, one on each of the two side faces, about halfway up. These are easy to miss because they are on a different face from the four M4 above, and they are what the <a href="{{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}">layer connectors</a> screw into when the chute goes on top. The pockets are measured off the published model rather than off a built machine, so if your print has nothing there, correct this page.</p>
+    <p><strong>Lazy Susan chute mount:</strong> 2 × M3 for the <a href="{{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}">layer connectors</a>, one on each side face, on the small raised tab about halfway up.</p>
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-render3-full-bf44835e1437.png" alt="Render of the Lazy Susan chute mount seen from one side, with a red circle around a small pocket on a raised tab partway up the side wall">
-      <figcaption>Where it is: the pocket sits on the small raised tab on the side wall. The far side is a mirror of this one. <cite>Render: Balloon.</cite></figcaption>
+      <figcaption>The pocket on the near side face. The far side is a mirror of it. <cite>Render: Balloon.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-photo-full-ea22d619b316.png" alt="Close photo of the same raised tab on a printed chute mount, with a red circle around the empty pocket in it">
-      <figcaption>The same tab on a printed part, circled. No insert is in it here. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+      <figcaption>The same pocket on a printed part, empty. <cite>Photo: BrickCycleAlice.</cite></figcaption>
     </figure>
   </div>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -109,7 +109,7 @@ Press the heat inserts into both printed parts while they are still loose. See [
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-render2-full-73129c8af447.png" alt="Render of the Lazy Susan chute mount seen from one side, with a red circle around a small pocket on a raised tab partway up the side wall">
+      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-render3-full-bf44835e1437.png" alt="Render of the Lazy Susan chute mount seen from one side, with a red circle around a small pocket on a raised tab partway up the side wall">
       <figcaption>Where it is: the pocket sits on the small raised tab on the side wall. The far side is a mirror of this one. <cite>Render: Balloon.</cite></figcaption>
     </figure>
     <figure>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -108,7 +108,7 @@ Press the heat inserts into both printed parts while they are still loose. See [
     <p><strong>Lazy Susan chute mount:</strong> 2 × M3, one on each of the two side faces, about halfway up. These are easy to miss because they are on a different face from the four M4 above, and they are what the <a href="{{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}">layer connectors</a> screw into when the chute goes on top. The pockets are measured off the published model rather than off a built machine, so if your print has nothing there, correct this page.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-prep-chute-mount-m3-inserts-full-0822332eee5c.png" alt="Two views of the Lazy Susan chute mount: the whole part with a red circle around a small pocket partway up the near side wall, and a close-up of that pocket highlighted in red">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-prep-chute-mount-m3-pocket-full-912ab394cb68.png" alt="Two stacked views of the Lazy Susan chute mount: the whole part with a red circle around a small pocket partway up the near side wall, and below it a close-up of that pocket highlighted in red">
     <figcaption>The M3 pocket on the near side face, and a close-up. The far side is a mirror of it. <cite>Render: Balloon.</cite></figcaption>
   </figure>
 </div>

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -859,7 +859,7 @@
         "bottom interface chute mount"
       ],
       "description": "Bottom lazy Susan adapter that connects to the chute. White.",
-      "internal_notes": "The adapter/connector that mounts to the chute. White. The rest of the lazy Susan is frame color. 4 M4 inserts; the other half of the bottom lazy Susan sandwich.",
+      "internal_notes": "The adapter/connector that mounts to the chute. White. The rest of the lazy Susan is frame color. 4 M4 inserts (the other half of the bottom lazy Susan sandwich), plus 2 M3 on the side faces for the layer connector. The M3 pair was measured off the STL 2026-09-01: blind 4.20 x 5.70 mm pockets at (13.22, +-69.15, 11.42), opening outward on a face at y = +-72.0, the same x/y as the chute core's own layer-connector pockets. Screws are the chute's, 2 of its 8 scr-m3-8-cs.",
       "version": "1",
       "created_at": "2026-06-27",
       "updated_at": "2026-06-27",
@@ -877,6 +877,10 @@
         {
           "part": "hsi-m4",
           "qty": 4
+        },
+        {
+          "part": "hsi-m3",
+          "qty": 2
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -5097,6 +5097,10 @@
 				{
 					"part": "hsi-m4",
 					"qty": 4
+				},
+				{
+					"part": "hsi-m3",
+					"qty": 2
 				}
 			],
 			"caption": null,


### PR DESCRIPTION
The Lazy Susan chute mount takes **two M3 heat inserts** that were in neither its parts list nor the page's Preparation step.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1544432803293438012):** *"Wir werden die layer connectors an der Lazy Susan — chute mount an der Seite montiert? Werden sie verschraubt und braucht es da auf der chute Seite heat inserts?"*, then [asked for the fix](https://discord.com/channels/1430279849171222682/1544432803293438012/1544434803703549962): *"Add the heat inserts to the required parts and, during the preparation step, to the bottom interface side."*

## What the geometry says

Measured off the published `ls-mount-to-chute` STL. It has two blind Ø4.20 × 5.70 mm pockets on its side faces, one per side, at **(13.22, ±69.15, 11.42)** in the assembly frame, opening outward on a face at y = ±72.0. That is the ruthex RX-M3x5.7 signature (`hsi-m3`), and it is exactly the same x/y as the [chute core](https://docs.basically.website/hardware/assembly/distribution/chute/chute-core/)'s own layer-connector pockets, which sit at (13.22, ±69.15, 42.77) and (13.22, ±69.15, 171.49) on the same axis.

So the joint is the one [Layer connectors](https://docs.basically.website/hardware/assembly/distribution/chute/layer-connectors/) already describes, with the chute mount playing the part of the core below: the connector's two Ø3.40 clearance holes are 31.858 mm apart, one screw goes into the bottommost chute core's lower pocket and the other into the mount. Screws are the chute's own, 2 of its 8 × `scr-m3-8-cs`, so no screw count changes here.

## Changes

- **`parts-calculator/catalog/parts.json`** — `ls-mount-to-chute` now requires 2 × `hsi-m3` alongside its 4 × `hsi-m4`, with the measurement in `internal_notes`. `catalog.generated.json` regenerated (`generate.py --metadata-only`); `check_generated_pins.py` and `check_asset_urls.py` both pass.
- **`bottom-interface.md`** — `hsi-m3` × 2 in `parts_needed`, and a Preparation item saying they are on a different face from the four M4, with two figures: a render locating the pocket, and a photo of it on a printed part.

**The photo is real.** barthel [asked for one](https://discord.com/channels/1430279849171222682/1544432803293438012/1544435221817065603) rather than an illustration, and BrickCycleAlice's `IMG_4220` from the [bottom interface build thread](https://discord.com/channels/1430279849171222682/1542125633520406668/1542818753790611466) (2026-08-28) catches the pocket on the side wall, empty. Cropped and circled. Nothing anywhere shows an insert actually fitted in it, which is expected: until this PR the pocket was in no parts list, so nobody has pressed one.

The render is mine, from `parts-calculator/scripts/meshfig.py`, cut in the same style as the [chute core insert views](https://docs.basically.website/hardware/assembly/distribution/chute/chute-core/) (#406) so the two read as a pair. Both hosted on `sorter-parts` because my asset-service token still has no `write:sorter-docs` (#408). No burned-in captions on the render and the background is pure white, [per barthel](https://discord.com/channels/1430279849171222682/1544432803293438012/1544439056400654506).

## Not in this PR

The **top** interface's chute mount (`top-interface-split-spur-gear-3`) has no side pockets at all: its 7 M3 are 5 for the chute gear and 2 for the cable clamp, all on the top face, which matches the count barthel took off the physical part. But the `interface` assembly still carries a `layer-connector` pair, and `top-interface.md` never mentions one. Either that model is missing two pockets or the catalog line is wrong, and it needs somebody who has the machine in front of them.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1544432803293438012
request: https://discord.com/channels/1430279849171222682/1544432803293438012/1544434803703549962
request: https://discord.com/channels/1430279849171222682/1544432803293438012/1544435221817065603
request: https://discord.com/channels/1430279849171222682/1544432803293438012/1544439056400654506
request: https://discord.com/channels/1430279849171222682/1544432803293438012/1544439413591900290
request: https://discord.com/channels/1430279849171222682/1544432803293438012/1544440822509084712
preview: /hardware/assembly/distribution/bin-frame/bottom-interface/
-->




