### PR TITLE
parts-calculator: count the interface frame's run in the C quantity

### DIFF
--- a/parts-calculator/src/lib/framing.ts
+++ b/parts-calculator/src/lib/framing.ts
@@ -46,11 +46,15 @@ export const FRAMING_PIECES: FramingPiece[] = [
 		cadLen: 160,
 		len: 160 - CLEARANCE_MM,
 		category: 'per-layer',
-		from: '6 per layer, above the bottom 2',
+		from: '6 per layer above the bottom 2, plus 6 up to the interface frame',
 		badge: '#ffffff',
 		zeroNote:
-			'The bottom two layers do not use C. One foot extension (D) spans both of them in place of a C on each, so C is only cut from 3 layers up.',
-		qtyFor: (n) => 6 * Math.max(0, n - 2)
+			'The bottom two layers do not use C. One foot extension (D) spans both of them in place of a C on each, so the only C on a 2-layer build is the run up to the interface frame.',
+		// One run of C per gap between rings, less the bottom gap that D takes.
+		// The rings are the N bin layers plus the interface frame above the top
+		// one, so that is N gaps, N - 1 of them C. The interface frame's own run
+		// up into the Interface brackets is F, not C.
+		qtyFor: (n) => 6 * Math.max(0, n - 1)
 	},
 	// ---- interface (one set per machine) ----
 	{ letter: 'E', name: 'Interface spoke (long)', cadLen: 244, len: 244 - CLEARANCE_MM, category: 'interface', from: 'per machine', badge: '#1c1c1c', qtyFor: () => 6 },

--- a/parts-calculator/src/routes/framing/+page.svelte
+++ b/parts-calculator/src/routes/framing/+page.svelte
@@ -66,7 +66,14 @@
 					<b class="text-text">D stands in for C at the bottom.</b> Every layer above the bottom two
 					gets 6 layer supports (<b class="text-text">C</b>, {lenC} mm). The bottom two share 6 foot
 					extensions (<b class="text-text">D</b>, {lenD} mm), one spanning both, in place of a C on
-					each. So a 1 or 2 layer build has no C in the list at all, and that is not a missing piece.
+					each. So a 1 layer build has no C in the list at all, and that is not a missing piece.
+				</li>
+				<li>
+					<b class="text-text">The top layer needs a C too.</b> The interface frame, the hex frame the
+					electronics bolt onto, is its own ring above the top bin layer, so there is a run of
+					<b class="text-text">C</b> between the two. Piece <b class="text-text">F</b> only spans from
+					that frame up into the Interface brackets. That is why C comes out at 6 × (layers − 1)
+					rather than one set per layer.
 				</li>
 				<li>
 					Pieces that share a cut length stack together at the saw — mark and cut the top bar, the rest


### PR DESCRIPTION
Closes #519 if the count is accepted.

**Piece C goes from `6 × (layers − 2)` to `6 × (layers − 1)`.**

The cut list counted one vertical set per bin layer, with D covering two of them at the bottom and F covering the top. **Daddy-O's Bricks - Bill** assembled a 5-layer machine to the docs and came up 6 pieces short: the list called for 18 C and 24 were needed.

His marked-up photo walks the machine from the caster up, naming every segment and circling every break point:

![Bill's 5-layer machine, each extrusion segment marked C or D with the break points circled](https://basically-assets.nyc3.digitaloceanspaces.com/discord/1544508123832647720/1544512227279769625/IMG_1564.jpg)

> Above this is another vertical layer support then the hexagon where the electronics go and the interface vertical supports drop down into the electronics hexagon's brackets

So the interface frame, the hex frame the PSU box, control board housing and Orange Pi mount bolt onto, is **its own ring above the top bin layer**, with a run of C between the two. Piece F only spans from that frame up into the Interface brackets on the top plate. The old formula assumed F did both jobs, so that run was never cut.

Counting rings for N = 5: five bin layers plus the interface frame is 6 rings and 5 runs between them. D takes the bottom run plus the foot, leaving 4 runs of C, which is 24.

## What changed

- `framing.ts`: C's `qtyFor` is now `6 * Math.max(0, n - 1)`, with a comment giving the ring/gap reasoning. Its `from` cell and `zeroNote` say where the extra set goes.
- `framing/+page.svelte`: a new Notes bullet, "The top layer needs a C too", explaining the interface-frame run alongside the existing D bullet.

Nothing about D changed. Bill's photo confirms it does exactly what `bottom-two-layers.md` says at the bottom, and Spencer's 1.5 × C length stands.

`npm run check` is 0 errors, 0 warnings. Built and read out of the prerendered page: C is ×12 at the default 3 layers, was ×6.

## Deliberately not in this PR

- **The 1-layer case.** At N = 1 C is still 0 and D's `n >= 2` guard still leaves a single-layer build with no feet, so it gets no vertical at all. That predates this change ([mollydrippy, 2026-07-25](https://discord.com/channels/1430279849171222682/1503528472818094220/1530497775551254699)) and is a design call.
- **The docs.** `top-interface.md` step 14 describes piece F running into "the top layer's bracket" as though the interface's hex frame and the top bin layer were one ring, and `hex-frame.md` says "N + 1" frames in its body while its lede enumerates N + 2. Both need the same ruling this PR is asking for, so they are left to #519.
- **A/G and B/H quantities**, which are not affected. Bill [confirmed](https://discord.com/channels/1430279849171222682/1544508123832647720/1544512834828763249) he "was fine on all the other aluminum": the list's `6N + 6` of each is N + 1 rings' worth, exactly his five bin layers plus the interface frame. The ring count is right; only the run between two of them was missing. Whether the bottom interface's hex frame is a further ring is left to #519.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1544508123832647720/1544512553277853806
request: https://discord.com/channels/1430279849171222682/1487518366020276397/1544507939337936936
request: https://discord.com/channels/1430279849171222682/1544508123832647720/1544512227690942555
preview: /framing
-->
