### PR TITLE
parts-calculator: lock the feeder with a tag that resolves its whole subtree

### DIFF
--- a/parts-calculator/VERSIONING.md
+++ b/parts-calculator/VERSIONING.md
@@ -87,7 +87,9 @@ change:
    `breaking` bit, `"commit": null` (pending).
 3. After committing, run `catalog/stamp_versions.py`: it ties the entry to
    its commit and snapshots the superseded lines with each member's uid of
-   the day, so the box as built then reads back part by part.
+   the day, so the box as built then reads back part by part. On a node's
+   first stamp it also writes the entry for the state being left behind, so
+   there is always a snapshot to flip back to.
 
 There is no "just filling in what was always there" exemption: the lines
 are the record, and every change to them is a moment someone may need to
@@ -123,6 +125,14 @@ forward promise — future revisions of a golden-tagged node must not be
 breaking, so anything built against it keeps working; `experimental` marks
 a coherent but unproven cut. A tag resolves against history exactly like a
 timeline point and renders highlighted on the timeline.
+
+A tag is the lock on a whole subtree. A version stamp records one node's
+own list and nothing below it; the tag names a moment, and at that moment
+every assembly under the node resolves to the lines it had then and every
+part to the revision it was then (both from the dates on their version
+entries). "Flip back to the feeder as it was" is: open History on the
+feeder, click the tag's row. A tag resolves at the end of its date, so a
+change that must fall outside it is stamped with a later date.
 
 Tags are appended only by a human decision. No tool, check, or agent ever
 mints one.

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column — both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) — these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until §5.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit — 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, §5.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views. TAGS (2026-08-31): top-level tags [{name, node, stability: 'golden'|'stable'|'experimental' ('golden' adds the forward promise: revisions under a golden-tagged node must not be breaking), date, commit, message?}] -- a blessed moment of a node's whole subtree, resolved against history exactly like a timeline point (see VERSIONING.md, History is derived). 'stable' means the build as of that moment is known good and compatibility with it must not be broken silently. Tags are only ever appended by a human decision; nothing mints them.",
+  "_comment": "Source-of-truth manifest. filament.py slices each STL once and writes ../src/lib/data/parts.generated.json + thumbnails + STL copies. Per part: id, uid (see UID below), name, category, description (short, shown in app), internal_notes (extended, agent-only, NOT emitted to the app), version, created_at, updated_at, stl_hash (sha256 pin of the master STL; publish with scripts/publish_assets.py --upload), quantity (per ONE instance of its category), color, optional. attributes (optional list of {label,value} shown in the app), versions (optional archetype history: list of {version,date,message,commit}; commit ties to a real git commit, null = pending an upcoming clean commit). low_tolerance (optional bool: part has little tolerance for dimensional error - a tight/precise fit - so a test print is worth doing) + low_tolerance_note (the specifics, shown in the app). color is one of {\"role\":\"<roleid>\"} (user-picked), {\"fixed\":\"<lego-id>\"}, {\"split\":[{\"color\":\"<lego-id>\",\"qty\":N},...]} (sums to quantity), or {\"any\":true}, or {\"by_section\":{\"<sectionid>\":<colorspec>,...}} (per-section color when a part lives in multiple sections). Machine = 1 of each non-scaling category + N of each scaling category. See ../notes/TERMINOLOGY.md. SCHEMA V2 (unified parts system, see ../notes/UNIFIED-PARTS-SYSTEM.md, incremental): a part may carry kind ('printed' when absent | 'cots'); cots parts have cots {type,size?,variant?}, category (display grouping on the hardware tab), note (builder-critical caveat from the BOM sheet), image (slicer-relative path, published by publish_assets.py and served from the asset service) OR image_url (an already-published content-addressed URL; BOM product images never touch git), sourcing {vendors:[{region,vendor,url,affiliate_url?,price,currency?,pack_qty?,as_of?,note?}]} (url is always the plain listing; affiliate_url is the same listing carrying the project's Amazon tag, mirroring the BOM sheet's 'US Source 1 with Affiliate' column — both are kept so a builder can choose) (price is USD unless currency says otherwise), and no stl/color/quantities. sheet_qty {per_machine|per_layer} / sheet_qty_text are TRANSITIONAL hand counts carried over from the BOM sheet; they die once these parts are placed as requires/lines in the tree. A printed part may carry requires [{part,qty}] = hardware committed to that single physical part (heat inserts, press-fit bearings); qty scales with the part automatically. An assembly may carry lines [{part|assembly, qty}] (qty is a number, or 'per-layer' = multiplied by the total layer count, or 'middle-layers' = layer count minus 2, the layers that sit between the top and bottom interfaces) — these form the experimental machine tree rooted at the 'machine' assembly. A line may also reference a laser-cut part by id (e.g. 'top-plate'); those still live in src/lib/lasercut.ts and are resolved from there until §5.5 folds them into this manifest. Line ids are unique within an assembly: two joints that use the same screw are one merged line. Screws and other hardware that JOIN parts are lines of the assembly that makes the joint, never requires of either member (requires is only for hardware committed to one physical part). joining [{method,note}] records how the lines become one unit — 'solder'|'crimp'|'glue'|'press'|'self-tap' (screw cuts its own thread in printed plastic, no insert or nut) |'friction' (held by clamping force alone, e.g. jammed in an extrusion slot). A cots part that is cut from a bought length carries stock {unit_length_mm, cut_length_mm, pieces_per_unit, unit_label, piece_label}; its lines count PIECES and the app divides to get lengths to buy. MERGES/CONFLICTS (2026-08-21, docs catalog folded in): top-level merges [{id,date,sources,note}] records source-of-truth merger events. A part may carry conflicts [{merge,field,claims:[{source,value},...],note}] = an unresolved factual disagreement between the merged catalogs, kept as data on purpose and rendered as a badge on BOTH sites (docs parts-needed cards + calculator detail views); resolving one means fixing the disputed field against the physical machine and DELETING the conflict entry (git is the history). A part may also carry caption (small text under its docs parts-needed card) and docs_page (its docs detail page path; lets either site cross-link). The docs site renders its parts data from parts.generated.json -- docs/src/liquid/_data/parts.yml is deleted; this manifest is the only parts catalog. LASERCUT (2026-08-21, §5.5 partly done): parts with kind 'lasercut' are the flat sheet parts, passed through to the generated JSON verbatim (fields match the app's LaserCutPart type in src/lib/lasercut.ts, which now reads the generated data instead of hardcoding it; the docs site reads the same JSON). dxf/preview are app-static paths; photo is a published URL. UID (2026-08-22): every part, whatever its kind, carries uid -- a minted 4-char id (catalog/mint_uid.py) naming its CURRENT VERSION: the exact thing in your hand, and what a print gets engraved with. A human bumping `version` mints a new uid; a re-export of the same design is new bytes (a new stl_hash) under the same uid, not a new version. A superseded version entry carries the uid it had (stamp_versions.py writes it beside the superseded stl_hash). Mint BEFORE the STL exists: the entry holds the uid, and the engraved downloads generate.py cuts are named for it. FILENAMES (2026-08-23, the asset service is the only store): a key is the name the file was published under plus a hash of its own bytes, in the sorter-parts namespace. A master STL, and every archived version and candidate of it, is published under the part's id -- sorter-parts/<part-id>-<hash12>.stl -- so the hash is what tells the versions apart, and it is the stl_hash pinned right here: grep a downloaded file's hash fragment in this file and you have the exact version. An engraved download carries the uid as well, sorter-parts/<part-id>-<uid>-stamped-<face>-<hash12>.stl, because that is the string recessed into the plastic. An image is published as a copy with the camera's metadata stripped, so its URL is read off the service, never derived. CANDIDATES (2026-08-22): a printed part may carry candidates [{uid, name?, stl_hash, created_at, message, onshape_version?, images?, support?, superseded_by?, superseded_at?, rejected_at?}] -- design revisions under test for that part's slot. Each is minted its own uid and pinned by hash (publish with publish_assets.py --upload <part-id>.stl), gets sliced and rendered and is downloadable from the part's page, counts toward nothing, and has NO version number: numbers are handed out in adoption order. Promotion = the candidate's uid + stl_hash become the part's current, version bumps, a versions entry is added, the candidate line is removed (its uid lives on at part level). A candidate that is iterated on or dropped is NEVER deleted: mark it superseded_by/superseded_at or rejected_at and leave its pin, so the uid engraved on a test print always resolves here. check_generated_pins.py fails any change that makes a uid disappear from this file. ASSEMBLIES (2026-08-22): every assembly carries uid and version exactly like a part. A new version is an authored STRUCTURAL change (a line added or removed, a qty changed) -- a member part revving is that part's own history, not the assembly's. versions [{version, uid, date, message, commit, lines}] is written like a part's: author the new entry with commit null, and stamp_versions.py carries the superseded uid plus a snapshot of the lines as they were, each line pinned to the member's uid at the time, so a box as built then can be read back part by part. candidates [{uid, name?, created_at, message, lines, joining?, images?, superseded_by?, superseded_at?, rejected_at?}] is a whole alternative bill of materials under test (new parts enter with empty quantities so they count toward nothing); promotion = the candidate's lines and uid become the assembly's, version bumps, a versions entry is added, the candidate line is removed. Same retention rule: a candidate is marked, never deleted. A candidate may carry name: what the slot is called if it is adopted (the housing candidate on ctrl-board-mount renames it on promotion). IMAGES (2026-08-22): any part (printed or cots), assembly, candidate or version may carry images [{url, alt, caption?}] -- extra pictures beyond the render or product photo: an Onshape screenshot, a section view, a photo of it built. On an assembly the first image is its main picture, shown large on its detail view. url is a pinned published URL exactly like image_url (publish_assets.py --upload <file>.png prints it; never a repo path) and alt says what the picture shows; generate.py refuses anything else and check_asset_urls.py fetches every one. The site shows them as a zoomable strip on the part, hardware and assembly views. TAGS (2026-08-31): top-level tags [{name, node, stability: 'golden'|'stable'|'experimental' ('golden' adds the forward promise: revisions under a golden-tagged node must not be breaking), date, commit, message?}] -- a blessed moment of a node's whole subtree, resolved against history exactly like a timeline point (see VERSIONING.md, History is derived). 'stable' means the build as of that moment is known good and compatibility with it must not be broken silently. Tags are only ever appended by a human decision; nothing mints them.",
   "sections": [
     {
       "id": "feeder",
@@ -5612,24 +5612,18 @@
   "assemblies": [
     {
       "id": "light-post-assembly",
-      "uid": "v06x",
-      "version": "1",
+      "uid": "lxof",
+      "version": "2",
       "name": "Light post",
-      "description": "The feeder light post: post, cap, and cap adapter. 2 per machine. Bolts to a C-channel NEMA bracket.",
+      "description": "The feeder light post: the post, the 50 mm COB plate on its end lighting down the channel, and the cap adapter and cap over it. 2 per machine, one each on C-channels 2 and 3, bolted to the C-channel drive's NEMA bracket.",
       "docs": "/hardware/assembly/feeder/light-post/",
-      "joining": [
-        {
-          "method": "self-tap",
-          "note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post — no insert, no nut."
-        }
-      ],
       "lines": [
         {
           "part": "light-post",
           "qty": 1
         },
         {
-          "part": "light-post-cap",
+          "part": "led-cob-50mm-24v",
           "qty": 1
         },
         {
@@ -5641,12 +5635,49 @@
           "qty": 3
         },
         {
-          "part": "scr-m3-20-cs",
-          "qty": 2
+          "part": "light-post-cap",
+          "qty": 1
+        }
+      ],
+      "connections": [
+        {
+          "from": "light-post-cap-adapter",
+          "to": "light-post",
+          "via": "scr-m3-12-cs",
+          "qty": 3,
+          "method": "self-tap",
+          "note": "Down through the adapter's three clearance holes and the COB plate clamped under it, threading into the pilot holes in the post's end."
+        }
+      ],
+      "images": [
+        {
+          "url": "https://assets.basically.website/sorter-parts/light-post-assembled-full-2b59e7e84bdb.jpg",
+          "alt": "A finished light post on the bench: the black printed post with the 50 mm COB plate on its end, and the red and black leads running out of the post to a DC barrel plug",
+          "caption": "The light post, assembled."
         },
         {
-          "part": "led-cob-50mm-24v",
-          "qty": 1
+          "url": "https://assets.basically.website/sorter-parts/light-post-top-cap-off-full-d076a7bff4a1.jpg",
+          "alt": "The end of the post with the cap off: the aluminium back of the COB plate with the black cap adapter on it, three countersunk screws going down through both into the post, and the leads coming up through the centre hole",
+          "caption": "Cap off: the adapter and its three M3 × 12 through the plate into the post."
+        },
+        {
+          "url": "https://assets.basically.website/sorter-parts/light-post-led-side-full-428b89ff9243.jpg",
+          "alt": "The LED side of the COB plate, close up: the post's forked end holds the plate at its centre, with the leads passing through the centre hole",
+          "caption": "LED side: the post's forked end at the plate's centre."
+        },
+        {
+          "url": "https://assets.basically.website/sorter-parts/light-post-led-side-centre-full-b25b6589047d.jpg",
+          "alt": "The LED side of the COB plate straight on: the post's forked end at the centre with the leads leaving through it",
+          "caption": "LED side, straight on."
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-09-02",
+          "message": "The two M3 × 20 that bolt the post to the C-channel drive's NEMA bracket moved out to C-channels 2 and 3: the joint belongs to the node that holds both sides. The COB plate, the adapter and the three M3 × 12 that clamp them to the post are now a recorded joint. No physical change.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },
@@ -6603,8 +6634,8 @@
     },
     {
       "id": "channel-two",
-      "uid": "hi96",
-      "version": "1",
+      "uid": "7sut",
+      "version": "2",
       "name": "C-channel 2",
       "description": "The middle feeder channel: a C-channel drive with a white faceted rotor, an output guide and a light post, standing on three supports with one leg extension each.",
       "lines": [
@@ -6631,6 +6662,10 @@
         {
           "assembly": "camera-mount",
           "qty": 1
+        },
+        {
+          "part": "scr-m3-20-cs",
+          "qty": 2
         }
       ],
       "connections": [
@@ -6640,13 +6675,30 @@
           "qty": 3,
           "method": "friction",
           "note": "Dovetail: each support's leg slides into the C-channel drive from below."
+        },
+        {
+          "from": "c-channel",
+          "to": "light-post-assembly",
+          "via": "scr-m3-20-cs",
+          "qty": 2,
+          "method": "self-tap",
+          "note": "Through the NEMA bracket, threading straight into the printed post — no insert, no nut."
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-09-02",
+          "message": "Took in the two M3 × 20 that bolt the light post to the C-channel drive's NEMA bracket; they were recorded inside the light post. No physical change.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },
     {
       "id": "channel-three",
-      "uid": "xlak",
-      "version": "1",
+      "uid": "p55u",
+      "version": "2",
       "name": "C-channel 3",
       "description": "The lowest feeder channel, just above the classification chamber: a C-channel drive with the gray faceted rotor, an output guide and a light post, on three foot-and-leg supports.",
       "lines": [
@@ -6673,6 +6725,10 @@
         {
           "assembly": "camera-mount",
           "qty": 1
+        },
+        {
+          "part": "scr-m3-20-cs",
+          "qty": 2
         }
       ],
       "connections": [
@@ -6682,6 +6738,23 @@
           "qty": 3,
           "method": "friction",
           "note": "Dovetail: each support's leg slides into the C-channel drive from below."
+        },
+        {
+          "from": "c-channel",
+          "to": "light-post-assembly",
+          "via": "scr-m3-20-cs",
+          "qty": 2,
+          "method": "self-tap",
+          "note": "Through the NEMA bracket, threading straight into the printed post — no insert, no nut."
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-09-02",
+          "message": "Took in the two M3 × 20 that bolt the light post to the C-channel drive's NEMA bracket; they were recorded inside the light post. No physical change.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5673,11 +5673,48 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "uid": "v06x",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "part": "light-post",
+              "qty": 1,
+              "uid": "oac5"
+            },
+            {
+              "part": "light-post-cap",
+              "qty": 1,
+              "uid": "7a8e"
+            },
+            {
+              "part": "light-post-cap-adapter",
+              "qty": 1,
+              "uid": "jcnt"
+            },
+            {
+              "part": "scr-m3-12-cs",
+              "qty": 3,
+              "uid": "0a9x"
+            },
+            {
+              "part": "scr-m3-20-cs",
+              "qty": 2,
+              "uid": "60g4"
+            },
+            {
+              "part": "led-cob-50mm-24v",
+              "qty": 1,
+              "uid": "s34o"
+            }
+          ]
+        },
+        {
           "version": "2",
           "date": "2026-09-02",
           "message": "The two M3 × 20 that bolt the post to the C-channel drive's NEMA bracket moved out to C-channels 2 and 3: the joint belongs to the node that holds both sides. The COB plate, the adapter and the three M3 × 12 that clamp them to the post are now a recorded joint. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "271ea214"
         }
       ]
     },
@@ -6687,11 +6724,48 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "uid": "hi96",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "assembly": "channel-two-support",
+              "qty": 3,
+              "uid": "dp63"
+            },
+            {
+              "assembly": "c-channel",
+              "qty": 1,
+              "uid": "4tvc"
+            },
+            {
+              "assembly": "rotor-unit-faceted",
+              "qty": 1,
+              "uid": "ylvv"
+            },
+            {
+              "part": "output-guide",
+              "qty": 1,
+              "uid": "8j3e"
+            },
+            {
+              "assembly": "light-post-assembly",
+              "qty": 1,
+              "uid": "v06x"
+            },
+            {
+              "assembly": "camera-mount",
+              "qty": 1,
+              "uid": "b3zx"
+            }
+          ]
+        },
+        {
           "version": "2",
           "date": "2026-09-02",
           "message": "Took in the two M3 × 20 that bolt the light post to the C-channel drive's NEMA bracket; they were recorded inside the light post. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "271ea214"
         }
       ]
     },
