### PR TITLE
steppers: AS5600 shaft-encoder position check as a second stall source

### DIFF
--- a/software/firmware/sorter_interface_firmware/AS5600.cpp
+++ b/software/firmware/sorter_interface_firmware/AS5600.cpp
@@ -1,0 +1,21 @@
+#include "AS5600.h"
+
+static const uint8_t REG_STATUS = 0x0B;
+static const uint8_t REG_RAW_ANGLE = 0x0C; // two bytes, MSB first, 12 bits used
+static const uint8_t REG_AGC = 0x1A;
+static const uint32_t XFER_TIMEOUT_US = 1000;
+
+bool AS5600::readRegisters(uint8_t reg, uint8_t *buf, size_t len) {
+    if (i2c_write_timeout_us(_port, _address, &reg, 1, true, XFER_TIMEOUT_US) != 1) return false;
+    return i2c_read_timeout_us(_port, _address, buf, len, false, XFER_TIMEOUT_US) == (int)len;
+}
+
+bool AS5600::readRawAngle(uint16_t *out) {
+    uint8_t b[2];
+    if (!readRegisters(REG_RAW_ANGLE, b, 2)) return false;
+    *out = (uint16_t)(((b[0] & 0x0F) << 8) | b[1]);
+    return true;
+}
+
+bool AS5600::readStatus(uint8_t *out) { return readRegisters(REG_STATUS, out, 1); }
+bool AS5600::readAgc(uint8_t *out) { return readRegisters(REG_AGC, out, 1); }

--- a/software/firmware/sorter_interface_firmware/AS5600.h
+++ b/software/firmware/sorter_interface_firmware/AS5600.h
@@ -1,0 +1,28 @@
+#ifndef AS5600_H
+#define AS5600_H
+#include "hardware/i2c.h"
+#include <stdint.h>
+
+// AMS AS5600 12-bit magnetic rotary encoder on I2C (fixed address 0x36).
+// Only the registers the stepper position check needs: RAW_ANGLE, STATUS, AGC.
+class AS5600 {
+  public:
+    static const uint8_t DEFAULT_ADDRESS = 0x36;
+    static const uint16_t COUNTS_PER_REV = 4096;
+    // STATUS bits
+    static const uint8_t STATUS_MAGNET_HIGH = 0x08;     // MH: magnet too strong
+    static const uint8_t STATUS_MAGNET_LOW = 0x10;      // ML: magnet too weak
+    static const uint8_t STATUS_MAGNET_DETECTED = 0x20; // MD
+
+    AS5600(i2c_inst_t *port, uint8_t address = DEFAULT_ADDRESS) : _port(port), _address(address) {}
+    // All return true on success; a failed transfer leaves *out untouched.
+    bool readRawAngle(uint16_t *out);
+    bool readStatus(uint8_t *out);
+    bool readAgc(uint8_t *out);
+
+  private:
+    bool readRegisters(uint8_t reg, uint8_t *buf, size_t len);
+    i2c_inst_t *_port;
+    uint8_t _address;
+};
+#endif

--- a/software/firmware/sorter_interface_firmware/CMakeLists.txt
+++ b/software/firmware/sorter_interface_firmware/CMakeLists.txt
@@ -98,6 +98,7 @@ add_executable(sorter_interface_firmware
     crc.c 
     message.cpp 
     PCA9685.cpp
+    AS5600.cpp
     Servo.cpp
 )
 

--- a/software/firmware/sorter_interface_firmware/Stepper.cpp
+++ b/software/firmware/sorter_interface_firmware/Stepper.cpp
@@ -32,7 +32,7 @@ Stepper::Stepper(int step_pin, int dir_pin)
       _mc_dir(1), _mc_home_pin(-1),
     _steps_moved(0), _steps_frac(0), _brake_distance(0),
     _current_speed(0), _current_speed_frac(0), _current_dir(1),
