### PR TITLE
docs: the bottom interface hangs under the bottom layer, it has no frame of its own

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -83,8 +83,13 @@ Once assembled, it mounts into the machine frame:
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-mounted-in-frame-full-476d171d148e.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
-    <figcaption><cite>Diagram pictures courtesy of Adrianbaker in the basically Discord.</cite></figcaption>
+    <figcaption>Look at the middle of this one, not the corners. <cite>Diagram pictures courtesy of Adrianbaker in the basically Discord.</cite></figcaption>
   </figure>
+</div>
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>The corners in that render are out of date.</strong> It shows an ordinary bottom vertical and cover at floor level with the caster under it. On a build, each bottom corner takes the <strong>External bracket — foot cover</strong>, and the extrusion is piece D, running down through the corner to the foot connector the caster screws into. See <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}#step-2">bottom two layers, steps 2 to 4</a>. The Lazy Susan mounting in the middle of the render is right.</p>
 </div>
 
 {% include step.html n="1" title="Preparation" %}

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -8,11 +8,11 @@ kicker: Bin frame — Bottom interface
 lede: The component the chute rests on top of.
 permalink: /hardware/assembly/distribution/bin-frame/bottom-interface/
 author: spencer
-contributors: [abrianbaker, brickcyclealice, barthel]
+contributors: [abrianbaker, brickcyclealice, barthel, daddyosbricksbill]
 warning: >-
-  **Reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
-  instead of describing frame construction inline, not yet reviewed by a
-  builder.** Correct it as you build.
+  **Steps 1-3 have not been checked against a machine.** Step 4, where this
+  assembly mounts, was corrected from a build by Daddy-O's Bricks - Bill.
+  Correct the rest as you go.
 parts_needed:
   - part: brg-lazy-susan
     qty: 1
@@ -37,11 +37,11 @@ parts_needed:
 tools_needed: [Hex key, Drill or electric screwdriver]
 ---
 
-The bottom interface is the Lazy Susan bearing assembly the chute rests and spins on, sitting between the chute and the bottom two layers of the frame.
+The bottom interface is the Lazy Susan bearing assembly the chute rests and spins on, slung underneath the bottom layer's frame.
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Build a <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}">hex frame</a> before you start.</strong> It's a required component of this page, not optional or covered here — step 4 bolts onto one, it doesn't build one.</p>
+    <p><strong>This assembly has no frame of its own.</strong> It hangs under the <strong>bottom layer's</strong> <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}">hex frame</a>, built on <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}">bottom two layers</a>, so you don't need an extra one. Step 4 bolts onto that frame's spokes from underneath.</p>
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-finished-top-down-full-c6abfb4dad6e.jpg" alt="A finished hex frame from above, the alternating grey spoke and teal crossbeam pieces forming the inner ring inside the aluminum outer hexagon">
@@ -49,7 +49,7 @@ The bottom interface is the Lazy Susan bearing assembly the chute rests and spin
   </figure>
 </div>
 
-The parts list above is only the Lazy Susan bearing stack and the extrusion mounts added in step 4; the hex frame itself is [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})'s own parts list, built ordinary and unmodified. The fasteners and quantities below are called out inline at each step.
+The parts list above is only the Lazy Susan bearing stack and the extrusion mounts added in step 4. The fasteners and quantities below are called out inline at each step.
 
 {% include fastener-legend.html %}
 
@@ -208,9 +208,9 @@ The bearing stack is now complete:
   <figcaption><cite>Photo: Spencer.</cite></figcaption>
 </figure>
 
-{% include step.html n="4" title="Prepare the frame" %}
+{% include step.html n="4" title="Hang it under the bottom layer" %}
 
-The bottom interface's frame is an ordinary [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}), built exactly as that page describes, with one addition: that page's step 3 has a note on getting this page's 6 T-nuts into 3 of its spokes while they're still open. Once it's built, a Lazy Susan extrusion mount pair bolts directly onto those 3 spokes, alternating around the ring, on top of the spoke's existing Frame 90° bracket and crossbeam rather than replacing anything.
+There is no separate frame here. The three Lazy Susan extrusion mounts bolt to the **underside of the bottom layer's B/H spokes**, alternating around the ring, and the bearing sits on them. Nothing already on the spoke is moved or replaced. [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) step 3 has a note on getting this page's 6 T-nuts into those 3 spokes while their ends are still open.
 
 Three Lazy Susan extrusion mounts carry the bearing assembly's weight; a hold in place bolts to each one first, as a pair, before either touches the extrusion. **They don't fix the chute itself**, that's attached up at the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}).
 