@@ -6750,11 +6824,48 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "uid": "xlak",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "assembly": "channel-three-support",
+              "qty": 3,
+              "uid": "r6ar"
+            },
+            {
+              "assembly": "c-channel",
+              "qty": 1,
+              "uid": "4tvc"
+            },
+            {
+              "assembly": "rotor-unit-faceted",
+              "qty": 1,
+              "uid": "ylvv"
+            },
+            {
+              "part": "output-guide",
+              "qty": 1,
+              "uid": "8j3e"
+            },
+            {
+              "assembly": "light-post-assembly",
+              "qty": 1,
+              "uid": "v06x"
+            },
+            {
+              "assembly": "camera-mount",
+              "qty": 1,
+              "uid": "b3zx"
+            }
+          ]
+        },
+        {
           "version": "2",
           "date": "2026-09-02",
           "message": "Took in the two M3 × 20 that bolt the light post to the C-channel drive's NEMA bracket; they were recorded inside the light post. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "271ea214"
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5647,6 +5647,13 @@
           "qty": 3,
           "method": "self-tap",
           "note": "Down through the adapter's three clearance holes and the COB plate clamped under it, threading into the pilot holes in the post's end."
+        },
+        {
+          "from": "light-post-cap",
+          "to": "light-post-cap-adapter",
+          "qty": 1,
+          "method": "gravity",
+          "note": "The cap just sits on the adapter."
         }
       ],
       "images": [
@@ -6720,6 +6727,13 @@
           "qty": 2,
           "method": "self-tap",
           "note": "Through the NEMA bracket, threading straight into the printed post — no insert, no nut."
+        },
+        {
+          "from": "output-guide",
+          "to": "c-channel",
+          "qty": 1,
+          "method": "friction",
+          "note": "The guide pushes onto the C-channel drive and is held by the fit alone."
         }
       ],
       "versions": [
@@ -6820,6 +6834,13 @@
           "qty": 2,
           "method": "self-tap",
           "note": "Through the NEMA bracket, threading straight into the printed post — no insert, no nut."
+        },
+        {
+          "from": "output-guide",
+          "to": "c-channel",
+          "qty": 1,
+          "method": "friction",
+          "note": "The guide pushes onto the C-channel drive and is held by the fit alone."
         }
       ],
       "versions": [

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -8834,6 +8834,14 @@
       "date": "2026-08-31",
       "commit": null,
       "message": "Golden with hex-frame-v2: future revisions must stay compatible with this part."
+    },
+    {
+      "name": "feeder-2026-09-02",
+      "node": "feeder",
+      "stability": "stable",
+      "date": "2026-09-02",
+      "commit": null,
+      "message": "Locked before the C-channel overhaul: every unit, part and screw count under the feeder as it stood this day."
     }
   ]
 }

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -458,7 +458,7 @@
           "version": "1",
           "date": "2026-06-27",
           "message": "Initial catalog entry, imported 2026-06-27.",
