### PR TITLE
parts-calculator: remove the partial/stub assembly status

### DIFF
--- a/parts-calculator/CLAUDE.md
+++ b/parts-calculator/CLAUDE.md
@@ -306,11 +306,10 @@ assembly version is an authored structural change; its superseded entries
 snapshot the lines with each member's uid of the day (`stamp_versions.py`),
 and a candidate is an alternative bill of materials under test, optionally
 carrying the `name` the slot takes if it is adopted. Same minting, same
-retention rule. A structural change to an assembly's `lines` (member
-removed/replaced, qty changed) MUST be stamped as a new assembly version
-with its `breaking` bit — `check_versioning.py` refuses it otherwise; the
-one exemption is purely additive completion of a `stub`/`partial` assembly.
-See `VERSIONING.md`.
+retention rule. Any change to an assembly's `lines` (member
+added/removed/replaced, qty changed) MUST be stamped as a new assembly
+version with its `breaking` bit — `check_versioning.py` refuses it
+otherwise. See `VERSIONING.md`.
 
 **An assembly's `connections` are its joints as a graph over its members.**
 One edge per joint: `{from, to, via, qty, method, through_mm?, thread_mm?,

--- a/parts-calculator/VERSIONING.md
+++ b/parts-calculator/VERSIONING.md
@@ -78,7 +78,7 @@ the chain of bits — never reconstructed from memory or CAD archaeology.
 
 ## Revising an assembly
 
-A structural change to an assembly's `lines` — a member removed or replaced,
+Any change to an assembly's `lines` — a member added, removed or replaced,
 a quantity changed — is a revision and must be **stamped** in the same
 change:
 
@@ -89,11 +89,9 @@ change:
    its commit and snapshots the superseded lines with each member's uid of
    the day, so the box as built then reads back part by part.
 
-One exemption: purely *adding* lines to a `stub`/`partial` assembly is
-completing the record of what was always physically there, not changing the
-design — no stamp needed. The moment a line is removed or altered, or the
-assembly is no longer partial, the full rule applies. CI enforces both
-halves (`scripts/check_versioning.py`).
+There is no "just filling in what was always there" exemption: the lines
+are the record, and every change to them is a moment someone may need to
+flip back to. CI enforces this (`scripts/check_versioning.py`).
 
 ## History is derived, not recorded
 
@@ -154,9 +152,9 @@ Worked example: `washer-m3-15`, retired in
   the same design is a new hash under the same uid).
 - Deleting or overwriting an asset (the service cannot).
 - Hand-editing `src/lib/data/catalog.generated.json` (it is an output).
-- A new revision without its `breaking` bit, or a structural change to an
-  assembly's lines without a version stamp (CI refuses both, from
-  2026-08-31; `scripts/check_versioning.py`).
+- A new revision without its `breaking` bit, or a change to an assembly's
+  lines without a version stamp (CI refuses both, from 2026-08-31;
+  `scripts/check_versioning.py`).
 - Compatibility claims between arbitrary version pairs. Compatibility is
   computed from the chain of `breaking` bits; anything the chain can't
   derive is honestly unknown.

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column — both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) and status 'stub' (placeholder, nothing inside yet) or 'partial' (some lines filled in) — these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until §5.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit — 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, §5.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views. TAGS (2026-08-31): top-level tags [{name, node, stability: 'golden'|'stable'|'experimental' ('golden' adds the forward promise: revisions under a golden-tagged node must not be breaking), date, commit, message?}] -- a blessed moment of a node's whole subtree, resolved against history exactly like a timeline point (see VERSIONING.md, History is derived). 'stable' means the build as of that moment is known good and compatibility with it must not be broken silently. Tags are only ever appended by a human decision; nothing mints them.",
+  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column — both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) — these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until §5.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit — 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, §5.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views. TAGS (2026-08-31): top-level tags [{name, node, stability: 'golden'|'stable'|'experimental' ('golden' adds the forward promise: revisions under a golden-tagged node must not be breaking), date, commit, message?}] -- a blessed moment of a node's whole subtree, resolved against history exactly like a timeline point (see VERSIONING.md, History is derived). 'stable' means the build as of that moment is known good and compatibility with it must not be broken silently. Tags are only ever appended by a human decision; nothing mints them.",
   "sections": [
     {
       "id": "feeder",
@@ -5616,7 +5616,6 @@
       "version": "1",
       "name": "Light post",
       "description": "The feeder light post: post, cap, and cap adapter. 2 per machine. Bolts to a C-channel NEMA bracket.",
-      "status": "partial",
       "docs": "/hardware/assembly/feeder/light-post/",
       "joining": [
         {
@@ -5658,7 +5657,6 @@
       "name": "External distribution-frame bracket",
       "description": "Three parts that bolt together into one external bracket. 6 per distribution frame (per layer). The cover clips on and takes no screws. The top interface uses only the side and cover from this set, no bottom vertical, see the interface assembly.",
       "docs": "/hardware/helpers/external-bracket/",
-      "status": "partial",
       "joining": [
         {
           "method": "self-tap",
@@ -5691,7 +5689,6 @@
       "name": "Fixed upper section",
       "description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 × [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "joining": [
         {
           "method": "self-tap",
@@ -5728,7 +5725,6 @@
       "name": "Cable clamp",
       "description": "Inner + outer ribbon cable clamp; the two halves clamp together around the cable and the pair bolts to the top interface chute mount.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "cable-clamp-inner",
@@ -5755,7 +5751,6 @@
       "name": "Classification chamber",
       "description": "The classification chamber: the dome, the finned rotor, and the camera & LED insert. All three print white, so the chamber bounces light onto the part instead of absorbing it.",
       "docs": "/hardware/assembly/feeder/classification-chamber/",
-      "status": "partial",
       "versions": [
         {
           "version": "1",
@@ -5766,7 +5761,7 @@
         {
           "version": "2",
           "date": "2026-08-31",
-          "message": "First recorded line: the finned rotor unit (rotor + bolted-on Output gear (130T)). Marked partial — the dome and the camera & LED insert are still unrecorded.",
+          "message": "First recorded line: the finned rotor unit (rotor + bolted-on Output gear (130T)); the dome and the camera & LED insert were still unrecorded.",
           "breaking": false,
           "commit": null
         }
@@ -5796,7 +5791,6 @@
       "version": "1",
       "name": "Chute bearing assembly",
       "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 × 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
-      "status": "partial",
       "lines": [
         {
           "part": "bearing-race",
@@ -5835,7 +5829,6 @@
       "name": "Servo adapter (MG995)",
       "description": "MG995 servo adapter: servo side + flap side, clamping the MG995 Servo Horn (comes with the servo) between them. 4 M3 x 8 countersunk hold the two halves together, no heat inserts.",
       "docs": "/hardware/assembly/distribution/chute/door-module/",
-      "status": "partial",
       "lines": [
         {
           "part": "servo-adapter-servo-side",
@@ -5862,7 +5855,6 @@
       "name": "Servo assembly (MG995)",
       "description": "The MG995 servo in its bracket: lower arm, side arm, cover, housing. Bolts to the chute core's two arm inserts as a unit.",
       "docs": "/hardware/assembly/distribution/chute/mg995-servo/servo-mount/",
-      "status": "partial",
       "lines": [
         {
           "part": "servo-bracket-lower-arm",
@@ -5900,7 +5892,6 @@
       "version": "1",
       "name": "Overhead camera mount",
       "description": "Camera mount for the C-channels. 2 per machine, each hanging off two ~1 ft steel rods.",
-      "status": "partial",
       "docs": "/hardware/assembly/feeder/camera-mount/",
       "lines": [
         {
@@ -5944,7 +5935,6 @@
       "name": "Layer connector",
       "description": "Pair of connectors. 1 of each per layer + 1 of each per bottom interface.",
       "docs": "/hardware/assembly/distribution/chute/layer-connectors/",
-      "status": "partial",
       "lines": [
         {
           "part": "layer-connector-1",
@@ -5963,7 +5953,6 @@
       "name": "Chute limit switch",
       "description": "Interface limit switch: printed dowel pin, housing, hammer, and the switch itself. Bolts to the interface frame as a unit.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "limit-switch-dowel-pin",
@@ -6042,7 +6031,6 @@
       "name": "Cable cage",
       "description": "Six cable cage brackets (5 regular + 1 cable mount) stacked with the ribbon cable clamp. Also sandwiches the laser-cut cage top and bottom plates, which are not in the parts registry yet.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "interface-cage-bracket",
@@ -6077,7 +6065,6 @@
       "name": "Meanwell 24V PSU box",
       "description": "Enclosure for the Meanwell 24V power supply: back mount, connections plate, and cap, screwed to the supply's own case.",
       "docs": "/hardware/electronics/installation/psu-box/",
-      "status": "partial",
       "lines": [
         {
           "part": "meanwell-psu-back-mount",
@@ -6170,7 +6157,6 @@
       "version": "2",
       "name": "Camera extension",
       "description": "Classification-channel camera extension for the 4K camera module: the 50 mm extension tube, its mount, and the camera. 1 per machine.",
-      "status": "partial",
       "lines": [
         {
           "part": "camera-extension",
@@ -6239,7 +6225,6 @@
       "name": "Pico with headers",
       "description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare — the pins are a separate purchase.",
       "docs": "/hardware/helpers/pico-headers/",
-      "status": "partial",
       "joining": [
         {
           "method": "solder",
@@ -6264,7 +6249,6 @@
       "name": "Sorter V2",
       "description": "The whole machine: feeder on top, interface, the distribution layers between the interfaces, and the bottom interface.",
       "docs": "/hardware/assembly/",
-      "status": "partial",
       "lines": [
         {
           "assembly": "feeder",
@@ -6328,7 +6312,6 @@
       "version": "1",
       "name": "Superstructure",
       "description": "What the feeder and the electronics mount onto: the top plate, the top interface, the distribution layers between the interfaces, and the bottom interface.",
-      "status": "partial",
       "lines": [
         {
           "part": "top-plate",
@@ -6372,7 +6355,6 @@
       "name": "Feeder",
       "description": "Everything above the top interface: the bulk bucket, C-channels 2 and 3, and the classification chamber.",
       "docs": "/hardware/assembly/feeder/",
-      "status": "partial",
       "versions": [
         {
           "version": "1",
@@ -6484,7 +6466,6 @@
       "version": "1",
       "name": "Channel 3 support",
       "description": "One of C-channel 3's three standoffs: a foot and the leg the channel dovetails onto.",
-      "status": "partial",
       "lines": [
         {
           "part": "foot",
@@ -6511,7 +6492,6 @@
       "version": "1",
       "name": "Channel 2 support",
       "description": "One of C-channel 2's three standoffs: a foot, one leg extension, and the leg the channel dovetails onto.",
-      "status": "partial",
       "lines": [
         {
           "part": "foot",
@@ -6549,7 +6529,6 @@
       "version": "1",
       "name": "Bulk bucket support",
       "description": "One of the bulk bucket's three standoffs — the tallest stack: a foot, two leg extensions, and the leg.",
-      "status": "partial",
       "lines": [
         {
           "part": "foot",
@@ -6594,7 +6573,6 @@
       "version": "1",
       "name": "Bulk bucket C-channel",
       "description": "The top feeder unit: a C-channel drive with a white faceted rotor, capped by the Bulk cap instead of an output guide and with no light post, standing on the tallest supports.",
-      "status": "partial",
       "lines": [
         {
           "assembly": "bulk-bucket-support",
@@ -6629,7 +6607,6 @@
       "version": "1",
       "name": "C-channel 2",
       "description": "The middle feeder channel: a C-channel drive with a white faceted rotor, an output guide and a light post, standing on three supports with one leg extension each.",
-      "status": "partial",
       "lines": [
         {
           "assembly": "channel-two-support",
@@ -6672,7 +6649,6 @@
       "version": "1",
       "name": "C-channel 3",
       "description": "The lowest feeder channel, just above the classification chamber: a C-channel drive with the gray faceted rotor, an output guide and a light post, on three foot-and-leg supports.",
-      "status": "partial",
       "lines": [
         {
           "assembly": "channel-three-support",
@@ -6715,7 +6691,6 @@
       "version": "1",
       "name": "Camera & LED insert assembly",
       "description": "The Camera & LED insert print with the camera extension assembled into it; the loaded insert drops into the classification dome.",
-      "status": "partial",
       "lines": [
         {
           "part": "camera-led-insert",
@@ -6747,7 +6722,6 @@
       "name": "Top interface",
       "description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 × [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "assembly": "interface-bracket-mount",
@@ -7186,7 +7160,6 @@
       "name": "Distribution layer",
       "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 × [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
-      "status": "partial",
       "lines": [
         {
           "assembly": "layer-frame",
@@ -7266,7 +7239,6 @@
       "name": "Bottom interface",
       "description": "The bottom interface / lazy Susan level. The chute above it is one of the machine's N regular chutes, already counted there; this assembly only adds the layer connector that bridges down to it.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
-      "status": "partial",
       "lines": [
         {
           "assembly": "layer-frame",
@@ -7289,7 +7261,6 @@
       "name": "Chute",
       "description": "One chute: the core plus its door module, funnel brackets, connectors, and PCB. Every screw here lands in one of the chute core's 18 M3 inserts.",
       "docs": "/hardware/assembly/distribution/chute/chute-core/",
-      "status": "partial",
       "lines": [
         {
           "part": "chute-core",
@@ -7332,7 +7303,6 @@
       "name": "Flap module",
       "description": "The chute's flap: the door itself, the bearing assembly it swings on, and the servo that drives it.",
       "docs": "/hardware/assembly/distribution/chute/door-module/",
-      "status": "partial",
       "lines": [
         {
           "part": "chute-door",
@@ -7359,7 +7329,6 @@
       "name": "Chute PCB",
       "description": "The layer adapter board, screwed onto the chute core's four PCB inserts.",
       "docs": "/hardware/assembly/distribution/chute/pcb/",
-      "status": "partial",
       "lines": [
         {
           "part": "layer-adapter-board-basically",
@@ -7378,7 +7347,6 @@
       "name": "C-channel drive",
       "description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
-      "status": "partial",
       "versions": [
         {
           "version": "1",
@@ -7730,7 +7698,6 @@
       "name": "Chute Stepper Gearing",
       "description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 × [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 × [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3×35 keeps it clear of the limit switch hammer.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "interface-nema23-bracket",
@@ -7785,7 +7752,6 @@
       "name": "Chute stepper NEMA 23 mount",
       "description": "The NEMA 23 stepper on its interface bracket. 1 per interface.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "interface-nema23-bracket",
@@ -7808,7 +7774,6 @@
       "name": "Chute stepper drive gear",
       "description": "The chute stepper drive gear with its 8 mm bore timing pulley. 1 per interface.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "interface-spur-gear",
@@ -7831,7 +7796,6 @@
       "name": "Interface chute gear + mount",
       "description": "The Chute gear screwed onto the Top interface chute mount with five M3x12 countersunk screws (top-interface.md step 6). Despite their ids (inherited from an earlier three-piece gear design), these are two distinct parts fastened together, not two sections of one gear.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "top-interface-split-spur-gear-1",
@@ -8087,7 +8051,6 @@
       "name": "Distribution frame",
       "description": "The frame of one distribution layer: one hex frame, whose bracket segments form the collars for piece C.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
-      "status": "partial",
       "lines": [
         {
           "assembly": "hex-frame",
@@ -8161,9 +8124,7 @@
       "version": "2",
       "name": "basically Embedded Control Board Housing",
       "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base — no bracket, no standoffs — and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
-      "section": "electronics",
       "docs": "/hardware/electronics/installation/control-board-housing/",
-      "status": "partial",
       "lines": [
         {
           "part": "ctrl-board-housing-base",
@@ -8297,9 +8258,7 @@
       "version": "1",
       "name": "Orange Pi mount",
       "description": "The Orange Pi 5 standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
-      "section": "electronics",
       "docs": "/hardware/electronics/installation/orange-pi-mount/",
-      "status": "partial",
       "lines": [
         {
           "part": "orange-pi-extrusion-mount",
@@ -8353,7 +8312,6 @@
       "name": "Electronics",
       "description": "The three boxes that bolt to the frame: the PSU, the control board, and the Orange Pi.",
       "docs": "/hardware/electronics/installation/",
-      "status": "partial",
       "lines": [
         {
           "assembly": "meanwell-psu-box",
@@ -8376,7 +8334,6 @@
       "name": "Interface bracket",
       "description": "One interface bracket with its spacer, bolted onto its vertical extrusion (piece F) and its spoke extrusion (piece E). 6 per interface.",
       "docs": "/hardware/assembly/distribution/top-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "interface-bracket",
@@ -8446,7 +8403,6 @@
       "name": "Bottom lazy Susan",
       "description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 × [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
-      "status": "partial",
       "lines": [
         {
           "part": "ls-mount-to-chute",

--- a/parts-calculator/scripts/check_versioning.py
+++ b/parts-calculator/scripts/check_versioning.py
@@ -13,14 +13,12 @@ previous main commit on a push, the base branch on a PR's merge ref):
    experiment, not a revision; the bit belongs to the version minted if it
    is adopted). Revisions predating adoption are exempt, not failed.
 
-2. **The stamp rule.** A structural change to an assembly's `lines` — a
-   member removed, replaced, or a quantity changed — must be stamped: the
+2. **The stamp rule.** Any change to an assembly's `lines` — a member
+   added, removed, replaced, or a quantity changed — must be stamped: the
    assembly's `version` bumped and a new versions[] entry authored with a
-   date, a message, and its breaking bit. Exception: purely ADDING lines to
-   a `stub`/`partial` assembly is completing the record of what was always
-   physically there, not changing the design, and needs no stamp. A part
-   whose `uid` changed is a new revision by definition and must bump its
-   `version` with a new entry the same way.
+   date, a message, and its breaking bit. A part whose `uid` changed is a
+   new revision by definition and must bump its `version` with a new entry
+   the same way.
 
     python scripts/check_versioning.py [--base <ref>]
 
@@ -129,12 +127,6 @@ def check_change_stamps(manifest, prev):
         cur = [json.dumps(line, sort_keys=True) for line in a.get("lines") or []]
         old = [json.dumps(line, sort_keys=True) for line in q.get("lines") or []]
         if collections.Counter(cur) == collections.Counter(old):
-            continue
-        # Filling in a stub/partial assembly -- only adding lines, every old
-        # line untouched -- records what was always physically there and is
-        # not a design change. Anything removed or altered is one.
-        additive = not (collections.Counter(old) - collections.Counter(cur))
-        if additive and q.get("status") in ("stub", "partial"):
             continue
         bad += [f"assembly {b}" for b in stamp_missing(a, q, "lines changed")]
     return bad

--- a/parts-calculator/src/lib/components/AssemblyDetail.svelte
+++ b/parts-calculator/src/lib/components/AssemblyDetail.svelte
@@ -48,14 +48,6 @@
 		onAssembly?: (id: string) => void;
 	} = $props();
 
-	// Same wording as the tree: the data records that a node is incomplete, never
-	// which pieces are missing, so the tooltip claims nothing more than that.
-	const STATUS_NOTE = {
-		stub: 'Placeholder — nothing has been recorded inside this assembly yet. What it actually contains is not captured anywhere in the data.',
-		partial:
-			'Some of this assembly is recorded, but not all of it. The parts and hardware shown are real; the list is known to be missing pieces, and the data does not say which.'
-	};
-
 	/** Printed parts reachable below an assembly, id -> count, quantities
 	 *  multiplied down. Depth-capped rather than cycle-checked: authored data has
 	 *  no cycles, and a `seen` set would undercount a part used in two branches. */
@@ -180,15 +172,6 @@
 		<div class="mt-2 flex flex-wrap items-center gap-2">
 			<span class="font-mono text-xs text-text">{assembly.uid}</span>
 			{#if assembly.version}<span class="text-xs text-text-muted">v{assembly.version}</span>{/if}
-			{#if assembly.status === 'stub'}
-				<span
-					class="cursor-help border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
-					title={STATUS_NOTE.stub}>stub — not yet detailed</span>
-			{:else if assembly.status === 'partial'}
-				<span
-					class="cursor-help border border-warning/50 bg-warning/[0.08] px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-warning-dark"
-					title={STATUS_NOTE.partial}>partial</span>
-			{/if}
 			<ChangeStatus kind="assemblies" id={assembly.id} name={assembly.name} />
 		</div>
 

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -492,7 +492,6 @@
 			"version": "1",
 			"name": "Light post",
 			"description": "The feeder light post: post, cap, and cap adapter. 2 per machine. Bolts to a C-channel NEMA bracket.",
-			"status": "partial",
 			"docs": "/hardware/assembly/feeder/light-post/",
 			"joining": [
 				{
@@ -534,7 +533,6 @@
 			"name": "External distribution-frame bracket",
 			"description": "Three parts that bolt together into one external bracket. 6 per distribution frame (per layer). The cover clips on and takes no screws. The top interface uses only the side and cover from this set, no bottom vertical, see the interface assembly.",
 			"docs": "/hardware/helpers/external-bracket/",
-			"status": "partial",
 			"joining": [
 				{
 					"method": "self-tap",
@@ -567,7 +565,6 @@
 			"name": "Fixed upper section",
 			"description": "The interface's fixed upper section: the upper-fixed-section plate, its ribs (5 plain + 1 with the limit-switch gap), and the big spacer. 1 per interface. Each rib takes 2 \u00d7 [[hw:scr-m5-16-shcs]] into the plate; the screw that ties it to its bracket's extrusion belongs to the interface above.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"joining": [
 				{
 					"method": "self-tap",
@@ -604,7 +601,6 @@
 			"name": "Cable clamp",
 			"description": "Inner + outer ribbon cable clamp; the two halves clamp together around the cable and the pair bolts to the top interface chute mount.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "cable-clamp-inner",
@@ -631,7 +627,6 @@
 			"name": "Classification chamber",
 			"description": "The classification chamber: the dome, the finned rotor, and the camera & LED insert. All three print white, so the chamber bounces light onto the part instead of absorbing it.",
 			"docs": "/hardware/assembly/feeder/classification-chamber/",
-			"status": "partial",
 			"versions": [
 				{
 					"version": "1",
@@ -643,7 +638,7 @@
 					"version": "2",
 					"uid": "fyqw",
 					"date": "2026-08-31",
-					"message": "First recorded line: the finned rotor unit (rotor + bolted-on Output gear (130T)). Marked partial \u2014 the dome and the camera & LED insert are still unrecorded.",
+					"message": "First recorded line: the finned rotor unit (rotor + bolted-on Output gear (130T)); the dome and the camera & LED insert were still unrecorded.",
 					"breaking": false,
 					"commit": null
 				}
@@ -673,7 +668,6 @@
 			"version": "1",
 			"name": "Chute bearing assembly",
 			"description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 \u00d7 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "bearing-race",
@@ -712,7 +706,6 @@
 			"name": "Servo adapter (MG995)",
 			"description": "MG995 servo adapter: servo side + flap side, clamping the MG995 Servo Horn (comes with the servo) between them. 4 M3 x 8 countersunk hold the two halves together, no heat inserts.",
 			"docs": "/hardware/assembly/distribution/chute/door-module/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "servo-adapter-servo-side",
@@ -739,7 +732,6 @@
 			"name": "Servo assembly (MG995)",
 			"description": "The MG995 servo in its bracket: lower arm, side arm, cover, housing. Bolts to the chute core's two arm inserts as a unit.",
 			"docs": "/hardware/assembly/distribution/chute/mg995-servo/servo-mount/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "servo-bracket-lower-arm",
@@ -777,7 +769,6 @@
 			"version": "1",
 			"name": "Overhead camera mount",
 			"description": "Camera mount for the C-channels. 2 per machine, each hanging off two ~1 ft steel rods.",
-			"status": "partial",
 			"docs": "/hardware/assembly/feeder/camera-mount/",
 			"lines": [
 				{
@@ -821,7 +812,6 @@
 			"name": "Layer connector",
 			"description": "Pair of connectors. 1 of each per layer + 1 of each per bottom interface.",
 			"docs": "/hardware/assembly/distribution/chute/layer-connectors/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "layer-connector-1",
@@ -840,7 +830,6 @@
 			"name": "Chute limit switch",
 			"description": "Interface limit switch: printed dowel pin, housing, hammer, and the switch itself. Bolts to the interface frame as a unit.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "limit-switch-dowel-pin",
@@ -920,7 +909,6 @@
 			"name": "Cable cage",
 			"description": "Six cable cage brackets (5 regular + 1 cable mount) stacked with the ribbon cable clamp. Also sandwiches the laser-cut cage top and bottom plates, which are not in the parts registry yet.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "interface-cage-bracket",
@@ -955,7 +943,6 @@
 			"name": "Meanwell 24V PSU box",
 			"description": "Enclosure for the Meanwell 24V power supply: back mount, connections plate, and cap, screwed to the supply's own case.",
 			"docs": "/hardware/electronics/installation/psu-box/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "meanwell-psu-back-mount",
@@ -1048,7 +1035,6 @@
 			"version": "2",
 			"name": "Camera extension",
 			"description": "Classification-channel camera extension for the 4K camera module: the 50 mm extension tube, its mount, and the camera. 1 per machine.",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "camera-extension",
@@ -1118,7 +1104,6 @@
 			"name": "Pico with headers",
 			"description": "The Raspberry Pi Pico with 2.54 mm header pins fitted, so it can seat in the PCB. The board ships bare \u2014 the pins are a separate purchase.",
 			"docs": "/hardware/helpers/pico-headers/",
-			"status": "partial",
 			"joining": [
 				{
 					"method": "solder",
@@ -1143,7 +1128,6 @@
 			"name": "Sorter V2",
 			"description": "The whole machine: feeder on top, interface, the distribution layers between the interfaces, and the bottom interface.",
 			"docs": "/hardware/assembly/",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "feeder",
@@ -1208,7 +1192,6 @@
 			"version": "1",
 			"name": "Superstructure",
 			"description": "What the feeder and the electronics mount onto: the top plate, the top interface, the distribution layers between the interfaces, and the bottom interface.",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "top-plate",
@@ -1252,7 +1235,6 @@
 			"name": "Feeder",
 			"description": "Everything above the top interface: the bulk bucket, C-channels 2 and 3, and the classification chamber.",
 			"docs": "/hardware/assembly/feeder/",
-			"status": "partial",
 			"versions": [
 				{
 					"version": "1",
@@ -1365,7 +1347,6 @@
 			"version": "1",
 			"name": "Channel 3 support",
 			"description": "One of C-channel 3's three standoffs: a foot and the leg the channel dovetails onto.",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "foot",
@@ -1392,7 +1373,6 @@
 			"version": "1",
 			"name": "Channel 2 support",
 			"description": "One of C-channel 2's three standoffs: a foot, one leg extension, and the leg the channel dovetails onto.",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "foot",
@@ -1430,7 +1410,6 @@
 			"version": "1",
 			"name": "Bulk bucket support",
 			"description": "One of the bulk bucket's three standoffs \u2014 the tallest stack: a foot, two leg extensions, and the leg.",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "foot",
@@ -1475,7 +1454,6 @@
 			"version": "1",
 			"name": "Bulk bucket C-channel",
 			"description": "The top feeder unit: a C-channel drive with a white faceted rotor, capped by the Bulk cap instead of an output guide and with no light post, standing on the tallest supports.",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "bulk-bucket-support",
@@ -1510,7 +1488,6 @@
 			"version": "1",
 			"name": "C-channel 2",
 			"description": "The middle feeder channel: a C-channel drive with a white faceted rotor, an output guide and a light post, standing on three supports with one leg extension each.",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "channel-two-support",
@@ -1553,7 +1530,6 @@
 			"version": "1",
 			"name": "C-channel 3",
 			"description": "The lowest feeder channel, just above the classification chamber: a C-channel drive with the gray faceted rotor, an output guide and a light post, on three foot-and-leg supports.",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "channel-three-support",
@@ -1596,7 +1572,6 @@
 			"version": "1",
 			"name": "Camera & LED insert assembly",
 			"description": "The Camera & LED insert print with the camera extension assembled into it; the loaded insert drops into the classification dome.",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "camera-led-insert",
@@ -1628,7 +1603,6 @@
 			"name": "Top interface",
 			"description": "The interface between the feeder and the distribution layers. Its lazy Susan sandwiches the upper fixed section and the chute mount, 4 \u00d7 [[hw:scr-m4-12-cs]] a side, and the plywood top plate bolts down onto the six brackets' inserts.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "interface-bracket-mount",
@@ -2068,7 +2042,6 @@
 			"name": "Distribution layer",
 			"description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "layer-frame",
@@ -2149,7 +2122,6 @@
 			"name": "Bottom interface",
 			"description": "The bottom interface / lazy Susan level. The chute above it is one of the machine's N regular chutes, already counted there; this assembly only adds the layer connector that bridges down to it.",
 			"docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "layer-frame",
@@ -2172,7 +2144,6 @@
 			"name": "Chute",
 			"description": "One chute: the core plus its door module, funnel brackets, connectors, and PCB. Every screw here lands in one of the chute core's 18 M3 inserts.",
 			"docs": "/hardware/assembly/distribution/chute/chute-core/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "chute-core",
@@ -2215,7 +2186,6 @@
 			"name": "Flap module",
 			"description": "The chute's flap: the door itself, the bearing assembly it swings on, and the servo that drives it.",
 			"docs": "/hardware/assembly/distribution/chute/door-module/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "chute-door",
@@ -2242,7 +2212,6 @@
 			"name": "Chute PCB",
 			"description": "The layer adapter board, screwed onto the chute core's four PCB inserts.",
 			"docs": "/hardware/assembly/distribution/chute/pcb/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "layer-adapter-board-basically",
@@ -2261,7 +2230,6 @@
 			"name": "C-channel drive",
 			"description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
 			"docs": "/hardware/assembly/feeder/c-channel/",
-			"status": "partial",
 			"versions": [
 				{
 					"version": "1",
@@ -2616,7 +2584,6 @@
 			"name": "Chute Stepper Gearing",
 			"description": "The printed drive and idler gearing that transfers motion from the NEMA 23 chute stepper. The idler gear's 608 2RS bearing is retained by two printed caps: [[hw:chute-stepper-idler-bearing-retainer-outer]] bolts over the bearing pocket on 4 \u00d7 [[hw:scr-m3-8-cs]] into the gear's own heat inserts (the same screw the Interface spur gear uses two lines up), and [[hw:chute-stepper-idler-bearing-retainer-inner]] caps the bore where 1 \u00d7 [[hw:scr-m3-35-bhcs]] still runs through into the bracket. The low head on the M3\u00d735 keeps it clear of the limit switch hammer.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "interface-nema23-bracket",
@@ -2671,7 +2638,6 @@
 			"name": "Chute stepper NEMA 23 mount",
 			"description": "The NEMA 23 stepper on its interface bracket. 1 per interface.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "interface-nema23-bracket",
@@ -2694,7 +2660,6 @@
 			"name": "Chute stepper drive gear",
 			"description": "The chute stepper drive gear with its 8 mm bore timing pulley. 1 per interface.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "interface-spur-gear",
@@ -2717,7 +2682,6 @@
 			"name": "Interface chute gear + mount",
 			"description": "The Chute gear screwed onto the Top interface chute mount with five M3x12 countersunk screws (top-interface.md step 6). Despite their ids (inherited from an earlier three-piece gear design), these are two distinct parts fastened together, not two sections of one gear.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "top-interface-split-spur-gear-1",
@@ -2975,7 +2939,6 @@
 			"name": "Distribution frame",
 			"description": "The frame of one distribution layer: one hex frame, whose bracket segments form the collars for piece C.",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "hex-frame",
@@ -3050,9 +3013,7 @@
 			"version": "2",
 			"name": "basically Embedded Control Board Housing",
 			"description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base \u2014 no bracket, no standoffs \u2014 and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
-			"section": "electronics",
 			"docs": "/hardware/electronics/installation/control-board-housing/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "ctrl-board-housing-base",
@@ -3187,9 +3148,7 @@
 			"version": "1",
 			"name": "Orange Pi mount",
 			"description": "The Orange Pi 5 standing off its bracket, which bolts to the 2020 extrusion, with a 40 mm fan on a bracket cantilevered over it.",
-			"section": "electronics",
 			"docs": "/hardware/electronics/installation/orange-pi-mount/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "orange-pi-extrusion-mount",
@@ -3243,7 +3202,6 @@
 			"name": "Electronics",
 			"description": "The three boxes that bolt to the frame: the PSU, the control board, and the Orange Pi.",
 			"docs": "/hardware/electronics/installation/",
-			"status": "partial",
 			"lines": [
 				{
 					"assembly": "meanwell-psu-box",
@@ -3266,7 +3224,6 @@
 			"name": "Interface bracket",
 			"description": "One interface bracket with its spacer, bolted onto its vertical extrusion (piece F) and its spoke extrusion (piece E). 6 per interface.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "interface-bracket",
@@ -3337,7 +3294,6 @@
 			"name": "Bottom lazy Susan",
 			"description": "The bottom interface's lazy Susan: the static half, the chute mount that spins on it, the extrusion mounts, and the bearing itself. Bolted through 4 \u00d7 [[hw:scr-m4-12-cs]] a side, same as the top interface's.",
 			"docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
-			"status": "partial",
 			"lines": [
 				{
 					"part": "ls-mount-to-chute",

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -104,9 +104,7 @@ export type AssemblyCandidate = {
 };
 
 /** Assemblies double as (a) legacy flat groupings the parts list rolls up under
- *  and (b) nodes of the experimental machine tree (when they carry `lines`).
- *  status: 'stub' = placeholder with nothing inside yet, 'partial' = some lines
- *  filled in but not everything the real assembly contains. */
+ *  and (b) nodes of the experimental machine tree (when they carry `lines`). */
 export type Assembly = {
 	id: string;
 	uid: string; // the current structure's id, minted like a part's
@@ -116,8 +114,6 @@ export type Assembly = {
 	name: string;
 	description: string;
 	docs?: string; // path on the docs site to the full assembly guide, e.g. /hardware/assembly/...
-	section?: string; // places an empty/stub assembly in the legacy section list
-	status?: 'stub' | 'partial';
 	joining?: Joining[]; // work needed to make these lines into one unit
 	lines?: AssemblyLine[];
 	connections?: Connection[]; // the joints, as edges over this assembly's lines

--- a/parts-calculator/src/lib/parts-csv.ts
+++ b/parts-calculator/src/lib/parts-csv.ts
@@ -120,7 +120,6 @@ const TREE_COLUMNS = [
 	'name',
 	'qty_each',
 	'qty_total',
-	'status',
 	'joining',
 	'grams_each',
 	'download_url',
@@ -146,7 +145,6 @@ export function assemblyCsv(root: string, spec: ExportSpec): string {
 			asm.name,
 			'',
 			mult,
-			asm.status ?? 'complete',
 			(asm.joining ?? []).map((j) => j.method).join('; '),
 			'',
 			'',
@@ -173,7 +171,6 @@ export function assemblyCsv(root: string, spec: ExportSpec): string {
 				each,
 				total,
 				'',
-				'',
 				part ? +part.grams.toFixed(1) : '',
 				part?.stl ?? (lc ? absolute(lc.dxf) : ''),
 				hw?.description ?? part?.description ?? lc?.description ?? ''
@@ -192,7 +189,6 @@ export function assemblyCsv(root: string, spec: ExportSpec): string {
 					'',
 					'',
 					'',
-					'',
 					`Committed to the ${name}`
 				]);
 			}
@@ -201,8 +197,7 @@ export function assemblyCsv(root: string, spec: ExportSpec): string {
 	walk(root, [], 1, 0);
 	return (
 		preamble(spec, 'machine assembly tree', [
-			`# Rows: ${rows.length}. qty_each is per parent; qty_total is per machine.`,
-			'# Branches marked stub/partial are known to be incomplete.'
+			`# Rows: ${rows.length}. qty_each is per parent; qty_total is per machine.`
 		]) + csvText(TREE_COLUMNS, rows)
 	);
 }

