### PR TITLE
Four output guides, one per channel, not two at the handovers

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -88,7 +88,7 @@ The numbers this page most needs, and none of them are written down anywhere tod
 
 {% include step.html n="4" title="Fit the output guides" %}
 
-One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) at each handover, C1 to C2 and C2 to C3.
+One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) on each of the four channels. Each one belongs to the channel it pushes onto, not to the gap between two, so the classification channel gets one as well.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/feeder/output-guides.md
+++ b/docs/src/content/hardware/assembly/feeder/output-guides.md
@@ -5,23 +5,23 @@ type: how-to
 section: hardware
 slug: assembly-output-guides
 kicker: Feeder — Output guides
-lede: The printed guides that carry parts from one C-channel to the next.
+lede: The printed guide on each channel's exit that stops parts riding round instead of dropping off.
 permalink: /hardware/assembly/feeder/output-guides/
 author: barthel
 warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly), not from an actual build.
-  The Output guide is in the parts catalog with a quantity and a colour and nothing else: it is
-  in no assembly there, and where it mounts is not recorded anywhere. This page exists to be
-  filled in, not to be followed.
+  The tree records which channels take a guide and that it is held by friction, but not where on
+  the channel it sits, at what angle, or how far it projects. This page exists to be filled in,
+  not to be followed.
 parts_needed:
   - part: output-guide
-    qty: 2
+    qty: 4
 ---
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Build and <a href="{{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}">arrange the C-channels</a> before you start.</strong> It's a required stage before this page, not optional or covered here — the guide only goes in once the channels either side of it are standing at their final heights.</p>
+    <p><strong>Build and <a href="{{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}">arrange the C-channels</a> before you start.</strong> It's a required stage before this page, not optional or covered here — a guide only goes in once its channel and the one below it are standing at their final heights.</p>
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
@@ -29,9 +29,9 @@ parts_needed:
   </figure>
 </div>
 
-An output guide bridges the gap where one C-channel hands parts to the next, so a part leaving a rotor lands on the following channel instead of on the floor.
+An output guide sits on one channel's exit and stops a part riding round past it. Without one a piece that doesn't drop off at the exit carries on round the rotor instead, so the guide is a wall that forces it off.
 
-Two per machine. Which channels they sit between is not recorded: three feeder channels give two handovers, C1 to C2 and C2 to C3 (see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for what these names mean), so two guides is consistent with one per handover, but that is inference from the count rather than a documented fact.
+**Four per machine, one on every channel**, C1 and the classification channel included (see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for what these names mean). It belongs to the channel it's mounted on rather than to the gap between two, which is why the count is four and not three.
 
 {% include fastener-legend.html %}
 
@@ -46,11 +46,11 @@ Two per machine. Which channels they sit between is not recorded: three feeder c
   </figure>
 </div>
 
-{% include step.html n="2" title="Fit a guide at each handover" %}
+{% include step.html n="2" title="Fit a guide on each channel" %}
 
-The guide goes in once the two channels either side of it are at their final heights.
+The guide pushes onto the C-channel drive and is held by the fit alone: no screws, no inserts, nothing to tighten. Fit it once its channel is at its final height.
 
-**Not recorded:** what the guide fastens to, with what, and at what angle. <span class="fastener-todo">fastener not recorded</span>
+**Not recorded:** where on the drive it seats, at what angle, and how far it projects over the exit.
 
 <div class="img-placeholder">Image coming</div>
 


### PR DESCRIPTION
Extremetaz asked whether the Short and Angled Output Guide is really 4, whether C1 still needs one when the bulk bucket is used, and whether C4 needs one. The catalog answers yes to all three; the docs still describe the pre-overhaul arrangement, so this fixes them.

### What the tree says

All four channel assemblies (`bulk-bucket`, `channel-two`, `channel-three`, `classification-chamber`) carry `{"part": "output-guide", "qty": 1}`, each with the same connection:

> The guide pushes onto the C-channel drive and is held by the fit alone.

Until `e22fce30` (#534, 2026-09-02) there were two, on C2 and C3 only; the overhaul added one to C1 and one to C4 as part of consolidating all four channels to one shape. `classification-chamber` v3's own message is "it gains the output guide".

### What the docs said

- **output-guides.md**: "Two per machine", `parts_needed: qty 2`, and a lede and opening paragraph built on the guide bridging the gap between two channels. Its draft banner also claimed the part "is in no assembly there", which the tree now contradicts.
- **arranging-c-channels.md**: step 4, "One output guide at each handover, C1 to C2 and C2 to C3".

The count was the visible error; the model behind it was the real one. A guide belongs to the channel it is mounted on, not to a handover, which is why four channels take four guides rather than three handovers taking three.

### Sources

- Quantities, placement and the joint: `parts-calculator/catalog/parts.json`, the four channel assemblies.
- Purpose, for the rewritten opening paragraph: mneuhaus in `#c-channels`, 2026-03-04, "purpose of the 'output guide' is to prevent stuff going in infinite circles", and 2026-02-27, "there to prevent stuff from going in circles".

### Still unrecorded, and still flagged as such

Where on the drive the guide seats, at what angle, and how far it projects over the exit. The draft banner stays for that reason.

### Note on #538

That PR touches `output-guides.md` too, one line in step 1 ("Prints in the feeder colour" to ash grey). This branch does not touch that line, so the two should merge in either order without conflict. #538 is the colour pass; this is the count and the purpose.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1545190826551017492/1545472598467420240
preview: /hardware/assembly/feeder/output-guides/
preview: /hardware/assembly/feeder/arranging-c-channels/
-->
