### PR TITLE
chute: back out of the endstop flag before homing

### DIFF
--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -42,6 +42,11 @@ DEFAULT_FIRST_SECTION_OFFSET_DEG = 8.25
 
 HOME_SPEED_MICROSTEPS_PER_SEC = -1000
 HOME_TIMEOUT_MS = 15000
+# The endstop flag is wide (>45° chute on the B1). Homing must start outside
+# it, otherwise the firmware sees the sensor active on its first tick and
+# zeroes the position wherever the chute happens to stand inside the flag.
+HOME_BACKOUT_STEP_STEPPER_DEG = 108.0  # 22.5° chute per probe
+HOME_BACKOUT_MAX_PROBES = 12
 
 
 @dataclass
@@ -290,8 +295,31 @@ class Chute:
             self.logger.error(f"Chute: backoff to bin 1 failed: {exc}")
             return False
 
+    def _backOutOfEndstop(self) -> bool:
+        """Move away from the endstop until it releases so the sensor search
+        below starts outside the flag and stops on its true edge."""
+        if not self.endstop_triggered:
+            return True
+        self.logger.info("Chute: endstop already active before homing — backing out")
+        for probe in range(1, HOME_BACKOUT_MAX_PROBES + 1):
+            self.stepper.move_degrees_blocking(HOME_BACKOUT_STEP_STEPPER_DEG, timeout_ms=3000)
+            if not self.endstop_triggered:
+                self.logger.info(
+                    f"Chute: endstop released after {probe} probe(s) "
+                    f"({probe * HOME_BACKOUT_STEP_STEPPER_DEG / GEAR_RATIO:.1f}° chute)"
+                )
+                return True
+        self.logger.error(
+            f"Chute: endstop still active after backing out "
+            f"{HOME_BACKOUT_MAX_PROBES * HOME_BACKOUT_STEP_STEPPER_DEG / GEAR_RATIO:.1f}° chute — "
+            "sensor stuck or wired wrong?"
+        )
+        return False
+
     def home(self) -> bool:
         self.logger.info("Chute: homing via sensor")
