### PR TITLE
tests: catch 21 stale backend tests up with the code they cover

### DIFF
--- a/software/sorter/backend/perception/tests/test_no_camera_crossover.py
+++ b/software/sorter/backend/perception/tests/test_no_camera_crossover.py
@@ -189,7 +189,10 @@ def test_three_workers_do_not_cross_outputs_when_run_concurrently() -> None:
         rad = math.radians(angle_deg)
         cx = 50.0 + 30.0 * math.cos(rad)
         cy = 50.0 + 30.0 * math.sin(rad)
-        return (int(cx - 5), int(cy - 5), int(cx + 5), int(cy + 5))
+        # The worker infers on the polygon's bounding-rect crop and offsets the
+        # runtime's bboxes back by the crop origin (outer radius 40 -> (10, 10)).
+        ox, oy = 50 - 40, 50 - 40
+        return (int(cx - 5) - ox, int(cy - 5) - oy, int(cx + 5) - ox, int(cy + 5) - oy)
 
     runtimes = {
         2: (bbox_at(90.0),),    # in drop arc

--- a/software/sorter/backend/tests/test_bin_reset_actions.py
+++ b/software/sorter/backend/tests/test_bin_reset_actions.py
@@ -35,6 +35,7 @@ class BinResetActionTests(unittest.TestCase):
             layer_index=0,
             section_index=0,
             bin_index=0,
+            bin_categories=categories,
         )
         runtime_stats.clearBinContents.assert_called_once_with(
             scope="bin",
@@ -71,7 +72,7 @@ class BinResetActionTests(unittest.TestCase):
             section_index=None,
             bin_index=None,
         )
