### PR TITLE
parts-calculator: a version is a commit of everything below the node; feeder locked at v4

### DIFF
--- a/parts-calculator/VERSIONING.md
+++ b/parts-calculator/VERSIONING.md
@@ -95,6 +95,17 @@ There is no "just filling in what was always there" exemption: the lines
 are the record, and every change to them is a moment someone may need to
 flip back to. CI enforces this (`scripts/check_versioning.py`).
 
+**A version is a commit of everything below the node.** When
+`stamp_versions.py` stamps an assembly's version it writes the entry's
+`tree`: every assembly under the node as it stood at that commit —
+description, photos, joints, and every line pinned to the member's uid of
+the day, sub-assemblies included, all the way down. Flipping a node to one
+of its versions ("Viewing vN" on the assembly page) renders from that tree
+alone, so it shows exactly what was there then, whatever has changed since:
+the old prints at their archived geometry, the old screws at their old
+counts, the old photos. A node may be stamped with its own list unchanged
+purely to take that commit before an overhaul — the feeder's v4 is one.
+
 ## History is derived, not recorded
 
 A node's change log — everything that ever happened at or below it — is
@@ -126,13 +137,9 @@ breaking, so anything built against it keeps working; `experimental` marks
 a coherent but unproven cut. A tag resolves against history exactly like a
 timeline point and renders highlighted on the timeline.
 