-          "commit": null,
+          "commit": "340f63ad",
           "onshape_version": "https://cad.onshape.com/documents/60aa51fc61d18f2155b99910/v/b76489d0ca46a1169a2a6081/e/66109ce96b305bf318354f93"
         }
       ]
@@ -5763,7 +5763,7 @@
           "date": "2026-08-31",
           "message": "First recorded line: the finned rotor unit (rotor + bolted-on Output gear (130T)); the dome and the camera & LED insert were still unrecorded.",
           "breaking": false,
-          "commit": null
+          "commit": "aa3a4bac"
         }
       ],
       "lines": [
@@ -6214,7 +6214,7 @@
           "date": "2026-09-01",
           "message": "The 4 × M3 × 12 moved out to the Camera & LED insert assembly: they fasten this whole assembly into the insert, so the joint and its screws belong to the node that holds both. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "e47151a1"
         }
       ]
     },
@@ -6302,7 +6302,7 @@
           "date": "2026-09-01",
           "message": "The machine splits into what it physically is: the feeder, the superstructure it mounts onto — top plate, top interface, distribution layers, bottom interface — and the electronics. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "e47151a1"
         }
       ]
     },
@@ -6438,7 +6438,7 @@
           "date": "2026-09-01",
           "message": "Restructured into the four physical units — the bulk bucket, C-channels 2 and 3, and the classification chamber — each carrying its own C-channel drive, rotor, supports, guide or cap, and lighting. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "e47151a1"
         }
       ],
       "lines": [
@@ -7149,7 +7149,7 @@
           "date": "2026-09-01",
           "message": "The top plate moved up to the superstructure: it sits on top of the machine at this assembly's level, not inside it. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "e47151a1"
         }
       ]
     },