--- a/parts-calculator/src/lib/search.ts
+++ b/parts-calculator/src/lib/search.ts
@@ -436,7 +436,7 @@ function buildIndex(): SearchItem[] {
 			kind: 'assembly',
 			scope: 'assemblies',
 			label: 'Assembly',
-			note: a.version ? `v${a.version}` : a.status === 'stub' ? 'stub' : undefined,
+			note: a.version ? `v${a.version}` : undefined,
 			name: a.name,
 			uid: a.uid,
 			id: a.id,

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -2,7 +2,6 @@
 	import {
 		PARTS,
 		SECTIONS,
-		ASSEMBLIES,
 		CHANGES,
 		COLOR_ROLES,
 		SETTINGS,
@@ -420,7 +419,6 @@
 		| { kind: 'group'; groupKind: 'assembly' | 'folder'; id: string; parts: Part[] };
 	function groupBlocks(parts: Part[], sectionId: string): Block[] {
 		const blocks: Block[] = [];
-		const represented = new Set<string>();
 		// The assembly comes from the machine tree (which assembly LISTS this part),
 		// never from a field on the part: one part is used in several assemblies and
 		// a single field cannot say so. Members of a group need not be adjacent in
@@ -435,7 +433,6 @@
 				blocks.push({ kind: 'part', part: p });
 				continue;
 			}
-			if (groupKind === 'assembly') represented.add(groupId);
 			const key = `${groupKind}:${groupId}`;
 			let g = byGroup.get(key);
 			if (!g) {
@@ -445,14 +442,6 @@
 			}
 			g.parts.push(p);
 		}
-		// Stubs are placeholders for assemblies with nothing in them yet. They match
-		// nothing, so while a filter is on they are noise around the thing you asked for.
-		if (!filtering)
-			for (const assembly of ASSEMBLIES) {
-				if (assembly.section === sectionId && assembly.status === 'stub' && !represented.has(assembly.id)) {
-					blocks.push({ kind: 'group', groupKind: 'assembly', id: assembly.id, parts: [] });
-				}
-			}
 		return blocks;
 	}
 	// Assemblies collapse to a single rollup row carrying the part count and the
