### PR TITLE
Bin retainers take M5 x 16, not M5 x 12

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -31,9 +31,7 @@ parts_needed:
   - part: caster-wheel-m6
     qty: 6
   - part: scr-m5-16-shcs
-    qty: 48
-  - part: scr-m5-12-shcs
-    qty: 48
+    qty: 96
 tools_needed: [Hex key, Tape measure]
 ---
 
@@ -85,8 +83,7 @@ Here's where the {% include fastener.html size="M5" variant="socket-button" leng
 - **24** for the foot extensions, 4 per corner (step 2 below), two into each layer
 - **12** for the second layer's External bracket — bottom verticals, 2 per corner (step 3 below)
 - **12** for the bottom layer's External bracket — foot covers, 2 per corner (step 3 below), the same as the bottom vertical it replaces
-
-The {% include fastener.html size="M5" variant="socket-button" length="12" %} count is the same arithmetic: **24** per layer for the bin retainers, so **48** across both.
+- **48** for the bin retainers (step 5 below), 24 per layer, so 48 across both
 
 You should already have two [hex frames]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) built, one for each layer. The verticals are the part that differs here, and they are step 2 below.
 
@@ -172,7 +169,7 @@ Screw a **swivel stem caster (M6 × 15 mm)** into the connector's M6 thread. The
 
 {% include step.html n="5" title="Add the bin retainers" %}
 
-Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 2: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into T-nuts.
+Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 2: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into T-nuts.
 
 {% include step.html n="6" title="Attach the bottom interface" %}
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -26,9 +26,7 @@ parts_needed:
   - part: ext-2020-c
     qty: 6
   - part: scr-m5-16-shcs
-    qty: 36
-  - part: scr-m5-12-shcs
-    qty: 24
+    qty: 60
 ---
 
 Each layer holds one chute-and-bin pair (built separately) that catches pieces routed to it; a regular layer's job is simply to repeat the same hexagonal ring, vertical supports, and flange joint as the layer below it, so the stack can go as tall as the machine needs.