@@ -7455,7 +7455,7 @@
           "date": "2026-09-01",
           "message": "The screws are all countersunk — socket/button was recorded wrong. The idler's 608 bearing is a line of its own with its press fit as a connection, and the screw joints carry measured pass-through and thread depths. Connections bench-confirmed and listed in assembly order.",
           "breaking": false,
-          "commit": null
+          "commit": "441d9114"
         }
       ],
       "lines": [
@@ -7613,7 +7613,7 @@
           "date": "2026-09-01",
           "message": "The output gear's 6806 bearing is a line of its own with its press fit as a connection (was the gear's requires).",
           "breaking": false,
-          "commit": null
+          "commit": "441d9114"
         }
       ]
     },
@@ -7687,7 +7687,7 @@
           "date": "2026-09-01",
           "message": "The output gear's 6806 bearing is a line of its own with its press fit as a connection (was the gear's requires).",
           "breaking": false,
-          "commit": null
+          "commit": "441d9114"
         }
       ]
     },
@@ -7885,7 +7885,7 @@
           "date": "2026-08-31",
           "message": "Recording correction: the bottom vertical is screwed into the side bracket with 2 x M5 x 16, not 1, and the screws run from the bottom vertical into the side. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "937a96e5"
         }
       ]
     },
@@ -8031,7 +8031,7 @@
           "date": "2026-08-31",
           "message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) become External bracket with support units; the A/G extrusions slide between them in the outer hex, held by 12 friction fits and jammed by screws that self-tap through the brackets and ram against the extrusions; the 24 T-nuts are dropped. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "6573b255"
         }
       ],
       "connections": [
@@ -8114,7 +8114,7 @@
           "date": "2026-08-31",
           "message": "The bottom verticals, covers and their 24 screws move inside the hex frame's External bracket with support segments. No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "6573b255"
         }
       ]
     },

--- a/parts-calculator/catalog/stamp_versions.py
+++ b/parts-calculator/catalog/stamp_versions.py
@@ -24,6 +24,9 @@ The workflow the version system assumes:
   3. Run this script. It stamps the pending version with the commit that
      changed the uid, and writes the REPLACED uid + stl_hash onto the version
      it superseded -- which is how old geometry stays retrievable forever.
+     The first stamp on a node has no superseded entry to write onto, so the
+     script adds one (undated: the state from before anything was dated),
+     and the moment before the change still resolves on the timeline.
   4. Commit the resulting parts.json (+ re-run generate.py) as a small "stamp"
      commit.
 
@@ -120,12 +123,21 @@ def main():
         commit, (replaced_uid, replaced_pin) = found
         versions[-1]["commit"] = commit
         stamped.append((p["id"], versions[-1].get("version"), commit))
+        pin_key = "stl_hash" if kind == "parts" else "lines"
+        newest_ver = str(versions[-1].get("version"))
+        if len(versions) == 1 and newest_ver != "1" and replaced_uid and replaced_pin:
+            # the node's first stamp: nothing recorded the state it just left
+            prev_ver = str(int(newest_ver) - 1) if newest_ver.isdigit() else "1"
+            versions.insert(0, collections.OrderedDict([
+                ("version", prev_ver), ("uid", replaced_uid),
+                ("message", "As recorded before the first stamped change."),
+                (pin_key, replaced_pin)]))
+            print(f"  + {p['id']}: wrote v{prev_ver} ({replaced_uid}), the state it superseded")
         if len(versions) > 1 and not versions[-2].get("uid"):
             if replaced_uid and replaced_pin:
                 old = versions[-2]
                 # a part pins its geometry (stl_hash); an assembly its lines,
                 # each carrying the member's uid of the day