@@ -967,7 +956,6 @@
 												<span class="pl-name">
 													{group?.name}
 													<Badge variant={block.groupKind === 'folder' ? 'neutral' : 'info'}>{block.groupKind === 'folder' ? 'Folder' : 'Assembly'}</Badge>
-													{#if block.groupKind === 'assembly' && a?.status === 'stub'}<Badge variant="neutral">Coming soon</Badge>{/if}
 													{#if a?.candidates?.some((c) => !c.superseded_by && !c.rejected_at)}<Badge variant="info"><FlaskConical size={11} /> Candidate</Badge>{/if}
 													{#if block.groupKind === 'assembly' && a}<ChangeStatus kind="assemblies" id={a.id} name={a.name} />{/if}
 												</span>

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -81,8 +81,7 @@
 
 	// Experimental view of the unified parts system (notes/UNIFIED-PARTS-SYSTEM.md):
 	// the machine as a recursive assembly tree whose lines reference printed parts,
-	// sub-assemblies, and (eventually) all the COTS hardware. Most nodes are stubs;
-	// the chute core is the first branch carrying real hardware via `requires`.
+	// sub-assemblies, and (eventually) all the COTS hardware.
 	const layers = $derived(layerStore.sizes.length);
 
 	// ---- collapsing the tree -------------------------------------------------
@@ -342,15 +341,6 @@
 		const qs = params.toString().replaceAll('%2C', ',');
 		replaceState(qs ? `${location.pathname}?${qs}` : location.pathname, {});
 	});
-
-	// What the badge means. The tree records that a node is incomplete but not
-	// which pieces are missing, so the tooltip says exactly that much and no
-	// more. Only stubs get a badge: `partial` is true of nearly every assembly
-	// right now, so a badge for it was wallpaper — the status still shows in
-	// the detail view.
-	const STATUS_NOTE = {
-		stub: 'Placeholder — nothing has been recorded inside this assembly yet. What it actually contains is not captured anywhere in the data.'
-	};
 
 	// ---- assembly versions: view any revision, diff any two ------------------
 	// versions[] ends with the current revision; superseded entries carry the
@@ -1171,11 +1161,6 @@
 					{:else if qty !== 1}×{qty}{/if}
 				</span>
 				{@render tagChips(asm.id)}
-				{#if asm.status === 'stub'}
-					<span
-						class="cursor-help border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted"
-						title={STATUS_NOTE.stub}>stub — not yet detailed</span>
-				{/if}
 				<span class="relative ml-auto flex items-center gap-3" data-asm-menu>
 					<!-- The docs site is where the step-by-step build lives; this node is only
 					     the bill of materials for it. Link out when a page exists. -->
@@ -1454,8 +1439,8 @@
 			</div>
 			{#if filtering && matchCount === 0}
 				<p class="px-1 py-6 text-center text-sm text-text-muted">
-					Nothing in the tree matches. Most branches are still stubs — the part may be in the
-					catalog without being placed here yet.
+					Nothing in the tree matches — the part may be in the catalog without being placed
+					here yet.
 				</p>
 			{/if}
 			{#if timeView && viewKeys && !filtering}


### PR DESCRIPTION
## What

Removes the `stub` / `partial` assembly status from the catalog entirely — the field, the rule that depended on it, and every place the site showed it.

## Why

`partial` was a flag on the *record* ("we haven't written down everything inside this assembly yet"), not on the design. 42 of the 48 assemblies carried it — even the bench-confirmed C-channel drive — so it meant nothing except its one consequence: purely additive line changes to a stub/partial assembly were exempt from the version stamp. That exemption let an assembly's contents change without leaving a snapshot to flip back to, which is exactly what the history/time-travel view needs to keep working through the coming C-channel overhaul.

## Changes

- **Data** — `status` dropped from all 42 assemblies in `parts.json`; the schema comment no longer describes it; one historical version message reworded so the word doesn't linger. The legacy `section` field goes too: its only reader was the stub placeholder path on the parts page.
- **Rule** — `check_versioning.py`: any change to an assembly's `lines` (added, removed, replaced, qty) must be stamped. No exemption.
- **Site** — the `partial` chip in the assembly modal, the `stub` badge in the tree, the "Coming soon" badge and stub placeholder rows on the parts page, the search-note fallback, and the `status` column in the assembly CSV.
- **Docs** — `VERSIONING.md` and `CLAUDE.md` describe the rule without the exemption.
- `catalog.generated.json` regenerated (`--metadata-only`); `check_generated_pins` agrees.

## Checks

svelte-check 0 errors · `check_versioning --base origin/main` holds · `check_connections` 28 edges consistent · `check_generated_pins` agrees · verified live: tree and assembly modal render with no status chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
