### PR TITLE
firmware: software StallGuard for boards without a wired DIAG pin

### DIFF
--- a/software/firmware/sorter_interface_firmware/Stepper.cpp
+++ b/software/firmware/sorter_interface_firmware/Stepper.cpp
@@ -32,7 +32,7 @@ Stepper::Stepper(int step_pin, int dir_pin)
       _mc_dir(1), _mc_home_pin(-1),
     _steps_moved(0), _steps_frac(0), _brake_distance(0),
     _current_speed(0), _current_speed_frac(0), _current_dir(1),
-    _jitter_active(false), _jitter_amplitude(0), _jitter_strokes_remaining(0), _jitter_dir(1) {
+    _jitter_active(false), _stall_request(false), _jitter_amplitude(0), _jitter_strokes_remaining(0), _jitter_dir(1) {
 }
 
 void Stepper::initialize() {
@@ -274,8 +274,13 @@ void Stepper::motion_update_tick() {
     // stop immediately — the backend poll then raises an operator incident.
     // Skip while jittering: the unstick wiggle is *meant* to fight load, and a
     // stall during it is expected, not a fault.
-    if (_stall_enabled.load() && _stall_pin >= 0 && _state.load() != STEPPER_STOPPED &&
-        !_jitter_active.load() && gpio_get(_stall_pin)) {
+    // The software StallGuard poll on core 0 only requests the stop (see
+    // latchStall); the transition itself happens here, on the core that owns
+    // the state, so no in-flight transition can undo it.
+    bool software_stall = _stall_request.exchange(false) && _state.load() != STEPPER_STOPPED &&
+                          !_jitter_active.load();
+    if (software_stall || (_stall_enabled.load() && _stall_pin >= 0 && _state.load() != STEPPER_STOPPED &&
+                           !_jitter_active.load() && gpio_get(_stall_pin))) {
         _stalled.store(true);
         _state.store(STEPPER_STOPPED);
         _current_speed.store(0);

--- a/software/firmware/sorter_interface_firmware/Stepper.h
+++ b/software/firmware/sorter_interface_firmware/Stepper.h
@@ -77,6 +77,20 @@ public:
     }
     bool wasStalled() { return _stalled.load(); }
     void clearStall() { _stalled.store(false); }
+    // Software StallGuard for boards without a wired DIAG pin (SKR Pico): core0
+    // polls SG_RESULT/TSTEP over UART while the motor runs and calls
+    // latchStall() when the driver reports the condition that would raise DIAG.
+    bool stallDetectionEnabled() { return _stall_enabled.load(); }
+    bool hasStallPin() { return _stall_pin >= 0; }
+    bool isRunningForStallCheck() {
+        return _state.load() != STEPPER_STOPPED && !_jitter_active.load();
+    }
+    void latchStall() {
+        _stalled.store(true);
+        _state.store(STEPPER_STOPPED);
+        _current_speed.store(0);
+        _current_speed_frac.store(0);
+    }
 
 private:
     void beginJitterStroke();

--- a/software/firmware/sorter_interface_firmware/Stepper.h
+++ b/software/firmware/sorter_interface_firmware/Stepper.h
@@ -82,8 +82,12 @@ public:
     // latchStall() when the driver reports the condition that would raise DIAG.
     bool stallDetectionEnabled() { return _stall_enabled.load(); }
     bool hasStallPin() { return _stall_pin >= 0; }
-    bool isRunningForStallCheck() {
-        return _state.load() != STEPPER_STOPPED && !_jitter_active.load();
+    // Software StallGuard only samples the cruise phase: SG_RESULT reads near
+    // zero while a stepper ramps (measured 4 on the B1 chute at 10000 µsteps/s²),
+    // which would look like a stall. Homing cruises too, but below the
+    // TCOOLTHRS velocity floor, so the poll skips it by TSTEP.
+    bool isCruisingForStallCheck() {
+        return _state.load() == STEPPER_CRUISING && !_jitter_active.load();
     }
     void latchStall() {
         _stalled.store(true);

--- a/software/firmware/sorter_interface_firmware/Stepper.h
+++ b/software/firmware/sorter_interface_firmware/Stepper.h
@@ -89,12 +89,13 @@ public:
     bool isCruisingForStallCheck() {
         return _state.load() == STEPPER_CRUISING && !_jitter_active.load();
     }
-    void latchStall() {
-        _stalled.store(true);
-        _state.store(STEPPER_STOPPED);
-        _current_speed.store(0);
-        _current_speed_frac.store(0);
-    }
+    // Called from core 0 (the UART poll). Only *requests* the stop: the motion
+    // state machine is owned by core 1, and a state stored from core 0 could be
+    // overwritten by a transition core 1 was in the middle of (CRUISING ->
+    // BRAKING -> CRUISING), letting the motor resume after a detected stall.
+    // core 1 consumes the request at the top of its next motion tick.
+    void latchStall() { _stall_request.store(true); }
+    bool stallRequested() { return _stall_request.load(); }
 
 private:
     void beginJitterStroke();
@@ -130,6 +131,7 @@ private:
     // motion tick ever mutate these. core0 stop/move commands are REJECTED while
     // jittering rather than tearing the run down, so there is no cross-core race.
     std::atomic<bool> _jitter_active; // true from start until the last stroke completes
+    std::atomic<bool> _stall_request; // core 0 -> core 1: stop for a software-detected stall
     std::atomic<int32_t> _jitter_amplitude; // microsteps per stroke
     std::atomic<int32_t> _jitter_strokes_remaining; // strokes still to perform (2 per cycle)
     std::atomic<int32_t> _jitter_dir; // direction of the next stroke (1 / -1)

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -239,22 +239,29 @@ static auto tmc_drivers = make_tmc_array(std::make_index_sequence<STEPPER_COUNT>
 // Software StallGuard (boards whose TMC DIAG lines are not wired to the MCU,
 // e.g. the SKR Pico config). The backend configures SGTHRS/TCOOLTHRS over UART
 // exactly as for the DIAG path; we remember the last written values and, while
-// an armed stepper runs, poll TSTEP and SG_RESULT on core0 and latch a stall
+// an armed stepper cruises, poll TSTEP and SG_RESULT on core0 and latch a stall
 // under the same rule the driver applies to DIAG: SG_RESULT <= 2*SGTHRS while
 // TSTEP <= TCOOLTHRS (i.e. above the velocity floor). Two consecutive hits are
 // required so a single noisy read cannot stop a motor.
+//
+// Each poll tick issues exactly one UART read per channel: TSTEP on one tick,
+// SG_RESULT on the next. Two reads back to back fail: the TMC2209 needs the
+// bus idle after its reply before it accepts the next sync byte, and the
+// second read then times out (measured on the B1 chute: TSTEP fine, SG_RESULT
+// failing on ~40 of 44 polls).
 #define TMC_REG_TSTEP 0x12
 #define TMC_REG_TCOOLTHRS 0x14
 #define TMC_REG_SGTHRS 0x40
 #define TMC_REG_SG_RESULT 0x41
-#define SOFT_SG_POLL_INTERVAL_US 5000
+#define SOFT_SG_POLL_INTERVAL_US 2500
 #define SOFT_SG_HITS_TO_LATCH 2
 static uint32_t soft_sg_sgthrs[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_tcoolthrs[STEPPER_COUNT] = {0};
 static uint8_t soft_sg_hits[STEPPER_COUNT] = {0};
+static bool soft_sg_read_sg_next[STEPPER_COUNT] = {false}; // false = TSTEP next, true = SG_RESULT next
 // Debug view of the software poll, exported in GET_OBSERVABILITY.
-static uint32_t soft_sg_polls[STEPPER_COUNT] = {0};     // polls that passed the gating
-static uint32_t soft_sg_latches[STEPPER_COUNT] = {0};
+static uint16_t soft_sg_polls[STEPPER_COUNT] = {0};     // polls that passed the gating (wraps)
+static uint16_t soft_sg_latches[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_last_tstep[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_last_sg[STEPPER_COUNT] = {0};
 static uint8_t soft_sg_gate[STEPPER_COUNT] = {0};       // why the last poll returned early
@@ -356,15 +363,19 @@ int dump_observability(char *buf, size_t buf_size) {
     }
     snprintf(led_gpios_buf + led_len, sizeof(led_gpios_buf) - led_len, "]");
 
+    // Armed channels only (the payload is capped at MAX_PAYLOAD_SIZE): c=channel,
     // p=polls past the gating, l=latches, t/s=last TSTEP/SG_RESULT, g=last early-return reason
     char soft_sg_buf[200];
     int sg_len = snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[");
+    bool first = true;
     for (int i = 0; i < STEPPER_COUNT && sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf); i++) {
+        if (!steppers[i].stallDetectionEnabled()) continue;
         sg_len += snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len,
-                           "%s{\"p\":%lu,\"l\":%lu,\"t\":%lu,\"s\":%lu,\"g\":%u}",
-                           i == 0 ? "" : ",", (unsigned long)soft_sg_polls[i],
-                           (unsigned long)soft_sg_latches[i], (unsigned long)soft_sg_last_tstep[i],
+                           "%s{\"c\":%d,\"p\":%u,\"l\":%u,\"t\":%lu,\"s\":%lu,\"g\":%u}",
+                           first ? "" : ",", i, (unsigned)soft_sg_polls[i],
+                           (unsigned)soft_sg_latches[i], (unsigned long)soft_sg_last_tstep[i],
                            (unsigned long)soft_sg_last_sg[i], (unsigned)soft_sg_gate[i]);
+        first = false;
     }
     if (sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf) - 1) {
         snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len, "]");
@@ -1009,18 +1020,31 @@ static void software_stallguard_poll() {
     if (stepper.hasStallPin()) { soft_sg_gate[i] = 1; soft_sg_hits[i] = 0; return; }
     if (!stepper.stallDetectionEnabled()) { soft_sg_gate[i] = 2; soft_sg_hits[i] = 0; return; }
     if (soft_sg_sgthrs[i] == 0) { soft_sg_gate[i] = 3; soft_sg_hits[i] = 0; return; }
-    if (!stepper.isRunningForStallCheck()) { soft_sg_gate[i] = 4; soft_sg_hits[i] = 0; return; }
-    soft_sg_polls[i]++;
-    uint32_t tstep = 0;
-    if (tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep) != 0) { soft_sg_gate[i] = 5; return; }
-    soft_sg_last_tstep[i] = tstep & 0xFFFFF;
-    if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
-        soft_sg_gate[i] = 6; // below the velocity floor DIAG would be inactive too
+    if (!stepper.isCruisingForStallCheck()) {
+        soft_sg_gate[i] = 4;
         soft_sg_hits[i] = 0;
+        soft_sg_read_sg_next[i] = false;
         return;
     }
+    soft_sg_polls[i]++;
+    // Gate codes 5x/7x carry the UART result: x1 = timeout, x2 = CRC error.
+    if (!soft_sg_read_sg_next[i]) {
+        uint32_t tstep = 0;
+        int rc = tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep);
+        if (rc != 0) { soft_sg_gate[i] = (uint8_t)(50 - rc); return; }
+        soft_sg_last_tstep[i] = tstep & 0xFFFFF;
+        if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
+            soft_sg_gate[i] = 6; // below the velocity floor DIAG would be inactive too
+            soft_sg_hits[i] = 0;
+            return;
+        }
+        soft_sg_read_sg_next[i] = true;
+        return;
+    }
+    soft_sg_read_sg_next[i] = false;
     uint32_t sg_result = 0;
-    if (tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result) != 0) { soft_sg_gate[i] = 7; return; }
+    int rc = tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result);
+    if (rc != 0) { soft_sg_gate[i] = (uint8_t)(70 - rc); return; }
     soft_sg_last_sg[i] = sg_result & 0x3FF;
     soft_sg_gate[i] = 0;
     if ((sg_result & 0x3FF) <= 2 * soft_sg_sgthrs[i]) {

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -236,6 +236,24 @@ static std::array<TMC2209, STEPPER_COUNT> make_tmc_array(std::index_sequence<I..
 
 static auto tmc_drivers = make_tmc_array(std::make_index_sequence<STEPPER_COUNT>{});
 
+// Software StallGuard (boards whose TMC DIAG lines are not wired to the MCU,
+// e.g. the SKR Pico config). The backend configures SGTHRS/TCOOLTHRS over UART
+// exactly as for the DIAG path; we remember the last written values and, while
+// an armed stepper runs, poll TSTEP and SG_RESULT on core0 and latch a stall
+// under the same rule the driver applies to DIAG: SG_RESULT <= 2*SGTHRS while
+// TSTEP <= TCOOLTHRS (i.e. above the velocity floor). Two consecutive hits are
+// required so a single noisy read cannot stop a motor.
+#define TMC_REG_TSTEP 0x12
+#define TMC_REG_TCOOLTHRS 0x14
+#define TMC_REG_SGTHRS 0x40
+#define TMC_REG_SG_RESULT 0x41
+#define SOFT_SG_POLL_INTERVAL_US 5000
+#define SOFT_SG_HITS_TO_LATCH 2
+static uint32_t soft_sg_sgthrs[STEPPER_COUNT] = {0};
+static uint32_t soft_sg_tcoolthrs[STEPPER_COUNT] = {0};
+static uint8_t soft_sg_hits[STEPPER_COUNT] = {0};
+
+
 template <size_t... I>
 static std::array<Stepper, STEPPER_COUNT> make_stepper_array(std::index_sequence<I...>) {
     return {Stepper(STEPPER_STEP_PINS[I], STEPPER_DIR_PINS[I])...};
@@ -802,16 +820,15 @@ void CMDH_stepper_drv_write_register(const BusMessage *msg, BusMessage *resp) {
     memcpy(&value, msg->payload + 1, sizeof(value));
     tmc_drivers[msg->channel].writeRegister(reg, value);
     resp->payload_length = 0;
+    if (reg == TMC_REG_SGTHRS) soft_sg_sgthrs[msg->channel] = value;
+    if (reg == TMC_REG_TCOOLTHRS) soft_sg_tcoolthrs[msg->channel] = value;
 }
 
 void CMDH_stepper_enable_stall_detection(const BusMessage *msg, BusMessage *resp) {
     bool enable = msg->payload[0] != 0;
-    if (enable && STEPPER_DIAG_PINS[msg->channel] < 0) {
-        resp->command = msg->command | 0x80; // Set error bit
-        resp->payload_length =
-            snprintf((char *)resp->payload, MAX_PAYLOAD_SIZE, "No DIAG pin for channel %u", msg->channel);
-        return;
-    }
+    // Without a DIAG pin the software poll (core0, UART) takes over; it needs
+    // SGTHRS/TCOOLTHRS to have been written first, which the backend does.
+    soft_sg_hits[msg->channel] = 0;
     steppers[msg->channel].enableStallDetection(enable);
     resp->payload_length = 0;
 }
@@ -957,6 +974,38 @@ void core1_entry() {
     }
 }
 
+static void software_stallguard_poll() {
+    static uint64_t next_poll_us = 0;
+    static uint8_t next_channel = 0;
+    uint64_t now = time_us_64();
+    if (now < next_poll_us) return;
+    next_poll_us = now + SOFT_SG_POLL_INTERVAL_US;
+    uint8_t i = next_channel;
+    next_channel = (uint8_t)((next_channel + 1) % STEPPER_COUNT);
+    Stepper &stepper = steppers[i];
+    if (stepper.hasStallPin() || !stepper.stallDetectionEnabled() || soft_sg_sgthrs[i] == 0 ||
+        !stepper.isRunningForStallCheck()) {
+        soft_sg_hits[i] = 0;
+        return;
+    }
+    uint32_t tstep = 0;
+    if (tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep) != 0) return; // UART hiccup: skip this round
+    if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
+        soft_sg_hits[i] = 0; // below the velocity floor DIAG would be inactive too
+        return;
+    }
+    uint32_t sg_result = 0;
+    if (tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result) != 0) return;
+    if ((sg_result & 0x3FF) <= 2 * soft_sg_sgthrs[i]) {
+        if (++soft_sg_hits[i] >= SOFT_SG_HITS_TO_LATCH) {
+            soft_sg_hits[i] = 0;
+            stepper.latchStall();
+        }
+    } else {
+        soft_sg_hits[i] = 0;
+    }
+}
+
 int main() {
     stdio_init_all();
     initialize_hardware();
@@ -976,5 +1025,6 @@ int main() {
             msg_processor.processIncomingData((char)c);
             msg_processor.processQueuedMessage();
         }
+        software_stallguard_poll();
     }
 }

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -252,6 +252,12 @@ static auto tmc_drivers = make_tmc_array(std::make_index_sequence<STEPPER_COUNT>
 static uint32_t soft_sg_sgthrs[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_tcoolthrs[STEPPER_COUNT] = {0};
 static uint8_t soft_sg_hits[STEPPER_COUNT] = {0};
+// Debug view of the software poll, exported in GET_OBSERVABILITY.
+static uint32_t soft_sg_polls[STEPPER_COUNT] = {0};     // polls that passed the gating
+static uint32_t soft_sg_latches[STEPPER_COUNT] = {0};
+static uint32_t soft_sg_last_tstep[STEPPER_COUNT] = {0};
+static uint32_t soft_sg_last_sg[STEPPER_COUNT] = {0};
+static uint8_t soft_sg_gate[STEPPER_COUNT] = {0};       // why the last poll returned early
 
 
 template <size_t... I>
@@ -350,13 +356,30 @@ int dump_observability(char *buf, size_t buf_size) {
     }
     snprintf(led_gpios_buf + led_len, sizeof(led_gpios_buf) - led_len, "]");
 
+    // p=polls past the gating, l=latches, t/s=last TSTEP/SG_RESULT, g=last early-return reason
+    char soft_sg_buf[200];
+    int sg_len = snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[");
+    for (int i = 0; i < STEPPER_COUNT && sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf); i++) {
+        sg_len += snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len,
+                           "%s{\"p\":%lu,\"l\":%lu,\"t\":%lu,\"s\":%lu,\"g\":%u}",
+                           i == 0 ? "" : ",", (unsigned long)soft_sg_polls[i],
+                           (unsigned long)soft_sg_latches[i], (unsigned long)soft_sg_last_tstep[i],
+                           (unsigned long)soft_sg_last_sg[i], (unsigned)soft_sg_gate[i]);
+    }
+    if (sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf) - 1) {
+        snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len, "]");
+    } else {
+        snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[]");
+    }
+
     int n_bytes = snprintf(
         buf,
         buf_size,
-        "{\"hw\":\"%s\",\"diag_pins\":%s,\"led_gpios\":%s}",
+        "{\"hw\":\"%s\",\"diag_pins\":%s,\"led_gpios\":%s,\"soft_sg\":%s}",
         HW_ID,
         diag_pins_len > 0 ? diag_pins_buf : "[]",
-        led_gpios_buf);
+        led_gpios_buf,
+        soft_sg_buf);
 
     if (n_bytes >= 0 && (size_t)n_bytes < buf_size) {
         return n_bytes;
@@ -983,22 +1006,27 @@ static void software_stallguard_poll() {
     uint8_t i = next_channel;
     next_channel = (uint8_t)((next_channel + 1) % STEPPER_COUNT);
     Stepper &stepper = steppers[i];
-    if (stepper.hasStallPin() || !stepper.stallDetectionEnabled() || soft_sg_sgthrs[i] == 0 ||
-        !stepper.isRunningForStallCheck()) {
+    if (stepper.hasStallPin()) { soft_sg_gate[i] = 1; soft_sg_hits[i] = 0; return; }
+    if (!stepper.stallDetectionEnabled()) { soft_sg_gate[i] = 2; soft_sg_hits[i] = 0; return; }
+    if (soft_sg_sgthrs[i] == 0) { soft_sg_gate[i] = 3; soft_sg_hits[i] = 0; return; }
+    if (!stepper.isRunningForStallCheck()) { soft_sg_gate[i] = 4; soft_sg_hits[i] = 0; return; }
+    soft_sg_polls[i]++;
+    uint32_t tstep = 0;
+    if (tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep) != 0) { soft_sg_gate[i] = 5; return; }
+    soft_sg_last_tstep[i] = tstep & 0xFFFFF;
+    if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
+        soft_sg_gate[i] = 6; // below the velocity floor DIAG would be inactive too
         soft_sg_hits[i] = 0;
         return;
     }
-    uint32_t tstep = 0;
-    if (tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep) != 0) return; // UART hiccup: skip this round
-    if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
-        soft_sg_hits[i] = 0; // below the velocity floor DIAG would be inactive too
-        return;
-    }
     uint32_t sg_result = 0;