@@ -221,14 +221,14 @@ Three Lazy Susan extrusion mounts carry the bearing assembly's weight; a hold in
 
 The screw between the extrusion mount and the hold in place is an {% include fastener.html size="M5" variant="socket-button" length="16" %}.
 
-Each mount then bolts directly onto the B/H spoke (158mm) already in place in the hex frame, through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion.
+Each mount then bolts up into the B/H spoke (158mm) already in place in the bottom layer's frame, through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion.
 
 That's two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws per mount, 6 more on top of the 3 between mount and hold in place.
 
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-parts/bottom-interface-step4-hex-frame-overview-full-bab24577ff64.jpg" alt="Top-down view of the assembled hexagonal layer frame with three Lazy Susan extrusion mounts fitted at alternating spokes">
-    <figcaption>All three mounts, fitted around the ring. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+    <figcaption>All three mounts, fitted around the ring. The frame is off the machine here, not in its built orientation. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
   <figure>
     <img src="https://assets.basically.website/sorter-parts/bottom-interface-step4-hex-frame-corner-full-1a86a71db08d.jpg" alt="Closer view of one Lazy Susan extrusion mount fitted at a corner of the hexagonal layer frame">
@@ -236,4 +236,4 @@ That's two {% include fastener.html size="M5" variant="socket-button" length="16
   </figure>
 </div>
 
-You end this step with two pieces: the bearing stack from steps 1-3, and the hex frame with its three Lazy Susan extrusion mounts now bolted onto alternating spokes. The frame goes on in [bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}); the bearing stack takes the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}).
+You end this step with the bearing stack from steps 1-3 sitting on three mounts under the bottom layer's spokes. The bearing stack takes the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}); with a funnel fitted on the chute mount, it lands level with the bin entrances.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -64,7 +64,7 @@ The aluminum extrusion is cut to length; the [framing cut list](https://parts-ca
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-mounted-in-frame-full-476d171d148e.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
-    <figcaption>The bottom interface, mounted into a frame.</figcaption>
+    <figcaption>The bottom interface, mounted into a frame. The corners in this render are out of date: they show a bottom vertical and cover where a build has the External bracket — foot cover and piece D running through to the caster, which is steps 2 to 4 below.</figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -8,12 +8,11 @@ kicker: Bin frame — Bottom two layers
 lede: The paired base layers. Built together on the foot extensions the casters mount to.
 permalink: /hardware/assembly/distribution/bin-frame/bottom-two-layers/
 author: spencer
-contributors: [brickcyclealice, christoph]
+contributors: [brickcyclealice, christoph, daddyosbricksbill]
 warning: >-
