### PR TITLE
bins: misc can be routed into an explicitly assigned bin

### DIFF
--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -3098,12 +3098,9 @@ def assign_bin_categories(
         category_id = category_id.strip()
         if not category_id or category_id in cleaned:
             continue
-        # MISC is the virtual discard passthrough, never a physical bin.
-        if category_id == MISC_CATEGORY:
-            raise HTTPException(
-                status_code=400,
-                detail="Misc is the discard passthrough and cannot be assigned to a bin.",
-            )
+        # MISC may be routed into a bin only by this explicit assignment; the
+        # positioner never claims a bin for it on its own (without one, misc
+        # passes through to the discard bucket).
         cleaned.append(category_id)
 
     # A category lives in exactly one bin. Drop these category_ids from every

--- a/software/sorter/backend/subsystems/distribution/positioning.py
+++ b/software/sorter/backend/subsystems/distribution/positioning.py
@@ -826,11 +826,7 @@ class Positioning(BaseState):
                         continue
                     count = piece_counts.get((layer_idx, section_idx, bin_idx), 0)
                     is_full = max_per_bin is not None and count >= max_per_bin
-                    if (
-                        category_id != MISC_CATEGORY
-                        and category_id in b.category_ids
-                        and not is_full
-                    ):
+                    if category_id in b.category_ids and not is_full:
                         matching_candidates.append(address)
                         continue
                     if b.category_ids:
@@ -871,10 +867,9 @@ class Positioning(BaseState):
         if matching_candidates:
             return random.choice(matching_candidates), False
 
-        # MISC must never claim or use a real bin. The discard bucket below
-        # the chute (rendered in the UI as the virtual Discard Bin) is what
-        # catches misc passthrough; treating MISC as a physical bin category
-        # silently swaps that behavior.
+        # MISC never claims a bin on its own: unless the operator assigned a
+        # bin to it explicitly (matched above), misc passes through to the
+        # discard bucket below the chute (the UI's virtual Discard Bin).
         if first_unassigned is not None and category_id != MISC_CATEGORY:
             address, b = first_unassigned
             b.category_ids = [category_id]
@@ -906,10 +901,10 @@ class Positioning(BaseState):
 
         if category_id != MISC_CATEGORY and not not_in_inventory:
             # No bin slot available for this category; fall back to MISC,
-            # which will only succeed if the operator pre-assigned a bin
-            # to MISC. Otherwise it returns None and the piece passes
-            # through to the discard bucket. Not-in-inventory pieces never fall
-            # back to a normal MISC bin — they stay in their pool or pass through.
+            # which only lands in a bin the operator assigned to misc.
+            # Otherwise it returns None and the piece passes through to the
+            # discard bucket. Not-in-inventory pieces never fall back to a
+            # misc bin — they stay in their pool or pass through.
             return self._findOrAssignBinForCategory(MISC_CATEGORY)
 
         self.logger.info(

--- a/software/sorter/backend/tests/test_servo_bus_fatal.py
+++ b/software/sorter/backend/tests/test_servo_bus_fatal.py
@@ -247,9 +247,30 @@ class ServoBusFatalTests(unittest.TestCase):
         self.assertEqual("positioning.passthrough_no_bin", positioning._occupancy_state)
         servo.open.assert_called_once()
 
-    def test_misc_assigned_bin_is_ignored_for_bottom_passthrough(self) -> None:
+    def test_misc_routes_to_an_explicitly_assigned_bin(self) -> None:
+        # The operator may assign misc to a bin (e.g. no bucket under the
+        # chute); only then does misc leave the discard passthrough.
         servo = _mk_healthy_servo()
         section = BinSection(bins=[Bin(size=BinSize.MEDIUM, category_ids=[MISC_CATEGORY])])
+        layer = Layer(sections=[section])
+        layer.enabled = True
+        layout = DistributionLayout(layers=[layer])
+        positioning = self._mk_positioning(
+            servos=[servo],
+            layout=layout,
+            sorting_profile=_AllCategoriesProfile(MISC_CATEGORY),
+        )
+
+        positioning.step()
+
+        self.assertIsNone(self.runtime_stats.snapshot().get("active_incident"))
+        self.assertIsNotNone(positioning._piece.destination_bin)
+        self.assertNotEqual("positioning.passthrough_no_bin", positioning._occupancy_state)
+        positioning.chute.moveToBin.assert_called_once()
+
+    def test_misc_never_claims_an_empty_bin(self) -> None:
+        servo = _mk_healthy_servo()
+        section = BinSection(bins=[Bin(size=BinSize.MEDIUM, category_ids=[])])
         layer = Layer(sections=[section])
         layer.enabled = True
         layout = DistributionLayout(layers=[layer])
@@ -262,9 +283,9 @@ class ServoBusFatalTests(unittest.TestCase):
         next_state = positioning.step()
 
         self.assertEqual(DistributionState.READY, next_state)
-        self.assertIsNone(self.runtime_stats.snapshot().get("active_incident"))
         self.assertIsNone(positioning._piece.destination_bin)
         self.assertEqual("positioning.passthrough_no_bin", positioning._occupancy_state)
+        self.assertEqual([], section.bins[0].category_ids)
         positioning.chute.moveToBin.assert_not_called()
         servo.open.assert_called_once()
 

--- a/software/sorter/frontend/src/lib/components/bins/BinDetailsModal.svelte
+++ b/software/sorter/frontend/src/lib/components/bins/BinDetailsModal.svelte
@@ -64,11 +64,17 @@
 		return { name: match.name, set_num: match.set_num, img_url: match.set_meta?.img_url };
 	});
 
+	// Misc is the discard passthrough; it only lands in a bin when assigned
+	// here explicitly (e.g. no bucket under the chute), so offer it too.
+	const MISC_CATEGORY = { id: 'misc', name: 'Misc (discard)' };
+
 	function availableCategories(): { id: string; name: string }[] {
 		const cats = sortingProfileStore.data?.categories ?? {};
-		return Object.entries(cats)
+		const list = Object.entries(cats)
 			.map(([id, cat]) => ({ id, name: cat?.name ?? id }))
 			.sort((a, b) => a.name.localeCompare(b.name));
+		if (!(MISC_CATEGORY.id in cats)) list.push(MISC_CATEGORY);
+		return list;
 	}
 
 	// Where each category is currently assigned across the persisted layout, so


### PR DESCRIPTION
Without a bucket under the chute the misc passthrough has nowhere to go. Positioning now honours a bin the operator assigned to `misc` (the assign endpoint no longer rejects it, and the bin modal offers "Misc (discard)"). Misc still never claims an empty bin on its own; unassigned it passes through as before.

Tests: the old `test_misc_assigned_bin_is_ignored_for_bottom_passthrough` encoded the previous behaviour and is replaced by two tests (routes to an assigned misc bin; never auto-claims an empty bin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)