-        clear_mock.assert_called_once_with(scope="layer", layer_index=0)
+        clear_mock.assert_called_once_with(scope="layer", layer_index=0, bin_categories=categories)
         self.assertEqual(
             "Reset all bins on layer 1 and cleared their assignments.",
             result["message"],
@@ -105,6 +106,7 @@ class BinResetActionTests(unittest.TestCase):
             layer_index=0,
             section_index=0,
             bin_index=1,
+            bin_categories=[[[[], []]]],
         )
         runtime_stats.clearBinContents.assert_called_once_with(
             scope="bin",
@@ -139,7 +141,7 @@ class BinResetActionTests(unittest.TestCase):
         self.assertEqual([], layout.layers[0].sections[0].bins[0].category_ids)
         self.assertEqual([], layout.layers[0].sections[0].bins[1].category_ids)
         set_categories_mock.assert_called_once_with([[[[], []]]])
-        clear_mock.assert_called_once_with(scope="all")
+        clear_mock.assert_called_once_with(scope="all", bin_categories=[[[["rule-1"], ["rule-2"]]]])
         runtime_stats.clearBinContents.assert_called_once_with(
             scope="all",
             layer_index=None,

--- a/software/sorter/backend/tests/test_classification_channel_rev01.py
+++ b/software/sorter/backend/tests/test_classification_channel_rev01.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from subsystems.classification_channel.simple_state_machine_rev01.constants import C4_TRAVEL_SIGN
 
 import numpy as np
 
@@ -145,4 +146,4 @@ def test_rev01_discharging_legacy_fallback_fixed_kick_then_idle() -> None:
     # (200 steps/rev * 8 microsteps * 130/12 gear ratio = 17333.33 µsteps/output_rev),
     # -180°/360 * 17333.33 ≈ -8667 microsteps.
     assert next_state == ClassificationChannelState.IDLE
-    assert stepper.moves == [-8667]
+    assert stepper.moves == [int(round(C4_TRAVEL_SIGN * 8667))]

--- a/software/sorter/backend/tests/test_dropzone_incidents.py
+++ b/software/sorter/backend/tests/test_dropzone_incidents.py
@@ -108,15 +108,15 @@ class DropzoneIncidentTests(unittest.TestCase):
         self.assertFalse(ignored.ch2_dropzone_occupied)
         self.assertGreater(ignored.ch2_dropzone_overlap_max, 0.0)
 
-    def test_analyzer_ignores_unconfirmed_tracker_hits_for_exit_signal(self) -> None:
-        gc = SimpleNamespace()
-
+    def test_analyzer_counts_unconfirmed_tracker_hits_for_exit_signal(self) -> None:
+        # A piece parked at the exit (no motion confirmation) must still drive
+        # PULSE_PRECISE rather than being normal-pulsed off the channel.
         unconfirmed = analyzeFeederChannels(
             [_exit_detection(motion_confirmed=False)],
         )
-        self.assertEqual(0.0, unconfirmed.ch2_exit_overlap_max)
-        self.assertFalse(unconfirmed.ch2_exit_center_crossed)
-        self.assertEqual(ChannelAction.PULSE_NORMAL, unconfirmed.ch2_action)
+        self.assertGreater(unconfirmed.ch2_exit_overlap_max, 0.0)
+        self.assertTrue(unconfirmed.ch2_exit_center_crossed)
+        self.assertEqual(ChannelAction.PULSE_PRECISE, unconfirmed.ch2_action)
 
         confirmed = analyzeFeederChannels(
             [_exit_detection(motion_confirmed=True)],

--- a/software/sorter/backend/tests/test_perception_arcs_reverse.py
+++ b/software/sorter/backend/tests/test_perception_arcs_reverse.py
@@ -13,6 +13,7 @@ Precise centre ≈ 175.
 """
 
 import math
+from dataclasses import replace
 
 import numpy as np
 
@@ -21,7 +22,7 @@ from perception.arcs import (
     comInPreciseZone,
     exitComForwardDeg,
 )
-from perception.channel import buildChannelDef
+from perception.channel import REVERSE_TRAVEL_CHANNELS, buildChannelDef
 
 CENTER = (200.0, 200.0)
 RADIUS = 150.0
@@ -39,7 +40,7 @@ def _make_channel(channel_id: int):
     # Full-frame polygon → every bbox center is "on channel"; we are testing the
     # angle math, not the mask.
     poly = np.array([[0, 0], [400, 0], [400, 400], [0, 400]], dtype=np.float64)
-    return buildChannelDef(
+    ch = buildChannelDef(
         channel_id=channel_id,
         polygon=poly,
         frame_shape=(400, 400),
@@ -49,12 +50,17 @@ def _make_channel(channel_id: int):
         precise_arc=(160.0, 190.0),
         arc_center=CENTER,
     )
+    # Force the travel direction under test regardless of the build constant.
+    return replace(ch, reverse=(channel_id == 4))
 
 
 def test_reverse_flag_set_only_for_channel_4() -> None:
-    assert _make_channel(4).reverse is True
-    assert _make_channel(2).reverse is False
-    assert _make_channel(3).reverse is False
+    poly = np.array([[0, 0], [400, 0], [400, 400], [0, 400]], dtype=np.float64)
+    for cid in (2, 3, 4):
+        ch = buildChannelDef(channel_id=cid, polygon=poly, frame_shape=(400, 400),
+                             section_zero_angle=0.0, drop_arc=None, exit_arc=None, precise_arc=None)
+        assert ch.reverse is (cid in REVERSE_TRAVEL_CHANNELS)
+    assert 2 not in REVERSE_TRAVEL_CHANNELS and 3 not in REVERSE_TRAVEL_CHANNELS
 
 
 def test_reverse_exit_gap_measures_to_far_edge() -> None:

--- a/software/sorter/backend/tests/test_secrets_crypto.py
+++ b/software/sorter/backend/tests/test_secrets_crypto.py
@@ -93,16 +93,18 @@ class SecretsCryptoTests(unittest.TestCase):
         assert config is not None
         self.assertEqual("hive-token-xyz", config["targets"][0]["api_token"])
 
-    def test_seed_file_is_created_with_restrictive_mode(self) -> None:
+    def test_seed_is_persisted_in_state_db(self) -> None:
+        import base64
+
         from local_state import set_api_keys
+        from secrets_crypto import _SEED_STATE_KEY
 
         set_api_keys({"openrouter": "kick-off"})
 
-        self.assertTrue(self.seed_path.exists())
-        mode = self.seed_path.stat().st_mode & 0o777
-        # chmod may silently no-op on some filesystems; only assert when it stuck.
-        if mode != 0:
-            self.assertEqual(0o600, mode)
+        raw = self._raw_state_value(_SEED_STATE_KEY)
+        assert raw is not None
+        self.assertGreaterEqual(len(base64.b64decode(raw.strip('"'))), 32)
+        self.assertFalse(self.seed_path.exists())
 
     def test_missing_ciphertext_decrypts_to_empty_string(self) -> None:
         from secrets_crypto import decrypt_str

--- a/software/sorter/backend/tests/test_stepper_endpoint_safety.py
+++ b/software/sorter/backend/tests/test_stepper_endpoint_safety.py
@@ -15,13 +15,16 @@ class _RejectingStepper:
         self.stopped = True
         self.speed_limits: list[tuple[int, int]] = []
 
-    def move_at_speed(self, _speed: int) -> bool:
+    def enable_force(self, value: bool) -> None:
+        self.enabled = bool(value)
+
+    def move_at_speed(self, _speed: int, force: bool = False) -> bool:
         return False
 
     def set_speed_limits(self, min_speed: int, max_speed: int) -> None:
         self.speed_limits.append((int(min_speed), int(max_speed)))
 
-    def move_degrees(self, _degrees: float) -> bool:
+    def move_degrees(self, _degrees: float, acceleration: int | None = None, force: bool = False) -> bool:
         return False
 
 
@@ -76,10 +79,13 @@ def test_move_degrees_halts_if_background_stopped_poll_crashes(monkeypatch) -> N
             self.enabled = False
             self.halted = False
 
+        def enable_force(self, value: bool) -> None:
+            self.enabled = bool(value)
+
         def set_speed_limits(self, min_speed: int, max_speed: int) -> None:
             pass
 
-        def move_degrees(self, _degrees: float) -> bool:
+        def move_degrees(self, _degrees: float, acceleration: int | None = None, force: bool = False) -> bool:
             return True
 
         @property

--- a/software/sorter/backend/tests/test_vision_manager_feeder_dynamic.py
+++ b/software/sorter/backend/tests/test_vision_manager_feeder_dynamic.py
@@ -18,7 +18,7 @@ sys.modules.setdefault("subsystems", subsystems_stub)
 sys.modules.setdefault("subsystems.feeder", feeder_stub)
 sys.modules.setdefault("subsystems.feeder.analysis", analysis_stub)
 
-from vision.vision_manager import VisionManager
+from vision.vision_manager import FeederDynamicOverlayPath, VisionManager
 from vision.detection_registry import DetectionResult
 from vision.tracking.history import PieceHistoryBuffer, SectorSnapshot, TrackSegment
 
@@ -36,6 +36,13 @@ class _OverlayFeed:
 
     def set_pinned_ts_provider(self, provider) -> None:
         self.pinned_ts_provider = provider
+
+
+def _gc() -> SimpleNamespace:
+    return SimpleNamespace(
+        logger=SimpleNamespace(warning=lambda *_a, **_k: None, info=lambda *_a, **_k: None),
+        runtime_stats=SimpleNamespace(observePerfMs=lambda *_a, **_k: None),
+    )
 
 
 class VisionManagerFeederDynamicTests(unittest.TestCase):
@@ -68,6 +75,9 @@ class VisionManagerFeederDynamicTests(unittest.TestCase):
         vm._feeder_dynamic_detection_cache = {}
         vm._per_channel_detectors = {}
         vm._per_channel_analysis = {}
+        vm._path_config = SimpleNamespace(
+            feeder_dynamic_overlay_path=FeederDynamicOverlayPath.TRACKS
+        )
 
         VisionManager._initOverlays(vm)
 
@@ -112,6 +122,7 @@ class VisionManagerFeederDynamicTests(unittest.TestCase):
             )
         )
 
+        vm.gc = _gc()
         result = VisionManager._getFeederDynamicDetection(vm, "carousel", force=False)
 
         self.assertIsNone(result)
@@ -121,13 +132,20 @@ class VisionManagerFeederDynamicTests(unittest.TestCase):
     def test_get_feeder_dynamic_detection_updates_tracker_from_same_frame_cache(self) -> None:
         vm = VisionManager.__new__(VisionManager)
         frame = SimpleNamespace(timestamp=123.0, raw=np.zeros((8, 8, 3), dtype=np.uint8))
-        detection = SimpleNamespace(bboxes=[(1, 1, 4, 4)], score=0.9)
+        detection = DetectionResult(
+            bbox=(1, 1, 4, 4),
+            bboxes=((1, 1, 4, 4),),
+            score=0.9,
+            algorithm="gemini_sam",
+            found=True,
+        )
         updates: list[tuple[str, object, float]] = []
 
         vm.getCaptureThreadForRole = lambda role: SimpleNamespace(latest_frame=frame)
         vm.getFeederDetectionAlgorithm = lambda role=None: "gemini_sam"
         vm._getCachedFeederDynamicDetection = lambda role, timestamp: detection
         vm._computeFeederGeminiDetection = lambda role, current_frame, force_call=False: None
+        vm._filterFeederDetectionResultToChannel = lambda role, current_detection: current_detection
         vm._feeder_dynamic_detection_cache = {"c_channel_2": (123.0, detection)}
         vm._feeder_track_cache = {}
         vm._updateFeederTracker = (
@@ -135,6 +153,7 @@ class VisionManagerFeederDynamicTests(unittest.TestCase):
                 (role, current_detection, float(timestamp))
             )
         )
+        vm.gc = _gc()
 
         result = VisionManager._getFeederDynamicDetection(vm, "c_channel_2", force=False)
 
@@ -160,7 +179,9 @@ class VisionManagerFeederDynamicTests(unittest.TestCase):
         vm._feeder_dynamic_detection_cache = {}
         vm._filterFeederDetectionResultToChannel = lambda role, current_detection: current_detection
         vm._runHiveDetection = (
-            lambda algorithm, raw, scope, role: infer_calls.append((algorithm, scope, role))
+            lambda algorithm, raw, scope, role, conf_threshold=None: infer_calls.append(
+                (algorithm, scope, role)
+            )
             or detection
         )
         vm._updateFeederTracker = (
@@ -168,6 +189,7 @@ class VisionManagerFeederDynamicTests(unittest.TestCase):
                 (role, current_detection, float(timestamp))
             )
         )
+        vm.gc = _gc()
 
         result = VisionManager._getFeederDynamicDetection(vm, "c_channel_2", force=False)
 
@@ -229,14 +251,16 @@ class VisionManagerFeederDynamicTests(unittest.TestCase):
         vm._getCarouselDynamicDetection = (
             lambda force=False: carousel_calls.append(1) or None
         )
-        vm.gc = SimpleNamespace(logger=SimpleNamespace(warning=lambda *_a, **_k: None))
+        vm.gc = _gc()
+        vm._aux_detection_pool = None
 
         VisionManager._refreshAuxiliaryDetections(vm)
 
         # Dynamic roles fan out; mog2 role is skipped.
         self.assertEqual(["c_channel_2", "carousel"], feeder_calls)
-        # Carousel hive driven independently of the feeder fan-out.
-        self.assertEqual([1], carousel_calls)
+        # "carousel" is already a feeder-tracker role, so the dedicated carousel
+        # path is NOT dispatched (its inference is mirrored from the feeder call).
+        self.assertEqual([], carousel_calls)
 
     def test_filter_feeder_detection_result_discards_bboxes_outside_channel_mask(self) -> None:
         vm = VisionManager.__new__(VisionManager)
@@ -310,6 +334,7 @@ class VisionManagerFeederDynamicTests(unittest.TestCase):
     def test_channel_info_for_role_falls_back_to_saved_polygon_when_detector_missing(self) -> None:
         vm = VisionManager.__new__(VisionManager)
         vm._per_channel_detectors = {}
+        vm._channel_info_cache = {}
         vm._channel_angles = {"classification_channel": 12.5}
         vm._channelPolygonKeyForRole = lambda role: "classification_channel"
         vm._channelAngleKeyForPolygonKey = lambda key: "classification_channel"


### PR DESCRIPTION
Tests only. On `main` the backend suite currently fails 21 tests that assert behaviour the code no longer has (the tests were never updated alongside the changes). This brings them in line; no production code touched.

Suite on `main`: 21 failed / 698 passed. With this PR: 719 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)