-A tag is the lock on a whole subtree. A version stamp records one node's
-own list and nothing below it; the tag names a moment, and at that moment
-every assembly under the node resolves to the lines it had then and every
-part to the revision it was then (both from the dates on their version
-entries). "Flip back to the feeder as it was" is: open History on the
-feeder, click the tag's row. A tag resolves at the end of its date, so a
-change that must fall outside it is stamped with a later date.
+A tag resolves exactly like a version flip — the whole subtree as of the
+end of its date — but adds a stability claim about that build. Locking a
+subtree needs no tag: stamp a version (previous section).
 
 Tags are appended only by a human decision. No tool, check, or agent ever
 mints one.

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6425,8 +6425,8 @@
     },
     {
       "id": "feeder",
-      "uid": "y5ws",
-      "version": "3",
+      "uid": "i4f8",
+      "version": "4",
       "name": "Feeder",
       "description": "Everything above the top interface: the bulk bucket, C-channels 2 and 3, and the classification chamber.",
       "docs": "/hardware/assembly/feeder/",
@@ -6514,6 +6514,13 @@
           "message": "Restructured into the four physical units — the bulk bucket, C-channels 2 and 3, and the classification chamber — each carrying its own C-channel drive, rotor, supports, guide or cap, and lighting. No physical change.",
           "breaking": false,
           "commit": "e47151a1"
+        },
+        {
+          "version": "4",
+          "date": "2026-09-02",
+          "message": "Stamped to lock the feeder before the C-channel overhaul: flip to v4 for every unit, part revision and screw count as they stood this day. The feeder's own list is unchanged.",
+          "breaking": false,
+          "commit": null
         }
       ],
       "lines": [
@@ -8834,14 +8841,6 @@
       "date": "2026-08-31",
       "commit": null,
       "message": "Golden with hex-frame-v2: future revisions must stay compatible with this part."
-    },
-    {
-      "name": "feeder-2026-09-02",
-      "node": "feeder",
-      "stability": "stable",
-      "date": "2026-09-02",
-      "commit": null,
-      "message": "Locked before the C-channel overhaul: every unit, part and screw count under the feeder as it stood this day."
     }
   ]
 }

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6510,17 +6510,738 @@
         },
         {
           "version": "3",
+          "uid": "y5ws",
           "date": "2026-09-01",
           "message": "Restructured into the four physical units — the bulk bucket, C-channels 2 and 3, and the classification chamber — each carrying its own C-channel drive, rotor, supports, guide or cap, and lighting. No physical change.",
           "breaking": false,
-          "commit": "e47151a1"
+          "commit": "e47151a1",
+          "lines": [
+            {
+              "assembly": "bulk-bucket",
+              "qty": 1,
+              "uid": "1sej"
+            },
+            {
+              "assembly": "channel-two",
+              "qty": 1,
+              "uid": "7sut"
+            },
+            {
+              "assembly": "channel-three",
+              "qty": 1,
+              "uid": "p55u"
+            },
+            {
+              "assembly": "classification-chamber",
+              "qty": 1,
+              "uid": "fyqw"
+            }
+          ]
         },
         {
           "version": "4",
           "date": "2026-09-02",
           "message": "Stamped to lock the feeder before the C-channel overhaul: flip to v4 for every unit, part revision and screw count as they stood this day. The feeder's own list is unchanged.",
           "breaking": false,
-          "commit": null
+          "commit": "30279a44",
+          "tree": {
+            "feeder": {
+              "uid": "i4f8",
+              "name": "Feeder",
+              "description": "Everything above the top interface: the bulk bucket, C-channels 2 and 3, and the classification chamber.",
+              "docs": "/hardware/assembly/feeder/",
+              "lines": [
+                {
+                  "assembly": "bulk-bucket",
+                  "qty": 1,
+                  "uid": "1sej"
+                },
+                {
+                  "assembly": "channel-two",
+                  "qty": 1,
+                  "uid": "7sut"
+                },
+                {
+                  "assembly": "channel-three",
+                  "qty": 1,
+                  "uid": "p55u"
+                },
+                {
+                  "assembly": "classification-chamber",
+                  "qty": 1,
+                  "uid": "fyqw"
+                }
+              ]
+            },
+            "bulk-bucket": {
+              "uid": "1sej",
+              "name": "Bulk bucket C-channel",
+              "description": "The top feeder unit: a C-channel drive with a white faceted rotor, capped by the Bulk cap instead of an output guide and with no light post, standing on the tallest supports.",
+              "connections": [
+                {
+                  "from": "bulk-bucket-support",
+                  "to": "c-channel",
+                  "qty": 3,
+                  "method": "friction",
+                  "note": "Dovetail: each support's leg slides into the C-channel drive from below."
+                }
+              ],
+              "lines": [
+                {
+                  "assembly": "bulk-bucket-support",
+                  "qty": 3,
+                  "uid": "xo6j"
+                },
+                {
+                  "assembly": "c-channel",
+                  "qty": 1,
+                  "uid": "4tvc"
+                },
+                {
+                  "assembly": "rotor-unit-faceted",
+                  "qty": 1,
+                  "uid": "ylvv"
+                },
+                {
+                  "part": "bulk-cap",
+                  "qty": 1,
+                  "uid": "737f"
+                }
+              ]
+            },
+            "channel-two": {
+              "uid": "7sut",
+              "name": "C-channel 2",
+              "description": "The middle feeder channel: a C-channel drive with a white faceted rotor, an output guide and a light post, standing on three supports with one leg extension each.",
+              "connections": [
+                {
+                  "from": "channel-two-support",
+                  "to": "c-channel",
+                  "qty": 3,
+                  "method": "friction",
+                  "note": "Dovetail: each support's leg slides into the C-channel drive from below."
+                },
+                {
+                  "from": "c-channel",
+                  "to": "light-post-assembly",
+                  "via": "scr-m3-20-cs",
+                  "qty": 2,
+                  "method": "self-tap",
+                  "note": "Through the NEMA bracket, threading straight into the printed post — no insert, no nut."
+                },
+                {
+                  "from": "output-guide",
+                  "to": "c-channel",
+                  "qty": 1,
+                  "method": "friction",
+                  "note": "The guide pushes onto the C-channel drive and is held by the fit alone."
+                }
+              ],
+              "lines": [
+                {
+                  "assembly": "channel-two-support",
+                  "qty": 3,
+                  "uid": "dp63"
+                },
+                {
+                  "assembly": "c-channel",
+                  "qty": 1,
+                  "uid": "4tvc"
+                },
+                {
+                  "assembly": "rotor-unit-faceted",
+                  "qty": 1,
+                  "uid": "ylvv"
+                },
+                {
+                  "part": "output-guide",
+                  "qty": 1,
+                  "uid": "8j3e"
+                },
+                {
+                  "assembly": "light-post-assembly",
+                  "qty": 1,
+                  "uid": "lxof"
+                },
+                {
+                  "assembly": "camera-mount",
+                  "qty": 1,
+                  "uid": "b3zx"
+                },
+                {
+                  "part": "scr-m3-20-cs",
+                  "qty": 2,
+                  "uid": "60g4"
+                }
+              ]
+            },
+            "channel-three": {
+              "uid": "p55u",
+              "name": "C-channel 3",
+              "description": "The lowest feeder channel, just above the classification chamber: a C-channel drive with the gray faceted rotor, an output guide and a light post, on three foot-and-leg supports.",
+              "connections": [
+                {
+                  "from": "channel-three-support",
+                  "to": "c-channel",
+                  "qty": 3,
+                  "method": "friction",
+                  "note": "Dovetail: each support's leg slides into the C-channel drive from below."
+                },
+                {
+                  "from": "c-channel",
+                  "to": "light-post-assembly",
+                  "via": "scr-m3-20-cs",
+                  "qty": 2,
+                  "method": "self-tap",
+                  "note": "Through the NEMA bracket, threading straight into the printed post — no insert, no nut."
+                },
+                {
+                  "from": "output-guide",
+                  "to": "c-channel",
+                  "qty": 1,
+                  "method": "friction",
+                  "note": "The guide pushes onto the C-channel drive and is held by the fit alone."
+                }
+              ],
+              "lines": [
+                {
+                  "assembly": "channel-three-support",
+                  "qty": 3,
+                  "uid": "r6ar"
+                },
+                {
+                  "assembly": "c-channel",
+                  "qty": 1,
+                  "uid": "4tvc"
+                },
+                {
+                  "assembly": "rotor-unit-faceted",
+                  "qty": 1,
+                  "uid": "ylvv"
+                },
+                {
+                  "part": "output-guide",
+                  "qty": 1,
+                  "uid": "8j3e"
+                },
+                {
+                  "assembly": "light-post-assembly",
+                  "qty": 1,
+                  "uid": "lxof"
+                },
+                {
+                  "assembly": "camera-mount",
+                  "qty": 1,
+                  "uid": "b3zx"
+                },
+                {
+                  "part": "scr-m3-20-cs",
+                  "qty": 2,
+                  "uid": "60g4"
+                }
+              ]
+            },
+            "classification-chamber": {
+              "uid": "fyqw",
+              "name": "Classification chamber",
+              "description": "The classification chamber: the dome, the finned rotor, and the camera & LED insert. All three print white, so the chamber bounces light onto the part instead of absorbing it.",
+              "docs": "/hardware/assembly/feeder/classification-chamber/",
+              "lines": [
+                {
+                  "assembly": "c-channel",
+                  "qty": 1,
+                  "uid": "4tvc"
+                },
+                {
+                  "assembly": "rotor-unit-finned",
+                  "qty": 1,
+                  "uid": "7ol7"
+                },
+                {
+                  "part": "classification-dome",
+                  "qty": 1,
+                  "uid": "fheh"
+                },
+                {
+                  "assembly": "camera-led-insert-assembly",
+                  "qty": 1,
+                  "uid": "434r"
+                }
+              ]
+            },
+            "bulk-bucket-support": {
+              "uid": "xo6j",
+              "name": "Bulk bucket support",
+              "description": "One of the bulk bucket's three standoffs — the tallest stack: a foot, two leg extensions, and the leg.",
+              "connections": [
+                {
+                  "from": "foot",
+                  "to": "leg-extension",
+                  "qty": 1,
+                  "method": "friction",
+                  "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+                },
+                {
+                  "from": "leg-extension",
+                  "to": "leg-extension",
+                  "qty": 1,
+                  "method": "friction",
+                  "note": "The two extensions stack tail-into-slot. Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+                },
+                {
+                  "from": "leg-extension",
+                  "to": "leg",
+                  "qty": 1,
+                  "method": "friction",
+                  "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+                }
+              ],
+              "lines": [
+                {
+                  "part": "foot",
+                  "qty": 1,
+                  "uid": "jqdx"
+                },
+                {
+                  "part": "leg-extension",
+                  "qty": 2,
+                  "uid": "jewq"
+                },
+                {
+                  "part": "leg",
+                  "qty": 1,
+                  "uid": "xse1"
+                }
+              ]
+            },
+            "c-channel": {
+              "uid": "4tvc",
+              "name": "C-channel drive",
+              "description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
+              "docs": "/hardware/assembly/feeder/c-channel/",
+              "connections": [
+                {
+                  "from": "brg-608-2rs",
+                  "to": "idler-gear",
+                  "qty": 1,
+                  "method": "press"
+                },
+                {
+                  "from": "nema-bracket",
+                  "to": "motor-nema17",
+                  "via": "scr-m3-16-cs",
+                  "qty": 3,
+                  "method": "thread",
+                  "through_mm": 10.45,
+                  "note": "Into the NEMA 17's tapped face holes; tapped depth not yet measured."
+                },
+                {
+                  "from": "input-gear",
+                  "to": "motor-nema17",
+                  "via": "scr-m3-8-cs",
+                  "qty": 1,
+                  "method": "self-tap",
+                  "note": "Threads through the gear hub and bears on the motor shaft flat."
+                },
+                {
+                  "from": "nema-bracket",
+                  "to": "stator",
+                  "via": "scr-m3-12-cs",
+                  "qty": 2,
+                  "method": "self-tap",
+                  "through_mm": 6.45,
+                  "thread_mm": 10
+                },
+                {
+                  "from": "nema-bracket",
+                  "to": "stator",
+                  "via": "scr-m3-12-cs",
+                  "qty": 2,
+                  "method": "self-tap",
+                  "through_mm": 8.45,
+                  "thread_mm": 10,
+                  "note": "The bracket's four stator holes come in two depths: two at 6.45 mm, two at 8.45 mm."
+                }
+              ],
+              "lines": [
+                {
+                  "part": "idler-gear",
+                  "qty": 1,
+                  "uid": "7bv7"
+                },
+                {
+                  "part": "brg-608-2rs",
+                  "qty": 1,
+                  "uid": "mi1l"
+                },
+                {
+                  "part": "nema-bracket",
+                  "qty": 1,
+                  "uid": "x09t"
+                },
+                {
+                  "part": "motor-nema17",
+                  "qty": 1,
+                  "uid": "w7pq"
+                },
+                {
+                  "part": "input-gear",
+                  "qty": 1,
+                  "uid": "70ul"
+                },
+                {
+                  "part": "stator",
+                  "qty": 1,
+                  "uid": "n6bm"
+                },
+                {
+                  "part": "scr-m3-16-cs",
+                  "qty": 3,
+                  "uid": "bdi4"
+                },
+                {
+                  "part": "scr-m3-8-cs",
+                  "qty": 1,
+                  "uid": "l6br"
+                },
+                {
+                  "part": "scr-m3-12-cs",
+                  "qty": 4,
+                  "uid": "0a9x"
+                }
+              ]
+            },
+            "rotor-unit-faceted": {
+              "uid": "ylvv",
+              "name": "Rotor unit (faceted)",
+              "description": "The faceted rotor with the Output gear (130T) bolted on. Assembled once as a unit; a C-channel drive spins it.",
+              "connections": [
+                {
+                  "from": "brg-6806-2rs",
+                  "to": "output-gear",
+                  "qty": 1,
+                  "method": "press"
+                },
+                {
+                  "from": "output-gear",
+                  "to": "rotor-faceted",
+                  "via": "scr-m3-12-cs",
+                  "qty": 6,
+                  "method": "self-tap",
+                  "note": "One per spoke. Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 × 8 seated flush reaches nothing.",
+                  "through_mm": 6.45,
+                  "thread_mm": 5
+                }
+              ],
+              "lines": [
+                {
+                  "part": "rotor-faceted",
+                  "qty": 1,
+                  "uid": "9v9q"
+                },
+                {
+                  "part": "output-gear",
+                  "qty": 1,
+                  "uid": "26ek"
+                },
+                {
+                  "part": "brg-6806-2rs",
+                  "qty": 1,
+                  "uid": "elxe"
+                },
+                {
+                  "part": "scr-m3-12-cs",
+                  "qty": 6,
+                  "uid": "0a9x"
+                }
+              ]
+            },
+            "channel-two-support": {
+              "uid": "dp63",
+              "name": "Channel 2 support",
+              "description": "One of C-channel 2's three standoffs: a foot, one leg extension, and the leg the channel dovetails onto.",
+              "connections": [
+                {
+                  "from": "foot",
+                  "to": "leg-extension",
+                  "qty": 1,
+                  "method": "friction",
+                  "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+                },
+                {
+                  "from": "leg-extension",
+                  "to": "leg",
+                  "qty": 1,
+                  "method": "friction",
+                  "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+                }
+              ],
+              "lines": [
+                {
+                  "part": "foot",
+                  "qty": 1,
+                  "uid": "jqdx"
+                },
+                {
+                  "part": "leg-extension",
+                  "qty": 1,
+                  "uid": "jewq"
+                },
+                {
+                  "part": "leg",
+                  "qty": 1,
+                  "uid": "xse1"
+                }
+              ]
+            },
+            "light-post-assembly": {
+              "uid": "lxof",
+              "name": "Light post",
+              "description": "The feeder light post: the post, the 50 mm COB plate on its end lighting down the channel, and the cap adapter and cap over it. 2 per machine, one each on C-channels 2 and 3, bolted to the C-channel drive's NEMA bracket.",
+              "docs": "/hardware/assembly/feeder/light-post/",
+              "connections": [
+                {
+                  "from": "light-post-cap-adapter",
+                  "to": "light-post",
+                  "via": "scr-m3-12-cs",
+                  "qty": 3,
+                  "method": "self-tap",
+                  "note": "Down through the adapter's three clearance holes and the COB plate clamped under it, threading into the pilot holes in the post's end."
+                },
+                {
+                  "from": "light-post-cap",
+                  "to": "light-post-cap-adapter",
+                  "qty": 1,
+                  "method": "gravity",
+                  "note": "The cap just sits on the adapter."
+                }
+              ],
+              "images": [
+                {
+                  "url": "https://assets.basically.website/sorter-parts/light-post-assembled-full-2b59e7e84bdb.jpg",
+                  "alt": "A finished light post on the bench: the black printed post with the 50 mm COB plate on its end, and the red and black leads running out of the post to a DC barrel plug",
+                  "caption": "The light post, assembled."
+                },
+                {
+                  "url": "https://assets.basically.website/sorter-parts/light-post-top-cap-off-full-d076a7bff4a1.jpg",
+                  "alt": "The end of the post with the cap off: the aluminium back of the COB plate with the black cap adapter on it, three countersunk screws going down through both into the post, and the leads coming up through the centre hole",
+                  "caption": "Cap off: the adapter and its three M3 × 12 through the plate into the post."
+                },
+                {
+                  "url": "https://assets.basically.website/sorter-parts/light-post-led-side-full-428b89ff9243.jpg",
+                  "alt": "The LED side of the COB plate, close up: the post's forked end holds the plate at its centre, with the leads passing through the centre hole",
+                  "caption": "LED side: the post's forked end at the plate's centre."
+                },
+                {
+                  "url": "https://assets.basically.website/sorter-parts/light-post-led-side-centre-full-b25b6589047d.jpg",
+                  "alt": "The LED side of the COB plate straight on: the post's forked end at the centre with the leads leaving through it",
+                  "caption": "LED side, straight on."
+                }
+              ],
+              "lines": [
+                {
+                  "part": "light-post",
+                  "qty": 1,
+                  "uid": "oac5"
+                },
+                {
+                  "part": "led-cob-50mm-24v",
+                  "qty": 1,
+                  "uid": "s34o"
+                },
+                {
+                  "part": "light-post-cap-adapter",
+                  "qty": 1,
+                  "uid": "jcnt"
+                },
+                {
+                  "part": "scr-m3-12-cs",
+                  "qty": 3,
+                  "uid": "0a9x"
+                },
+                {
+                  "part": "light-post-cap",
+                  "qty": 1,
+                  "uid": "7a8e"
+                }
+              ]
+            },
+            "camera-mount": {
+              "uid": "b3zx",
+              "name": "Overhead camera mount",
+              "description": "Camera mount for the C-channels. 2 per machine, each hanging off two ~1 ft steel rods.",
+              "docs": "/hardware/assembly/feeder/camera-mount/",
+              "lines": [
+                {
+                  "part": "camera-mount-part-6",
+                  "qty": 1,
+                  "uid": "v9dv"
+                },
+                {
+                  "part": "camera-mount-part-37",
+                  "qty": 1,
+                  "uid": "8bqo"
+                },
+                {
+                  "part": "camera-mount-part-37b",
+                  "qty": 1,
+                  "uid": "gut5"
+                },
+                {
+                  "part": "camera-mount-rod-mount",
+                  "qty": 2,
+                  "uid": "twuu"
+                },
+                {
+                  "part": "rod-steel-3-8",
+                  "qty": 2,
+                  "uid": "1o92"
+                },
+                {
+                  "part": "cam-ov9732",
+                  "qty": 1,
+                  "uid": "6g79"
+                },
+                {
+                  "part": "scr-m3-12-cs",
+                  "qty": 3,
+                  "uid": "0a9x"
+                },
+                {
+                  "part": "nut-m3",
+                  "qty": 3,
+                  "uid": "sc1c"
+                }
+              ]
+            },
+            "channel-three-support": {
+              "uid": "r6ar",
+              "name": "Channel 3 support",
+              "description": "One of C-channel 3's three standoffs: a foot and the leg the channel dovetails onto.",
+              "connections": [
+                {
+                  "from": "foot",
+                  "to": "leg",
+                  "qty": 1,
+                  "method": "friction",
+                  "note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+                }
+              ],
+              "lines": [
+                {
+                  "part": "foot",
+                  "qty": 1,
+                  "uid": "jqdx"
+                },
+                {
+                  "part": "leg",
+                  "qty": 1,
+                  "uid": "xse1"
+                }
+              ]
+            },
+            "rotor-unit-finned": {
+              "uid": "7ol7",
+              "name": "Rotor unit (finned)",
+              "description": "The finned rotor with the Output gear (130T) bolted on. Assembled once as a unit; the classification channel's C-channel drive spins it.",
+              "connections": [
+                {
+                  "from": "brg-6806-2rs",
+                  "to": "output-gear",
+                  "qty": 1,
+                  "method": "press"
+                },
+                {
+                  "from": "output-gear",
+                  "to": "rotor-finned",
+                  "via": "scr-m3-12-cs",
+                  "qty": 6,
+                  "method": "self-tap",
+                  "note": "One per spoke. Same joint as the faceted rotor unit."
+                }
+              ],
+              "lines": [
+                {
+                  "part": "rotor-finned",
+                  "qty": 1,
+                  "uid": "brsr"
+                },
+                {
+                  "part": "output-gear",
+                  "qty": 1,
+                  "uid": "26ek"
+                },
+                {
+                  "part": "brg-6806-2rs",
+                  "qty": 1,
+                  "uid": "elxe"
+                },
+                {
+                  "part": "scr-m3-12-cs",
+                  "qty": 6,
+                  "uid": "0a9x"
+                }
+              ]
+            },
+            "camera-led-insert-assembly": {
+              "uid": "434r",
+              "name": "Camera & LED insert assembly",
+              "description": "The Camera & LED insert print with the camera extension assembled into it; the loaded insert drops into the classification dome.",
+              "connections": [
+                {
+                  "from": "camera-extension-assembly",
+                  "to": "camera-led-insert",
+                  "via": "scr-m3-12-bhcs",
+                  "qty": 4,
+                  "method": "self-tap"
+                }
+              ],
+              "lines": [
+                {
+                  "part": "camera-led-insert",
+                  "qty": 1,
+                  "uid": "b2v9"
+                },
+                {
+                  "assembly": "camera-extension-assembly",
+                  "qty": 1,
+                  "uid": "q2re"
+                },
+                {
+                  "part": "scr-m3-12-bhcs",
+                  "qty": 4,
+                  "uid": "izrb"
+                }
+              ]
+            },
+            "camera-extension-assembly": {
+              "uid": "q2re",
+              "name": "Camera extension",
+              "description": "Classification-channel camera extension for the 4K camera module: the 50 mm extension tube, its mount, and the camera. 1 per machine.",
+              "lines": [
+                {
+                  "part": "camera-extension",
+                  "qty": 1,
+                  "uid": "v684"
+                },
+                {
+                  "part": "camera-extension-mount",
+                  "qty": 1,
+                  "uid": "wt9t"
+                },
+                {
+                  "part": "cam-imx415",
+                  "qty": 1,
+                  "uid": "1lze"
+                },
+                {
+                  "part": "scr-m2-8-shcs",
+                  "qty": 4,
+                  "uid": "iwk6"
+                }
+              ]
+            }
+          }
         }
       ],
       "lines": [

--- a/parts-calculator/catalog/stamp_versions.py
+++ b/parts-calculator/catalog/stamp_versions.py
@@ -10,7 +10,10 @@ re-export of the same design and is not a version.
 
 Assemblies version the same way, and what gets carried onto the superseded
 entry is a snapshot of the lines as they were, each pinned to the member's
-uid at the time, so the box as built then reads back part by part.
+uid at the time, so the box as built then reads back part by part. An
+assembly's new version also gets its `tree`: every assembly below it as of
+the stamping commit, lines pinned to member uids -- the commit of the whole
+subtree, which is what flipping the page to that version renders.
 
 The workflow the version system assumes:
   1. Mint a uid (`python catalog/mint_uid.py`), put it on the part, bump
@@ -51,17 +54,67 @@ def manifest_commits():
     return [h for h in out.splitlines() if h.strip()]
 
 
+_manifests = {}
+
+
+def manifest_at(commit):
+    """parts.json as of `commit`, or None if unreadable there."""
+    if commit in _manifests:
+        return _manifests[commit]
+    r = subprocess.run(["git", "-C", HERE, "show", f"{commit}:./parts.json"],
+                       capture_output=True)
+    d = None
+    if r.returncode == 0 and r.stdout:
+        try:
+            d = json.loads(r.stdout, object_pairs_hook=collections.OrderedDict)
+        except ValueError:
+            d = None
+    _manifests[commit] = d
+    return d
+
+
+def freeze_subtree(d, root):
+    """Every assembly under `root` (root first) as it stood in manifest `d`,
+    each line pinned to the member's uid of the day. This is a version's
+    `tree`: the commit of everything below the node -- sub-assemblies, prints,
+    screws, photos -- from which the page renders that version exactly,
+    whatever has changed since. Parts and hardware are pinned by uid; their
+    own records (archived geometry, renders, weights) resolve from there."""
+    member_uid = {p["id"]: p.get("uid") for p in d.get("parts", [])}
+    asms = {a["id"]: a for a in d.get("assemblies", [])}
+    member_uid.update({k: a.get("uid") for k, a in asms.items()})
+    keep = ("uid", "name", "description", "docs", "joining", "connections", "images")
+    tree = collections.OrderedDict()
+    todo = [root]
+    while todo:
+        aid = todo.pop(0)
+        a = asms.get(aid)
+        if a is None or aid in tree:
+            continue
+        rec = collections.OrderedDict()
+        for k in keep:
+            if k in a:
+                rec[k] = a[k]
+        lines = []
+        for line in a.get("lines") or []:
+            snap = collections.OrderedDict(line)
+            uid = member_uid.get(line.get("part") or line.get("assembly"))
+            if uid:
+                snap["uid"] = uid
+            lines.append(snap)
+            if line.get("assembly"):
+                todo.append(line["assembly"])
+        rec["lines"] = lines
+        tree[aid] = rec
+    return tree
+
+
 def pins_at(commit):
     """As of `commit`: {"parts": {id: (uid, stl_hash)}, "assemblies": {id: (uid,
     lines)}} with each line pinned to its member's uid then, or None if
     parts.json is unreadable there."""
-    r = subprocess.run(["git", "-C", HERE, "show", f"{commit}:./parts.json"],
-                       capture_output=True)
-    if r.returncode != 0 or not r.stdout:
-        return None
-    try:
-        d = json.loads(r.stdout)
-    except ValueError:
+    d = manifest_at(commit)
+    if d is None:
         return None
     member_uid = {p["id"]: p.get("uid") for p in d.get("parts", [])}
     member_uid.update({a["id"]: a.get("uid") for a in d.get("assemblies", [])})
@@ -122,6 +175,9 @@ def main():
             continue
         commit, (replaced_uid, replaced_pin) = found
         versions[-1]["commit"] = commit
+        if kind == "assemblies":
+            # the version's tree: everything below the node as of this commit
+            versions[-1]["tree"] = freeze_subtree(manifest_at(commit), p["id"])
         stamped.append((p["id"], versions[-1].get("version"), commit))
         pin_key = "stl_hash" if kind == "parts" else "lines"
         newest_ver = str(versions[-1].get("version"))

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1391,10 +1391,33 @@
 				},
 				{
 					"version": "3",
+					"uid": "y5ws",
 					"date": "2026-09-01",
 					"message": "Restructured into the four physical units \u2014 the bulk bucket, C-channels 2 and 3, and the classification chamber \u2014 each carrying its own C-channel drive, rotor, supports, guide or cap, and lighting. No physical change.",
 					"breaking": false,
-					"commit": "e47151a1"
+					"commit": "e47151a1",
+					"lines": [
+						{
+							"assembly": "bulk-bucket",
+							"qty": 1,
+							"uid": "1sej"
+						},
+						{
+							"assembly": "channel-two",
+							"qty": 1,
+							"uid": "7sut"
+						},
+						{
+							"assembly": "channel-three",
+							"qty": 1,
+							"uid": "p55u"
+						},
+						{
+							"assembly": "classification-chamber",
+							"qty": 1,
+							"uid": "fyqw"
+						}
+					]
 				},
 				{
 					"version": "4",
@@ -1402,7 +1425,705 @@
 					"date": "2026-09-02",
 					"message": "Stamped to lock the feeder before the C-channel overhaul: flip to v4 for every unit, part revision and screw count as they stood this day. The feeder's own list is unchanged.",
 					"breaking": false,
-					"commit": null
+					"commit": "30279a44",
+					"tree": {
+						"feeder": {
+							"uid": "i4f8",
+							"name": "Feeder",
+							"description": "Everything above the top interface: the bulk bucket, C-channels 2 and 3, and the classification chamber.",
+							"docs": "/hardware/assembly/feeder/",
+							"lines": [
+								{
+									"assembly": "bulk-bucket",
+									"qty": 1,
+									"uid": "1sej"
+								},
+								{
+									"assembly": "channel-two",
+									"qty": 1,
+									"uid": "7sut"
+								},
+								{
+									"assembly": "channel-three",
+									"qty": 1,
+									"uid": "p55u"
+								},
+								{
+									"assembly": "classification-chamber",
+									"qty": 1,
+									"uid": "fyqw"
+								}
+							]
+						},
+						"bulk-bucket": {
+							"uid": "1sej",
+							"name": "Bulk bucket C-channel",
+							"description": "The top feeder unit: a C-channel drive with a white faceted rotor, capped by the Bulk cap instead of an output guide and with no light post, standing on the tallest supports.",
+							"connections": [
+								{
+									"from": "bulk-bucket-support",
+									"to": "c-channel",
+									"qty": 3,
+									"method": "friction",
+									"note": "Dovetail: each support's leg slides into the C-channel drive from below."
+								}
+							],
+							"lines": [
+								{
+									"assembly": "bulk-bucket-support",
+									"qty": 3,
+									"uid": "xo6j"
+								},
+								{
+									"assembly": "c-channel",
+									"qty": 1,
+									"uid": "4tvc"
+								},
+								{
+									"assembly": "rotor-unit-faceted",
+									"qty": 1,
+									"uid": "ylvv"
+								},
+								{
+									"part": "bulk-cap",
+									"qty": 1,
+									"uid": "737f"
+								}
+							]
+						},
+						"channel-two": {
+							"uid": "7sut",
+							"name": "C-channel 2",
+							"description": "The middle feeder channel: a C-channel drive with a white faceted rotor, an output guide and a light post, standing on three supports with one leg extension each.",
+							"connections": [
+								{
+									"from": "channel-two-support",
+									"to": "c-channel",
+									"qty": 3,
+									"method": "friction",
+									"note": "Dovetail: each support's leg slides into the C-channel drive from below."
+								},
+								{
+									"from": "c-channel",
+									"to": "light-post-assembly",
+									"via": "scr-m3-20-cs",
+									"qty": 2,
+									"method": "self-tap",
+									"note": "Through the NEMA bracket, threading straight into the printed post \u2014 no insert, no nut."
+								},
+								{
+									"from": "output-guide",
+									"to": "c-channel",
+									"qty": 1,
+									"method": "friction",
+									"note": "The guide pushes onto the C-channel drive and is held by the fit alone."
+								}
+							],
+							"lines": [
+								{
+									"assembly": "channel-two-support",
+									"qty": 3,
+									"uid": "dp63"
+								},
+								{
+									"assembly": "c-channel",
+									"qty": 1,
+									"uid": "4tvc"
+								},
+								{
+									"assembly": "rotor-unit-faceted",
+									"qty": 1,
+									"uid": "ylvv"
+								},
+								{
+									"part": "output-guide",
+									"qty": 1,
+									"uid": "8j3e"
+								},
+								{
+									"assembly": "light-post-assembly",
+									"qty": 1,
+									"uid": "lxof"
+								},
+								{
+									"assembly": "camera-mount",
+									"qty": 1,
+									"uid": "b3zx"
+								},
+								{
+									"part": "scr-m3-20-cs",
+									"qty": 2,
+									"uid": "60g4"
+								}
+							]
+						},
+						"channel-three": {
+							"uid": "p55u",
+							"name": "C-channel 3",
+							"description": "The lowest feeder channel, just above the classification chamber: a C-channel drive with the gray faceted rotor, an output guide and a light post, on three foot-and-leg supports.",
+							"connections": [
+								{
+									"from": "channel-three-support",
+									"to": "c-channel",
+									"qty": 3,
+									"method": "friction",
+									"note": "Dovetail: each support's leg slides into the C-channel drive from below."
+								},
+								{
+									"from": "c-channel",
+									"to": "light-post-assembly",
+									"via": "scr-m3-20-cs",
+									"qty": 2,
+									"method": "self-tap",
+									"note": "Through the NEMA bracket, threading straight into the printed post \u2014 no insert, no nut."
+								},
+								{
+									"from": "output-guide",
+									"to": "c-channel",
+									"qty": 1,
+									"method": "friction",
+									"note": "The guide pushes onto the C-channel drive and is held by the fit alone."
+								}
+							],
+							"lines": [
+								{
+									"assembly": "channel-three-support",
+									"qty": 3,
+									"uid": "r6ar"
+								},
+								{
+									"assembly": "c-channel",
+									"qty": 1,
+									"uid": "4tvc"
+								},
+								{
+									"assembly": "rotor-unit-faceted",
+									"qty": 1,
+									"uid": "ylvv"
+								},
+								{
+									"part": "output-guide",
+									"qty": 1,
+									"uid": "8j3e"
+								},
+								{
+									"assembly": "light-post-assembly",
+									"qty": 1,
+									"uid": "lxof"
+								},
+								{
+									"assembly": "camera-mount",
+									"qty": 1,
+									"uid": "b3zx"
+								},
+								{
+									"part": "scr-m3-20-cs",
+									"qty": 2,
+									"uid": "60g4"
+								}
+							]
+						},
+						"classification-chamber": {
+							"uid": "fyqw",
+							"name": "Classification chamber",
+							"description": "The classification chamber: the dome, the finned rotor, and the camera & LED insert. All three print white, so the chamber bounces light onto the part instead of absorbing it.",
+							"docs": "/hardware/assembly/feeder/classification-chamber/",
+							"lines": [
+								{
+									"assembly": "c-channel",
+									"qty": 1,
+									"uid": "4tvc"
+								},
+								{
+									"assembly": "rotor-unit-finned",
+									"qty": 1,
+									"uid": "7ol7"
+								},
+								{
+									"part": "classification-dome",
+									"qty": 1,
+									"uid": "fheh"
+								},
+								{
+									"assembly": "camera-led-insert-assembly",
+									"qty": 1,
+									"uid": "434r"
+								}
+							]
+						},
+						"bulk-bucket-support": {
+							"uid": "xo6j",
+							"name": "Bulk bucket support",
+							"description": "One of the bulk bucket's three standoffs \u2014 the tallest stack: a foot, two leg extensions, and the leg.",
+							"connections": [
+								{
+									"from": "foot",
+									"to": "leg-extension",
+									"qty": 1,
+									"method": "friction",
+									"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+								},
+								{
+									"from": "leg-extension",
+									"to": "leg-extension",
+									"qty": 1,
+									"method": "friction",
+									"note": "The two extensions stack tail-into-slot. Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+								},
+								{
+									"from": "leg-extension",
+									"to": "leg",
+									"qty": 1,
+									"method": "friction",
+									"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+								}
+							],
+							"lines": [
+								{
+									"part": "foot",
+									"qty": 1,
+									"uid": "jqdx"
+								},
+								{
+									"part": "leg-extension",
+									"qty": 2,
+									"uid": "jewq"
+								},
+								{
+									"part": "leg",
+									"qty": 1,
+									"uid": "xse1"
+								}
+							]
+						},
+						"c-channel": {
+							"uid": "4tvc",
+							"name": "C-channel drive",
+							"description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
+							"docs": "/hardware/assembly/feeder/c-channel/",
+							"connections": [
+								{
+									"from": "brg-608-2rs",
+									"to": "idler-gear",
+									"qty": 1,
+									"method": "press"
+								},
+								{
+									"from": "nema-bracket",
+									"to": "motor-nema17",
+									"via": "scr-m3-16-cs",
+									"qty": 3,
+									"method": "thread",
+									"through_mm": 10.45,
+									"note": "Into the NEMA 17's tapped face holes; tapped depth not yet measured."
+								},
+								{
+									"from": "input-gear",
+									"to": "motor-nema17",
+									"via": "scr-m3-8-cs",
+									"qty": 1,
+									"method": "self-tap",
+									"note": "Threads through the gear hub and bears on the motor shaft flat."
+								},
+								{
+									"from": "nema-bracket",
+									"to": "stator",
+									"via": "scr-m3-12-cs",
+									"qty": 2,
+									"method": "self-tap",
+									"through_mm": 6.45,
+									"thread_mm": 10
+								},
+								{
+									"from": "nema-bracket",
+									"to": "stator",
+									"via": "scr-m3-12-cs",
+									"qty": 2,
+									"method": "self-tap",
+									"through_mm": 8.45,
+									"thread_mm": 10,
+									"note": "The bracket's four stator holes come in two depths: two at 6.45 mm, two at 8.45 mm."
+								}
+							],
+							"lines": [
+								{
+									"part": "idler-gear",
+									"qty": 1,
+									"uid": "7bv7"
+								},
+								{
+									"part": "brg-608-2rs",
+									"qty": 1,
+									"uid": "mi1l"
+								},
+								{
+									"part": "nema-bracket",
+									"qty": 1,
+									"uid": "x09t"
+								},
+								{
+									"part": "motor-nema17",
+									"qty": 1,
+									"uid": "w7pq"
+								},
+								{
+									"part": "input-gear",
+									"qty": 1,
+									"uid": "70ul"
+								},
+								{
+									"part": "stator",
+									"qty": 1,
+									"uid": "n6bm"
+								},
+								{
+									"part": "scr-m3-16-cs",
+									"qty": 3,
+									"uid": "bdi4"
+								},
+								{
+									"part": "scr-m3-8-cs",
+									"qty": 1,
+									"uid": "l6br"
+								},
+								{
+									"part": "scr-m3-12-cs",
+									"qty": 4,
+									"uid": "0a9x"
+								}
+							]
+						},
+						"rotor-unit-faceted": {
+							"uid": "ylvv",
+							"name": "Rotor unit (faceted)",
+							"description": "The faceted rotor with the Output gear (130T) bolted on. Assembled once as a unit; a C-channel drive spins it.",
+							"connections": [
+								{
+									"from": "brg-6806-2rs",
+									"to": "output-gear",
+									"qty": 1,
+									"method": "press"
+								},
+								{
+									"from": "output-gear",
+									"to": "rotor-faceted",
+									"via": "scr-m3-12-cs",
+									"qty": 6,
+									"method": "self-tap",
+									"note": "One per spoke. Needs the 12 mm length: the gear is 8 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 \u00d7 8 seated flush reaches nothing.",
+									"through_mm": 6.45,
+									"thread_mm": 5
+								}
+							],
+							"lines": [
+								{
+									"part": "rotor-faceted",
+									"qty": 1,
+									"uid": "9v9q"
+								},
+								{
+									"part": "output-gear",
+									"qty": 1,
+									"uid": "26ek"
+								},
+								{
+									"part": "brg-6806-2rs",
+									"qty": 1,
+									"uid": "elxe"
+								},
+								{
+									"part": "scr-m3-12-cs",
+									"qty": 6,
+									"uid": "0a9x"
+								}
+							]
+						},
+						"channel-two-support": {
+							"uid": "dp63",
+							"name": "Channel 2 support",
+							"description": "One of C-channel 2's three standoffs: a foot, one leg extension, and the leg the channel dovetails onto.",
+							"connections": [
+								{
+									"from": "foot",
+									"to": "leg-extension",
+									"qty": 1,
+									"method": "friction",
+									"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+								},
+								{
+									"from": "leg-extension",
+									"to": "leg",
+									"qty": 1,
+									"method": "friction",
+									"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+								}
+							],
+							"lines": [
+								{
+									"part": "foot",
+									"qty": 1,
+									"uid": "jqdx"
+								},
+								{
+									"part": "leg-extension",
+									"qty": 1,
+									"uid": "jewq"
+								},
+								{
+									"part": "leg",
+									"qty": 1,
+									"uid": "xse1"
+								}
+							]
+						},
+						"light-post-assembly": {
+							"uid": "lxof",
+							"name": "Light post",
+							"description": "The feeder light post: the post, the 50 mm COB plate on its end lighting down the channel, and the cap adapter and cap over it. 2 per machine, one each on C-channels 2 and 3, bolted to the C-channel drive's NEMA bracket.",
+							"docs": "/hardware/assembly/feeder/light-post/",
+							"connections": [
+								{
+									"from": "light-post-cap-adapter",
+									"to": "light-post",
+									"via": "scr-m3-12-cs",
+									"qty": 3,
+									"method": "self-tap",
+									"note": "Down through the adapter's three clearance holes and the COB plate clamped under it, threading into the pilot holes in the post's end."
+								},
+								{
+									"from": "light-post-cap",
+									"to": "light-post-cap-adapter",
+									"qty": 1,
+									"method": "gravity",
+									"note": "The cap just sits on the adapter."
+								}
+							],
+							"images": [
+								{
+									"url": "https://assets.basically.website/sorter-parts/light-post-assembled-full-2b59e7e84bdb.jpg",
+									"alt": "A finished light post on the bench: the black printed post with the 50 mm COB plate on its end, and the red and black leads running out of the post to a DC barrel plug",
+									"caption": "The light post, assembled."
+								},
+								{
+									"url": "https://assets.basically.website/sorter-parts/light-post-top-cap-off-full-d076a7bff4a1.jpg",
+									"alt": "The end of the post with the cap off: the aluminium back of the COB plate with the black cap adapter on it, three countersunk screws going down through both into the post, and the leads coming up through the centre hole",
+									"caption": "Cap off: the adapter and its three M3 \u00d7 12 through the plate into the post."
+								},
+								{
+									"url": "https://assets.basically.website/sorter-parts/light-post-led-side-full-428b89ff9243.jpg",
+									"alt": "The LED side of the COB plate, close up: the post's forked end holds the plate at its centre, with the leads passing through the centre hole",
+									"caption": "LED side: the post's forked end at the plate's centre."
+								},
+								{
+									"url": "https://assets.basically.website/sorter-parts/light-post-led-side-centre-full-b25b6589047d.jpg",
+									"alt": "The LED side of the COB plate straight on: the post's forked end at the centre with the leads leaving through it",
+									"caption": "LED side, straight on."
+								}
+							],
+							"lines": [
+								{
+									"part": "light-post",
+									"qty": 1,
+									"uid": "oac5"
+								},
+								{
+									"part": "led-cob-50mm-24v",
+									"qty": 1,
+									"uid": "s34o"
+								},
+								{
+									"part": "light-post-cap-adapter",
+									"qty": 1,
+									"uid": "jcnt"
+								},
+								{
+									"part": "scr-m3-12-cs",
+									"qty": 3,
+									"uid": "0a9x"
+								},
+								{
+									"part": "light-post-cap",
+									"qty": 1,
+									"uid": "7a8e"
+								}
+							]
+						},
+						"camera-mount": {
+							"uid": "b3zx",
+							"name": "Overhead camera mount",
+							"description": "Camera mount for the C-channels. 2 per machine, each hanging off two ~1 ft steel rods.",
+							"docs": "/hardware/assembly/feeder/camera-mount/",
+							"lines": [
+								{
+									"part": "camera-mount-part-6",
+									"qty": 1,
+									"uid": "v9dv"
+								},
+								{
+									"part": "camera-mount-part-37",
+									"qty": 1,
+									"uid": "8bqo"
+								},
+								{
+									"part": "camera-mount-part-37b",
+									"qty": 1,
+									"uid": "gut5"
+								},
+								{
+									"part": "camera-mount-rod-mount",
+									"qty": 2,
+									"uid": "twuu"
+								},
+								{
+									"part": "rod-steel-3-8",
+									"qty": 2,
+									"uid": "1o92"
+								},
+								{
+									"part": "cam-ov9732",
+									"qty": 1,
+									"uid": "6g79"
+								},
+								{
+									"part": "scr-m3-12-cs",
+									"qty": 3,
+									"uid": "0a9x"
+								},
+								{
+									"part": "nut-m3",
+									"qty": 3,
+									"uid": "sc1c"
+								}
+							]
+						},
+						"channel-three-support": {
+							"uid": "r6ar",
+							"name": "Channel 3 support",
+							"description": "One of C-channel 3's three standoffs: a foot and the leg the channel dovetails onto.",
+							"connections": [
+								{
+									"from": "foot",
+									"to": "leg",
+									"qty": 1,
+									"method": "friction",
+									"note": "Dovetail: the male tail on top of the lower part slides into the female slot under the upper."
+								}
+							],
+							"lines": [
+								{
+									"part": "foot",
+									"qty": 1,
+									"uid": "jqdx"
+								},
+								{
+									"part": "leg",
+									"qty": 1,
+									"uid": "xse1"
+								}
+							]
+						},
+						"rotor-unit-finned": {
+							"uid": "7ol7",
+							"name": "Rotor unit (finned)",
+							"description": "The finned rotor with the Output gear (130T) bolted on. Assembled once as a unit; the classification channel's C-channel drive spins it.",
+							"connections": [
+								{
+									"from": "brg-6806-2rs",
+									"to": "output-gear",
+									"qty": 1,
+									"method": "press"
+								},
+								{
+									"from": "output-gear",
+									"to": "rotor-finned",
+									"via": "scr-m3-12-cs",
+									"qty": 6,
+									"method": "self-tap",
+									"note": "One per spoke. Same joint as the faceted rotor unit."
+								}
+							],
+							"lines": [
+								{
+									"part": "rotor-finned",
+									"qty": 1,
+									"uid": "brsr"
+								},
+								{
+									"part": "output-gear",
+									"qty": 1,
+									"uid": "26ek"
+								},
+								{
+									"part": "brg-6806-2rs",
+									"qty": 1,
+									"uid": "elxe"
+								},
+								{
+									"part": "scr-m3-12-cs",
+									"qty": 6,
+									"uid": "0a9x"
+								}
+							]
+						},
+						"camera-led-insert-assembly": {
+							"uid": "434r",
+							"name": "Camera & LED insert assembly",
+							"description": "The Camera & LED insert print with the camera extension assembled into it; the loaded insert drops into the classification dome.",
+							"connections": [
+								{
+									"from": "camera-extension-assembly",
+									"to": "camera-led-insert",
+									"via": "scr-m3-12-bhcs",
+									"qty": 4,
+									"method": "self-tap"
+								}
+							],
+							"lines": [
+								{
+									"part": "camera-led-insert",
+									"qty": 1,
+									"uid": "b2v9"
+								},
+								{
+									"assembly": "camera-extension-assembly",
+									"qty": 1,
+									"uid": "q2re"
+								},
+								{
+									"part": "scr-m3-12-bhcs",
+									"qty": 4,
+									"uid": "izrb"
+								}
+							]
+						},
+						"camera-extension-assembly": {
+							"uid": "q2re",
+							"name": "Camera extension",
+							"description": "Classification-channel camera extension for the 4K camera module: the 50 mm extension tube, its mount, and the camera. 1 per machine.",
+							"lines": [
+								{
+									"part": "camera-extension",
+									"qty": 1,
+									"uid": "v684"
+								},
+								{
+									"part": "camera-extension-mount",
+									"qty": 1,
+									"uid": "wt9t"
+								},
+								{
+									"part": "cam-imx415",
+									"qty": 1,
+									"uid": "1lze"
+								},
+								{
+									"part": "scr-m2-8-shcs",
+									"qty": 4,
+									"uid": "iwk6"
+								}
+							]
+						}
+					}
 				}
 			],
 			"lines": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1306,8 +1306,8 @@
 		},
 		{
 			"id": "feeder",
-			"uid": "y5ws",
-			"version": "3",
+			"uid": "i4f8",
+			"version": "4",
 			"name": "Feeder",
 			"description": "Everything above the top interface: the bulk bucket, C-channels 2 and 3, and the classification chamber.",
 			"docs": "/hardware/assembly/feeder/",
@@ -1391,11 +1391,18 @@
 				},
 				{
 					"version": "3",
-					"uid": "y5ws",
 					"date": "2026-09-01",
 					"message": "Restructured into the four physical units \u2014 the bulk bucket, C-channels 2 and 3, and the classification chamber \u2014 each carrying its own C-channel drive, rotor, supports, guide or cap, and lighting. No physical change.",
 					"breaking": false,
 					"commit": "e47151a1"
+				},
+				{
+					"version": "4",
+					"uid": "i4f8",
+					"date": "2026-09-02",
+					"message": "Stamped to lock the feeder before the C-channel overhaul: flip to v4 for every unit, part revision and screw count as they stood this day. The feeder's own list is unchanged.",
+					"breaking": false,
+					"commit": null
 				}
 			],
 			"lines": [
@@ -19806,14 +19813,6 @@
 			"date": "2026-08-31",
 			"commit": null,
 			"message": "Golden with hex-frame-v2: future revisions must stay compatible with this part."
-		},
-		{
-			"name": "feeder-2026-09-02",
-			"node": "feeder",
-			"stability": "stable",
-			"date": "2026-09-02",
-			"commit": null,
-			"message": "Locked before the C-channel overhaul: every unit, part and screw count under the feeder as it stood this day."
 		}
 	]
 }

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -77,6 +77,19 @@ export const JOIN_LABELS: Record<JoinMethod, string> = {
  *  pinned to the uid it had then, so the box as built at that time reads back
  *  part by part. Written by stamp_versions.py at supersession. */
 export type AssemblySnapshotLine = AssemblyLine & { uid?: string };
+/** One assembly inside a version's frozen tree: its record as it stood when
+ *  the version was stamped, lines pinned to member uids. */
+export type FrozenAssembly = {
+	uid: string;
+	name: string;
+	description?: string;
+	docs?: string;
+	joining?: Joining[];
+	connections?: Connection[];
+	images?: CatalogImage[];
+	lines: AssemblySnapshotLine[];
+};
+
 export type AssemblyVersion = {
 	version: string;
 	uid?: string;
@@ -85,6 +98,7 @@ export type AssemblyVersion = {
 	commit: string | null;
 	breaking?: boolean; // required on entries since 2026-08-31 (VERSIONING.md)
 	lines?: AssemblySnapshotLine[];
+	tree?: Record<string, FrozenAssembly>; // the whole subtree as of the stamp, root first
 	images?: CatalogImage[];
 };
 

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -54,6 +54,7 @@
 		type AssemblyLine,
 		type AssemblySnapshotLine,
 		type Connection,
+		type FrozenAssembly,
 		type Hardware,
 		type Joining,
 		type Part,
@@ -959,6 +960,36 @@
 	{/if}
 {/snippet}
 
+<!-- One assembly of a version's frozen tree, recursively: its record as it
+     stood at the stamp — description, photos, every line at the member's uid
+     of the day — with sub-assemblies nested the same way. Nothing here reads
+     the live catalog except to resolve a pinned uid to its archived render. -->
+{#snippet frozenNode(tree: Record<string, FrozenAssembly>, id: string, mult: number, root: boolean)}
+	{@const rec = tree[id]}
+	{#if rec}
+		<div class="{root ? '' : 'ml-1.5 mt-2 border border-border bg-surface p-2 sm:ml-4 sm:p-3'}">
+			{#if !root}
+				<div class="flex flex-wrap items-baseline gap-x-2">
+					<span class="text-sm font-semibold text-text">{rec.name}</span>
+					<span class="border border-border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-text-muted">assembly</span>
+					<span class="font-mono text-xs text-text-muted">{rec.uid}</span>
+					{#if memberRev(id, rec.uid)}<span class="text-xs text-text-muted">· v{memberRev(id, rec.uid)}</span>{/if}
+				</div>
+			{/if}
+			{#if rec.description}<AssemblyDescription text={rec.description} class="mt-1 max-w-2xl text-xs text-text-muted" />{/if}
+			{#if rec.images?.length}<div class="mt-2"><ImageStrip images={rec.images} /></div>{/if}
+			{@render joiningRows(rec.joining)}
+			{#each rec.lines as l, i (`${l.part ?? l.assembly}-${i}`)}
+				{#if l.assembly && tree[l.assembly]}
+					{@render frozenNode(tree, l.assembly, lineQty(l, layers) * mult, false)}
+				{:else}
+					{@render snapshotRow(l, mult)}
+				{/if}
+			{/each}
+		</div>
+	{/if}
+{/snippet}
+
 <!-- A node's line rows, routed by the header's version controls: the live
      lines, one version's snapshot, or the diff between two versions. -->
 {#snippet versionSwitch(asm: Assembly, mult: number, depth: number)}
@@ -993,7 +1024,11 @@
 				<button type="button" class="ml-auto font-medium underline underline-offset-2" onclick={() => delete shownVersion[asm.id]}>back to v{cur}</button>
 			</div>
 			{#if entry?.message}<AssemblyDescription text={entry.message} class="mt-1 max-w-2xl text-xs text-text-muted" />{/if}
-			{#if entry?.lines?.length}
+			{#if entry?.tree?.[asm.id]}
+				<!-- the version's commit of its whole subtree: rendered from the
+				     frozen tree alone, so what you see is what was there then -->
+				{@render frozenNode(entry.tree, asm.id, mult, true)}
+			{:else if entry?.lines?.length}
 				{#each entry.lines as l, i (`${l.part ?? l.assembly}-${i}`)}
 					{@render snapshotRow(l, mult)}
 				{/each}


### PR DESCRIPTION
## A version is a commit of everything below the node

Stamping an assembly's version now freezes its **whole subtree** into the version entry: every assembly under the node as it stood at that commit — description, photos, joints, and every line pinned to the member's uid of the day, sub-assemblies all the way down to the screws. `stamp_versions.py` writes it (`freeze_subtree`); nothing is resolved from dates or reconstructed later. Flipping a node to an old version ("Viewing vN") renders from that frozen tree alone, so it shows exactly what was there then, whatever has changed since: old prints at their archived revisions, old screw counts, old photos.

## Feeder locked at v4

The feeder is stamped **v4** with its own list unchanged, purely to take that commit before the C-channel overhaul. Its v4 entry carries the frozen tree: 15 assemblies, every part, bearing and screw pinned by uid.

The `stable` tag added earlier today is removed — it was a stability claim nobody made. Locking needs no tag; it's a version stamp.

## Proven

Simulated a destructive overhaul locally (uncommitted, reverted): feeder v5 with the bulk bucket deleted, channel-two gutted of its output guide, light post and screws, stator revised to a new uid. Flipping Feeder → v4 rendered the complete frozen subtree: bulk bucket back, channel-two whole, **Stator n6bm · v1** while the live part was at v2, light post photos intact.

svelte-check 0 errors · versioning, connections, generated-pins checks hold.

Merged with a merge commit, not a squash: the v4 entry's `commit` field points at the exact hash on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
