### PR TITLE
docs: hex frame ring takes 12 M5x16 not 8, and step 1 labels standard vs option

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -54,7 +54,13 @@ This frame's fastener total is fixed: 12 M5x16 screws (one per extrusion end, so
   </figure>
 </div>
 
-Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side (the smaller of the pair), bracing it against the extrusion. That is the standard fix. As an option, if you would rather not tap and brace, place T-nuts in the extrusion and fasten through the inner holes (the larger of the pair) instead; those need T-nuts of their own, the 24 in the parts list are spoken for by the bin retainers.
+Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of aluminum extrusion into an External bracket — side. Where the extrusion goes in, the bracket has two holes next to each other, and you use one of them.
+
+**Standard:** use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side (the smaller of the pair), bracing it against the extrusion.
+
+**Option:** if you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes (the larger of the pair) to fasten into them instead. These need T-nuts of their own; the 24 in the parts list are for the bin retainers.
+
+The bracket carries other holes that neither method uses, including one on its inward-facing side further along the extrusion. Leave those empty.
 
 If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 4 into the outermost section of the extrusion before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -25,7 +25,7 @@ parts_needed:
   - part: frame-90deg-bracket
     qty: 12
   - part: scr-m5-16-shcs
-    qty: 8
+    qty: 12
   - part: tnut-m5-2020
     qty: 24
 tools_needed: [Hex key, Mallet or hammer with a cloth to protect the brackets]
@@ -37,7 +37,7 @@ An N-layer machine needs **N + 1 of these**: one per planned layer, plus one for
 
 The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions. Each frame uses 6 A/G (320mm) and 6 B/H (158mm). The 24 T-nuts in the list above aren't used by anything in this guide — they're pre-installed in step 1 while the extrusion ends are still accessible, for the bin retainers a later page attaches to the outer ring.
 
-This frame's fastener total is fixed: 8 M5x16 screws and 24 T-nuts, all installed in step 1 — steps 2 through 8 use none. Regular layers and bottom two layers reuse these same 24 T-nuts for their bin retainers, so don't count them twice.
+This frame's fastener total is fixed: 12 M5x16 screws (one per extrusion end, so two per bracket) and 24 T-nuts, all installed in step 1. Steps 2 through 8 use none. Regular layers and bottom two layers reuse these same 24 T-nuts for their bin retainers, so don't count them twice.
 
 {% include fastener-legend.html %}
 
@@ -54,7 +54,7 @@ This frame's fastener total is fixed: 8 M5x16 screws and 24 T-nuts, all installe
   </figure>
 </div>
 
-Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side (the smaller of the pair), bracing it against the extrusion.
+Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side (the smaller of the pair), bracing it against the extrusion. That is the standard fix. As an option, if you would rather not tap and brace, place T-nuts in the extrusion and fasten through the inner holes (the larger of the pair) instead; those need T-nuts of their own, the 24 in the parts list are spoken for by the bin retainers.
 
 If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 4 into the outermost section of the extrusion before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -54,7 +54,7 @@ This frame's fastener total is fixed: 8 M5x16 screws and 24 T-nuts, all installe
   </figure>
 </div>
 
-Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side, bracing it against the extrusion. If you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes to fasten into them instead.
+Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of aluminum extrusion into an External bracket — side. Use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side (the smaller of the pair), bracing it against the extrusion.
 
 If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 4 into the outermost section of the extrusion before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
 


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1545404957757276292/1545413213590519838
request: https://discord.com/channels/1430279849171222682/1545404957757276292/1545413967327928423
request: https://discord.com/channels/1430279849171222682/1545404957757276292/1545413470852485231
request: https://discord.com/channels/1430279849171222682/1545404957757276292/1545416277525536859
request: https://discord.com/channels/1430279849171222682/1545404957757276292/1545410613323239524
request: https://discord.com/channels/1430279849171222682/1545404957757276292/1545410081967964210
preview: /hardware/assembly/distribution/bin-frame/hex-frame/
-->

Two fixes to Build the hex frame, both out of the same thread with barthel.

**1. The ring takes 12 M5x16, not 8.** Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545404957757276292/1545413213590519838): *"I just noticed that if two screws are supposed to be used on each external bracket, that makes 12 in total. But the "needed parts" list only shows 8?"*