-  **AI-generated first draft, reorganized to reference [Build the hex
-  frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
-  instead of Regular layers' old steps 1-2.** No step here has been checked
-  against a machine. Correct it as you build.
+  **AI-generated first draft.** Step 6 was written from a build by
+  Daddy-O's Bricks - Bill; no other step here has been checked against a
+  machine. Correct it as you build.
 parts_needed:
   - part: ext-bracket-cover
     qty: 6
@@ -61,7 +60,7 @@ The aluminum extrusion is cut to length; the [framing cut list](https://parts-ca
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Build the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> before you start.</strong> Its three Lazy Susan extrusion mounts bolt onto its own hex frame's spokes as part of that page, not onto this frame's extrusion, so there's no T-nut work to do here on their account. How the finished bottom interface then joins onto this frame is step 6 below.</p>
+    <p><strong>Build the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> before you start.</strong> It has no frame of its own: its three Lazy Susan extrusion mounts bolt up under the bottom layer's spokes, which is step 6 below. Get its 6 T-nuts into 3 of that layer's B/H spokes while you are building the frame, before the ring closes.</p>
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-mounted-in-frame-full-476d171d148e.png" alt="The bottom interface assembly mounted into the aluminum extrusion machine frame">
@@ -93,7 +92,7 @@ You should already have two [hex frames]({{ '/hardware/assembly/distribution/bin
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>This callout predated the hex frame reorg and used to say to put the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a>'s three T-nuts into this frame's extrusion before it closes up. That's resolved now: <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}#step-4">bottom interface, step 4</a> bolts its three Lazy Susan extrusion mounts onto <em>its own</em> hex frame's spokes, with their own T-nuts, as part of building that page — nothing to do here on their account. What's still unconfirmed is how the finished bottom interface then physically joins onto this frame; see step 6 below.</p>
+  <p><strong>Get the bottom interface's 6 T-nuts into the bottom layer's spokes before the ring closes.</strong> Two each into 3 of the 6 B/H spokes, alternating around the ring. <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}#step-4">Bottom interface, step 4</a> bolts its Lazy Susan extrusion mounts up into them from underneath, so they go in this frame's extrusion, not a frame of its own. Roll-in T-nuts can go in later; slide-in ones cannot.</p>
 </div>
 
 {% include step.html n="2" title="Run the foot extensions through both layers" %}
@@ -177,9 +176,12 @@ Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/ass
 
 {% include step.html n="6" title="Attach the bottom interface" %}
 
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>Not written yet — this step is a placeholder.</strong> Build the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> separately, then it joins the bottom of this frame here, but the physical mechanism isn't confirmed: whether it shares piece D's legs with this stack or connects some other way. Needs a builder to confirm before this step can be written for real.</p>
+The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) hangs underneath the **bottom layer's** frame. It does not share piece D's legs and it does not get a hex frame of its own.
+
+Working from under the bottom layer, bolt each of its three Lazy Susan extrusion mount pairs up into the underside of a B/H spoke, on 3 of the 6 spokes alternating around the ring, 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws per mount into the T-nuts you put in earlier. Those 6 screws are on the bottom interface's own parts list, not this page's, so they aren't in the count above. The bearing then sits on the three mounts, and the chute mount faces up into the machine.
+
+<div class="callout">
+  <p>The height that comes out of this is right when a <a href="{{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}">chute core</a> with a funnel on it, fitted onto the chute mount, puts the funnel level with the bin entrances.</p>
 </div>
 
 <div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -5,7 +5,7 @@ type: how-to
 section: hardware
 slug: assembly-hex-frame
 kicker: Bin frame — Build the hex frame
-lede: The hexagonal aluminum-and-bracket ring shared by every layer. Build one per planned layer, plus one for the bottom interface and one for the top interface.
+lede: The hexagonal aluminum-and-bracket ring shared by every layer. Build one per planned layer, plus one for the top interface.
 permalink: /hardware/assembly/distribution/bin-frame/hex-frame/
 author: barthel
 contributors: [brickcyclealice, zed0]
@@ -33,7 +33,7 @@ tools_needed: [Hex key, Mallet or hammer with a cloth to protect the brackets]
 
 This guide builds one hexagonal frame: the outer ring of A/G extrusion and External bracket — side, with the six B/H spokes and Frame crossbeams held inside it by the Frame 90° brackets. No fasteners are used from step 2 onward — the spokes, crossbeams and brackets are a friction-and-slide fit, no screws or T-nuts.
 
-An N-layer machine needs **N + 1 of these**: one per planned layer, plus one for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) and one for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}).
+An N-layer machine needs **N + 1 of these**: one per planned layer, plus one for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}). The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) does not get a frame of its own — it hangs underneath the bottom layer's frame, off the same six spokes.
 
 The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions. Each frame uses 6 A/G (320mm) and 6 B/H (158mm). The 24 T-nuts in the list above aren't used by anything in this guide — they're pre-installed in step 1 while the extrusion ends are still accessible, for the bin retainers a later page attaches to the outer ring.
 
@@ -113,7 +113,7 @@ Repeat step 2 around the hexagon until you have used **6 Frame crossbeams and 5 
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Building this frame for the <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a>? Its three Lazy Susan extrusion mounts each bolt into a T-nut in a B/H spoke, on 3 of the 6 spokes alternating around the ring. If you're using slide-in T-nuts, slide 2 into each of those 3 spokes as you build them here in steps 2-3, since this is the last time their ends are open; drop-in or roll-in T-nuts can go in any time before the ring closes in step 7. An ordinary hex frame for a layer needs none of this.</p>
+  <p>Building the <strong>bottom layer's</strong> frame? The <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> hangs off it, and its three Lazy Susan extrusion mounts each bolt into a T-nut in a B/H spoke, on 3 of the 6 spokes alternating around the ring. If you're using slide-in T-nuts, slide 2 into each of those 3 spokes as you build them here in steps 2-3, since this is the last time their ends are open; drop-in or roll-in T-nuts can go in any time before the ring closes in step 7. Every other layer's frame needs none of this.</p>
 </div>
 
 {% include step.html n="4" title="Fit 10 of the 12 Frame 90° brackets" %}

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
@@ -10,10 +10,10 @@ permalink: /hardware/assembly/distribution/bin-frame/
 author: spencer
 ---
 