@@ -91,7 +89,9 @@ Matching parts from the same print run are embossed with a shared set code (e.g.
   <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
-On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front face of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into the T-nuts your hex frame already has installed there.
+On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front face of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the T-nuts your hex frame already has installed there.
+
+Each retainer's bore is 12.8 mm deep, so a shorter M5 reaches the extrusion face with nothing left to bite in the T-nut. Use a socket head rather than a button head here: the flat the head lands on stops 4.1 mm below the hole, which a button head overhangs, and a washer will not sit flat on it at all.
 
 A regular layer is now complete.
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -8026,16 +8026,49 @@
         },
         {
           "version": "2",
+          "uid": "jog7",
           "date": "2026-08-29",
           "message": "Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones), same double-count barthel already caught on bottom two layers. Added the 12 scr-m5-16-shcs that join this layer's flange up to the layer above, previously missing.",
-          "commit": "a2c66436"
+          "commit": "a2c66436",
+          "lines": [
+            {
+              "assembly": "layer-frame",
+              "qty": 1,
+              "uid": "yq92"
+            },
+            {
+              "assembly": "chute",
+              "qty": 1,
+              "uid": "axlb"
+            },
+            {
+              "part": "bin-retainer-left",
+              "qty": 6,
+              "uid": "hqz0"
+            },
+            {
+              "part": "bin-retainer-right",
+              "qty": 6,
+              "uid": "ybpv"
+            },
+            {
+              "part": "scr-m5-12-shcs",
+              "qty": 24,
+              "uid": "kmah"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 12,
+              "uid": "2e0s"
+            }
+          ]
         },
         {
           "version": "3",
           "date": "2026-09-05",
           "breaking": false,
           "message": "The 24 bin-retainer screws are M5 x 16, not M5 x 12: the retainer's bore is 12.8 mm, so an M5 x 12 reaches the extrusion face with nothing left for the T-nut. Reported by BrickCycleAlice, who tried them on a build; confirmed by measuring the STL. Merged into the existing scr-m5-16-shcs line, 12 + 24 = 36, and the joint recorded in connections with its measured through_mm.",
-          "commit": null
+          "commit": "1ce549ec"
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7939,10 +7939,10 @@
     },
     {
       "id": "layer",
-      "uid": "jog7",
-      "version": "2",
+      "uid": "mnpn",
+      "version": "3",
       "name": "Distribution layer",
-      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 × [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
+      "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
       "lines": [
         {
@@ -7962,12 +7962,28 @@
           "qty": 6
         },
         {
-          "part": "scr-m5-12-shcs",
-          "qty": 24
+          "part": "scr-m5-16-shcs",
+          "qty": 36
+        }
+      ],
+      "connections": [
+        {
+          "from": "bin-retainer-left",
+          "to": "layer-frame",
+          "via": "scr-m5-16-shcs",
+          "qty": 12,
+          "method": "tnut",
+          "through_mm": 12.8,
+          "note": "Two per retainer, into the 4 T-nuts per A/G extrusion the hex frame pre-installs. Measured off the STL: 12.00 mm of plastic between the head face and the face that sits on the extrusion, plus a 0.8 mm locating rib that drops into the slot, so the bore the screw crosses is 12.8 mm. An M5 x 12 stops level with the extrusion face with no thread in the nut; an M5 x 20 stands 8 mm into a slot about 5.9 mm deep and bottoms out before it clamps."
         },
         {
-          "part": "scr-m5-16-shcs",
-          "qty": 12
+          "from": "bin-retainer-right",
+          "to": "layer-frame",
+          "via": "scr-m5-16-shcs",
+          "qty": 12,
+          "method": "tnut",
+          "through_mm": 12.8,
+          "note": "Mirror of the left retainer's joint, same bore and same screw."
         }
       ],
       "versions": [
@@ -8013,6 +8029,13 @@
           "date": "2026-08-29",
           "message": "Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones), same double-count barthel already caught on bottom two layers. Added the 12 scr-m5-16-shcs that join this layer's flange up to the layer above, previously missing.",
           "commit": "a2c66436"
+        },
+        {
+          "version": "3",
+          "date": "2026-09-05",
+          "breaking": false,
+          "message": "The 24 bin-retainer screws are M5 x 16, not M5 x 12: the retainer's bore is 12.8 mm, so an M5 x 12 reaches the extrusion face with nothing left for the T-nut. Reported by BrickCycleAlice, who tried them on a build; confirmed by measuring the STL. Merged into the existing scr-m5-16-shcs line, 12 + 24 = 36, and the joint recorded in connections with its measured through_mm.",
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2576,10 +2576,10 @@
 		},
 		{
 			"id": "layer",
-			"uid": "jog7",
+			"uid": "mnpn",
 			"version": "3",
 			"name": "Distribution layer",
-			"description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-16-shcs]] into a [[hw:tnut-m5-2020]].",
+			"description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins.",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
 			"lines": [
 				{
@@ -2663,17 +2663,50 @@
 				},
 				{
 					"version": "2",
+					"uid": "jog7",
 					"date": "2026-08-29",
 					"message": "Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones), same double-count barthel already caught on bottom two layers. Added the 12 scr-m5-16-shcs that join this layer's flange up to the layer above, previously missing.",
-					"commit": "a2c66436"
+					"commit": "a2c66436",
+					"lines": [
+						{
+							"assembly": "layer-frame",
+							"qty": 1,
+							"uid": "yq92"
+						},
+						{
+							"assembly": "chute",
+							"qty": 1,
+							"uid": "axlb"
+						},
+						{
+							"part": "bin-retainer-left",
+							"qty": 6,
+							"uid": "hqz0"
+						},
+						{
+							"part": "bin-retainer-right",
+							"qty": 6,
+							"uid": "ybpv"
+						},
+						{
+							"part": "scr-m5-12-shcs",
+							"qty": 24,
+							"uid": "kmah"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 12,
+							"uid": "2e0s"
+						}
+					]
 				},
 				{
 					"version": "3",
-					"uid": "jog7",
+					"uid": "mnpn",
 					"date": "2026-09-05",
 					"breaking": false,
 					"message": "The 24 bin-retainer screws are M5 x 16, not M5 x 12: the retainer's bore is 12.8 mm, so an M5 x 12 reaches the extrusion face with nothing left for the T-nut. Reported by BrickCycleAlice, who tried them on a build; confirmed by measuring the STL. Merged into the existing scr-m5-16-shcs line, 12 + 24 = 36, and the joint recorded in connections with its measured through_mm.",
-					"commit": null
+					"commit": "1ce549ec"
 				}
 			]
 		},

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2577,9 +2577,9 @@
 		{
 			"id": "layer",
 			"uid": "jog7",
-			"version": "2",
+			"version": "3",
 			"name": "Distribution layer",
-			"description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-12-shcs]] into a [[hw:tnut-m5-2020]].",
+			"description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins. Each bin retainer takes 2 \u00d7 [[hw:scr-m5-16-shcs]] into a [[hw:tnut-m5-2020]].",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
 			"lines": [
 				{
@@ -2599,12 +2599,28 @@
 					"qty": 6
 				},
 				{
-					"part": "scr-m5-12-shcs",
-					"qty": 24
+					"part": "scr-m5-16-shcs",
+					"qty": 36
+				}
+			],
+			"connections": [
+				{
+					"from": "bin-retainer-left",
+					"to": "layer-frame",
+					"via": "scr-m5-16-shcs",
+					"qty": 12,
+					"method": "tnut",
+					"through_mm": 12.8,
+					"note": "Two per retainer, into the 4 T-nuts per A/G extrusion the hex frame pre-installs. Measured off the STL: 12.00 mm of plastic between the head face and the face that sits on the extrusion, plus a 0.8 mm locating rib that drops into the slot, so the bore the screw crosses is 12.8 mm. An M5 x 12 stops level with the extrusion face with no thread in the nut; an M5 x 20 stands 8 mm into a slot about 5.9 mm deep and bottoms out before it clamps."
 				},
 				{
-					"part": "scr-m5-16-shcs",
-					"qty": 12
+					"from": "bin-retainer-right",
+					"to": "layer-frame",
+					"via": "scr-m5-16-shcs",
+					"qty": 12,
+					"method": "tnut",
+					"through_mm": 12.8,
+					"note": "Mirror of the left retainer's joint, same bore and same screw."
 				}
 			],
 			"versions": [
@@ -2647,10 +2663,17 @@
 				},
 				{
 					"version": "2",
-					"uid": "jog7",
 					"date": "2026-08-29",
 					"message": "Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones), same double-count barthel already caught on bottom two layers. Added the 12 scr-m5-16-shcs that join this layer's flange up to the layer above, previously missing.",
 					"commit": "a2c66436"
+				},
+				{
+					"version": "3",
+					"uid": "jog7",
+					"date": "2026-09-05",
+					"breaking": false,
+					"message": "The 24 bin-retainer screws are M5 x 16, not M5 x 12: the retainer's bore is 12.8 mm, so an M5 x 12 reaches the extrusion face with nothing left for the T-nut. Reported by BrickCycleAlice, who tried them on a build; confirmed by measuring the STL. Merged into the existing scr-m5-16-shcs line, 12 + 24 = 36, and the joint recorded in connections with its measured through_mm.",
+					"commit": null
 				}
 			]
 		},


### PR DESCRIPTION
The bin retainers need an **M5 × 16**, not the M5 × 12 the docs and the catalog both call for.

**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1487518366020276397/1545685109615759371): "can you measure the Stl for the bin retainers, check what screw size is needed to attach them."** She then reported the failure herself, [from Discord](https://discord.com/channels/1430279849171222682/1545685109615759371/1545686385615446108): "That's what I'm getting, I tried the m5x12's and they didn't clear the whole. I think it's and m5x16 needed."

## What the STL says

Measured off the pinned `bin-retainer-left` (`hqz0`) and `bin-retainer-right` (`ybpv`) masters, which are exact mirrors of each other:

- **Holes:** 5.400 mm, two per retainer, 76.00 mm apart, axis square to the mounting face. Standard M5 clearance.
- **Bore the screw crosses:** 12.80 mm. That is 12.00 mm of plastic between the head face and the face that sits on the A/G extrusion, plus a 0.8 mm locating rib (4.68 mm tall, centred on the hole line) that drops into the slot.
- **M5 × 12** therefore stops level with the extrusion face with no thread in the T-nut at all, which is what she hit on the bench.
- **M5 × 16** stands 4.0 mm past the face. A 2020 ball-spring roll-in M5 nut is about 4.3 mm thick ([handsontec datasheet](https://www.handsontec.com/dataspecs/screw-nut/2020M5-T-Nut.pdf), C = 4.3 mm) sitting in a slot about 5.9 mm deep ([2020 profile spec](https://premiumalu.com/product/2020-aluminum-extrusion/)), so its thread starts roughly 1.6 mm down and about 2.4 mm of the screw is in it. Light, and it is the longest standard length that fits.
- **M5 × 20** does not fit: 8 mm into a 5.9 mm slot bottoms on the slot floor before it clamps anything.

The head also wants to be a socket cap rather than a button head. The flat it bears against only reaches 4.13 mm below the hole centre, so a button head (9.5 mm) overhangs the bottom edge and a washer will not sit flat.

## Changes

- `regular-layers.md` step 2 and `bottom-two-layers.md` step 5 now call for M5 × 16, and both parts lists fold the bin-retainer screws into their existing `scr-m5-16-shcs` line (36 → 60 and 48 → 96). The `scr-m5-12-shcs` line is gone from both; it is still correct everywhere else it appears (NEMA 23 mount, PSU box, Orange Pi mount) and is untouched there.
- `catalog/parts.json`: the `layer` assembly's 24 `scr-m5-12-shcs` merge into its `scr-m5-16-shcs` line, 12 + 24 = 36. Stamped as v3 with a fresh uid (`mnpn`, superseding `jog7`), `breaking: false` — an already-assembled layer mates outward exactly the same.
- The joint is now recorded in the assembly's `connections` with its measured `through_mm`, and the sentence enumerating it has come out of the description, per this directory's `CLAUDE.md`.

The counts on these two pages come from [#449](https://github.com/basicallysource/sorter-v2/pull/449), which reconciled them against each page's own steps but took the M5 × 12 at face value.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1487518366020276397/1545685109615759371
request: https://discord.com/channels/1430279849171222682/1545685109615759371/1545686385615446108
preview: /hardware/assembly/distribution/bin-frame/regular-layers/
preview: /hardware/assembly/distribution/bin-frame/bottom-two-layers/
-->