He is right, and three things agree on 12:

- The parts calculator's `outer-hex-frame` assembly carries `scr-m5-16-shcs` qty **12**, with the joint recorded as "Two per bracket: self-taps through the bracket print and the tip rams against the extrusion".
- Six brackets have two wings each, and every wing has its own Ø4.40 self-tap hole (measured off `ext-bracket-left`'s STL).
- The page's own build order works out to 12: a half hexagon of three brackets and three extrusions makes five joints, so five screws a side, and the text then asks for "2 more" to close the ring. 5 + 5 + 2 = 12. The old 8 only works if a bracket gets one screw rather than one per end.

The 8 came in with the bin-frame reorg (#449) and was already superseded on the calculator side by the 2026-08-31 restructure ([`6573b255`](https://github.com/basicallysource/sorter-v2/commit/6573b255)), which moved the ring screws into `outer-hex-frame` at 12. The docs page kept the old number. `parts_needed` and the "fastener total is fixed" sentence both now say 12, and that sentence says where they go so the count can be checked by eye.

**2. Step 1 keeps both methods, as visible labels.** Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545404957757276292/1545413967327928423): *"The previous wording was fine and actually easy to understand. Maybe you could label the self-tapping version as the standard and the other one as an option."*

This supersedes his [earlier instruction in the same thread](https://discord.com/channels/1430279849171222682/1545404957757276292/1545410613323239524) to describe the self-tapping version only, which the first commit on this branch had done. The T-nut route is back. Each method is now its own paragraph behind a bold **Standard:** / **Option:** lead-in, the same shape the top interface page already uses for `**Heat inserts first:**` and `**Alternative:**`, rather than being buried mid-sentence.

Both holes are also now named by size as well as position, because the pair is what started the thread: [Dov2000 asked](https://discord.com/channels/1430279849171222682/1487518366020276397/1545404957757276292) why the bracket has extra holes. Measured, they are **Ø4.40** outboard (M5 self-tap) and **Ø5.50** inboard (M5 clearance), 10 mm apart on a shared axis, so "the smaller of the pair" is unambiguous with the part in your hand where "outer" is not.

One note added with the option: it needs T-nuts of its own. The 24 in `parts_needed` are pre-installed for the bin retainers a later page fits, which the page already says two paragraphs up.



---

**Open question this PR does not settle, raised by barthel [in the same thread](https://discord.com/channels/1430279849171222682/1545404957757276292/1545413470852485231):** *"The only relevant reference photos are those of Spencer showing the screwless hex frame."*

Worth a reviewer's attention: **nothing from Spencer puts a screw in a bracket wing at all.** His own account of this bracket when he redesigned it is *"Has 4 screws. Two that hold the bottom to the top and two that hold the vertical extrusion"* ([2026-06-03, #distribution](https://discord.com/channels/1430279849171222682/1437144782819426537/1511813527155773550)), which is the layer joint and the piece C clamp, neither of them into the A/G extrusion. His photos in the [screwless hex frame thread](https://discord.com/channels/1430279849171222682/1542144753641066616/1542299893329305701) are a stack of printed inner-frame parts with no aluminium in them and a render of the Frame 90° bracket, and his June photos from the redesign have expired off Discord's CDN.

What does put screws there is this page's own step, the calculator's `outer-hex-frame` assembly, and zed0's corner photo on the page, which shows one screw per wing. That last one is a builder following the page rather than a statement of intent.

So 12 is the right number **for the page as written**, and this PR makes the page self-consistent with its own steps. Whether the ring should be screwed at all is a separate question and Spencer's to answer.



**3. Step 1 now says to leave the unused holes empty.** Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545404957757276292/1545416277525536859): *"I assume that these screws are not needed on the inside of the long leg. Did we clearly describe this in the documentation as well?"*

It was not described anywhere: no page mentions that hole at all, which is what left [Dov2000 asking what it was for](https://discord.com/channels/1430279849171222682/1487518366020276397/1545404957757276292) with nothing to read. Measured, it is a **Ø5.50** M5 clearance hole on the bracket's inward-facing side, aimed dead centre at the extrusion's slot, so it can only take a screw with a T-nut behind it, and no page or message allocates one. One line now tells a builder to leave it, and the others like it, alone.
