### PR TITLE
chute: acceleration and operating speed actually reach the stepper

### DIFF
--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -954,8 +954,11 @@ def cameraDeviceSettingsToDict(
 def mkStepperConfig(
     default_steps_per_second: int = 2000,
     microsteps: int = 8,
+    acceleration_microsteps_per_second_sq: int = FIRMWARE_DEFAULT_ACCELERATION_MICROSTEPS_PER_SECOND_SQ,
 ) -> StepperConfig:
-    return StepperConfig(default_steps_per_second, microsteps)
+    return StepperConfig(
+        default_steps_per_second, microsteps, acceleration_microsteps_per_second_sq
+    )
 
 
 def mkIRLConfig(machine_params: dict[str, object] | None = None) -> IRLConfig:
@@ -1430,7 +1433,11 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
         if stepper_config is not None:
             microsteps = stepper_config.microsteps
             default_steps_per_second = stepper_config.default_steps_per_second
-            default_acceleration = stepper_config.acceleration_microsteps_per_second_sq
+            # [stepper_acceleration_overrides.<name>] beats the code default: a
+            # long-armed chute skips steps at the firmware's 10000 µsteps/s².
+            default_acceleration = machine_config.stepper_acceleration_overrides.get(
+                canonical_name, stepper_config.acceleration_microsteps_per_second_sq
+            )
             _run_stepper_init_command_with_retry(
                 gc,
                 attr_base,

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -170,6 +170,9 @@ class MachineConfig:
     servo_close_speed: int | None = None
     servo_homing_speed: int | None = None
     stepper_current_overrides: dict[str, tuple[int, int, int]] = field(default_factory=dict)
+    # canonical stepper name -> acceleration in µsteps/s². From
+    # [stepper_acceleration_overrides]; motors not listed keep the code default.
+    stepper_acceleration_overrides: dict[str, int] = field(default_factory=dict)
     # canonical stepper name -> (sgthrs, tcoolthrs, enabled). From
     # [stepper_stallguard.*]; consumed by applyStepperStallguard + the stall monitor.
     stepper_stallguard: dict[str, tuple[int, int, bool]] = field(default_factory=dict)
@@ -214,6 +217,27 @@ def loadMachineSpecificParams(gc: GlobalConfig) -> dict[str, object]:
         return {}
 
     return raw
+
+
+def _parseStepperAccelerationOverrides(
+    gc: GlobalConfig,
+    raw: dict[str, object],
+) -> dict[str, int]:
+    table: object = raw.get("stepper_acceleration_overrides")
+    if table is None:
+        return {}
+    if not isinstance(table, dict):
+        gc.logger.warning("stepper_acceleration_overrides must be a table of <stepper> = <µsteps/s²>. Ignoring.")
+        return {}
+    overrides: dict[str, int] = {}
+    for stepper_name, value in table.items():
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            gc.logger.warning(
+                f"Ignoring stepper_acceleration_overrides.{stepper_name}={value!r}: expected a positive integer (µsteps/s²)."
+            )
+            continue
+        overrides[str(stepper_name)] = value
+    return overrides
 
 
 def _parseStepperCurrentOverrides(
@@ -505,6 +529,7 @@ def loadMachineConfig(
         gc.logger.warning("Ignoring invalid servo config: expected object.")
 
     config.stepper_current_overrides = _parseStepperCurrentOverrides(gc, raw)
+    config.stepper_acceleration_overrides = _parseStepperAccelerationOverrides(gc, raw)
     config.stepper_stallguard = _parseStepperStallguard(gc, raw)
 
     return config

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -236,7 +236,9 @@ def _parseStepperAccelerationOverrides(
                 f"Ignoring stepper_acceleration_overrides.{stepper_name}={value!r}: expected a positive integer (µsteps/s²)."
             )
             continue
-        overrides[str(stepper_name)] = value
+        # Legacy physical names (first_c_channel_rotor, ...) map to the
+        # canonical ones the init lookup uses, like the current overrides do.
+        overrides[normalizePhysicalStepperBindingName(str(stepper_name))] = value
     return overrides
 
 
@@ -752,10 +754,12 @@ def loadChuteCalibrationConfig(
         )
         operating_speed_microsteps_per_second = DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC
 
-    if operating_speed_microsteps_per_second <= 0:
+    # The firmware's minimum speed is 16 µsteps/s and it rejects min > max
+    # silently, leaving the previous (possibly much faster) limit in force.
+    if operating_speed_microsteps_per_second < 16:
         gc.logger.warning(
             "Invalid chute.operating_speed_microsteps_per_second="
-            f"{operating_speed_microsteps_per_second!r}; expected > 0. Using default "
+            f"{operating_speed_microsteps_per_second!r}; expected >= 16 (firmware minimum). Using default "
             f"{DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC}."
         )
         operating_speed_microsteps_per_second = DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC

--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -145,6 +145,22 @@ class Chute:
     def setOperatingSpeed(self, operating_speed_microsteps_per_second: int) -> None:
         self.operating_speed_microsteps_per_second = max(1, int(operating_speed_microsteps_per_second))
 
+    def _applyOperatingSpeed(self) -> None:
+        """Push the operating speed to the stepper's speed limit before a move.
+        The stepper is initialised with its config default (3000); without
+        this the [chute] operating speed only shaped the time estimate while
+        every move ran at the default."""
+        # Not cached on purpose: the stepper API endpoints (move-degrees,
+        # pulse) set their own limits, so re-assert ours on every move.
+        speed = self.operating_speed_microsteps_per_second
+        setter = getattr(self.stepper, "set_speed_limits", None)
+        if not callable(setter):
+            return
+        try:
+            setter(16, speed)
+        except Exception as exc:
+            self.logger.warning(f"Chute: could not apply operating speed {speed}: {exc}")
+
     @property
     def raw_endstop_active(self) -> bool:
         return bool(self.home_pin.value)
@@ -229,6 +245,7 @@ class Chute:
         self.logger.info(
             f"Chute: moving from {current:.1f}° to {target:.1f}° (delta_stepper_deg={delta_stepper_angle:.2f}, est_ms={estimated_ms})"
         )
+        self._applyOperatingSpeed()
         self.stepper.move_degrees(delta_stepper_angle)
         return estimated_ms
 
@@ -266,6 +283,7 @@ class Chute:
         self.logger.info(
             f"Chute: moving(blocking) from {current:.1f}° to {target:.1f}° (delta_stepper_deg={delta_stepper_angle:.2f}, est_ms={estimated_ms}, timeout_ms={timeout_ms})"
         )
+        self._applyOperatingSpeed()
         self.stepper.move_degrees_blocking(delta_stepper_angle, timeout_ms=timeout_ms)
         return estimated_ms
 

--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -143,7 +143,8 @@ class Chute:
             self.endstop_active_high = endstop_active_high
 
     def setOperatingSpeed(self, operating_speed_microsteps_per_second: int) -> None:
-        self.operating_speed_microsteps_per_second = max(1, int(operating_speed_microsteps_per_second))
+        # Never below the firmware minimum: set_speed_limits(16, <16) is rejected.
+        self.operating_speed_microsteps_per_second = max(16, int(operating_speed_microsteps_per_second))
 
     def _applyOperatingSpeed(self) -> None:
         """Push the operating speed to the stepper's speed limit before a move.
@@ -152,7 +153,7 @@ class Chute:
         every move ran at the default."""
         # Not cached on purpose: the stepper API endpoints (move-degrees,
         # pulse) set their own limits, so re-assert ours on every move.
-        speed = self.operating_speed_microsteps_per_second
+        speed = max(16, int(self.operating_speed_microsteps_per_second))  # firmware minimum
         setter = getattr(self.stepper, "set_speed_limits", None)
         if not callable(setter):
             return

--- a/software/sorter/backend/tests/test_chute_drive_config.py
+++ b/software/sorter/backend/tests/test_chute_drive_config.py
@@ -1,0 +1,35 @@
+"""[chute] operating speed and [stepper_acceleration_overrides] parsing."""
+import logging
+from types import SimpleNamespace
+
+from irl.parse_user_toml import _parseStepperAccelerationOverrides, loadChuteCalibrationConfig, normalizePhysicalStepperBindingName
+from subsystems.distribution.chute import Chute, DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC
+
+
+def _gc():
+    return SimpleNamespace(logger=logging.getLogger("test"))
+
+
+def test_operating_speed_below_the_firmware_minimum_falls_back_to_the_default() -> None:
+    cfg = loadChuteCalibrationConfig(_gc(), {"chute": {"operating_speed_microsteps_per_second": 5}})
+    assert cfg.operating_speed_microsteps_per_second == DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC
+    cfg = loadChuteCalibrationConfig(_gc(), {"chute": {"operating_speed_microsteps_per_second": 16}})
+    assert cfg.operating_speed_microsteps_per_second == 16
+
+
+def test_chute_never_pushes_a_speed_below_the_firmware_minimum() -> None:
+    limits = []
+    stepper = SimpleNamespace(set_speed_limits=lambda lo, hi: limits.append((lo, hi)), position_degrees=0.0)
+    chute = Chute(_gc(), stepper=stepper, home_pin=SimpleNamespace(value=False), layout=SimpleNamespace(layers=[]),
+                  operating_speed_microsteps_per_second=3)
+    chute._applyOperatingSpeed()
+    assert limits == [(16, 16)]
+
+
+def test_acceleration_overrides_accept_legacy_physical_names() -> None:
+    legacy = "first_c_channel_rotor"
+    canonical = normalizePhysicalStepperBindingName(legacy)
+    overrides = _parseStepperAccelerationOverrides(_gc(), {"stepper_acceleration_overrides": {legacy: 20000, "chute": 5000, "bad": -1}})
+    assert overrides[canonical] == 20000
+    assert overrides["chute"] == 5000
+    assert "bad" not in overrides


### PR DESCRIPTION
Two config gaps found while taming a skipping chute:

- `[stepper_acceleration_overrides]` (`<stepper> = <µsteps/s²>`, next to the current overrides) is applied where the default acceleration is set at stepper init. The chute used the firmware default of 10000 with no way to lower it from `machine.toml`.
- `[chute] operating_speed_microsteps_per_second` only shaped the move-time estimate; the stepper kept its 3000 µsteps/s init default, so the setting never changed how fast the chute moved. The chute now re-asserts its speed limit before every move (the stepper API endpoints set their own limits).

Verified on the machine: `set_speed_limits max=1500` logged per move, TSTEP matches the configured speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)