### PR TITLE
parts-calculator: mark the unused M3 x 8 screw and M3 x 15 washer for deletion, and badge a removal as one

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -352,6 +352,17 @@
       }
     },
     {
+      "id": "delete-unused-m3-8-shcs-screw",
+      "name": "Delete the unused M3 x 8 mm socket/button head screw",
+      "priority": "P4",
+      "description": "This screw is not used anywhere in the machine any more. It was added as the clamp screw holding the C-channel input gear (12T) onto the NEMA 17 shaft flat; the C-channel overhaul established that the screws on that assembly are countersunk, so the joint carries the M3 x 8 mm countersunk (scr-m3-8-cs) instead, and this row has no quantity anywhere. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #536.",
+      "targets": {
+        "hardware": [
+          "scr-m3-8-shcs"
+        ]
+      }
+    },
+    {
       "id": "unconfirmed-servo-adapter-heat-insert",
       "name": "Servo adapter's 4x M3S heat inserts are unconfirmed against the current CAD",
       "priority": "P2",
@@ -3068,9 +3079,9 @@
       "name": "M3 × 8 mm socket/button head",
       "category": "Screws",
       "alternative": "Socket or button head",
-      "description": "Retired, no longer used anywhere. Was recorded as the screw clamping the C-channel input gear (12T) to the NEMA 17 shaft flat, but that screw is countersunk (scr-m3-8-cs).",
+      "description": "Retired, no longer used anywhere. Was recorded as the screw clamping the C-channel input gear (12T) to the NEMA 17 shaft flat, but that screw is countersunk (scr-m3-8-cs). Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md); deletion is tracked as sorter-v2 issue #536.",
       "created_at": "2026-08-21",
-      "updated_at": "2026-09-01",
+      "updated_at": "2026-09-03",
       "attributes": [
         {
           "label": "Thread",
@@ -3085,7 +3096,7 @@
           "value": "Socket or button head, interchangeable (both bottom on the counterbore floor, so either just clamps)"
         }
       ],
-      "note": "Head type and length measured off the input-gear STL: the boss carries a Ø2.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the Ø4.87 mm bore; the head sits in a round Ø6.40 mm × 2.7 mm counterbore with a 90° cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (Ø5.5 × 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (Ø5.7 × 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic. Unused as of 2026-09-01: the screw is the countersunk M3 × 8 (scr-m3-8-cs)."
+      "note": "Head type and length measured off the input-gear STL: the boss carries a Ø2.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the Ø4.87 mm bore; the head sits in a round Ø6.40 mm × 2.7 mm counterbore with a 90° cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (Ø5.5 × 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (Ø5.7 × 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic. Unused as of 2026-09-01: the screw is the countersunk M3 × 8 (scr-m3-8-cs). Do not add a new joint to this entry. Measure the real screw and use a live catalog part instead."
     },
     {
       "id": "scr-m3-12-cs",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -333,6 +333,7 @@
       "id": "delete-unused-m3-tbd-placeholder",
       "name": "Delete the unused M3 screw placeholder",
       "priority": "P4",
+      "condition": "retired",
       "description": "This placeholder screw is not used anywhere in the machine any more — every joint that carried it (the cable-mount cage bracket, the camera extension, the Orange Pi mount) turned out to already have a specific screw recorded, and those catalog lines have been updated to point at the real ones. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #453.",
       "targets": {
         "hardware": [
@@ -344,6 +345,7 @@
       "id": "delete-unused-m3-shcs-tbd-placeholder",
       "name": "Delete the unused M3 socket/button head length-TBD placeholder",
       "priority": "P4",
+      "condition": "retired",
       "description": "This placeholder screw is not used anywhere in the machine — it stood in for the basically Embedded Control Board's screws before they were measured as M3 x 6 mm button head (scr-m3-6-bhcs), and nothing has called for it since. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #454.",
       "targets": {
         "hardware": [
@@ -355,6 +357,7 @@
       "id": "delete-unused-m3-8-shcs-screw",
       "name": "Delete the unused M3 x 8 mm socket/button head screw",
       "priority": "P4",
+      "condition": "retired",
       "description": "This screw is not used anywhere in the machine any more. It was added as the clamp screw holding the C-channel input gear (12T) onto the NEMA 17 shaft flat; the C-channel overhaul established that the screws on that assembly are countersunk, so the joint carries the M3 x 8 mm countersunk (scr-m3-8-cs) instead, and this row has no quantity anywhere. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #536.",
       "targets": {
         "hardware": [
@@ -366,6 +369,7 @@
       "id": "delete-unused-m3-15-washer",
       "name": "Delete the unused M3 x 15 mm washer",
       "priority": "P4",
+      "condition": "retired",
       "description": "This washer is not used anywhere in the machine. It was added to match the documentation's description of the interface idler gear joint, under the M3 x 35 screw holding the gear onto the NEMA 23 bracket, and that description was wrong: the joint uses the printed chute stepper idler bearing retainers instead, so the washer was never correct there and its last assembly line was dropped on 2026-08-25. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #478.",
       "targets": {
         "hardware": [

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -363,6 +363,17 @@
       }
     },
     {
+      "id": "delete-unused-m3-15-washer",
+      "name": "Delete the unused M3 x 15 mm washer",
+      "priority": "P4",
+      "description": "This washer is not used anywhere in the machine. It was added to match the documentation's description of the interface idler gear joint, under the M3 x 35 screw holding the gear onto the NEMA 23 bracket, and that description was wrong: the joint uses the printed chute stepper idler bearing retainers instead, so the washer was never correct there and its last assembly line was dropped on 2026-08-25. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #478.",
+      "targets": {
+        "hardware": [
+          "washer-m3-15"
+        ]
+      }
+    },
+    {
       "id": "unconfirmed-servo-adapter-heat-insert",
       "name": "Servo adapter's 4x M3S heat inserts are unconfirmed against the current CAD",
       "priority": "P2",
@@ -3712,9 +3723,9 @@
       },
       "name": "M3 × 15 mm washer",
       "category": "Washers",
-      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md).",
+      "description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 × 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md). Deletion is tracked as sorter-v2 issue #478.",
       "created_at": "2026-08-18",
-      "updated_at": "2026-08-30",
+      "updated_at": "2026-09-03",
       "note": "Unused as of 2026-08-30. Do not add a new joint to this washer — the idler gear joint it was meant for uses the printed chute stepper idler bearing retainers instead.",
       "attributes": [
         {

--- a/parts-calculator/src/lib/components/ChangeStatus.svelte
+++ b/parts-calculator/src/lib/components/ChangeStatus.svelte
@@ -53,10 +53,10 @@
 			: allRetired
 				? `${name} is being removed from the catalog`
 				: allNiceToHave
-				? `Possible improvement for ${name}`
-				: anyBroken
-					? `Broken feature on ${name}`
-					: `Why ${name} is subject to change`
+					? `Possible improvement for ${name}`
+					: anyBroken
+						? `Broken feature on ${name}`
+						: `Why ${name} is subject to change`
 	);
 	const headline = $derived(
 		anyBroken
@@ -64,8 +64,8 @@
 			: allRetired
 				? 'This item is no longer used anywhere and is waiting to be deleted from the catalog.'
 				: allNiceToHave
-				? 'The current design is usable; these improvements would be nice to have.'
-				: 'Works now, but is intended to be replaced shortly with an improvement.'
+					? 'The current design is usable; these improvements would be nice to have.'
+					: 'Works now, but is intended to be replaced shortly with an improvement.'
 	);
 </script>
 
@@ -75,7 +75,14 @@
 	     sits in the narrow thumbnail cell at the very left — so a right-aligned
 	     panel runs 20rem off the edge of the table and loses its first half.
 	     Opening rightwards into the table body always has room. -->
-	<Popover width="w-80" {align} {label}>
+	<Popover
+		width="w-80"
+		{align}
+		{label}
+		class={variant === 'marker'
+			? 'absolute -bottom-px -left-px z-10 inline-flex'
+			: 'relative inline-flex align-middle'}
+	>
 		{#snippet trigger({ toggle, open })}
 			{#if variant === 'marker'}
 				<button
@@ -164,12 +171,11 @@
 
 <style>
 	/* Deliberately quiet: a builder scanning a list of renders should notice it
-	   without reading it as a stop sign. The panel is where the alarm lives. */
+	   without reading it as a stop sign. The panel is where the alarm lives.
+	   Positioning belongs to the Popover root (this button is inside it), which
+	   is what puts the mark in the tile's bottom-left corner, mirroring the
+	   length stamp the hardware page puts in the bottom-right. */
 	.change-marker {
-		position: absolute;
-		top: 1px;
-		right: 1px;
-		z-index: 10;
 		display: inline-flex;
 		align-items: center;
 		gap: 0.0625rem;
@@ -184,13 +190,14 @@
 	:global(.dark) .change-marker {
 		color: var(--color-warning);
 	}
-	/* Removal is not an alarm: the mark stays quiet and the trash can carries the
-	   meaning, the same way the warning triangle does for everything else. */
+	/* Red, at barthel's request: on a page of pictures the trash can is the whole
+	   signal, and a muted one was missed entirely. */
 	.change-marker.is-retired {
-		color: var(--color-text-muted);
+		border-color: color-mix(in srgb, var(--color-danger) 50%, transparent);
+		color: var(--color-danger);
 	}
 	:global(.dark) .change-marker.is-retired {
-		color: var(--color-text-muted);
+		color: #ff6b6c;
 	}
 	.retired-badge {
 		display: inline-flex;

--- a/parts-calculator/src/lib/components/ChangeStatus.svelte
+++ b/parts-calculator/src/lib/components/ChangeStatus.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { AlertTriangle, RefreshCw } from 'lucide-svelte';
+	import { AlertTriangle, RefreshCw, Trash2 } from 'lucide-svelte';
 	import PriorityBadge from './PriorityBadge.svelte';
 	import Popover from './Popover.svelte';
 	import { plannedChangesFor, type ChangePriority, type ChangeTargetKind, type PlannedChange } from '$lib/filament';
@@ -32,6 +32,10 @@
 	const changes = $derived([...plannedChangesFor(kind, id)].sort((a, b) => rank(a) - rank(b)));
 	const lead = $derived(changes[0]);
 	const anyBroken = $derived(changes.some((change) => change.condition === 'broken'));
+	// A part on its way out of the catalog is not an improvement to make, so it
+	// gets its own icon and words instead of reading as "Nice to Improve · P4".
+	const anyRetired = $derived(changes.some((change) => change.condition === 'retired'));
+	const allRetired = $derived(changes.every((change) => change.condition === 'retired'));
 	// Worst priority across the notices, which is the number the trigger shows.
 	const topPriority = $derived(
 		changes.reduce<ChangePriority>(
@@ -46,7 +50,9 @@
 	const label = $derived(
 		changes.length > 1
 			? `${changes.length} notices on ${name}`
-			: allNiceToHave
+			: allRetired
+				? `${name} is being removed from the catalog`
+				: allNiceToHave
 				? `Possible improvement for ${name}`
 				: anyBroken
 					? `Broken feature on ${name}`
@@ -55,7 +61,9 @@
 	const headline = $derived(
 		anyBroken
 			? 'This design has a broken feature that is intended to be fixed.'
-			: allNiceToHave
+			: allRetired
+				? 'This item is no longer used anywhere and is waiting to be deleted from the catalog.'
+				: allNiceToHave
 				? 'The current design is usable; these improvements would be nice to have.'
 				: 'Works now, but is intended to be replaced shortly with an improvement.'
 	);
@@ -74,12 +82,22 @@
 					type="button"
 					class="change-marker"
 					class:is-broken={anyBroken}
+					class:is-retired={!anyBroken && allRetired}
 					onclick={toggle}
 					aria-expanded={open}
 					aria-label={label}
 				>
-					<AlertTriangle size={11} />
+					{#if !anyBroken && allRetired}<Trash2 size={11} />{:else}<AlertTriangle size={11} />{/if}
 					{#if changes.length > 1}<span class="change-marker-n">{changes.length}</span>{/if}
+				</button>
+			{:else if !anyBroken && allRetired}
+				<!-- Its own chip, not a PriorityBadge: the priority palette generates a
+				     pale hue for anything past P3, and "to be removed" is a state, not a
+				     rung on the fix-this-first ladder. -->
+				<button type="button" class="retired-badge" onclick={toggle} aria-expanded={open} aria-label={label}>
+					<Trash2 size={11} />
+					{changes.length > 1 ? `${changes.length} Notices · To Be Removed` : 'To Be Removed'}
+					· {topPriority}
 				</button>
 			{:else}
 				<PriorityBadge
@@ -89,7 +107,7 @@
 					onclick={toggle}
 					aria-expanded={open}
 				>
-					{#if anyBroken}<AlertTriangle size={11} />{:else}<RefreshCw size={11} />{/if}
+					{#if anyBroken}<AlertTriangle size={11} />{:else if anyRetired}<Trash2 size={11} />{:else}<RefreshCw size={11} />{/if}
 					{#if changes.length > 1}
 						{changes.length} Notices
 					{:else if anyBroken}
@@ -102,7 +120,11 @@
 			{/if}
 		{/snippet}
 		<div class="flex items-start gap-2">
-			<AlertTriangle size={14} class="mt-0.5 shrink-0 {anyBroken ? 'text-danger' : 'text-warning-dark'}" />
+			{#if !anyBroken && allRetired}
+				<Trash2 size={14} class="mt-0.5 shrink-0 text-text-muted" />
+			{:else}
+				<AlertTriangle size={14} class="mt-0.5 shrink-0 {anyBroken ? 'text-danger' : 'text-warning-dark'}" />
+			{/if}
 			<div>
 				<b class="text-text">{headline}</b>
 				<p class="mt-1">
@@ -122,6 +144,7 @@
 			<div class="mt-2 border-t border-border pt-2 text-text">
 				<PriorityBadge priority={change.priority} />
 				{#if change.condition === 'broken'}<span class="ml-1 text-[10px] font-semibold uppercase tracking-wide text-danger">Broken</span>{/if}
+				{#if change.condition === 'retired'}<span class="ml-1 text-[10px] font-semibold uppercase tracking-wide text-text-muted">To be removed</span>{/if}
 				<a class="ml-1 font-semibold text-primary hover:text-primary-hover" href="/changes#{change.id}">{change.name}</a>
 				<p class="mt-1">{change.description}</p>
 				{#if change.images?.length}
@@ -160,6 +183,30 @@
 	   dark theme takes the bright warning instead. */
 	:global(.dark) .change-marker {
 		color: var(--color-warning);
+	}
+	/* Removal is not an alarm: the mark stays quiet and the trash can carries the
+	   meaning, the same way the warning triangle does for everything else. */
+	.change-marker.is-retired {
+		color: var(--color-text-muted);
+	}
+	:global(.dark) .change-marker.is-retired {
+		color: var(--color-text-muted);
+	}
+	.retired-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.1875rem;
+		border: 1px solid var(--color-text-muted);
+		background: color-mix(in srgb, var(--color-text-muted) 12%, transparent);
+		padding: 0 0.25rem;
+		color: var(--color-text);
+		font-size: 0.75rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.02em;
+	}
+	.retired-badge:hover {
+		background: color-mix(in srgb, var(--color-text-muted) 22%, transparent);
 	}
 	.change-marker.is-broken {
 		border-color: color-mix(in srgb, var(--color-danger) 50%, transparent);

--- a/parts-calculator/src/lib/components/Popover.svelte
+++ b/parts-calculator/src/lib/components/Popover.svelte
@@ -5,11 +5,16 @@
 	// Generic click-to-open context popover. Reuse anywhere you need an inline
 	// explanation. Provide content via the `text` prop or a `children` snippet,
 	// and (optionally) a custom trigger via the `trigger` snippet.
+	// `class` replaces the root's own positioning classes, for a trigger that has
+	// to sit somewhere specific (a corner mark on an image tile). The root is the
+	// panel's containing block, so anything that moves the trigger has to move
+	// this element, not just the button inside it.
 	let {
 		text = '',
 		label = 'More information',
 		align = 'left',
 		width = 'w-64',
+		class: cls = 'relative inline-flex align-middle',
 		children,
 		trigger
 	}: {
@@ -17,6 +22,7 @@
 		label?: string;
 		align?: 'left' | 'right';
 		width?: string;
+		class?: string;
 		children?: Snippet;
 		trigger?: Snippet<[{ toggle: () => void; open: boolean }]>;
 	} = $props();
@@ -44,7 +50,7 @@
 
 <span
 	bind:this={root}
-	class="relative inline-flex align-middle"
+	class={cls}
 	onmouseenter={() => (hovered = true)}
 	onmouseleave={() => (hovered = false)}
 	onfocusin={() => (hovered = true)}

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -347,6 +347,7 @@
 			"id": "delete-unused-m3-tbd-placeholder",
 			"name": "Delete the unused M3 screw placeholder",
 			"priority": "P4",
+			"condition": "retired",
 			"description": "This placeholder screw is not used anywhere in the machine any more \u2014 every joint that carried it (the cable-mount cage bracket, the camera extension, the Orange Pi mount) turned out to already have a specific screw recorded, and those catalog lines have been updated to point at the real ones. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #453.",
 			"targets": {
 				"hardware": [
@@ -358,6 +359,7 @@
 			"id": "delete-unused-m3-shcs-tbd-placeholder",
 			"name": "Delete the unused M3 socket/button head length-TBD placeholder",
 			"priority": "P4",
+			"condition": "retired",
 			"description": "This placeholder screw is not used anywhere in the machine \u2014 it stood in for the basically Embedded Control Board's screws before they were measured as M3 x 6 mm button head (scr-m3-6-bhcs), and nothing has called for it since. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #454.",
 			"targets": {
 				"hardware": [
@@ -369,6 +371,7 @@
 			"id": "delete-unused-m3-8-shcs-screw",
 			"name": "Delete the unused M3 x 8 mm socket/button head screw",
 			"priority": "P4",
+			"condition": "retired",
 			"description": "This screw is not used anywhere in the machine any more. It was added as the clamp screw holding the C-channel input gear (12T) onto the NEMA 17 shaft flat; the C-channel overhaul established that the screws on that assembly are countersunk, so the joint carries the M3 x 8 mm countersunk (scr-m3-8-cs) instead, and this row has no quantity anywhere. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #536.",
 			"targets": {
 				"hardware": [
@@ -380,6 +383,7 @@
 			"id": "delete-unused-m3-15-washer",
 			"name": "Delete the unused M3 x 15 mm washer",
 			"priority": "P4",
+			"condition": "retired",
 			"description": "This washer is not used anywhere in the machine. It was added to match the documentation's description of the interface idler gear joint, under the M3 x 35 screw holding the gear onto the NEMA 23 bracket, and that description was wrong: the joint uses the printed chute stepper idler bearing retainers instead, so the washer was never correct there and its last assembly line was dropped on 2026-08-25. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #478.",
 			"targets": {
 				"hardware": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -377,6 +377,17 @@
 			}
 		},
 		{
+			"id": "delete-unused-m3-15-washer",
+			"name": "Delete the unused M3 x 15 mm washer",
+			"priority": "P4",
+			"description": "This washer is not used anywhere in the machine. It was added to match the documentation's description of the interface idler gear joint, under the M3 x 35 screw holding the gear onto the NEMA 23 bracket, and that description was wrong: the joint uses the printed chute stepper idler bearing retainers instead, so the washer was never correct there and its last assembly line was dropped on 2026-08-25. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #478.",
+			"targets": {
+				"hardware": [
+					"washer-m3-15"
+				]
+			}
+		},
+		{
 			"id": "unconfirmed-servo-adapter-heat-insert",
 			"name": "Servo adapter's 4x M3S heat inserts are unconfirmed against the current CAD",
 			"priority": "P2",
@@ -19969,10 +19980,10 @@
 			},
 			"name": "M3 \u00d7 15 mm washer",
 			"category": "Washers",
-			"description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md).",
+			"description": "Flat/fender washer, 15 mm outer diameter. Added to the catalog to match the documentation's description of the interface idler gear joint, under the M3 \u00d7 35 screw that holds the gear onto the NEMA 23 bracket. That documentation was wrong: the joint's actual design uses the printed chute stepper idler bearing retainers instead (wired up 2026-08-25), so this part was never correct here. Not used anywhere in the machine. Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md). Deletion is tracked as sorter-v2 issue #478.",
 			"note": "Unused as of 2026-08-30. Do not add a new joint to this washer \u2014 the idler gear joint it was meant for uses the printed chute stepper idler bearing retainers instead.",
 			"created_at": "2026-08-18",
-			"updated_at": "2026-08-30",
+			"updated_at": "2026-09-03",
 			"attributes": [
 				{
 					"label": "Thread",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -366,6 +366,17 @@
 			}
 		},
 		{
+			"id": "delete-unused-m3-8-shcs-screw",
+			"name": "Delete the unused M3 x 8 mm socket/button head screw",
+			"priority": "P4",
+			"description": "This screw is not used anywhere in the machine any more. It was added as the clamp screw holding the C-channel input gear (12T) onto the NEMA 17 shaft flat; the C-channel overhaul established that the screws on that assembly are countersunk, so the joint carries the M3 x 8 mm countersunk (scr-m3-8-cs) instead, and this row has no quantity anywhere. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #536.",
+			"targets": {
+				"hardware": [
+					"scr-m3-8-shcs"
+				]
+			}
+		},
+		{
 			"id": "unconfirmed-servo-adapter-heat-insert",
 			"name": "Servo adapter's 4x M3S heat inserts are unconfirmed against the current CAD",
 			"priority": "P2",
@@ -19180,10 +19191,10 @@
 			},
 			"name": "M3 \u00d7 8 mm socket/button head",
 			"category": "Screws",
-			"description": "Retired, no longer used anywhere. Was recorded as the screw clamping the C-channel input gear (12T) to the NEMA 17 shaft flat, but that screw is countersunk (scr-m3-8-cs).",
-			"note": "Head type and length measured off the input-gear STL: the boss carries a \u00d82.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the \u00d84.87 mm bore; the head sits in a round \u00d86.40 mm \u00d7 2.7 mm counterbore with a 90\u00b0 cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (\u00d85.5 \u00d7 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (\u00d85.7 \u00d7 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic. Unused as of 2026-09-01: the screw is the countersunk M3 \u00d7 8 (scr-m3-8-cs).",
+			"description": "Retired, no longer used anywhere. Was recorded as the screw clamping the C-channel input gear (12T) to the NEMA 17 shaft flat, but that screw is countersunk (scr-m3-8-cs). Kept as an unused entry rather than deleted, since a minted uid has to stay resolvable (see parts-calculator's own CLAUDE.md); deletion is tracked as sorter-v2 issue #536.",
+			"note": "Head type and length measured off the input-gear STL: the boss carries a \u00d82.80 mm hole parallel to the shaft, 3.61 mm off the axis, opening into the \u00d84.87 mm bore; the head sits in a round \u00d86.40 mm \u00d7 2.7 mm counterbore with a 90\u00b0 cone at the bottom, which is a flat-bottomed head seat rather than a countersink. A socket cap head (\u00d85.5 \u00d7 3.0) bottoms on that floor and stands about 0.3 mm proud; a button head (\u00d85.7 \u00d7 1.65) bottoms on the same floor about 1 mm below flush, so either clamps. At 8 mm the head seats and about 6 mm of thread is left in the plastic. Unused as of 2026-09-01: the screw is the countersunk M3 \u00d7 8 (scr-m3-8-cs). Do not add a new joint to this entry. Measure the real screw and use a live catalog part instead.",
 			"created_at": "2026-08-21",
-			"updated_at": "2026-09-01",
+			"updated_at": "2026-09-03",
 			"attributes": [
 				{
 					"label": "Thread",

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -36,7 +36,11 @@ export type PlannedChange = {
 	name: string;
 	priority: ChangePriority;
 	description: string;
-	condition?: 'working' | 'broken';
+	// 'broken' = does not work as built. 'retired' = the item itself is on its way
+	// out of the catalog (unused everywhere, waiting on a deletion nobody can do
+	// from a branch), which is a different thing from a fix or an improvement and
+	// is badged as its own state rather than hiding behind a low priority number.
+	condition?: 'working' | 'broken' | 'retired';
 	status?: 'planned' | 'complete';
 	completed_at?: string;
 	images?: CatalogImage[];

--- a/parts-calculator/src/routes/changes/+page.svelte
+++ b/parts-calculator/src/routes/changes/+page.svelte
@@ -92,7 +92,9 @@
 							{:else}
 								<PriorityBadge priority={change.priority} />
 								{#if change.condition === 'broken'}<div class="mt-1 text-[10px] font-semibold uppercase leading-tight tracking-wide text-danger">Broken feature</div>{/if}
-								{#if change.condition === 'retired'}<div class="mt-1 inline-flex items-center gap-1 text-[10px] font-semibold uppercase leading-tight tracking-wide text-text"><Trash2 size={10} /> To be removed</div>{/if}
+								<!-- One line, never wrapped: at 10px beside a label broken over two
+								     lines the icon read as a smudge rather than a trash can. -->
+								{#if change.condition === 'retired'}<div class="mt-1 inline-flex items-center gap-1 whitespace-nowrap text-[10px] font-semibold uppercase leading-tight tracking-wide text-text"><Trash2 size={13} class="shrink-0" /> To be removed</div>{/if}
 							{/if}
 						</td>
 						<td class="px-3 py-3">

--- a/parts-calculator/src/routes/changes/+page.svelte
+++ b/parts-calculator/src/routes/changes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ArrowLeft, Box, Boxes, CheckCircle2, Layers3 } from 'lucide-svelte';
+	import { ArrowLeft, Box, Boxes, CheckCircle2, Layers3, Trash2 } from 'lucide-svelte';
 	import Badge from '$lib/components/Badge.svelte';
 	import PriorityBadge from '$lib/components/PriorityBadge.svelte';
 	import Modal from '$lib/components/Modal.svelte';
@@ -92,6 +92,7 @@
 							{:else}
 								<PriorityBadge priority={change.priority} />
 								{#if change.condition === 'broken'}<div class="mt-1 text-[10px] font-semibold uppercase leading-tight tracking-wide text-danger">Broken feature</div>{/if}
+								{#if change.condition === 'retired'}<div class="mt-1 inline-flex items-center gap-1 text-[10px] font-semibold uppercase leading-tight tracking-wide text-text"><Trash2 size={10} /> To be removed</div>{/if}
 							{/if}
 						</td>
 						<td class="px-3 py-3">
@@ -151,7 +152,7 @@
 	<a href="/" class="mb-5 inline-flex items-center gap-1 text-sm font-semibold text-primary hover:text-primary-hover"><ArrowLeft size={15} /> Printed parts</a>
 	<div class="mb-6">
 		<h1 class="text-3xl font-bold tracking-tight text-text">Intended Changes</h1>
-		<p class="mt-2 max-w-3xl text-sm text-text-muted">Known fixes and planned improvements. P0 is reserved for broken features; higher numbers are progressively lower priority, with P4 used for nice-to-have improvements. Click any part thumbnail to inspect its current interactive 3D model.</p>
+		<p class="mt-2 max-w-3xl text-sm text-text-muted">Known fixes and planned improvements. P0 is reserved for broken features; higher numbers are progressively lower priority, with P4 used for nice-to-have improvements. Entries marked <b>To be removed</b> are catalog entries nothing uses any more, waiting to be deleted. Click any part thumbnail to inspect its current interactive 3D model.</p>
 	</div>
 
 	{@render changeTable(plannedChanges, false)}


### PR DESCRIPTION
barthel asked for `scr-m3-8-shcs` to get the same treatment as `scr-m3-tbd`: marked retired, tagged P4 in `changes`, and a GitHub issue for deleting it from the catalog. Then the same for `washer-m3-15`. Then, looking at the result, he pointed out that P4 alone is close to invisible and asked whether an icon would make more sense. It would, so the third commit adds one.

**`scr-m3-8-shcs` is genuinely unused.** No current assembly line and no connection edge; its only two references are the `c-channel` version 1 and version 2 historical snapshots, which are correct to leave alone. Spencer retired it at the bench in #515 (`441d9114`): the input gear's clamp screw is the countersunk `scr-m3-8-cs`. Every `M3 × 8` in `docs/` is the countersunk variant, and the Drive BOM sheet lists M3 countersunk in 8/12/16 mm with no M3 socket or button head at all.

**`washer-m3-15` is genuinely unused too.** PR #479 already gave it the retired `description` and `note`, and issue #478 already tracks the deletion, but it had no `changes` entry, so nothing rendered on the part itself. Its last assembly line went in PR #420 (2026-08-25) when the interface idler gear joint turned out to use the printed bearing retainers, not a washer.

**Why P4 alone was not enough.** `PriorityBadge` carries fixed hues for P0 to P3 only; P4 and up fall through to a generated hue, which is why it renders a pale teal nobody picked. Worse, with no `condition`, `ChangeStatus` classified these notices as nice-to-have and rendered "Nice to Improve · P4" with a refresh icon, so a part being deleted read as an optional improvement.

**What changed**

- New P4 `changes` entries `delete-unused-m3-8-shcs-screw` and `delete-unused-m3-15-washer`, both `targets.hardware`.
- Both parts' `description` fields point at their deletion issue; `scr-m3-8-shcs` also gains a `note` warning against attaching a new joint to it.
- `PlannedChange.condition` gains `'retired'`, for an entry whose subject is leaving the catalog rather than being fixed or improved. `ChangeStatus` gives it a trash-can icon and the words "To Be Removed" on the part badge and on the image-tile marker, and the changes page prints "To be removed" under the priority. All four deletion entries (`scr-m3-tbd`, `scr-m3-shcs-tbd`, `scr-m3-8-shcs`, `washer-m3-15`) carry it. The priority number stays as the urgency of the work; the state is now said in words.
- The changes page's "To be removed" caption is 13px and never wraps: at 10px beside a two-line label the trash can read as a smudge and barthel had to ask whether an icon was there at all.
- **The image-tile marker never reached the tile.** It positions absolutely, but the `Popover` root it lives in is itself `relative`, so it anchored to a zero-size inline wrapper after the image and rendered below the picture on every surface that uses it. `Popover` now takes a class for its root; the marker variant uses it to sit at the tile's bottom-left (`-1px`, mirroring the hardware page's length stamp in the bottom-right), and a removal mark is red.
- Regenerated `catalog.generated.json` with `generate.py --metadata-only` in each commit.

**Deletion is tracked in #536 (screw) and #478 (washer).** I cannot delete either part object myself: `check_generated_pins.py` refuses a change that drops a minted uid from `parts.json`. Same wall as #453 and #454.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545150490940022864
request: https://discord.com/channels/1430279849171222682/1545150490940022864/1545152404759253042
request: https://discord.com/channels/1430279849171222682/1545150490940022864/1545153616132833380
request: https://discord.com/channels/1430279849171222682/1545150490940022864/1545156429726359573
request: https://discord.com/channels/1430279849171222682/1545150490940022864/1545157151440371722
preview: /changes
-->