-                pin_key = "stl_hash" if kind == "parts" else "lines"
                 versions[-2] = collections.OrderedDict(
                     [("version", old.get("version")), ("uid", replaced_uid)]
                     + [(k, v) for k, v in old.items() if k != "version"]

--- a/parts-calculator/src/lib/components/AssemblyDetail.svelte
+++ b/parts-calculator/src/lib/components/AssemblyDetail.svelte
@@ -159,7 +159,7 @@
 <div class="ad">
 	<header class="ad-head">
 		{#if assembly.images?.length}
-			<ImageStrip images={assembly.images} />
+			<ImageStrip images={assembly.images} hero />
 		{:else if fan.length}
 			<div class="ad-fan ad-fan-lg">
 				{#each fan as p, i (p.id)}

--- a/parts-calculator/src/lib/components/ConnectionBraces.svelte
+++ b/parts-calculator/src/lib/components/ConnectionBraces.svelte
@@ -23,32 +23,24 @@
 	 *  components over shared members, so two unrelated self-tapped joints never
 	 *  merge into a single spine. Exported because the page sizes each branch's
 	 *  gutter off the same grouping. */
+	// One brace per joint. A joint is the two members and the fastener between
+	// them; it may be recorded as several edges (the same screws into holes of
+	// two depths), which draw as one brace. Two joints that merely share a
+	// member — the supports and the output guide both friction-fit to the
+	// drive — are two braces.
 	export function braceGroups(edges: Connection[]) {
-		const byMethod = new Map<string, Connection[]>();
-		for (const e of edges) byMethod.set(e.method, [...(byMethod.get(e.method) ?? []), e]);
-		const out: { key: string; method: string; edges: Connection[]; ids: string[]; draft: boolean }[] = [];
-		for (const [method, es] of byMethod) {
-			const comps: Connection[][] = [];
-			for (const e of es) {
-				const mine = new Set([e.from, e.to, ...(e.via ? [e.via] : [])]);
-				const touching = comps.filter((c) =>
-					c.some((o) => [o.from, o.to, o.via].some((x) => x && mine.has(x)))
-				);
-				for (const t of touching) comps.splice(comps.indexOf(t), 1);
-				comps.push([...touching.flat(), e]);
-			}
-			for (const c of comps) {
-				const ids = [...new Set(c.flatMap((e) => [e.from, e.to, ...(e.via ? [e.via] : [])]))];
-				out.push({
-					key: `${method}:${ids.join('+')}`,
-					method,
-					edges: c,
-					ids,
-					draft: c.every((e) => e.draft)
-				});
-			}
+		const joints = new Map<string, Connection[]>();
+		for (const e of edges) {
+			const key = `${e.method}:${e.from}>${e.to}:${e.via ?? ''}`;
+			joints.set(key, [...(joints.get(key) ?? []), e]);
 		}
-		return out;
+		return [...joints].map(([key, es]) => ({
+			key,
+			method: es[0].method,
+			edges: es,
+			ids: [...new Set(es.flatMap((e) => [e.from, e.to, ...(e.via ? [e.via] : [])]))],
+			draft: es.every((e) => e.draft)
+		}));
 	}
 </script>
 

--- a/parts-calculator/src/lib/components/ImageStrip.svelte
+++ b/parts-calculator/src/lib/components/ImageStrip.svelte
@@ -5,8 +5,10 @@
 	// Extra pictures of a thing -- an Onshape screenshot, a section view, a photo
 	// of it built. A row of thumbnails; clicking one opens it full-size. Used
 	// wherever the catalog carries `images`: parts, hardware, assemblies, their
-	// candidates and versions, and planned changes.
-	let { images }: { images?: CatalogImage[] | null } = $props();
+	// candidates and versions, and planned changes. With `hero` the first image
+	// is the thing's main picture and renders large above the rest.
+	let { images, hero = false }: { images?: CatalogImage[] | null; hero?: boolean } = $props();
+	const rest = $derived(hero ? (images ?? []).slice(1) : (images ?? []));
 
 	let open = $state(false);
 	let current = $state<CatalogImage | null>(null);
@@ -17,8 +19,18 @@
 </script>
 
 {#if images?.length}
+	{#if hero}
+		{@const main = images[0]}
+		<figure class="mb-2">
+			<button type="button" class="block w-full cursor-zoom-in" title="Open full-size image" onclick={() => show(main)}>
+				<img src={main.url} alt={main.alt} class="h-56 w-full border border-border bg-white object-contain hover:border-primary" />
+			</button>
+			{#if main.caption}<figcaption class="mt-0.5 text-[11px] text-text-muted">{main.caption}</figcaption>{/if}
+		</figure>
+	{/if}
+	{#if rest.length}
 	<div class="flex gap-2 overflow-x-auto">
-		{#each images as im (im.url)}
+		{#each rest as im (im.url)}
 			<figure class="w-40 shrink-0">
 				<button type="button" class="block cursor-zoom-in" title="Open full-size image" onclick={() => show(im)}>
 					<img src={im.url} alt={im.alt} class="h-24 w-40 border border-border bg-white object-contain hover:border-primary" />
@@ -27,6 +39,7 @@
 			</figure>
 		{/each}
 	</div>
+	{/if}
 	<Modal bind:open title={current?.alt} maxW="max-w-6xl">
 		<div class="flex min-h-0 flex-col items-center justify-center bg-white p-4">
 			{#if current}

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -549,12 +549,49 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "v06x",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"part": "light-post",
+							"qty": 1,
+							"uid": "oac5"
+						},
+						{
+							"part": "light-post-cap",
+							"qty": 1,
+							"uid": "7a8e"
+						},
+						{
+							"part": "light-post-cap-adapter",
+							"qty": 1,
+							"uid": "jcnt"
+						},
+						{
+							"part": "scr-m3-12-cs",
+							"qty": 3,
+							"uid": "0a9x"
+						},
+						{
+							"part": "scr-m3-20-cs",
+							"qty": 2,
+							"uid": "60g4"
+						},
+						{
+							"part": "led-cob-50mm-24v",
+							"qty": 1,
+							"uid": "s34o"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "lxof",
 					"date": "2026-09-02",
 					"message": "The two M3 \u00d7 20 that bolt the post to the C-channel drive's NEMA bracket moved out to C-channels 2 and 3: the joint belongs to the node that holds both sides. The COB plate, the adapter and the three M3 \u00d7 12 that clamp them to the post are now a recorded joint. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "271ea214"
 				}
 			]
 		},
@@ -1569,12 +1606,49 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "hi96",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"assembly": "channel-two-support",
+							"qty": 3,
+							"uid": "dp63"
+						},
+						{
+							"assembly": "c-channel",
+							"qty": 1,
+							"uid": "4tvc"
+						},
+						{
+							"assembly": "rotor-unit-faceted",
+							"qty": 1,
+							"uid": "ylvv"
+						},
+						{
+							"part": "output-guide",
+							"qty": 1,
+							"uid": "8j3e"
+						},
+						{
+							"assembly": "light-post-assembly",
+							"qty": 1,
+							"uid": "v06x"
+						},
+						{
+							"assembly": "camera-mount",
+							"qty": 1,
+							"uid": "b3zx"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "7sut",
 					"date": "2026-09-02",
 					"message": "Took in the two M3 \u00d7 20 that bolt the light post to the C-channel drive's NEMA bracket; they were recorded inside the light post. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "271ea214"
 				}
 			]
 		},
@@ -1633,12 +1707,49 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "xlak",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"assembly": "channel-three-support",
+							"qty": 3,
+							"uid": "r6ar"
+						},
+						{
+							"assembly": "c-channel",
+							"qty": 1,
+							"uid": "4tvc"
+						},
+						{
+							"assembly": "rotor-unit-faceted",
+							"qty": 1,
+							"uid": "ylvv"
+						},
+						{
+							"part": "output-guide",
+							"qty": 1,
+							"uid": "8j3e"
+						},
+						{
+							"assembly": "light-post-assembly",
+							"qty": 1,
+							"uid": "v06x"
+						},
+						{
+							"assembly": "camera-mount",
+							"qty": 1,
+							"uid": "b3zx"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "p55u",
 					"date": "2026-09-02",
 					"message": "Took in the two M3 \u00d7 20 that bolt the light post to the C-channel drive's NEMA bracket; they were recorded inside the light post. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "271ea214"
 				}
 			]
 		},

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -640,7 +640,7 @@
 					"date": "2026-08-31",
 					"message": "First recorded line: the finned rotor unit (rotor + bolted-on Output gear (130T)); the dome and the camera & LED insert were still unrecorded.",
 					"breaking": false,
-					"commit": null
+					"commit": "aa3a4bac"
 				}
 			],
 			"lines": [
@@ -1093,7 +1093,7 @@
 					"date": "2026-09-01",
 					"message": "The 4 \u00d7 M3 \u00d7 12 moved out to the Camera & LED insert assembly: they fasten this whole assembly into the insert, so the joint and its screws belong to the node that holds both. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "e47151a1"
 				}
 			]
 		},
@@ -1182,7 +1182,7 @@
 					"date": "2026-09-01",
 					"message": "The machine splits into what it physically is: the feeder, the superstructure it mounts onto \u2014 top plate, top interface, distribution layers, bottom interface \u2014 and the electronics. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "e47151a1"
 				}
 			]
 		},
@@ -1319,7 +1319,7 @@
 					"date": "2026-09-01",
 					"message": "Restructured into the four physical units \u2014 the bulk bucket, C-channels 2 and 3, and the classification chamber \u2014 each carrying its own C-channel drive, rotor, supports, guide or cap, and lighting. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "e47151a1"
 				}
 			],
 			"lines": [
@@ -2031,7 +2031,7 @@
 					"date": "2026-09-01",
 					"message": "The top plate moved up to the superstructure: it sits on top of the machine at this assembly's level, not inside it. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "e47151a1"
 				}
 			]
 		},