-    if (tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result) != 0) return;
+    if (tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result) != 0) { soft_sg_gate[i] = 7; return; }
+    soft_sg_last_sg[i] = sg_result & 0x3FF;
+    soft_sg_gate[i] = 0;
     if ((sg_result & 0x3FF) <= 2 * soft_sg_sgthrs[i]) {
         if (++soft_sg_hits[i] >= SOFT_SG_HITS_TO_LATCH) {
             soft_sg_hits[i] = 0;
+            soft_sg_latches[i]++;
             stepper.latchStall();
         }
     } else {

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -369,7 +369,9 @@ int dump_observability(char *buf, size_t buf_size) {
     int sg_len = snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[");
     bool first = true;
     for (int i = 0; i < STEPPER_COUNT && sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf); i++) {
-        if (!steppers[i].stallDetectionEnabled()) continue;
+        // Only the channels the software poll actually serves: a wired-DIAG
+        // channel never polls, and every entry costs ~45 of the 200 bytes.
+        if (!steppers[i].stallDetectionEnabled() || steppers[i].hasStallPin()) continue;
         sg_len += snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len,
                            "%s{\"c\":%d,\"p\":%u,\"l\":%u,\"t\":%lu,\"s\":%lu,\"g\":%u}",
                            first ? "" : ",", i, (unsigned)soft_sg_polls[i],
@@ -392,6 +394,19 @@ int dump_observability(char *buf, size_t buf_size) {
         led_gpios_buf,
         soft_sg_buf);
 
+    if (n_bytes >= 0 && (size_t)n_bytes < buf_size) {
+        return n_bytes;
+    }
+
+    // Too long with the poll counters: keep the hardware facts (id, DIAG pins,
+    // LED GPIOs) and drop only the soft_sg detail rather than everything.
+    n_bytes = snprintf(
+        buf,
+        buf_size,
+        "{\"hw\":\"%s\",\"diag_pins\":%s,\"led_gpios\":%s,\"soft_sg\":[]}",
+        HW_ID,
+        diag_pins_len > 0 ? diag_pins_buf : "[]",
+        led_gpios_buf);
     if (n_bytes >= 0 && (size_t)n_bytes < buf_size) {
         return n_bytes;
     }

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -96,7 +96,7 @@ def _control_board_observability(board: Any) -> Dict[str, Any]:
     observability: Dict[str, Any] = {}
     if interface is not None and hasattr(interface, "get_observability_info"):
         try:
-            observability = dict(interface.get_observability_info())
+            observability = dict(interface.get_observability_info(force_refresh=True))
         except Exception as exc:
             observability = {"error": str(exc)}
     return {


### PR DESCRIPTION
The SKR Pico boards have no usable TMC2209 DIAG pins (the chute's would collide with its home sensor), so StallGuard never worked there. The firmware now polls TSTEP/SG_RESULT over the TMC UART on core0 and latches the same stall flag the DIAG path uses; the backend's stall monitor and incident path are unchanged.

Three commits, in order:
1. the poll itself, gated on the backend's SGTHRS/TCOOLTHRS writes;
2. a compact per-armed-channel debug view in `GET_OBSERVABILITY` (`soft_sg`), which is what made the next fix findable;
3. the fix: the two UART reads must not follow each other back to back (the TMC2209 needs the bus idle after its reply, the second read timed out on ~40 of 44 polls), and the poll samples only the cruise phase, because SG_RESULT reads near zero on ramps.

Verified on the B1 machine: the chute latched on a real jam (SG 10 at cruise) and on the mechanical stop; zero false trips over several hours of sorting. Observability payload stays under the 246-byte cap (worst case measured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)