+        if not self._backOutOfEndstop():
+            return False
         pos_before = self.current_angle
         raw_before = self.raw_endstop_active
         self.stepper.home(

--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -301,8 +301,21 @@ class Chute:
         if not self.endstop_triggered:
             return True
         self.logger.info("Chute: endstop already active before homing — backing out")
+        # Same driver re-enable as StepperMotor.home(): after a force-halt the
+        # chopper is off and every probe would count steps on a motor that
+        # does not turn.
+        self.stepper.enabled = True
         for probe in range(1, HOME_BACKOUT_MAX_PROBES + 1):
-            self.stepper.move_degrees_blocking(HOME_BACKOUT_STEP_STEPPER_DEG, timeout_ms=3000)
+            if not self.stepper.move_degrees_blocking(HOME_BACKOUT_STEP_STEPPER_DEG, timeout_ms=3000):
+                # The probe did not report stopped in time: it may still be
+                # moving, and a second command on top of it would be rejected
+                # or race the sensor search. Cut the driver so the unfinished
+                # move cannot carry on; the next home() re-enables it.
+                self.logger.error(
+                    f"Chute: backout probe {probe} did not finish within 3 s — halting, homing aborted"
+                )
+                self.stepper.enable_force(False)
+                return False
             if not self.endstop_triggered:
                 self.logger.info(
                     f"Chute: endstop released after {probe} probe(s) "
@@ -318,6 +331,10 @@ class Chute:
 
     def home(self) -> bool:
         self.logger.info("Chute: homing via sensor")
+        # From here on the recorded position is being rebuilt: a backout that
+        # moves the chute and then fails must not leave a stale homed=True
+        # behind, or the move API would trust a position that is now wrong.
+        self._homed = False
         if not self._backOutOfEndstop():
             return False
         pos_before = self.current_angle

--- a/software/sorter/backend/tests/test_chute_homing_backout.py
+++ b/software/sorter/backend/tests/test_chute_homing_backout.py
@@ -1,0 +1,88 @@
+"""Homing starts outside the endstop flag: the backout probes until the sensor
+releases, halts on a probe that does not finish, and never leaves a stale
+home reference behind."""
+import inspect
+import logging
+import unittest
+from types import SimpleNamespace
+
+from subsystems.distribution.chute import Chute, HOME_BACKOUT_MAX_PROBES
+
+
+class _Stepper:
+    def __init__(self, probe_results=None):
+        self.moves: list[float] = []
+        self.probe_results = list(probe_results or [])
+        self.enabled = False
+        self.force_calls: list[bool] = []
+        self.position_degrees = 0.0
+
+    def move_degrees_blocking(self, degrees, timeout_ms=5000):
+        self.moves.append(degrees)
+        return self.probe_results.pop(0) if self.probe_results else True
+
+    def enable_force(self, value):
+        self.force_calls.append(bool(value))
+
+    def estimateMoveDegreesMs(self, delta, max_speed=None):
+        return 100
+
+    def set_speed_limits(self, lo, hi):
+        pass
+
+
+class _Pin:
+    """Endstop that releases after ``active_reads`` reads."""
+
+    def __init__(self, active_reads):
+        self.active_reads = active_reads
+        self.reads = 0
+
+    @property
+    def value(self):
+        self.reads += 1
+        return self.reads <= self.active_reads
+
+
+def _chute(stepper, pin, homed=False):
+    gc = SimpleNamespace(logger=logging.getLogger("test"), disable_chute=False)
+    wanted = dict(stepper=stepper, home_pin=pin, layout=SimpleNamespace(layers=[]),
+                  num_sections=6, section_width_deg=51.75, first_section_offset_deg=8.25, max_angle_deg=350)
+    accepted = inspect.signature(Chute.__init__).parameters
+    chute = Chute(gc, **{k: v for k, v in wanted.items() if k in accepted})
+    if hasattr(chute, "_applyOperatingSpeed"):
+        chute._applyOperatingSpeed = lambda: None
+    chute._homed = homed
+    return chute
+
+
+class BackoutTests(unittest.TestCase):
+    def test_probes_until_the_sensor_releases(self):
+        stepper = _Stepper()
+        chute = _chute(stepper, _Pin(active_reads=3))  # initial check + 2 probes still active
+        self.assertTrue(chute._backOutOfEndstop())
+        self.assertEqual(3, len(stepper.moves))
+        self.assertTrue(stepper.enabled, "driver re-enabled before probing")
+
+    def test_inactive_sensor_needs_no_backout(self):
+        stepper = _Stepper()
+        self.assertTrue(_chute(stepper, _Pin(active_reads=0))._backOutOfEndstop())
+        self.assertEqual([], stepper.moves)
+
+    def test_stuck_sensor_gives_up_after_the_probe_budget(self):
+        stepper = _Stepper()
+        chute = _chute(stepper, _Pin(active_reads=10_000))
+        self.assertFalse(chute._backOutOfEndstop())
+        self.assertEqual(HOME_BACKOUT_MAX_PROBES, len(stepper.moves))
+
+    def test_unfinished_probe_halts_and_aborts(self):
+        stepper = _Stepper(probe_results=[True, False])
+        chute = _chute(stepper, _Pin(active_reads=10_000), homed=True)
+        self.assertFalse(chute.home())
+        self.assertEqual(2, len(stepper.moves), "no further probe on top of a move that may still run")
+        self.assertEqual([False], stepper.force_calls, "driver cut so the unfinished move cannot continue")
+        self.assertFalse(chute.homed, "a failed backout leaves no stale home reference")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The chute's endstop flag is wide (over 45° on the B1). When homing started with the sensor already active (after a stall or a hard-stop hit) the firmware zeroed the position on its first tick, wherever the chute stood inside the flag, and every bin was aimed up to 45° off — this looked like "homing lost instantly" after each re-home. Homing now probes forward in 22.5° steps until the sensor releases, then searches for the edge as before.

Verified on the machine: "endstop already active before homing — backing out … released after 1 probe" followed by a correct home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)