@@ -2339,7 +2339,7 @@
 					"date": "2026-09-01",
 					"message": "The screws are all countersunk \u2014 socket/button was recorded wrong. The idler's 608 bearing is a line of its own with its press fit as a connection, and the screw joints carry measured pass-through and thread depths. Connections bench-confirmed and listed in assembly order.",
 					"breaking": false,
-					"commit": null
+					"commit": "441d9114"
 				}
 			],
 			"lines": [
@@ -2498,7 +2498,7 @@
 					"date": "2026-09-01",
 					"message": "The output gear's 6806 bearing is a line of its own with its press fit as a connection (was the gear's requires).",
 					"breaking": false,
-					"commit": null
+					"commit": "441d9114"
 				}
 			]
 		},
@@ -2573,7 +2573,7 @@
 					"date": "2026-09-01",
 					"message": "The output gear's 6806 bearing is a line of its own with its press fit as a connection (was the gear's requires).",
 					"breaking": false,
-					"commit": null
+					"commit": "441d9114"
 				}
 			]
 		},
@@ -2772,7 +2772,7 @@
 					"date": "2026-08-31",
 					"message": "Recording correction: the bottom vertical is screwed into the side bracket with 2 x M5 x 16, not 1, and the screws run from the bottom vertical into the side. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "937a96e5"
 				}
 			]
 		},
@@ -2919,7 +2919,7 @@
 					"date": "2026-08-31",
 					"message": "Restructured into Inner hex frame + Outer hex frame with connection edges. The corner brackets (side, bottom vertical, cover) become External bracket with support units; the A/G extrusions slide between them in the outer hex, held by 12 friction fits and jammed by screws that self-tap through the brackets and ram against the extrusions; the 24 T-nuts are dropped. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "6573b255"
 				}
 			],
 			"connections": [
@@ -3003,7 +3003,7 @@
 					"date": "2026-08-31",
 					"message": "The bottom verticals, covers and their 24 screws move inside the hex frame's External bracket with support segments. No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "6573b255"
 				}
 			]
 		},
@@ -3418,7 +3418,7 @@
 					"uid": "n6bm",
 					"date": "2026-06-27",
 					"message": "Initial catalog entry, imported 2026-06-27.",