-    _jitter_active(false), _jitter_amplitude(0), _jitter_strokes_remaining(0), _jitter_dir(1) {
+    _jitter_active(false), _stall_request(false), _jitter_amplitude(0), _jitter_strokes_remaining(0), _jitter_dir(1) {
 }
 
 void Stepper::initialize() {
@@ -274,8 +274,13 @@ void Stepper::motion_update_tick() {
     // stop immediately — the backend poll then raises an operator incident.
     // Skip while jittering: the unstick wiggle is *meant* to fight load, and a
     // stall during it is expected, not a fault.
-    if (_stall_enabled.load() && _stall_pin >= 0 && _state.load() != STEPPER_STOPPED &&
-        !_jitter_active.load() && gpio_get(_stall_pin)) {
+    // The software StallGuard poll on core 0 only requests the stop (see
+    // latchStall); the transition itself happens here, on the core that owns
+    // the state, so no in-flight transition can undo it.
+    bool software_stall = _stall_request.exchange(false) && _state.load() != STEPPER_STOPPED &&
+                          !_jitter_active.load();
+    if (software_stall || (_stall_enabled.load() && _stall_pin >= 0 && _state.load() != STEPPER_STOPPED &&
+                           !_jitter_active.load() && gpio_get(_stall_pin))) {
         _stalled.store(true);
         _state.store(STEPPER_STOPPED);
         _current_speed.store(0);

--- a/software/firmware/sorter_interface_firmware/Stepper.cpp
+++ b/software/firmware/sorter_interface_firmware/Stepper.cpp
@@ -225,6 +225,7 @@ void Stepper::stepgen_tick() {
             _state = STEPPER_STOPPED;
             _current_speed = 0;
             _absolute_position = 0;
+            _position_reset.store(true);
             _mc_home_pin.store(-1);
             return;
         }
@@ -338,6 +339,7 @@ void Stepper::motion_update_tick() {
                     _state = STEPPER_STOPPED;
                     _current_speed = 0;
                     _absolute_position = 0;
+                    _position_reset.store(true);
                     _mc_home_pin.store(-1); // Homing done
                     break;
                 }

--- a/software/firmware/sorter_interface_firmware/Stepper.h
+++ b/software/firmware/sorter_interface_firmware/Stepper.h
@@ -77,6 +77,20 @@ public:
     }
     bool wasStalled() { return _stalled.load(); }
     void clearStall() { _stalled.store(false); }
+    // Software StallGuard for boards without a wired DIAG pin (SKR Pico): core0
+    // polls SG_RESULT/TSTEP over UART while the motor runs and calls
+    // latchStall() when the driver reports the condition that would raise DIAG.
+    bool stallDetectionEnabled() { return _stall_enabled.load(); }
+    bool hasStallPin() { return _stall_pin >= 0; }
+    bool isRunningForStallCheck() {
+        return _state.load() != STEPPER_STOPPED && !_jitter_active.load();
+    }
+    void latchStall() {
+        _stalled.store(true);
+        _state.store(STEPPER_STOPPED);
+        _current_speed.store(0);
+        _current_speed_frac.store(0);
+    }
 
 private:
     void beginJitterStroke();

--- a/software/firmware/sorter_interface_firmware/Stepper.h
+++ b/software/firmware/sorter_interface_firmware/Stepper.h
@@ -82,8 +82,12 @@ public:
     // latchStall() when the driver reports the condition that would raise DIAG.
     bool stallDetectionEnabled() { return _stall_enabled.load(); }
     bool hasStallPin() { return _stall_pin >= 0; }
-    bool isRunningForStallCheck() {
-        return _state.load() != STEPPER_STOPPED && !_jitter_active.load();
+    // Software StallGuard only samples the cruise phase: SG_RESULT reads near
+    // zero while a stepper ramps (measured 4 on the B1 chute at 10000 µsteps/s²),
+    // which would look like a stall. Homing cruises too, but below the
+    // TCOOLTHRS velocity floor, so the poll skips it by TSTEP.
+    bool isCruisingForStallCheck() {
+        return _state.load() == STEPPER_CRUISING && !_jitter_active.load();
     }
     void latchStall() {
         _stalled.store(true);

--- a/software/firmware/sorter_interface_firmware/Stepper.h
+++ b/software/firmware/sorter_interface_firmware/Stepper.h
@@ -89,12 +89,13 @@ public:
     bool isCruisingForStallCheck() {
         return _state.load() == STEPPER_CRUISING && !_jitter_active.load();
     }
-    void latchStall() {
-        _stalled.store(true);
-        _state.store(STEPPER_STOPPED);
-        _current_speed.store(0);
-        _current_speed_frac.store(0);
-    }
+    // Called from core 0 (the UART poll). Only *requests* the stop: the motion
+    // state machine is owned by core 1, and a state stored from core 0 could be
+    // overwritten by a transition core 1 was in the middle of (CRUISING ->
+    // BRAKING -> CRUISING), letting the motor resume after a detected stall.
+    // core 1 consumes the request at the top of its next motion tick.
+    void latchStall() { _stall_request.store(true); }
+    bool stallRequested() { return _stall_request.load(); }
 
 private:
     void beginJitterStroke();
@@ -130,6 +131,7 @@ private:
     // motion tick ever mutate these. core0 stop/move commands are REJECTED while
     // jittering rather than tearing the run down, so there is no cross-core race.
     std::atomic<bool> _jitter_active; // true from start until the last stroke completes
+    std::atomic<bool> _stall_request; // core 0 -> core 1: stop for a software-detected stall
     std::atomic<int32_t> _jitter_amplitude; // microsteps per stroke
     std::atomic<int32_t> _jitter_strokes_remaining; // strokes still to perform (2 per cycle)
     std::atomic<int32_t> _jitter_dir; // direction of the next stroke (1 / -1)

--- a/software/firmware/sorter_interface_firmware/Stepper.h
+++ b/software/firmware/sorter_interface_firmware/Stepper.h
@@ -61,7 +61,10 @@ public:
     // still in progress" and the gate that refuses overlapping jitter requests.
     bool isJittering() { return _jitter_active.load(); }
     int32_t getPosition() { return _absolute_position; }
-    void setPosition(int32_t position) { _absolute_position = position; }
+    void setPosition(int32_t position) { _absolute_position = position; _position_reset.store(true); }
+    // True once after the counter was assigned instead of stepped (setPosition,
+    // homing zero); the shaft-encoder check re-captures its offset on it.
+    bool consumePositionReset() { return _position_reset.exchange(false); }
     void home(int32_t home_speed, int home_pin, bool home_pin_polarity);
 
     // StallGuard / DIAG. The TMC2209 drives its DIAG output high when SG_RESULT
@@ -117,6 +120,7 @@ private:
     std::atomic<int32_t> _mc_dir; // 1 = forward, -1 = reverse
     std::atomic<int32_t> _mc_home_pin; // Home switch pin, -1 if not homing
     std::atomic<bool> _mc_home_pin_polarity; // Home switch polarity, true if active high, false if active low
+    std::atomic<bool> _position_reset{false}; // _absolute_position was assigned, not stepped
 
     // Internal state
     std::atomic<int32_t> _steps_moved, _steps_frac; // How many steps have we moved in the current move, counted towards the _move_direction (if moving backwards we go negative)

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -239,22 +239,29 @@ static auto tmc_drivers = make_tmc_array(std::make_index_sequence<STEPPER_COUNT>
 // Software StallGuard (boards whose TMC DIAG lines are not wired to the MCU,
 // e.g. the SKR Pico config). The backend configures SGTHRS/TCOOLTHRS over UART
 // exactly as for the DIAG path; we remember the last written values and, while
-// an armed stepper runs, poll TSTEP and SG_RESULT on core0 and latch a stall
+// an armed stepper cruises, poll TSTEP and SG_RESULT on core0 and latch a stall
 // under the same rule the driver applies to DIAG: SG_RESULT <= 2*SGTHRS while
 // TSTEP <= TCOOLTHRS (i.e. above the velocity floor). Two consecutive hits are
 // required so a single noisy read cannot stop a motor.
+//
+// Each poll tick issues exactly one UART read per channel: TSTEP on one tick,
+// SG_RESULT on the next. Two reads back to back fail: the TMC2209 needs the
+// bus idle after its reply before it accepts the next sync byte, and the
+// second read then times out (measured on the B1 chute: TSTEP fine, SG_RESULT
+// failing on ~40 of 44 polls).
 #define TMC_REG_TSTEP 0x12
 #define TMC_REG_TCOOLTHRS 0x14
 #define TMC_REG_SGTHRS 0x40
 #define TMC_REG_SG_RESULT 0x41
-#define SOFT_SG_POLL_INTERVAL_US 5000
+#define SOFT_SG_POLL_INTERVAL_US 2500
 #define SOFT_SG_HITS_TO_LATCH 2
 static uint32_t soft_sg_sgthrs[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_tcoolthrs[STEPPER_COUNT] = {0};
 static uint8_t soft_sg_hits[STEPPER_COUNT] = {0};
+static bool soft_sg_read_sg_next[STEPPER_COUNT] = {false}; // false = TSTEP next, true = SG_RESULT next
 // Debug view of the software poll, exported in GET_OBSERVABILITY.
-static uint32_t soft_sg_polls[STEPPER_COUNT] = {0};     // polls that passed the gating
-static uint32_t soft_sg_latches[STEPPER_COUNT] = {0};
+static uint16_t soft_sg_polls[STEPPER_COUNT] = {0};     // polls that passed the gating (wraps)
+static uint16_t soft_sg_latches[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_last_tstep[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_last_sg[STEPPER_COUNT] = {0};
 static uint8_t soft_sg_gate[STEPPER_COUNT] = {0};       // why the last poll returned early
@@ -356,15 +363,19 @@ int dump_observability(char *buf, size_t buf_size) {
     }
     snprintf(led_gpios_buf + led_len, sizeof(led_gpios_buf) - led_len, "]");
 
+    // Armed channels only (the payload is capped at MAX_PAYLOAD_SIZE): c=channel,
     // p=polls past the gating, l=latches, t/s=last TSTEP/SG_RESULT, g=last early-return reason
     char soft_sg_buf[200];
     int sg_len = snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[");
+    bool first = true;
     for (int i = 0; i < STEPPER_COUNT && sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf); i++) {
+        if (!steppers[i].stallDetectionEnabled()) continue;
         sg_len += snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len,
-                           "%s{\"p\":%lu,\"l\":%lu,\"t\":%lu,\"s\":%lu,\"g\":%u}",
-                           i == 0 ? "" : ",", (unsigned long)soft_sg_polls[i],
-                           (unsigned long)soft_sg_latches[i], (unsigned long)soft_sg_last_tstep[i],
+                           "%s{\"c\":%d,\"p\":%u,\"l\":%u,\"t\":%lu,\"s\":%lu,\"g\":%u}",
+                           first ? "" : ",", i, (unsigned)soft_sg_polls[i],
+                           (unsigned)soft_sg_latches[i], (unsigned long)soft_sg_last_tstep[i],
                            (unsigned long)soft_sg_last_sg[i], (unsigned)soft_sg_gate[i]);
+        first = false;
     }
     if (sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf) - 1) {
         snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len, "]");
@@ -1009,18 +1020,31 @@ static void software_stallguard_poll() {
     if (stepper.hasStallPin()) { soft_sg_gate[i] = 1; soft_sg_hits[i] = 0; return; }
     if (!stepper.stallDetectionEnabled()) { soft_sg_gate[i] = 2; soft_sg_hits[i] = 0; return; }
     if (soft_sg_sgthrs[i] == 0) { soft_sg_gate[i] = 3; soft_sg_hits[i] = 0; return; }
-    if (!stepper.isRunningForStallCheck()) { soft_sg_gate[i] = 4; soft_sg_hits[i] = 0; return; }
-    soft_sg_polls[i]++;
-    uint32_t tstep = 0;
-    if (tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep) != 0) { soft_sg_gate[i] = 5; return; }
-    soft_sg_last_tstep[i] = tstep & 0xFFFFF;
-    if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
-        soft_sg_gate[i] = 6; // below the velocity floor DIAG would be inactive too
+    if (!stepper.isCruisingForStallCheck()) {
+        soft_sg_gate[i] = 4;
         soft_sg_hits[i] = 0;
+        soft_sg_read_sg_next[i] = false;
         return;
     }
+    soft_sg_polls[i]++;
+    // Gate codes 5x/7x carry the UART result: x1 = timeout, x2 = CRC error.
+    if (!soft_sg_read_sg_next[i]) {
+        uint32_t tstep = 0;
+        int rc = tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep);
+        if (rc != 0) { soft_sg_gate[i] = (uint8_t)(50 - rc); return; }
+        soft_sg_last_tstep[i] = tstep & 0xFFFFF;
+        if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
+            soft_sg_gate[i] = 6; // below the velocity floor DIAG would be inactive too
+            soft_sg_hits[i] = 0;
+            return;
+        }
+        soft_sg_read_sg_next[i] = true;
+        return;
+    }
+    soft_sg_read_sg_next[i] = false;
     uint32_t sg_result = 0;
-    if (tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result) != 0) { soft_sg_gate[i] = 7; return; }
+    int rc = tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result);
+    if (rc != 0) { soft_sg_gate[i] = (uint8_t)(70 - rc); return; }
     soft_sg_last_sg[i] = sg_result & 0x3FF;
     soft_sg_gate[i] = 0;
     if ((sg_result & 0x3FF) <= 2 * soft_sg_sgthrs[i]) {

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -236,6 +236,24 @@ static std::array<TMC2209, STEPPER_COUNT> make_tmc_array(std::index_sequence<I..
 
 static auto tmc_drivers = make_tmc_array(std::make_index_sequence<STEPPER_COUNT>{});
 
+// Software StallGuard (boards whose TMC DIAG lines are not wired to the MCU,
+// e.g. the SKR Pico config). The backend configures SGTHRS/TCOOLTHRS over UART
+// exactly as for the DIAG path; we remember the last written values and, while
+// an armed stepper runs, poll TSTEP and SG_RESULT on core0 and latch a stall
+// under the same rule the driver applies to DIAG: SG_RESULT <= 2*SGTHRS while
+// TSTEP <= TCOOLTHRS (i.e. above the velocity floor). Two consecutive hits are
+// required so a single noisy read cannot stop a motor.
+#define TMC_REG_TSTEP 0x12
+#define TMC_REG_TCOOLTHRS 0x14
+#define TMC_REG_SGTHRS 0x40
+#define TMC_REG_SG_RESULT 0x41
+#define SOFT_SG_POLL_INTERVAL_US 5000
+#define SOFT_SG_HITS_TO_LATCH 2
+static uint32_t soft_sg_sgthrs[STEPPER_COUNT] = {0};
+static uint32_t soft_sg_tcoolthrs[STEPPER_COUNT] = {0};
+static uint8_t soft_sg_hits[STEPPER_COUNT] = {0};
+
+
 template <size_t... I>
 static std::array<Stepper, STEPPER_COUNT> make_stepper_array(std::index_sequence<I...>) {
     return {Stepper(STEPPER_STEP_PINS[I], STEPPER_DIR_PINS[I])...};
@@ -802,16 +820,15 @@ void CMDH_stepper_drv_write_register(const BusMessage *msg, BusMessage *resp) {
     memcpy(&value, msg->payload + 1, sizeof(value));
     tmc_drivers[msg->channel].writeRegister(reg, value);
     resp->payload_length = 0;
+    if (reg == TMC_REG_SGTHRS) soft_sg_sgthrs[msg->channel] = value;
+    if (reg == TMC_REG_TCOOLTHRS) soft_sg_tcoolthrs[msg->channel] = value;
 }
 
 void CMDH_stepper_enable_stall_detection(const BusMessage *msg, BusMessage *resp) {
     bool enable = msg->payload[0] != 0;
-    if (enable && STEPPER_DIAG_PINS[msg->channel] < 0) {
-        resp->command = msg->command | 0x80; // Set error bit
-        resp->payload_length =
-            snprintf((char *)resp->payload, MAX_PAYLOAD_SIZE, "No DIAG pin for channel %u", msg->channel);
-        return;
-    }
+    // Without a DIAG pin the software poll (core0, UART) takes over; it needs
+    // SGTHRS/TCOOLTHRS to have been written first, which the backend does.
+    soft_sg_hits[msg->channel] = 0;
     steppers[msg->channel].enableStallDetection(enable);
     resp->payload_length = 0;
 }
@@ -957,6 +974,38 @@ void core1_entry() {
     }
 }
 
+static void software_stallguard_poll() {
+    static uint64_t next_poll_us = 0;
+    static uint8_t next_channel = 0;
+    uint64_t now = time_us_64();
+    if (now < next_poll_us) return;
+    next_poll_us = now + SOFT_SG_POLL_INTERVAL_US;
+    uint8_t i = next_channel;
+    next_channel = (uint8_t)((next_channel + 1) % STEPPER_COUNT);
+    Stepper &stepper = steppers[i];
+    if (stepper.hasStallPin() || !stepper.stallDetectionEnabled() || soft_sg_sgthrs[i] == 0 ||
+        !stepper.isRunningForStallCheck()) {
+        soft_sg_hits[i] = 0;
+        return;
+    }
+    uint32_t tstep = 0;
+    if (tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep) != 0) return; // UART hiccup: skip this round
+    if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
+        soft_sg_hits[i] = 0; // below the velocity floor DIAG would be inactive too
+        return;
+    }
+    uint32_t sg_result = 0;
+    if (tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result) != 0) return;
+    if ((sg_result & 0x3FF) <= 2 * soft_sg_sgthrs[i]) {
+        if (++soft_sg_hits[i] >= SOFT_SG_HITS_TO_LATCH) {
+            soft_sg_hits[i] = 0;
+            stepper.latchStall();
+        }
+    } else {
+        soft_sg_hits[i] = 0;
+    }
+}
+
 int main() {
     stdio_init_all();
     initialize_hardware();
@@ -976,5 +1025,6 @@ int main() {
             msg_processor.processIncomingData((char)c);
             msg_processor.processQueuedMessage();
         }
+        software_stallguard_poll();
     }
 }

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -252,6 +252,12 @@ static auto tmc_drivers = make_tmc_array(std::make_index_sequence<STEPPER_COUNT>
 static uint32_t soft_sg_sgthrs[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_tcoolthrs[STEPPER_COUNT] = {0};
 static uint8_t soft_sg_hits[STEPPER_COUNT] = {0};
+// Debug view of the software poll, exported in GET_OBSERVABILITY.
+static uint32_t soft_sg_polls[STEPPER_COUNT] = {0};     // polls that passed the gating
+static uint32_t soft_sg_latches[STEPPER_COUNT] = {0};
+static uint32_t soft_sg_last_tstep[STEPPER_COUNT] = {0};
+static uint32_t soft_sg_last_sg[STEPPER_COUNT] = {0};
+static uint8_t soft_sg_gate[STEPPER_COUNT] = {0};       // why the last poll returned early
 
 
 template <size_t... I>
@@ -350,13 +356,30 @@ int dump_observability(char *buf, size_t buf_size) {
     }
     snprintf(led_gpios_buf + led_len, sizeof(led_gpios_buf) - led_len, "]");
 
+    // p=polls past the gating, l=latches, t/s=last TSTEP/SG_RESULT, g=last early-return reason
+    char soft_sg_buf[200];
+    int sg_len = snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[");
+    for (int i = 0; i < STEPPER_COUNT && sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf); i++) {
+        sg_len += snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len,
+                           "%s{\"p\":%lu,\"l\":%lu,\"t\":%lu,\"s\":%lu,\"g\":%u}",
+                           i == 0 ? "" : ",", (unsigned long)soft_sg_polls[i],
+                           (unsigned long)soft_sg_latches[i], (unsigned long)soft_sg_last_tstep[i],
+                           (unsigned long)soft_sg_last_sg[i], (unsigned)soft_sg_gate[i]);
+    }
+    if (sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf) - 1) {
+        snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len, "]");
+    } else {
+        snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[]");
+    }
+
     int n_bytes = snprintf(
         buf,
         buf_size,
-        "{\"hw\":\"%s\",\"diag_pins\":%s,\"led_gpios\":%s}",
+        "{\"hw\":\"%s\",\"diag_pins\":%s,\"led_gpios\":%s,\"soft_sg\":%s}",
         HW_ID,
         diag_pins_len > 0 ? diag_pins_buf : "[]",
-        led_gpios_buf);
+        led_gpios_buf,
+        soft_sg_buf);
 
     if (n_bytes >= 0 && (size_t)n_bytes < buf_size) {
         return n_bytes;
@@ -983,22 +1006,27 @@ static void software_stallguard_poll() {
     uint8_t i = next_channel;
     next_channel = (uint8_t)((next_channel + 1) % STEPPER_COUNT);
     Stepper &stepper = steppers[i];
-    if (stepper.hasStallPin() || !stepper.stallDetectionEnabled() || soft_sg_sgthrs[i] == 0 ||
-        !stepper.isRunningForStallCheck()) {
+    if (stepper.hasStallPin()) { soft_sg_gate[i] = 1; soft_sg_hits[i] = 0; return; }
+    if (!stepper.stallDetectionEnabled()) { soft_sg_gate[i] = 2; soft_sg_hits[i] = 0; return; }
+    if (soft_sg_sgthrs[i] == 0) { soft_sg_gate[i] = 3; soft_sg_hits[i] = 0; return; }
+    if (!stepper.isRunningForStallCheck()) { soft_sg_gate[i] = 4; soft_sg_hits[i] = 0; return; }
+    soft_sg_polls[i]++;
+    uint32_t tstep = 0;
+    if (tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep) != 0) { soft_sg_gate[i] = 5; return; }
+    soft_sg_last_tstep[i] = tstep & 0xFFFFF;
+    if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
+        soft_sg_gate[i] = 6; // below the velocity floor DIAG would be inactive too
         soft_sg_hits[i] = 0;
         return;
     }
-    uint32_t tstep = 0;
-    if (tmc_drivers[i].readRegister(TMC_REG_TSTEP, &tstep) != 0) return; // UART hiccup: skip this round
-    if ((tstep & 0xFFFFF) > soft_sg_tcoolthrs[i]) {
-        soft_sg_hits[i] = 0; // below the velocity floor DIAG would be inactive too
-        return;
-    }
     uint32_t sg_result = 0;
-    if (tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result) != 0) return;
+    if (tmc_drivers[i].readRegister(TMC_REG_SG_RESULT, &sg_result) != 0) { soft_sg_gate[i] = 7; return; }
+    soft_sg_last_sg[i] = sg_result & 0x3FF;
+    soft_sg_gate[i] = 0;
     if ((sg_result & 0x3FF) <= 2 * soft_sg_sgthrs[i]) {
         if (++soft_sg_hits[i] >= SOFT_SG_HITS_TO_LATCH) {
             soft_sg_hits[i] = 0;
+            soft_sg_latches[i]++;
             stepper.latchStall();
         }
     } else {

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -73,6 +73,8 @@ void CMDH_stepper_drv_write_register(const BusMessage *msg, BusMessage *resp);
 void CMDH_stepper_enable_stall_detection(const BusMessage *msg, BusMessage *resp);
 void CMDH_stepper_get_stall_status(const BusMessage *msg, BusMessage *resp);
 void CMDH_stepper_clear_stall(const BusMessage *msg, BusMessage *resp);
+void CMDH_stepper_encoder_config(const BusMessage *msg, BusMessage *resp);
+void CMDH_stepper_encoder_status(const BusMessage *msg, BusMessage *resp);
 bool VAL_stepper_channel(uint8_t channel);
 
 const struct CommandTable stepperCmdTable = {
@@ -94,6 +96,12 @@ const struct CommandTable stepperCmdTable = {
         {"ENABLE_STALL_DETECTION", "?", "", 1, VAL_stepper_channel, CMDH_stepper_enable_stall_detection},
         {"GET_STALL_STATUS", "", "B", 0, VAL_stepper_channel, CMDH_stepper_get_stall_status},
         {"CLEAR_STALL", "", "", 0, VAL_stepper_channel, CMDH_stepper_clear_stall},
+        // Position encoder (AS5600 on the motor shaft, I2C). ENCODER_CONFIG:
+        // sign (+1/-1), encoder counts per 1000 microsteps, tolerance in counts,
+        // enable. ENCODER_STATUS: raw angle, deviation (counts), AS5600 status,
+        // AGC, latch count.
+        {"ENCODER_CONFIG", "bIH?", "", 8, VAL_stepper_channel, CMDH_stepper_encoder_config},
+        {"ENCODER_STATUS", "", "HiBBH", 0, VAL_stepper_channel, CMDH_stepper_encoder_status},
     }}};
 
 const struct CommandTable stepperDrvCmdTable = {
@@ -260,11 +268,51 @@ static uint32_t soft_sg_tcoolthrs[STEPPER_COUNT] = {0};
 static uint8_t soft_sg_hits[STEPPER_COUNT] = {0};
 static bool soft_sg_read_sg_next[STEPPER_COUNT] = {false}; // false = TSTEP next, true = SG_RESULT next
 // Debug view of the software poll, exported in GET_OBSERVABILITY.
-static uint16_t soft_sg_polls[STEPPER_COUNT] = {0};     // polls that passed the gating (wraps)
 static uint16_t soft_sg_latches[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_last_tstep[STEPPER_COUNT] = {0};
 static uint32_t soft_sg_last_sg[STEPPER_COUNT] = {0};
 static uint8_t soft_sg_gate[STEPPER_COUNT] = {0};       // why the last poll returned early
+
+// ---------------------------------------------------------------------------
+// Shaft encoder position check. One AS5600 per board (fixed I2C address) on
+// the motor's rear shaft; the backend tells us which channel it belongs to.
+// Every ENC_POLL_INTERVAL_US the poll reads the angle, unwraps it into a
+// running count and compares it with the stepper's commanded position
+// (counts = offset + sign * position * counts_per_1000_usteps / 1000). A
+// deviation beyond the tolerance on ENC_HITS_TO_LATCH consecutive polls
+// latches the same stall flag StallGuard uses, so the backend's incident
+// path (pause, re-home) is shared. Unlike StallGuard this works on ramps and
+// at the target. A position jump larger than any real move between two polls
+// (SET_POSITION / homing zeroed the counter) re-captures the offset.
+#include "AS5600.h"
+#define ENC_POLL_INTERVAL_US 5000
+#define ENC_HITS_TO_LATCH 3
+#define ENC_STATUS_EVERY_N_POLLS 20
+#define ENC_RESET_JUMP_USTEPS 2000
+static AS5600 shaft_encoder(I2C_PORT);
+struct EncoderCheck {
+    bool enabled = false;
+    int8_t sign = 1;
+    uint32_t counts_per_kusteps = 2560; // 4096 counts / 1600 microsteps * 1000
+    uint16_t tolerance_counts = 82;     // 4 full steps at 8 microsteps
+    bool synced = false;                // offset captured
+    uint16_t last_raw = 0;
+    int32_t unwrapped = 0;
+    int32_t offset = 0;
+    int32_t last_position = 0;
+    int32_t deviation = 0;
+    uint8_t hits = 0;
+    uint8_t status = 0;                 // AS5600 STATUS register (MD/ML/MH)
+    uint8_t agc = 0;
+    uint16_t latches = 0;
+    uint8_t i2c_errors = 0;             // saturating
+};
+static EncoderCheck enc[STEPPER_COUNT];
+static int8_t enc_channel = -1;         // the one channel with the encoder, -1 = none
+
+static int32_t enc_expected_counts(const EncoderCheck &e, int32_t position) {
+    return e.offset + (int32_t)(((int64_t)e.sign * position * (int64_t)e.counts_per_kusteps) / 1000);
+}
 
 
 template <size_t... I>
@@ -364,7 +412,7 @@ int dump_observability(char *buf, size_t buf_size) {
     snprintf(led_gpios_buf + led_len, sizeof(led_gpios_buf) - led_len, "]");
 
     // Armed channels only (the payload is capped at MAX_PAYLOAD_SIZE): c=channel,
-    // p=polls past the gating, l=latches, t/s=last TSTEP/SG_RESULT, g=last early-return reason
+    // l=latches, t/s=last TSTEP/SG_RESULT, g=last early-return reason
     char soft_sg_buf[200];
     int sg_len = snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[");
     bool first = true;
@@ -373,8 +421,8 @@ int dump_observability(char *buf, size_t buf_size) {
         // channel never polls, and every entry costs ~45 of the 200 bytes.
         if (!steppers[i].stallDetectionEnabled() || steppers[i].hasStallPin()) continue;
         sg_len += snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len,
-                           "%s{\"c\":%d,\"p\":%u,\"l\":%u,\"t\":%lu,\"s\":%lu,\"g\":%u}",
-                           first ? "" : ",", i, (unsigned)soft_sg_polls[i],
+                           "%s{\"c\":%d,\"l\":%u,\"t\":%lu,\"s\":%lu,\"g\":%u}",
+                           first ? "" : ",", i,
                            (unsigned)soft_sg_latches[i], (unsigned long)soft_sg_last_tstep[i],
                            (unsigned long)soft_sg_last_sg[i], (unsigned)soft_sg_gate[i]);
         first = false;
@@ -385,14 +433,27 @@ int dump_observability(char *buf, size_t buf_size) {
         snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[]");
     }
 
+    // enc: c=channel, st=AS5600 STATUS (0x20 magnet ok, 0x10 weak, 0x08 strong;
+    // 0 = never read, i.e. no sensor answering), agc, dev=last deviation in
+    // counts, l=latches. Worst case with two armed soft_sg channels stays
+    // under MAX_PAYLOAD_SIZE (measured 237 of 246 bytes).
+    char enc_buf[64] = "null";
+    if (enc_channel >= 0) {
+        const EncoderCheck &e = enc[enc_channel];
+        snprintf(enc_buf, sizeof(enc_buf), "{\"c\":%d,\"st\":%u,\"agc\":%u,\"dev\":%ld,\"l\":%u}",
+                 (int)enc_channel, (unsigned)e.status, (unsigned)e.agc, (long)e.deviation,
+                 (unsigned)e.latches);
+    }
+
     int n_bytes = snprintf(
         buf,
         buf_size,
-        "{\"hw\":\"%s\",\"diag_pins\":%s,\"led_gpios\":%s,\"soft_sg\":%s}",
+        "{\"hw\":\"%s\",\"diag_pins\":%s,\"led_gpios\":%s,\"soft_sg\":%s,\"enc\":%s}",
         HW_ID,
         diag_pins_len > 0 ? diag_pins_buf : "[]",
         led_gpios_buf,
-        soft_sg_buf);
+        soft_sg_buf,
+        enc_buf);
 
     if (n_bytes >= 0 && (size_t)n_bytes < buf_size) {
         return n_bytes;
@@ -882,6 +943,42 @@ void CMDH_stepper_enable_stall_detection(const BusMessage *msg, BusMessage *resp
     resp->payload_length = 0;
 }
 
+void CMDH_stepper_encoder_config(const BusMessage *msg, BusMessage *resp) {
+    EncoderCheck &e = enc[msg->channel];
+    int8_t sign = (int8_t)msg->payload[0];
+    uint32_t counts_per_kusteps;
+    uint16_t tolerance;
+    memcpy(&counts_per_kusteps, msg->payload + 1, sizeof(counts_per_kusteps));
+    memcpy(&tolerance, msg->payload + 5, sizeof(tolerance));
+    bool enable = msg->payload[7] != 0;
+    if (enable && (counts_per_kusteps == 0 || tolerance == 0 || (sign != 1 && sign != -1))) {
+        resp->command = msg->command | 0x80;
+        resp->payload_length = snprintf((char *)resp->payload, MAX_PAYLOAD_SIZE, "Invalid encoder config");
+        return;
+    }
+    for (int i = 0; i < STEPPER_COUNT; i++) enc[i].enabled = false; // one encoder per board
+    e.sign = sign;
+    e.counts_per_kusteps = counts_per_kusteps;
+    e.tolerance_counts = tolerance;
+    e.synced = false;
+    e.hits = 0;
+    e.enabled = enable;
+    enc_channel = enable ? (int8_t)msg->channel : -1;
+    resp->payload_length = 0;
+}
+
+void CMDH_stepper_encoder_status(const BusMessage *msg, BusMessage *resp) {
+    const EncoderCheck &e = enc[msg->channel];
+    uint16_t raw = e.last_raw;
+    int32_t deviation = e.deviation;
+    memcpy(resp->payload, &raw, 2);
+    memcpy(resp->payload + 2, &deviation, 4);
+    resp->payload[6] = e.status;
+    resp->payload[7] = e.agc;
+    memcpy(resp->payload + 8, &e.latches, 2);
+    resp->payload_length = 10;
+}
+
 void CMDH_stepper_get_stall_status(const BusMessage *msg, BusMessage *resp) {
     (void)msg; // Channel is ignored: we report every channel on this board at once.
     uint8_t mask = 0;
@@ -1041,7 +1138,6 @@ static void software_stallguard_poll() {
         soft_sg_read_sg_next[i] = false;
         return;
     }
-    soft_sg_polls[i]++;
     // Gate codes 5x/7x carry the UART result: x1 = timeout, x2 = CRC error.
     if (!soft_sg_read_sg_next[i]) {
         uint32_t tstep = 0;
@@ -1073,6 +1169,63 @@ static void software_stallguard_poll() {
     }
 }
 
+static void encoder_position_poll() {
+    static uint64_t next_poll_us = 0;
+    static uint32_t polls = 0;
+    if (enc_channel < 0) return;
+    uint64_t now = time_us_64();
+    if (now < next_poll_us) return;
+    next_poll_us = now + ENC_POLL_INTERVAL_US;
+    EncoderCheck &e = enc[enc_channel];
+    Stepper &stepper = steppers[enc_channel];
+    polls++;
+    uint16_t raw = 0;
+    if (!shaft_encoder.readRawAngle(&raw)) {
+        if (e.i2c_errors < 255) e.i2c_errors++;
+        return;
+    }
+    if ((polls % ENC_STATUS_EVERY_N_POLLS) == 0) {
+        shaft_encoder.readStatus(&e.status);
+        shaft_encoder.readAgc(&e.agc);
+    }
+    int32_t position = stepper.getPosition();
+    if (!e.synced) {
+        e.last_raw = raw;
+        e.unwrapped = raw;
+        e.last_position = position;
+        e.offset = e.unwrapped - (int32_t)(((int64_t)e.sign * position * (int64_t)e.counts_per_kusteps) / 1000);
+        e.deviation = 0;
+        e.hits = 0;
+        e.synced = true;
+        return;
+    }
+    int32_t delta = (int32_t)raw - (int32_t)e.last_raw;
+    if (delta > (int32_t)AS5600::COUNTS_PER_REV / 2) delta -= AS5600::COUNTS_PER_REV;
+    if (delta < -(int32_t)AS5600::COUNTS_PER_REV / 2) delta += AS5600::COUNTS_PER_REV;
+    e.unwrapped += delta;
+    e.last_raw = raw;
+    int32_t moved = position - e.last_position;
+    e.last_position = position;
+    if (moved > ENC_RESET_JUMP_USTEPS || moved < -ENC_RESET_JUMP_USTEPS) {
+        // The counter was set from outside (homing, SET_POSITION): re-sync.
+        e.synced = false;
+        return;
+    }
+    if (stepper.isJittering()) { e.hits = 0; return; }
+    e.deviation = e.unwrapped - enc_expected_counts(e, position);
+    int32_t magnitude = e.deviation < 0 ? -e.deviation : e.deviation;
+    if (magnitude > (int32_t)e.tolerance_counts) {
+        if (++e.hits >= ENC_HITS_TO_LATCH) {
+            e.hits = 0;
+            e.latches++;
+            stepper.latchStall();
+            e.synced = false; // measure the next move from wherever the shaft really is
+        }
+    } else {
+        e.hits = 0;
+    }
+}
+
 int main() {
     stdio_init_all();
     initialize_hardware();
@@ -1093,5 +1246,6 @@ int main() {
             msg_processor.processQueuedMessage();
         }
         software_stallguard_poll();
+        encoder_position_poll();
     }
 }

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -369,7 +369,9 @@ int dump_observability(char *buf, size_t buf_size) {
     int sg_len = snprintf(soft_sg_buf, sizeof(soft_sg_buf), "[");
     bool first = true;
     for (int i = 0; i < STEPPER_COUNT && sg_len > 0 && (size_t)sg_len < sizeof(soft_sg_buf); i++) {
-        if (!steppers[i].stallDetectionEnabled()) continue;
+        // Only the channels the software poll actually serves: a wired-DIAG
+        // channel never polls, and every entry costs ~45 of the 200 bytes.
+        if (!steppers[i].stallDetectionEnabled() || steppers[i].hasStallPin()) continue;
         sg_len += snprintf(soft_sg_buf + sg_len, sizeof(soft_sg_buf) - sg_len,
                            "%s{\"c\":%d,\"p\":%u,\"l\":%u,\"t\":%lu,\"s\":%lu,\"g\":%u}",
                            first ? "" : ",", i, (unsigned)soft_sg_polls[i],
@@ -392,6 +394,19 @@ int dump_observability(char *buf, size_t buf_size) {
         led_gpios_buf,
         soft_sg_buf);
 
+    if (n_bytes >= 0 && (size_t)n_bytes < buf_size) {
+        return n_bytes;
+    }
+
+    // Too long with the poll counters: keep the hardware facts (id, DIAG pins,
+    // LED GPIOs) and drop only the soft_sg detail rather than everything.
+    n_bytes = snprintf(
+        buf,
+        buf_size,
+        "{\"hw\":\"%s\",\"diag_pins\":%s,\"led_gpios\":%s,\"soft_sg\":[]}",
+        HW_ID,
+        diag_pins_len > 0 ? diag_pins_buf : "[]",
+        led_gpios_buf);
     if (n_bytes >= 0 && (size_t)n_bytes < buf_size) {
         return n_bytes;
     }

--- a/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
+++ b/software/firmware/sorter_interface_firmware/sorter_interface_firmware.cpp
@@ -282,13 +282,12 @@ static uint8_t soft_sg_gate[STEPPER_COUNT] = {0};       // why the last poll ret
 // deviation beyond the tolerance on ENC_HITS_TO_LATCH consecutive polls
 // latches the same stall flag StallGuard uses, so the backend's incident
 // path (pause, re-home) is shared. Unlike StallGuard this works on ramps and
-// at the target. A position jump larger than any real move between two polls
-// (SET_POSITION / homing zeroed the counter) re-captures the offset.
+// at the target. When the stepper reports that its counter was assigned from
+// outside (SET_POSITION, homing zero) the offset is re-captured.
 #include "AS5600.h"
 #define ENC_POLL_INTERVAL_US 5000
 #define ENC_HITS_TO_LATCH 3
 #define ENC_STATUS_EVERY_N_POLLS 20
-#define ENC_RESET_JUMP_USTEPS 2000
 static AS5600 shaft_encoder(I2C_PORT);
 struct EncoderCheck {
     bool enabled = false;
@@ -299,7 +298,6 @@ struct EncoderCheck {
     uint16_t last_raw = 0;
     int32_t unwrapped = 0;
     int32_t offset = 0;
-    int32_t last_position = 0;
     int32_t deviation = 0;
     uint8_t hits = 0;
     uint8_t status = 0;                 // AS5600 STATUS register (MD/ML/MH)
@@ -1189,10 +1187,10 @@ static void encoder_position_poll() {
         shaft_encoder.readAgc(&e.agc);
     }
     int32_t position = stepper.getPosition();
+    if (stepper.consumePositionReset()) e.synced = false; // homing zero / SET_POSITION
     if (!e.synced) {
         e.last_raw = raw;
         e.unwrapped = raw;
-        e.last_position = position;
         e.offset = e.unwrapped - (int32_t)(((int64_t)e.sign * position * (int64_t)e.counts_per_kusteps) / 1000);
         e.deviation = 0;
         e.hits = 0;
@@ -1204,13 +1202,6 @@ static void encoder_position_poll() {
     if (delta < -(int32_t)AS5600::COUNTS_PER_REV / 2) delta += AS5600::COUNTS_PER_REV;
     e.unwrapped += delta;
     e.last_raw = raw;
-    int32_t moved = position - e.last_position;
-    e.last_position = position;
-    if (moved > ENC_RESET_JUMP_USTEPS || moved < -ENC_RESET_JUMP_USTEPS) {
-        // The counter was set from outside (homing, SET_POSITION): re-sync.
-        e.synced = false;
-        return;
-    }
     if (stepper.isJittering()) { e.hits = 0; return; }
     e.deviation = e.unwrapped - enc_expected_counts(e, position);
     int32_t magnitude = e.deviation < 0 ? -e.deviation : e.deviation;

--- a/software/sorter/backend/hardware/sorter_interface.py
+++ b/software/sorter/backend/hardware/sorter_interface.py
@@ -36,6 +36,8 @@ class InterfaceCommandCode(BaseCommandCode):
     STEPPER_ENABLE_STALL_DETECTION = 0x1A
     STEPPER_GET_STALL_STATUS = 0x1B  # channel ignored; returns a per-board stall bitmask
     STEPPER_CLEAR_STALL = 0x1C
+    STEPPER_ENCODER_CONFIG = 0x1D  # sign, counts per 1000 µsteps, tolerance counts, enable
+    STEPPER_ENCODER_STATUS = 0x1E  # raw angle, deviation, AS5600 status, AGC, latches
     # Stepper driver commands
     STEPPER_DRV_SET_ENABLED = 0x20
     STEPPER_DRV_SET_MICROSTEPS = 0x21
@@ -509,6 +511,39 @@ class StepperMotor:
         if DISABLE_STALLGUARD:
             return
         self._dev.send_command(InterfaceCommandCode.STEPPER_CLEAR_STALL, self._channel, b'')
+
+    def configure_encoder(
+        self,
+        *,
+        enable: bool,
+        sign: int = 1,
+        counts_per_microstep: float = 4096 / 1600,
+        tolerance_microsteps: int = 32,
+    ) -> None:
+        """Arm the firmware's shaft-encoder position check (AS5600 on the motor's
+        rear shaft). Deviations beyond the tolerance latch the same stall flag as
+        StallGuard, so the stall monitor / incident path is shared."""
+        counts_per_kusteps = max(1, int(round(counts_per_microstep * 1000)))
+        tolerance_counts = max(1, min(65535, int(round(tolerance_microsteps * counts_per_microstep))))
+        payload = struct.pack("<bIH?", 1 if sign >= 0 else -1, counts_per_kusteps, tolerance_counts, bool(enable))
+        self._gc.logger.info(
+            f"Stepper '{self._name}' ch{self._channel}: encoder {'armed' if enable else 'disabled'} "
+            f"(sign={sign:+d}, counts/1000µsteps={counts_per_kusteps}, tolerance={tolerance_counts} counts)"
+        )
+        self._dev.send_command(InterfaceCommandCode.STEPPER_ENCODER_CONFIG, self._channel, payload)
+
+    def read_encoder_status(self) -> dict:
+        res = self._dev.send_command(InterfaceCommandCode.STEPPER_ENCODER_STATUS, self._channel, b"")
+        raw, deviation, status, agc, latches = struct.unpack("<HiBBH", bytes(res.payload[:10]))
+        return {
+            "raw_angle": raw,
+            "deviation_counts": deviation,
+            "magnet_detected": bool(status & 0x20),
+            "magnet_too_weak": bool(status & 0x10),
+            "magnet_too_strong": bool(status & 0x08),
+            "agc": agc,
+            "latches": latches,
+        }
 
     def read_stall_latched(self) -> bool:
         """True iff the firmware currently latches a StallGuard/DIAG stall on this

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -954,8 +954,11 @@ def cameraDeviceSettingsToDict(
 def mkStepperConfig(
     default_steps_per_second: int = 2000,
     microsteps: int = 8,
+    acceleration_microsteps_per_second_sq: int = FIRMWARE_DEFAULT_ACCELERATION_MICROSTEPS_PER_SECOND_SQ,
 ) -> StepperConfig:
-    return StepperConfig(default_steps_per_second, microsteps)
+    return StepperConfig(
+        default_steps_per_second, microsteps, acceleration_microsteps_per_second_sq
+    )
 
 
 def mkIRLConfig(machine_params: dict[str, object] | None = None) -> IRLConfig:
@@ -1430,7 +1433,11 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
         if stepper_config is not None:
             microsteps = stepper_config.microsteps
             default_steps_per_second = stepper_config.default_steps_per_second
-            default_acceleration = stepper_config.acceleration_microsteps_per_second_sq
+            # [stepper_acceleration_overrides.<name>] beats the code default: a
+            # long-armed chute skips steps at the firmware's 10000 µsteps/s².
+            default_acceleration = machine_config.stepper_acceleration_overrides.get(
+                canonical_name, stepper_config.acceleration_microsteps_per_second_sq
+            )
             _run_stepper_init_command_with_retry(
                 gc,
                 attr_base,

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -88,6 +88,7 @@ from .parse_user_toml import (
     loadChuteCalibrationConfig,
     loadCameraLayoutConfig,
     applyStepperCurrentOverride,
+    applyStepperEncoder,
     applyStepperStallguard,
 )
 from .leds import LedController, discoverLedOutputs
@@ -1469,6 +1470,13 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
 
         applyStepperCurrentOverride(stepper, canonical_name, stepper_current_overrides, gc)
         applyStepperStallguard(stepper, canonical_name, machine_config.stepper_stallguard, gc)
+        applyStepperEncoder(
+            stepper,
+            canonical_name,
+            machine_config.stepper_encoders,
+            stepper_config.microsteps if stepper_config is not None else 8,
+            gc,
+        )
         logical_name = logical_name_for_attr_base.get(attr_base)
         stepper.set_direction_inverted(
             stepper_direction_inverts.get(logical_name, False) if logical_name is not None else False

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -170,6 +170,9 @@ class MachineConfig:
     servo_close_speed: int | None = None
     servo_homing_speed: int | None = None
     stepper_current_overrides: dict[str, tuple[int, int, int]] = field(default_factory=dict)
+    # canonical stepper name -> acceleration in µsteps/s². From
+    # [stepper_acceleration_overrides]; motors not listed keep the code default.
+    stepper_acceleration_overrides: dict[str, int] = field(default_factory=dict)
     # canonical stepper name -> (sgthrs, tcoolthrs, enabled). From
     # [stepper_stallguard.*]; consumed by applyStepperStallguard + the stall monitor.
     stepper_stallguard: dict[str, tuple[int, int, bool]] = field(default_factory=dict)
@@ -214,6 +217,27 @@ def loadMachineSpecificParams(gc: GlobalConfig) -> dict[str, object]:
         return {}
 
     return raw
+
+
+def _parseStepperAccelerationOverrides(
+    gc: GlobalConfig,
+    raw: dict[str, object],
+) -> dict[str, int]:
+    table: object = raw.get("stepper_acceleration_overrides")
+    if table is None:
+        return {}
+    if not isinstance(table, dict):
+        gc.logger.warning("stepper_acceleration_overrides must be a table of <stepper> = <µsteps/s²>. Ignoring.")
+        return {}
+    overrides: dict[str, int] = {}
+    for stepper_name, value in table.items():
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            gc.logger.warning(
+                f"Ignoring stepper_acceleration_overrides.{stepper_name}={value!r}: expected a positive integer (µsteps/s²)."
+            )
+            continue
+        overrides[str(stepper_name)] = value
+    return overrides
 
 
 def _parseStepperCurrentOverrides(
@@ -505,6 +529,7 @@ def loadMachineConfig(
         gc.logger.warning("Ignoring invalid servo config: expected object.")
 
     config.stepper_current_overrides = _parseStepperCurrentOverrides(gc, raw)
+    config.stepper_acceleration_overrides = _parseStepperAccelerationOverrides(gc, raw)
     config.stepper_stallguard = _parseStepperStallguard(gc, raw)
 
     return config

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -236,7 +236,9 @@ def _parseStepperAccelerationOverrides(
                 f"Ignoring stepper_acceleration_overrides.{stepper_name}={value!r}: expected a positive integer (µsteps/s²)."
             )
             continue
-        overrides[str(stepper_name)] = value
+        # Legacy physical names (first_c_channel_rotor, ...) map to the
+        # canonical ones the init lookup uses, like the current overrides do.
+        overrides[normalizePhysicalStepperBindingName(str(stepper_name))] = value
     return overrides
 
 
@@ -752,10 +754,12 @@ def loadChuteCalibrationConfig(
         )
         operating_speed_microsteps_per_second = DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC
 
-    if operating_speed_microsteps_per_second <= 0:
+    # The firmware's minimum speed is 16 µsteps/s and it rejects min > max
+    # silently, leaving the previous (possibly much faster) limit in force.
+    if operating_speed_microsteps_per_second < 16:
         gc.logger.warning(
             "Invalid chute.operating_speed_microsteps_per_second="
-            f"{operating_speed_microsteps_per_second!r}; expected > 0. Using default "
+            f"{operating_speed_microsteps_per_second!r}; expected >= 16 (firmware minimum). Using default "
             f"{DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC}."
         )
         operating_speed_microsteps_per_second = DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC

--- a/software/sorter/backend/irl/parse_user_toml.py
+++ b/software/sorter/backend/irl/parse_user_toml.py
@@ -173,6 +173,10 @@ class MachineConfig:
     # canonical stepper name -> acceleration in µsteps/s². From
     # [stepper_acceleration_overrides]; motors not listed keep the code default.
     stepper_acceleration_overrides: dict[str, int] = field(default_factory=dict)
+    # canonical stepper name -> (enabled, sign, counts_per_rev, tolerance_fullsteps).
+    # From [stepper_encoder.*]; an AS5600 on the motor's rear shaft, applied by
+    # applyStepperEncoder at stepper init.
+    stepper_encoders: dict[str, tuple[bool, int, int, float]] = field(default_factory=dict)
     # canonical stepper name -> (sgthrs, tcoolthrs, enabled). From
     # [stepper_stallguard.*]; consumed by applyStepperStallguard + the stall monitor.
     stepper_stallguard: dict[str, tuple[int, int, bool]] = field(default_factory=dict)
@@ -240,6 +244,68 @@ def _parseStepperAccelerationOverrides(
         # canonical ones the init lookup uses, like the current overrides do.
         overrides[normalizePhysicalStepperBindingName(str(stepper_name))] = value
     return overrides
+
+
+def _parseStepperEncoders(
+    gc: GlobalConfig,
+    raw: dict[str, object],
+) -> dict[str, tuple[bool, int, int, float]]:
+    table: object = raw.get("stepper_encoder")
+    if table is None:
+        return {}
+    if not isinstance(table, dict):
+        gc.logger.warning("stepper_encoder must be a table of [stepper_encoder.<stepper>] entries. Ignoring.")
+        return {}
+    out: dict[str, tuple[bool, int, int, float]] = {}
+    for name, value in table.items():
+        if not isinstance(value, dict):
+            gc.logger.warning(f"Ignoring stepper_encoder.{name}: expected a table.")
+            continue
+        enabled = value.get("enabled", True)
+        sign = value.get("sign", 1)
+        counts_per_rev = value.get("counts_per_rev", 4096)
+        tolerance = value.get("tolerance_fullsteps", 4)
+        if (
+            not isinstance(enabled, bool)
+            or sign not in (1, -1)
+            or not isinstance(counts_per_rev, int) or isinstance(counts_per_rev, bool) or counts_per_rev <= 0
+            or not isinstance(tolerance, (int, float)) or isinstance(tolerance, bool) or tolerance <= 0
+        ):
+            gc.logger.warning(
+                f"Ignoring stepper_encoder.{name}: expected enabled (bool), sign (1/-1), "
+                f"counts_per_rev (>0), tolerance_fullsteps (>0)."
+            )
+            continue
+        out[str(name)] = (enabled, int(sign), int(counts_per_rev), float(tolerance))
+    return out
+
+
+def applyStepperEncoder(
+    stepper: "StepperMotor",
+    stepper_name: str,
+    encoders: dict[str, tuple[bool, int, int, float]],
+    microsteps: int,
+    gc: GlobalConfig,
+) -> None:
+    """Arm the shaft-encoder position check for steppers with a
+    [stepper_encoder.<name>] entry. Counts per microstep follow from the
+    encoder resolution and the motor's 200 full steps at the configured
+    microstepping."""
+    config = encoders.get(stepper_name)
+    if config is None:
+        return
+    enabled, sign, counts_per_rev, tolerance_fullsteps = config
+    microsteps = max(1, int(microsteps))
+    counts_per_microstep = counts_per_rev / (200 * microsteps)
+    try:
+        stepper.configure_encoder(
+            enable=enabled,
+            sign=sign,
+            counts_per_microstep=counts_per_microstep,
+            tolerance_microsteps=int(round(tolerance_fullsteps * microsteps)),
+        )
+    except (MCUBusError, OSError, DecodeError) as e:
+        gc.logger.warning(f"Failed to configure encoder for '{stepper_name}': {e}. Continuing.")
 
 
 def _parseStepperCurrentOverrides(
@@ -532,6 +598,7 @@ def loadMachineConfig(
 
     config.stepper_current_overrides = _parseStepperCurrentOverrides(gc, raw)
     config.stepper_acceleration_overrides = _parseStepperAccelerationOverrides(gc, raw)
+    config.stepper_encoders = _parseStepperEncoders(gc, raw)
     config.stepper_stallguard = _parseStepperStallguard(gc, raw)
 
     return config

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -96,7 +96,7 @@ def _control_board_observability(board: Any) -> Dict[str, Any]:
     observability: Dict[str, Any] = {}
     if interface is not None and hasattr(interface, "get_observability_info"):
         try:
-            observability = dict(interface.get_observability_info())
+            observability = dict(interface.get_observability_info(force_refresh=True))
         except Exception as exc:
             observability = {"error": str(exc)}
     return {

--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -145,6 +145,22 @@ class Chute:
     def setOperatingSpeed(self, operating_speed_microsteps_per_second: int) -> None:
         self.operating_speed_microsteps_per_second = max(1, int(operating_speed_microsteps_per_second))
 
+    def _applyOperatingSpeed(self) -> None:
+        """Push the operating speed to the stepper's speed limit before a move.
+        The stepper is initialised with its config default (3000); without
+        this the [chute] operating speed only shaped the time estimate while
+        every move ran at the default."""
+        # Not cached on purpose: the stepper API endpoints (move-degrees,
+        # pulse) set their own limits, so re-assert ours on every move.
+        speed = self.operating_speed_microsteps_per_second
+        setter = getattr(self.stepper, "set_speed_limits", None)
+        if not callable(setter):
+            return
+        try:
+            setter(16, speed)
+        except Exception as exc:
+            self.logger.warning(f"Chute: could not apply operating speed {speed}: {exc}")
+
     @property
     def raw_endstop_active(self) -> bool:
         return bool(self.home_pin.value)
@@ -229,6 +245,7 @@ class Chute:
         self.logger.info(
             f"Chute: moving from {current:.1f}° to {target:.1f}° (delta_stepper_deg={delta_stepper_angle:.2f}, est_ms={estimated_ms})"
         )
+        self._applyOperatingSpeed()
         self.stepper.move_degrees(delta_stepper_angle)
         return estimated_ms
 
@@ -266,6 +283,7 @@ class Chute:
         self.logger.info(
             f"Chute: moving(blocking) from {current:.1f}° to {target:.1f}° (delta_stepper_deg={delta_stepper_angle:.2f}, est_ms={estimated_ms}, timeout_ms={timeout_ms})"
         )
+        self._applyOperatingSpeed()
         self.stepper.move_degrees_blocking(delta_stepper_angle, timeout_ms=timeout_ms)
         return estimated_ms
 

--- a/software/sorter/backend/subsystems/distribution/chute.py
+++ b/software/sorter/backend/subsystems/distribution/chute.py
@@ -143,7 +143,8 @@ class Chute:
             self.endstop_active_high = endstop_active_high
 
     def setOperatingSpeed(self, operating_speed_microsteps_per_second: int) -> None:
-        self.operating_speed_microsteps_per_second = max(1, int(operating_speed_microsteps_per_second))
+        # Never below the firmware minimum: set_speed_limits(16, <16) is rejected.
+        self.operating_speed_microsteps_per_second = max(16, int(operating_speed_microsteps_per_second))
 
     def _applyOperatingSpeed(self) -> None:
         """Push the operating speed to the stepper's speed limit before a move.
@@ -152,7 +153,7 @@ class Chute:
         every move ran at the default."""
         # Not cached on purpose: the stepper API endpoints (move-degrees,
         # pulse) set their own limits, so re-assert ours on every move.
-        speed = self.operating_speed_microsteps_per_second
+        speed = max(16, int(self.operating_speed_microsteps_per_second))  # firmware minimum
         setter = getattr(self.stepper, "set_speed_limits", None)
         if not callable(setter):
             return

--- a/software/sorter/backend/tests/test_chute_drive_config.py
+++ b/software/sorter/backend/tests/test_chute_drive_config.py
@@ -1,0 +1,35 @@
+"""[chute] operating speed and [stepper_acceleration_overrides] parsing."""
+import logging
+from types import SimpleNamespace
+
+from irl.parse_user_toml import _parseStepperAccelerationOverrides, loadChuteCalibrationConfig, normalizePhysicalStepperBindingName
+from subsystems.distribution.chute import Chute, DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC
+
+
+def _gc():
+    return SimpleNamespace(logger=logging.getLogger("test"))
+
+
+def test_operating_speed_below_the_firmware_minimum_falls_back_to_the_default() -> None:
+    cfg = loadChuteCalibrationConfig(_gc(), {"chute": {"operating_speed_microsteps_per_second": 5}})
+    assert cfg.operating_speed_microsteps_per_second == DEFAULT_CHUTE_OPERATING_SPEED_MICROSTEPS_PER_SEC
+    cfg = loadChuteCalibrationConfig(_gc(), {"chute": {"operating_speed_microsteps_per_second": 16}})
+    assert cfg.operating_speed_microsteps_per_second == 16
+
+
+def test_chute_never_pushes_a_speed_below_the_firmware_minimum() -> None:
+    limits = []
+    stepper = SimpleNamespace(set_speed_limits=lambda lo, hi: limits.append((lo, hi)), position_degrees=0.0)
+    chute = Chute(_gc(), stepper=stepper, home_pin=SimpleNamespace(value=False), layout=SimpleNamespace(layers=[]),
+                  operating_speed_microsteps_per_second=3)
+    chute._applyOperatingSpeed()
+    assert limits == [(16, 16)]
+
+
+def test_acceleration_overrides_accept_legacy_physical_names() -> None:
+    legacy = "first_c_channel_rotor"
+    canonical = normalizePhysicalStepperBindingName(legacy)
+    overrides = _parseStepperAccelerationOverrides(_gc(), {"stepper_acceleration_overrides": {legacy: 20000, "chute": 5000, "bad": -1}})
+    assert overrides[canonical] == 20000
+    assert overrides["chute"] == 5000
+    assert "bad" not in overrides

--- a/software/sorter/backend/tests/test_stepper_encoder_config.py
+++ b/software/sorter/backend/tests/test_stepper_encoder_config.py
@@ -1,0 +1,54 @@
+import logging
+import unittest
+from types import SimpleNamespace
+
+from irl.parse_user_toml import _parseStepperEncoders, applyStepperEncoder
+
+
+def _gc():
+    return SimpleNamespace(logger=logging.getLogger("test"))
+
+
+class _Stepper:
+    def __init__(self):
+        self.calls = []
+
+    def configure_encoder(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class StepperEncoderConfigTests(unittest.TestCase):
+    def test_parses_defaults_and_overrides(self):
+        raw = {
+            "stepper_encoder": {
+                "chute_stepper": {},
+                "carousel": {"enabled": False, "sign": -1, "counts_per_rev": 4096, "tolerance_fullsteps": 2.5},
+            }
+        }
+        parsed = _parseStepperEncoders(_gc(), raw)
+        self.assertEqual((True, 1, 4096, 4.0), parsed["chute_stepper"])
+        self.assertEqual((False, -1, 4096, 2.5), parsed["carousel"])
+
+    def test_rejects_invalid_entries(self):
+        raw = {"stepper_encoder": {"chute_stepper": {"sign": 2}, "carousel": "nope"}}
+        self.assertEqual({}, _parseStepperEncoders(_gc(), raw))
+        self.assertEqual({}, _parseStepperEncoders(_gc(), {}))
+
+    def test_apply_derives_counts_per_microstep_and_tolerance(self):
+        stepper = _Stepper()
+        applyStepperEncoder(stepper, "chute_stepper", {"chute_stepper": (True, -1, 4096, 4.0)}, 8, _gc())
+        self.assertEqual(1, len(stepper.calls))
+        call = stepper.calls[0]
+        self.assertTrue(call["enable"])
+        self.assertEqual(-1, call["sign"])
+        self.assertAlmostEqual(4096 / 1600, call["counts_per_microstep"])
+        self.assertEqual(32, call["tolerance_microsteps"])
+
+    def test_apply_skips_steppers_without_entry(self):
+        stepper = _Stepper()
+        applyStepperEncoder(stepper, "carousel", {"chute_stepper": (True, 1, 4096, 4.0)}, 8, _gc())
+        self.assertEqual([], stepper.calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Stacked on #525 and #528** (their commits are included; only the last commit is new here).

StallGuard only sees the cruise phase; a hit on a ramp or at the target goes unnoticed and the chute silently loses its home. An AS5600 on the motor's rear shaft (I2C0 on GP0/GP1, fixed address 0x36, one per board) lets the firmware compare the unwrapped encoder count with the commanded position every 5 ms; three consecutive readings beyond the tolerance latch the same stall flag StallGuard uses, so the incident / re-home path is shared. Position resets (homing, `SET_POSITION`) re-sync the offset; jitter strokes are skipped.

Backend: `[stepper_encoder.<name>]` (enabled / sign / counts_per_rev / tolerance_fullsteps) → `ENCODER_CONFIG` at stepper init; `ENCODER_STATUS` and the observability `enc` field expose magnet status, AGC and deviation for bring-up. Disabled unless configured. Firmware builds for both SKR variants; sensor bring-up on the machine is pending (hardware arrives tomorrow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)