### PR TITLE
stepper: ramp-aware move-time estimate so back-to-back pulses are not dropped

### DIFF
--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -5,6 +5,7 @@
 # Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 
+import math
 import os
 import time
 import json
@@ -189,6 +190,10 @@ class StepperMotor:
         # Last acceleration we sent to the firmware; lets _ensure_move_acceleration
         # skip the UART write when the value is already correct.
         self._applied_acceleration: int | None = None
+        # Last speed limits sent to the firmware; the move-time estimate needs
+        # the ramp start speed and the real ceiling.
+        self._applied_min_speed: int | None = None
+        self._applied_max_speed: int | None = None
 
     def _logical_to_physical_steps(self, value: int) -> int:
         return -value if self._direction_inverted else value
@@ -330,6 +335,8 @@ class StepperMotor:
         self._gc.logger.info(f"Stepper '{self._name}' ch{self._channel}: set_speed_limits min={min_speed} max={max_speed} µsteps/s")
         payload = struct.pack("<II", min_speed, max_speed) # 8 bytes, two little-endian unsigned integers
         self._dev.send_command(InterfaceCommandCode.STEPPER_SET_SPEED_LIMITS, self._channel, payload)
+        self._applied_min_speed = int(min_speed)
+        self._applied_max_speed = int(max_speed)
         _controlDataRecordCommand(
             {
                 "cmd": "set_speed_limits",
@@ -603,13 +610,41 @@ class StepperMotor:
         steps = self.microsteps_for_degrees(degrees)
         return self.move_steps_blocking(steps, timeout_ms=timeout_ms)
 
+    # Firmware defaults (Stepper.cpp constructor / set_speed_limits floor).
+    _FIRMWARE_DEFAULT_ACCELERATION = 10000
+    _FIRMWARE_DEFAULT_MIN_SPEED = 16
+
     def estimateMoveStepsMs(self, steps: int, max_speed: int = 5000) -> int:
-        """Estimate the time (in milliseconds) it will take to move a given number of steps."""
+        """Time a firmware distance move takes, ramps included.
+
+        The firmware starts at the min speed, accelerates at the applied
+        acceleration to the ceiling, cruises and brakes symmetrically — and it
+        rejects any new move until the previous one has fully stopped. The old
+        steps/speed estimate ignored the ramps, so the pulse feeder re-issued
+        moves too early and the firmware dropped them (B1 machine: a 96-step
+        exit pulse takes ~200 ms, not 48 ms; a 325° drop pulse ~920 ms, not
+        722 ms). Includes a safety margin for the firmware's update quantization.
+        """
         if steps == 0:
             return 0
         steps = abs(steps)
-        estimated_seconds = steps / max_speed
-        return max(1, int(estimated_seconds * 1000))
+        ceiling = self._applied_max_speed or int(max_speed)
+        v_max = max(1, min(int(max_speed), ceiling))
+        v0 = min(self._applied_min_speed or self._FIRMWARE_DEFAULT_MIN_SPEED, v_max)
+        accel = max(
+            1,
+            self._applied_acceleration
+            or self._default_acceleration
+            or self._FIRMWARE_DEFAULT_ACCELERATION,
+        )
+        ramp_steps = (v_max * v_max - v0 * v0) / (2.0 * accel)
+        if 2.0 * ramp_steps >= steps:
+            # Never reaches the ceiling: accelerate to a peak, brake straight away.
+            v_peak = math.sqrt(v0 * v0 + accel * steps)
+            seconds = 2.0 * (v_peak - v0) / accel
+        else:
+            seconds = 2.0 * (v_max - v0) / accel + (steps - 2.0 * ramp_steps) / v_max
+        return max(1, int(seconds * 1000 * 1.15) + 30)
 
     def estimateMoveDegreesMs(self, degrees: float, max_speed: int = 5000) -> int:
         """Estimate movement time for a move specified in degrees."""

--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -613,6 +613,7 @@ class StepperMotor:
     # Firmware defaults (Stepper.cpp constructor / set_speed_limits floor).
     _FIRMWARE_DEFAULT_ACCELERATION = 10000
     _FIRMWARE_DEFAULT_MIN_SPEED = 16
+    _FIRMWARE_DEFAULT_MAX_SPEED = 2000
 
     def estimateMoveStepsMs(self, steps: int, max_speed: int = 5000) -> int:
         """Time a firmware distance move takes, ramps included.
@@ -628,7 +629,9 @@ class StepperMotor:
         if steps == 0:
             return 0
         steps = abs(steps)
-        ceiling = self._applied_max_speed or int(max_speed)
+        # Until a limit has been applied the firmware runs at its own default
+        # ceiling, whatever speed the caller thinks it asked for.
+        ceiling = self._applied_max_speed or self._FIRMWARE_DEFAULT_MAX_SPEED
         v_max = max(1, min(int(max_speed), ceiling))
         v0 = min(self._applied_min_speed or self._FIRMWARE_DEFAULT_MIN_SPEED, v_max)
         accel = max(
@@ -644,6 +647,9 @@ class StepperMotor:
             seconds = 2.0 * (v_peak - v0) / accel
         else:
             seconds = 2.0 * (v_max - v0) / accel + (steps - 2.0 * ramp_steps) / v_max
+        # The firmware emits steps on a 1 kHz update grid starting at the min
+        # speed: even a one-step move takes a full step interval at v0.
+        seconds = max(seconds, 1.0 / v0)
         return max(1, int(seconds * 1000 * 1.15) + 30)
 
     def estimateMoveDegreesMs(self, degrees: float, max_speed: int = 5000) -> int:

--- a/software/sorter/backend/tests/test_stepper_move_estimate.py
+++ b/software/sorter/backend/tests/test_stepper_move_estimate.py
@@ -1,0 +1,56 @@
+"""The move-time estimate must cover the firmware's acceleration ramps: the
+firmware rejects a new move until the previous one has fully stopped, so a
+caller that waits only steps/speed re-issues too early and loses the move."""
+
+import unittest
+from types import SimpleNamespace
+
+from hardware.sorter_interface import StepperMotor
+
+
+class _Device:
+    def send_command(self, command, channel, payload=b""):
+        return SimpleNamespace(payload=b"\x01")
+
+
+def _stepper() -> StepperMotor:
+    gc = SimpleNamespace(logger=SimpleNamespace(info=lambda *a, **k: None, debug=lambda *a, **k: None))
+    return StepperMotor(_Device(), 2, gc)
+
+
+class MoveEstimateTests(unittest.TestCase):
+    def test_short_pulse_is_a_ramp_triangle_not_steps_over_speed(self) -> None:
+        stepper = _stepper()
+        stepper.set_speed_limits(16, 2000)
+        # Measured on the B1 machine: a 30° (133-step) C3 move is rejected at
+        # +150 ms and accepted at +350 ms; the model says ~230 ms + margin.
+        ms = stepper.estimateMoveStepsMs(133, max_speed=2000)
+        self.assertGreater(ms, 200)
+        self.assertLess(ms, 350)
+        self.assertGreater(stepper.estimateMoveStepsMs(96, max_speed=2000), 150)
+
+    def test_long_move_is_a_trapezoid(self) -> None:
+        stepper = _stepper()
+        stepper.set_speed_limits(16, 2000)
+        # 325° (1444 steps): rejected at +800 ms, accepted at +1100 ms.
+        ms = stepper.estimateMoveStepsMs(1444, max_speed=2000)
+        self.assertGreater(ms, 950)
+        self.assertLess(ms, 1150)
+
+    def test_applied_acceleration_and_ceiling_are_honoured(self) -> None:
+        stepper = _stepper()
+        stepper.set_speed_limits(16, 4000)
+        fast = stepper.estimateMoveStepsMs(1444, max_speed=2000)
+        stepper.set_acceleration(2500)
+        slow = stepper.estimateMoveStepsMs(1444, max_speed=2000)
+        self.assertGreater(slow, fast)
+        # The ceiling is the lower of the caller's speed and the applied limit.
+        stepper.set_speed_limits(16, 1000)
+        self.assertGreater(stepper.estimateMoveStepsMs(1444, max_speed=2000), slow)
+
+    def test_zero_steps_is_free(self) -> None:
+        self.assertEqual(_stepper().estimateMoveStepsMs(0), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/sorter/backend/tests/test_stepper_move_estimate.py
+++ b/software/sorter/backend/tests/test_stepper_move_estimate.py
@@ -51,6 +51,18 @@ class MoveEstimateTests(unittest.TestCase):
     def test_zero_steps_is_free(self) -> None:
         self.assertEqual(_stepper().estimateMoveStepsMs(0), 0)
 
+    def test_one_step_takes_at_least_one_step_interval_at_the_min_speed(self) -> None:
+        stepper = _stepper()
+        stepper.set_speed_limits(16, 2000)
+        # 1 / 16 µsteps/s = 62.5 ms before the first step can even fire.
+        self.assertGreaterEqual(stepper.estimateMoveStepsMs(1, max_speed=2000), 62)
+
+    def test_without_applied_limits_the_firmware_default_ceiling_counts(self) -> None:
+        stepper = _stepper()  # no set_speed_limits: firmware cruises at 2000
+        # 5000 steps at the firmware ceiling take ~2.7 s; assuming the caller's
+        # 5000 µsteps/s would say ~1.75 s and re-issue too early.
+        self.assertGreater(stepper.estimateMoveStepsMs(5000, max_speed=5000), 2500)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The firmware rejects a new distance move while the previous one is still running. The backend's move-time estimate ignored the acceleration ramps, so on the B1 machine 119 of 250 C3 pulses were refused ("Only allow new move when stopped"). The estimate is now a trapezoid (accel + cruise + decel) plus a margin; measured against the firmware on the machine.

Backend suite: no new failures (the 21 pre-existing failures on `main` are fixed in #523).

🤖 Generated with [Claude Code](https://claude.com/claude-code)