-					"commit": null,
+					"commit": "340f63ad",
 					"onshape_version": "https://cad.onshape.com/documents/60aa51fc61d18f2155b99910/v/b76489d0ca46a1169a2a6081/e/66109ce96b305bf318354f93",
 					"stl": "https://assets.basically.website/sorter-parts/stator-323b2d1f94a5.stl",
 					"render": "https://assets.basically.website/sorter-parts/stator-full-8b6222d89d98.png",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -488,24 +488,18 @@
 	"assemblies": [
 		{
 			"id": "light-post-assembly",
-			"uid": "v06x",
-			"version": "1",
+			"uid": "lxof",
+			"version": "2",
 			"name": "Light post",
-			"description": "The feeder light post: post, cap, and cap adapter. 2 per machine. Bolts to a C-channel NEMA bracket.",
+			"description": "The feeder light post: the post, the 50 mm COB plate on its end lighting down the channel, and the cap adapter and cap over it. 2 per machine, one each on C-channels 2 and 3, bolted to the C-channel drive's NEMA bracket.",
 			"docs": "/hardware/assembly/feeder/light-post/",
-			"joining": [
-				{
-					"method": "self-tap",
-					"note": "The two [[hw:scr-m3-20-cs]] screws that join the post to the NEMA bracket thread straight into the printed post \u2014 no insert, no nut."
-				}
-			],
 			"lines": [
 				{
 					"part": "light-post",
 					"qty": 1
 				},
 				{
-					"part": "light-post-cap",
+					"part": "led-cob-50mm-24v",
 					"qty": 1
 				},
 				{
@@ -517,12 +511,50 @@
 					"qty": 3
 				},
 				{
-					"part": "scr-m3-20-cs",
-					"qty": 2
+					"part": "light-post-cap",
+					"qty": 1
+				}
+			],
+			"connections": [
+				{
+					"from": "light-post-cap-adapter",
+					"to": "light-post",
+					"via": "scr-m3-12-cs",
+					"qty": 3,
+					"method": "self-tap",
+					"note": "Down through the adapter's three clearance holes and the COB plate clamped under it, threading into the pilot holes in the post's end."
+				}
+			],
+			"images": [
+				{
+					"url": "https://assets.basically.website/sorter-parts/light-post-assembled-full-2b59e7e84bdb.jpg",
+					"alt": "A finished light post on the bench: the black printed post with the 50 mm COB plate on its end, and the red and black leads running out of the post to a DC barrel plug",
+					"caption": "The light post, assembled."
 				},
 				{
-					"part": "led-cob-50mm-24v",
-					"qty": 1
+					"url": "https://assets.basically.website/sorter-parts/light-post-top-cap-off-full-d076a7bff4a1.jpg",
+					"alt": "The end of the post with the cap off: the aluminium back of the COB plate with the black cap adapter on it, three countersunk screws going down through both into the post, and the leads coming up through the centre hole",
+					"caption": "Cap off: the adapter and its three M3 \u00d7 12 through the plate into the post."
+				},
+				{
+					"url": "https://assets.basically.website/sorter-parts/light-post-led-side-full-428b89ff9243.jpg",
+					"alt": "The LED side of the COB plate, close up: the post's forked end holds the plate at its centre, with the leads passing through the centre hole",
+					"caption": "LED side: the post's forked end at the plate's centre."
+				},
+				{
+					"url": "https://assets.basically.website/sorter-parts/light-post-led-side-centre-full-b25b6589047d.jpg",
+					"alt": "The LED side of the COB plate straight on: the post's forked end at the centre with the leads leaving through it",
+					"caption": "LED side, straight on."
+				}
+			],
+			"versions": [
+				{
+					"version": "2",
+					"uid": "lxof",
+					"date": "2026-09-02",
+					"message": "The two M3 \u00d7 20 that bolt the post to the C-channel drive's NEMA bracket moved out to C-channels 2 and 3: the joint belongs to the node that holds both sides. The COB plate, the adapter and the three M3 \u00d7 12 that clamp them to the post are now a recorded joint. No physical change.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -1484,8 +1516,8 @@
 		},
 		{
 			"id": "channel-two",
-			"uid": "hi96",
-			"version": "1",
+			"uid": "7sut",
+			"version": "2",
 			"name": "C-channel 2",
 			"description": "The middle feeder channel: a C-channel drive with a white faceted rotor, an output guide and a light post, standing on three supports with one leg extension each.",
 			"lines": [
@@ -1512,6 +1544,10 @@
 				{
 					"assembly": "camera-mount",
 					"qty": 1
+				},
+				{
+					"part": "scr-m3-20-cs",
+					"qty": 2
 				}
 			],
 			"connections": [
@@ -1521,13 +1557,31 @@
 					"qty": 3,
 					"method": "friction",
 					"note": "Dovetail: each support's leg slides into the C-channel drive from below."
+				},
+				{
+					"from": "c-channel",
+					"to": "light-post-assembly",
+					"via": "scr-m3-20-cs",
+					"qty": 2,
+					"method": "self-tap",
+					"note": "Through the NEMA bracket, threading straight into the printed post \u2014 no insert, no nut."
+				}
+			],
+			"versions": [
+				{
+					"version": "2",
+					"uid": "7sut",
+					"date": "2026-09-02",
+					"message": "Took in the two M3 \u00d7 20 that bolt the light post to the C-channel drive's NEMA bracket; they were recorded inside the light post. No physical change.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
 		{
 			"id": "channel-three",
-			"uid": "xlak",
-			"version": "1",
+			"uid": "p55u",
+			"version": "2",
 			"name": "C-channel 3",
 			"description": "The lowest feeder channel, just above the classification chamber: a C-channel drive with the gray faceted rotor, an output guide and a light post, on three foot-and-leg supports.",
 			"lines": [
@@ -1554,6 +1608,10 @@
 				{
 					"assembly": "camera-mount",
 					"qty": 1
+				},
+				{
+					"part": "scr-m3-20-cs",
+					"qty": 2
 				}
 			],
 			"connections": [
@@ -1563,6 +1621,24 @@
 					"qty": 3,
 					"method": "friction",
 					"note": "Dovetail: each support's leg slides into the C-channel drive from below."
+				},
+				{
+					"from": "c-channel",
+					"to": "light-post-assembly",
+					"via": "scr-m3-20-cs",
+					"qty": 2,
+					"method": "self-tap",
+					"note": "Through the NEMA bracket, threading straight into the printed post \u2014 no insert, no nut."
+				}
+			],
+			"versions": [
+				{
+					"version": "2",
+					"uid": "p55u",
+					"date": "2026-09-02",
+					"message": "Took in the two M3 \u00d7 20 that bolt the light post to the C-channel drive's NEMA bracket; they were recorded inside the light post. No physical change.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -19806,6 +19806,14 @@
 			"date": "2026-08-31",
 			"commit": null,
 			"message": "Golden with hex-frame-v2: future revisions must stay compatible with this part."
+		},
+		{
+			"name": "feeder-2026-09-02",
+			"node": "feeder",
+			"stability": "stable",
+			"date": "2026-09-02",
+			"commit": null,
+			"message": "Locked before the C-channel overhaul: every unit, part and screw count under the feeder as it stood this day."
 		}
 	]
 }

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -523,6 +523,13 @@
 					"qty": 3,
 					"method": "self-tap",
 					"note": "Down through the adapter's three clearance holes and the COB plate clamped under it, threading into the pilot holes in the post's end."
+				},
+				{
+					"from": "light-post-cap",
+					"to": "light-post-cap-adapter",
+					"qty": 1,
+					"method": "gravity",
+					"note": "The cap just sits on the adapter."
 				}
 			],
 			"images": [
@@ -1602,6 +1609,13 @@
 					"qty": 2,
 					"method": "self-tap",
 					"note": "Through the NEMA bracket, threading straight into the printed post \u2014 no insert, no nut."
+				},
+				{
+					"from": "output-guide",
+					"to": "c-channel",
+					"qty": 1,
+					"method": "friction",
+					"note": "The guide pushes onto the C-channel drive and is held by the fit alone."
 				}
 			],
 			"versions": [
@@ -1703,6 +1717,13 @@
 					"qty": 2,
 					"method": "self-tap",
 					"note": "Through the NEMA bracket, threading straight into the printed post \u2014 no insert, no nut."
+				},
+				{
+					"from": "output-guide",
+					"to": "c-channel",
+					"qty": 1,
+					"method": "friction",
+					"note": "The guide pushes onto the C-channel drive and is held by the fit alone."
 				}
 			],
 			"versions": [

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -117,7 +117,7 @@ export type Assembly = {
 	joining?: Joining[]; // work needed to make these lines into one unit
 	lines?: AssemblyLine[];
 	connections?: Connection[]; // the joints, as edges over this assembly's lines
-	images?: CatalogImage[]; // beyond the members' renders: a photo of it built, a section view
+	images?: CatalogImage[]; // photos of it built, section views; the first is its main picture
 };
 
 /** A joint recorded as an edge over the assembly's own lines. `to` is the

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -536,21 +536,34 @@
 
 	/** Every recorded state of an assembly's lines, oldest first: the era
 	 *  timeline, then versions[] snapshots dated past the era's horizon (the
-	 *  stamp rule guarantees those exist for every later structural change). */
-	const stateCache = new Map<string, { d: string; s: number; lines: AssemblyLine[] | null }[]>();
+	 *  stamp rule guarantees those exist for every later change). A superseded
+	 *  entry that carries a snapshot but no date is the state from before
+	 *  anything was dated — the first stamp on a node records what it held
+	 *  until then. */
+	type LineState = { d: string; s: number; lines: AssemblyLine[] | null };
+	const stateCache = new Map<string, LineState[]>();
 	function statesOf(id: string) {
 		const hit = stateCache.get(id);
 		if (hit) return hit;
-		const st = (eraAsm[id]?.timeline ?? []).map((t) => ({ d: t.date, s: t.seq, lines: t.lines }));
+		const era = eraAsm[id]?.timeline ?? [];
+		const undated: LineState[] = [];
+		const dated: LineState[] = [];
 		const asm = getAssembly(id);
 		const vs = asm?.versions ?? [];
 		vs.forEach((v, i) => {
+			const current = i === vs.length - 1;
+			if (!v.date) {
+				if (!current && v.lines) undated.push({ d: '', s: i, lines: v.lines });
+				return;
+			}
 			// >= : a stamp dated the era's own horizon (same-day) must still
 			// resolve. When the era already recorded that change, the extra
-			// state carries identical lines, so resolution is unaffected.
-			if (v.date && v.date >= eraThrough)
-				st.push({ d: v.date, s: VSEQ + i, lines: i === vs.length - 1 ? (asm!.lines ?? []) : (v.lines ?? null) });
+			// state carries identical lines, so resolution is unaffected. A node
+			// the era never saw keeps every dated entry.
+			if (v.date >= eraThrough || !era.length)
+				dated.push({ d: v.date, s: VSEQ + i, lines: current ? (asm!.lines ?? []) : (v.lines ?? null) });
 		});
+		const st = [...undated, ...era.map((t) => ({ d: t.date, s: t.seq, lines: t.lines })), ...dated];
 		stateCache.set(id, st);
 		return st;
 	}
@@ -565,8 +578,26 @@
 		// No recorded change anywhere in history — it has always been what it is.
 		return getAssembly(id)?.lines ?? null;
 	}