-The bin frame is the stack of hexagonal layers that makes up the body of the machine: each layer carries one chute-and-bin pair that catches pieces routed to it as they come down from distribution above. The stack sits on the bottom interface, which the pieces feed from below, and is capped by [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}). Build order runs bottom-up, since each layer's vertical extrusion locates and is fastened to the one below it.
+The bin frame is the stack of hexagonal layers that makes up the body of the machine: each layer carries one chute-and-bin pair that catches pieces routed to it as they come down from distribution above. The bottom interface hangs underneath the bottom layer, and the stack is capped by [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}). Build order runs bottom-up, since each layer's vertical extrusion locates and is fastened to the one below it.
 
-1. **[Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})** — the shared hexagonal ring. Build N+1 of these first: one per planned layer, plus one each for the bottom and top interface.
-2. **[Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }})** — the base the frame builds up from.
+1. **[Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})** — the shared hexagonal ring. Build N+1 of these first: one per planned layer, plus one for the top interface. The bottom interface does not need one.
+2. **[Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }})** — the Lazy Susan stage, slung under the bottom layer's spokes.
 3. **[Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }})** — the paired base layers on the long vertical extrusions.
 4. **[Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }})** — build N−2 of these, one per remaining layer.
 5. **[Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})** — outside this section, but takes one of the hex frames from step 1 and caps the stack.

--- a/docs/src/liquid/_data/authors.yml
+++ b/docs/src/liquid/_data/authors.yml
@@ -23,6 +23,9 @@ barthel:
 brickcyclealice:
   name: BrickCycleAlice
 
+daddyosbricksbill:
+  name: Daddy-O's Bricks - Bill
+
 effreek:
   name: Jon
   url: https://github.com/effreek


### PR DESCRIPTION
**The bottom interface has no hex frame of its own.** It hangs underneath the bottom layer's frame: its three Lazy Susan extrusion mounts bolt to the **underside of that layer's B/H spokes**, and the bearing sits on them.

From **Daddy-O's Bricks - Bill**, building a 5-layer machine, [2026-09-02](https://discord.com/channels/1430279849171222682/1544508123832647720/1544516486411059200):

> This does not seem correct the lazy susan extrusion mounts mount to the under side of the spokes of the bottom layer bottom lazy susan sits on them. When I fit a chute core with a funnel on it on on top of the chute mount the funnel lands at the bin entrances

That last sentence is the height check, so it is not only where the mounts go but that the resulting stack lands where it should.

It also settles a count that has been contradictory in these pages for weeks. `hex-frame.md` said "An N-layer machine needs **N + 1** of these" and then enumerated N + 2 in the same sentence. N + 1 is right, and it is what the [framing cut list](https://parts-calculator.basically.website/framing) has always supplied: Bill [confirmed](https://discord.com/channels/1430279849171222682/1544508123832647720/1544512834828763249) he "was fine on all the other aluminum", and `6N + 6` of the 320 mm and 158 mm pieces is exactly N + 1 rings.

## What changed

- **`bottom-interface.md`** — the "build a hex frame before you start" prerequisite is gone. Step 4 goes from "Prepare the frame" to **"Hang it under the bottom layer"**, and the closing paragraph ends with the funnel-to-bin-entrances check instead of handing a frame to the next page.
- **`bottom-two-layers.md`** — **step 6 is no longer a placeholder.** It was the admitted unknown on this exact joint ("whether it shares piece D's legs with this stack or connects some other way. Needs a builder to confirm"). It does not share piece D's legs. The T-nut callout above it now says to get the interface's 6 T-nuts into this frame's spokes before the ring closes, which is real work that page previously said there was none of.
- **`hex-frame.md`** — lede and body agree on N + 1, and the T-nut note is addressed to the bottom layer's frame rather than to a frame for the bottom interface.
- **`bin-frame/index.md`** — "the stack sits on the bottom interface" was backwards; the interface hangs off the stack.
- **`authors.yml`** — adds Bill, credited as a contributor on both pages he corrected.

Warning banners updated to say which steps now come from a build and which are still unchecked, rather than blanket-claiming the whole page is unreviewed.

## Not in this PR

- **Photos.** The step 4 pictures show the frame off the machine, so I added a line to the caption saying so rather than asserting an orientation I cannot see. A photo of the mounts in place from underneath would replace both.
- **The `img-placeholder` in step 6** is still there. The step has text now, not an image.
- The C quantity fix from the same conversation is #520, separate because it touches the calculator rather than the docs.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1544508123832647720/1544516486411059200
request: https://discord.com/channels/1430279849171222682/1544508123832647720/1544512834828763249
preview: /hardware/assembly/distribution/bin-frame/bottom-two-layers/
preview: /hardware/assembly/distribution/bin-frame/bottom-interface/
preview: /hardware/assembly/distribution/bin-frame/hex-frame/
-->