+	/** The uid a member carried at a moment, from the dates on its versions[]:
+	 *  the newest entry dated on or before the moment, else the earliest
+	 *  recorded one (it existed before anything was dated). */
+	function uidAt(id: string, k: TKey): string | undefined {
+		const m = memberOf(id) as { uid?: string; versions?: { uid?: string; date?: string }[] } | undefined;
+		if (!m) return undefined;
+		if (k.d === NOW.d) return m.uid;
+		const vs = m.versions ?? [];
+		let hit: { uid?: string } | undefined;
+		for (const v of vs) if (v.date && v.date <= k.d) hit = v;
+		return (hit ?? vs[0])?.uid ?? m.uid;
+	}
+	/** An assembly's lines at a moment, each pinned to the uid its member
+	 *  carried then — so a part revised after the lines were snapshotted, or
+	 *  never snapshotted at all, still reads back as the revision of the day. */
+	function snapshotAtKey(id: string, k: TKey): AssemblySnapshotLine[] {
+		return (linesAtKey(id, k) ?? []).map((l) => ({ ...l, uid: uidAt(l.part ?? l.assembly ?? '', k) }));
+	}
 	function timeRows(id: string, a: TKey, b: TKey): DiffRow[] {
-		return diffLines((linesAtKey(id, a) ?? []) as AssemblySnapshotLine[], (linesAtKey(id, b) ?? []) as AssemblySnapshotLine[]);
+		return diffLines(snapshotAtKey(id, a), snapshotAtKey(id, b));
 	}
 	const isAsmish = (id: string) => !!getAssembly(id) || !!eraAsm[id];
 	/** Did anything at or below this node move between the two moments? Drives
@@ -811,7 +842,8 @@
 <!-- One member of a version snapshot or diff row: name, kind, pinned uid and
      the member revision that uid names. -->
 {#snippet memberCell(id: string, uid: string | undefined, struck: boolean)}
-	{@const render = getPart(id)?.render}
+	{@const part = getPart(id)}
+	{@const render = part?.versions?.find((v) => v.uid === uid)?.render ?? part?.render}
 	{#if render}<img src={render} alt="" class="h-7 w-7 shrink-0 object-contain {struck ? 'opacity-50' : ''}" />{/if}
 	<span class="min-w-0 flex-1">
 		<span class="font-semibold text-text {struck ? 'line-through opacity-60' : ''}">{memberName(id)}</span>

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -358,6 +358,39 @@
 	function memberName(id: string): string {
 		return memberOf(id)?.name ?? ghostName(id) ?? id;
 	}
+	/** Rows in joint order: the authored order, except that once a member is
+	 *  placed, whatever it is joined to follows it straight away — fastener
+	 *  first, then the other side — so a brace spans neighbours more often
+	 *  than not. A member in several joints pulls all of them in after it,
+	 *  fastenerless ones first: a two-row brace stays tight, and the screwed
+	 *  joint's three rows follow as a block. */
+	function jointOrder(list: AssemblyLine[], edges: Connection[]): AssemblyLine[] {
+		if (!edges.length) return list;
+		const idOf = (l: AssemblyLine) => l.part ?? l.assembly ?? '';
+		const byId = new Map(list.map((l) => [idOf(l), l]));
+		const ordered = [...edges].sort((a, b) => (a.via ? 1 : 0) - (b.via ? 1 : 0));
+		const out: AssemblyLine[] = [];
+		const placed = new Set<string>();
+		const place = (id: string) => {
+			const l = byId.get(id);
+			if (!l || placed.has(id)) return;
+			placed.add(id);
+			out.push(l);
+			for (const e of ordered) {
+				if (e.from === id || e.to === id) {
+					if (e.via) place(e.via);
+					place(e.from === id ? e.to : e.from);
+				} else if (e.via === id) {
+					place(e.from);
+					place(e.to);
+				}
+			}
+		};
+		for (const l of list) place(idOf(l));
+		// a duplicated id (two lines naming one part) keeps its extra rows
+		for (const l of list) if (!out.includes(l)) out.push(l);
+		return out;
+	}
 	/** Which revision of the member a pinned uid names: its version number, or
 	 *  null when the uid predates the member's recorded history. */
 	function memberRev(id: string, uid?: string): string | null {
@@ -975,7 +1008,7 @@
 		<!-- assemblies a brace wires into get a box, so the tick lands on a
 		     visible container instead of ending in space -->
 		{@const eps = asm.connections?.length ? new Set(asm.connections.flatMap((c) => [c.from, c.to])) : null}
-		{@render lines(asm.lines ?? [], mult, depth, eps)}
+		{@render lines(jointOrder(asm.lines ?? [], asm.connections ?? []), mult, depth, eps)}
 	{/if}
 {/snippet}
 
@@ -1430,7 +1463,7 @@
 							{#if fStable}<Check size={12} class="ml-auto text-primary" />{/if}
 						</button>
 						<div class="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">Order</div>
-						{#each [['authored', 'As authored'], ['name', 'By name']] as [o, lbl] (o)}
+						{#each [['authored', 'Joints together'], ['name', 'By name']] as [o, lbl] (o)}
 							<button
 								type="button"
 								class="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs text-text hover:bg-[var(--color-bg)]"


### PR DESCRIPTION
Stacked on #522 (base branch `no-partial-status`) — without the stamp exemption gone, a tag can't promise anything.

## What

Makes a tag actually lock a node's whole subtree, then locks the feeder: tag **`feeder-2026-09-02`** (`stable`) on `feeder`. Open History on the Feeder row and click the tag: every unit, sub-assembly, part revision and screw count renders as of today, including the light post work below.

- **Resolver**: a superseded version entry that carries a lines snapshot but no date is now the state from before anything was dated. Before this, an assembly's first-ever stamp made it read as *not existing* at any earlier moment, because its undated v1 entry was skipped.
- **Parts at a moment**: every member in a time view is pinned to the uid it carried *then*, from the dates on its own version entries — so an old moment shows the old stator, not today's. The archived render follows the pinned revision.
- **`stamp_versions.py`**: on a node's first stamp it writes the entry for the state being left behind, so nobody has to hand-author a v1 snapshot for the timeline to work.
- The twelve version entries that were still `commit: null` are tied to their commits (`stamp_versions.py`, first run since the stamp rule).
- `VERSIONING.md` says plainly what a tag locks versus what a stamp records.

## Also here: the light post, from the bench

- The three M3 × 12 clamp the cap adapter and the COB plate down onto the post (one self-tap edge); the two M3 × 20 bolt the post to the C-channel drive's NEMA bracket, which is a joint of **C-channels 2 and 3**, so the screws and the edge move to those nodes. The cap sits on the adapter (gravity); the output guide friction-fits the drive. Light post v2, C-channels 2 and 3 v2, all `breaking: false`.
- Four bench photos on the light post assembly. An assembly's first image is its main picture and renders large in the detail view; the rest are the strip.
- The stamp commit is the first real run of the first-stamp path: each of the three nodes got its v1 entry written with the old uid and lines.
- One brace per joint (two joints that merely share a member no longer fuse), and the tree's default row order keeps joined members together.

## Stamp vs tag

A **stamp** is a version entry on one node when its own list changes — per-node history. A **tag** names a moment for a node's whole subtree — the cross-node lock. Stamps are what make a tag resolvable; the tag is the lock.

## Proof

Simulated locally (uncommitted, reverted) before tagging: "tomorrow" — C-channel 2 restamped v2 with the output guide dropped and the light post doubled, stator revised to v2 with a new uid, both dated 2026-09-03. Clicking the tag: C-channel 2 lists the output guide ×1 and light post ×1; the C-channel drive lists **Stator n6bm · v1**. The current tree shows the new state.

One rule that follows: a tag resolves at the end of its date, so the overhaul's stamps must be dated after 2026-09-02.

svelte-check 0 errors · versioning, connections and generated-pins checks hold · docs checker flags light-post.md as describing the old structure (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
