### PR TITLE
Machine tree: n bin layers plus one top interface, not n-2 between two

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6728,11 +6728,43 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "uid": "ywb3",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "part": "top-plate",
+              "qty": 1,
+              "uid": "1g22"
+            },
+            {
+              "assembly": "interface",
+              "qty": 1,
+              "uid": "vhrk"
+            },
+            {
+              "assembly": "layer",
+              "qty": "middle-layers",
+              "uid": "mnpn"
+            },
+            {
+              "assembly": "bottom-interface",
+              "qty": 1,
+              "uid": "67uq"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 6,
+              "uid": "2e0s"
+            }
+          ]
+        },
+        {
           "version": "2",
           "date": "2026-09-05",
           "breaking": false,
           "message": "The stack is n bin layers plus one top interface, not n - 2 layers between two interfaces. The layer node now runs non-bottom-layers (n - 1) and the new bottom-layer node runs once, because the lowest layer carries foot covers instead of bracket covers and bottom verticals. Brings the tree onto the same counts the 3D-parts and framing models already used: n + 1 hexagons, 12n bin retainers, 6 foot covers. No physical change.",
-          "commit": null
+          "commit": "36826f49"
         }
       ]
     },
@@ -8237,11 +8269,33 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "uid": "67uq",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "assembly": "layer-frame",
+              "qty": 1,
+              "uid": "yq92"
+            },
+            {
+              "assembly": "lazy-susan",
+              "qty": 1,
+              "uid": "v6ss"
+            },
+            {
+              "assembly": "layer-connector",
+              "qty": 1,
+              "uid": "6m38"
+            }
+          ]
+        },
+        {
           "version": "2",
           "date": "2026-09-05",
           "breaking": false,
           "message": "Dropped the layer-frame: the bottom interface hangs under the lowest bin layer's frame and does not get a hexagon of its own (bottom two layers, step 6). Dropped the layer connector too: the spare one belongs to the top interface, which slides onto the external bracket on that hex ring. No physical change.",
-          "commit": null
+          "commit": "36826f49"
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -2271,7 +2271,7 @@
       "id": "layer-connector-1",
       "uid": "iwzg",
       "name": "Layer connector A",
-      "description": "Layer connector. 1 per layer + 1 per bottom interface.",
+      "description": "Layer connector. 1 per layer + 1 for the top interface, which slides onto the external bracket on that hex ring.",
       "internal_notes": "Chute-core concept: A and B go on the chute core (1 each) + one set on the bottom interface (interface category). Chute-core color. NOT per-layer.",
       "version": "1",
       "created_at": "2026-06-27",
@@ -2293,7 +2293,7 @@
       "id": "layer-connector-2",
       "uid": "3wrh",
       "name": "Layer connector B",
-      "description": "Layer connector. 1 per layer + 1 per bottom interface.",
+      "description": "Layer connector. 1 per layer + 1 for the top interface, which slides onto the external bracket on that hex ring.",
       "internal_notes": "Chute-core concept: A and B go on the chute core (1 each) + one set on the bottom interface (interface category). Chute-core color. NOT per-layer.",
       "version": "1",
       "created_at": "2026-06-27",
@@ -6683,8 +6683,8 @@
     },
     {
       "id": "superstructure",
-      "uid": "ywb3",
-      "version": "1",
+      "uid": "t2t9",
+      "version": "2",
       "name": "Superstructure",
       "description": "What the feeder and the electronics mount onto: the top plate, the top interface, the distribution layers between the interfaces, and the bottom interface.",
       "lines": [
@@ -6698,7 +6698,11 @@
         },
         {
           "assembly": "layer",
-          "qty": "middle-layers"
+          "qty": "non-bottom-layers"
+        },
+        {
+          "assembly": "bottom-layer",
+          "qty": 1
         },
         {
           "assembly": "bottom-interface",
@@ -6720,6 +6724,15 @@
           "thread_mm": 9,
           "note": "Through the plate into the top interface's M5 heat-set inserts. The 16 mm length is assumed, not yet confirmed.",
           "draft": true
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-09-05",
+          "breaking": false,
+          "message": "The stack is n bin layers plus one top interface, not n - 2 layers between two interfaces. The layer node now runs non-bottom-layers (n - 1) and the new bottom-layer node runs once, because the lowest layer carries foot covers instead of bracket covers and bottom verticals. Brings the tree onto the same counts the 3D-parts and framing models already used: n + 1 hexagons, 12n bin retainers, 6 foot covers. No physical change.",
+          "commit": null
         }
       ]
     },
@@ -7938,6 +7951,143 @@
       ]
     },
     {
+      "id": "external-bracket-with-foot",
+      "uid": "hynq",
+      "version": "1",
+      "name": "External bracket with foot cover",
+      "description": "The bottom bin layer's corner segment: the side bracket with the foot cover, which stands in for the cover and the bottom vertical the other frames use.",
+      "lines": [
+        {
+          "part": "ext-bracket-left",
+          "qty": 1
+        },
+        {
+          "part": "ext-bracket-foot-cover",
+          "qty": 1
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 2
+        }
+      ],
+      "connections": [
+        {
+          "from": "ext-bracket-foot-cover",
+          "to": "ext-bracket-left",
+          "via": "scr-m5-16-shcs",
+          "qty": 2,
+          "method": "self-tap",
+          "note": "Through the foot cover's outer holes into the side bracket, the same two screws and the same holes the bottom vertical uses on every other frame."
+        }
+      ]
+    },
+    {
+      "id": "outer-hex-frame-bottom",
+      "uid": "r3v6",
+      "version": "1",
+      "name": "Outer hex frame (bottom layer)",
+      "description": "The outer hexagon of the lowest bin layer: six foot-cover corners with six A/G extrusions slid between them.",
+      "lines": [
+        {
+          "assembly": "external-bracket-with-foot",
+          "qty": 6
+        },
+        {
+          "part": "ext-2020-ag",
+          "qty": 6
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 12
+        }
+      ],
+      "connections": [
+        {
+          "from": "ext-2020-ag",
+          "to": "external-bracket-with-foot",
+          "qty": 12,
+          "method": "friction",
+          "note": "Each extrusion slides onto a bracket segment at either end -- one on either side of each bracket. These 12 fits hold the ring together."
+        },
+        {
+          "from": "external-bracket-with-foot",
+          "to": "ext-2020-ag",
+          "via": "scr-m5-16-shcs",
+          "qty": 12,
+          "method": "self-tap",
+          "note": "Two per bracket: self-taps through the bracket print and the tip rams against the extrusion, jamming the fit. No T-nuts."
+        }
+      ]
+    },
+    {
+      "id": "hex-frame-bottom",
+      "uid": "5l36",
+      "version": "1",
+      "name": "Hex frame (bottom layer)",
+      "description": "The lowest bin layer's hexagonal frame: the same inner hex, seated in the outer hex built from foot-cover corners.",
+      "docs": "/hardware/assembly/distribution/bin-frame/bottom-two-layers/",
+      "lines": [
+        {
+          "assembly": "inner-hex-frame",
+          "qty": 1
+        },
+        {
+          "assembly": "outer-hex-frame-bottom",
+          "qty": 1
+        }
+      ]
+    },
+    {
+      "id": "bottom-layer",
+      "uid": "sqsi",
+      "version": "1",
+      "name": "Bottom distribution layer",
+      "description": "The lowest bin layer. Identical to a distribution layer except that its frame carries foot covers instead of bracket covers and bottom verticals, and the bottom interface hangs underneath it.",
+      "docs": "/hardware/assembly/distribution/bin-frame/bottom-two-layers/",
+      "lines": [
+        {
+          "assembly": "hex-frame-bottom",
+          "qty": 1
+        },
+        {
+          "assembly": "chute",
+          "qty": 1
+        },
+        {
+          "part": "bin-retainer-left",
+          "qty": 6
+        },
+        {
+          "part": "bin-retainer-right",
+          "qty": 6
+        },
+        {
+          "part": "scr-m5-16-shcs",
+          "qty": 36
+        }
+      ],
+      "connections": [
+        {
+          "from": "bin-retainer-left",
+          "to": "hex-frame-bottom",
+          "via": "scr-m5-16-shcs",
+          "qty": 12,
+          "method": "tnut",
+          "through_mm": 12.8,
+          "note": "Two per retainer, into the 4 T-nuts per A/G extrusion the hex frame pre-installs. Same joint as on a regular distribution layer."
+        },
+        {
+          "from": "bin-retainer-right",
+          "to": "hex-frame-bottom",
+          "via": "scr-m5-16-shcs",
+          "qty": 12,
+          "method": "tnut",
+          "through_mm": 12.8,
+          "note": "Mirror of the left retainer's joint, same bore and same screw."
+        }
+      ]
+    },
+    {
       "id": "layer",
       "uid": "mnpn",
       "version": "3",
@@ -8074,23 +8224,24 @@
     },
     {
       "id": "bottom-interface",
-      "uid": "67uq",
-      "version": "1",
+      "uid": "oob0",
+      "version": "2",
       "name": "Bottom interface",
-      "description": "The bottom interface / lazy Susan level. The chute above it is one of the machine's N regular chutes, already counted there; this assembly only adds the layer connector that bridges down to it.",
+      "description": "The bottom interface / lazy Susan level. It hangs underneath the lowest bin layer and has no hexagonal frame of its own.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
       "lines": [
         {
-          "assembly": "layer-frame",
-          "qty": 1
-        },
-        {
           "assembly": "lazy-susan",
           "qty": 1
-        },
+        }
+      ],
+      "versions": [
         {
-          "assembly": "layer-connector",
-          "qty": 1
+          "version": "2",
+          "date": "2026-09-05",
+          "breaking": false,
+          "message": "Dropped the layer-frame: the bottom interface hangs under the lowest bin layer's frame and does not get a hexagon of its own (bottom two layers, step 6). Dropped the layer connector too: the spare one belongs to the top interface, which slides onto the external bracket on that hex ring. No physical change.",
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1315,8 +1315,8 @@
 		},
 		{
 			"id": "superstructure",
-			"uid": "ywb3",
-			"version": "1",
+			"uid": "t2t9",
+			"version": "2",
 			"name": "Superstructure",
 			"description": "What the feeder and the electronics mount onto: the top plate, the top interface, the distribution layers between the interfaces, and the bottom interface.",
 			"lines": [
@@ -1330,7 +1330,11 @@
 				},
 				{
 					"assembly": "layer",
-					"qty": "middle-layers"
+					"qty": "non-bottom-layers"
+				},
+				{
+					"assembly": "bottom-layer",
+					"qty": 1
 				},
 				{
 					"assembly": "bottom-interface",
@@ -1352,6 +1356,16 @@
 					"thread_mm": 9,
 					"note": "Through the plate into the top interface's M5 heat-set inserts. The 16 mm length is assumed, not yet confirmed.",
 					"draft": true
+				}
+			],
+			"versions": [
+				{
+					"version": "2",
+					"uid": "t2t9",
+					"date": "2026-09-05",
+					"breaking": false,
+					"message": "The stack is n bin layers plus one top interface, not n - 2 layers between two interfaces. The layer node now runs non-bottom-layers (n - 1) and the new bottom-layer node runs once, because the lowest layer carries foot covers instead of bracket covers and bottom verticals. Brings the tree onto the same counts the 3D-parts and framing models already used: n + 1 hexagons, 12n bin retainers, 6 foot covers. No physical change.",
+					"commit": null
 				}
 			]
 		},
@@ -2575,6 +2589,143 @@
 			]
 		},
 		{
+			"id": "external-bracket-with-foot",
+			"uid": "hynq",
+			"version": "1",
+			"name": "External bracket with foot cover",
+			"description": "The bottom bin layer's corner segment: the side bracket with the foot cover, which stands in for the cover and the bottom vertical the other frames use.",
+			"lines": [
+				{
+					"part": "ext-bracket-left",
+					"qty": 1
+				},
+				{
+					"part": "ext-bracket-foot-cover",
+					"qty": 1
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 2
+				}
+			],
+			"connections": [
+				{
+					"from": "ext-bracket-foot-cover",
+					"to": "ext-bracket-left",
+					"via": "scr-m5-16-shcs",
+					"qty": 2,
+					"method": "self-tap",
+					"note": "Through the foot cover's outer holes into the side bracket, the same two screws and the same holes the bottom vertical uses on every other frame."
+				}
+			]
+		},
+		{
+			"id": "outer-hex-frame-bottom",
+			"uid": "r3v6",
+			"version": "1",
+			"name": "Outer hex frame (bottom layer)",
+			"description": "The outer hexagon of the lowest bin layer: six foot-cover corners with six A/G extrusions slid between them.",
+			"lines": [
+				{
+					"assembly": "external-bracket-with-foot",
+					"qty": 6
+				},
+				{
+					"part": "ext-2020-ag",
+					"qty": 6
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 12
+				}
+			],
+			"connections": [
+				{
+					"from": "ext-2020-ag",
+					"to": "external-bracket-with-foot",
+					"qty": 12,
+					"method": "friction",
+					"note": "Each extrusion slides onto a bracket segment at either end -- one on either side of each bracket. These 12 fits hold the ring together."
+				},
+				{
+					"from": "external-bracket-with-foot",
+					"to": "ext-2020-ag",
+					"via": "scr-m5-16-shcs",
+					"qty": 12,
+					"method": "self-tap",
+					"note": "Two per bracket: self-taps through the bracket print and the tip rams against the extrusion, jamming the fit. No T-nuts."
+				}
+			]
+		},
+		{
+			"id": "hex-frame-bottom",
+			"uid": "5l36",
+			"version": "1",
+			"name": "Hex frame (bottom layer)",
+			"description": "The lowest bin layer's hexagonal frame: the same inner hex, seated in the outer hex built from foot-cover corners.",
+			"docs": "/hardware/assembly/distribution/bin-frame/bottom-two-layers/",
+			"lines": [
+				{
+					"assembly": "inner-hex-frame",
+					"qty": 1
+				},
+				{
+					"assembly": "outer-hex-frame-bottom",
+					"qty": 1
+				}
+			]
+		},
+		{
+			"id": "bottom-layer",
+			"uid": "sqsi",
+			"version": "1",
+			"name": "Bottom distribution layer",
+			"description": "The lowest bin layer. Identical to a distribution layer except that its frame carries foot covers instead of bracket covers and bottom verticals, and the bottom interface hangs underneath it.",
+			"docs": "/hardware/assembly/distribution/bin-frame/bottom-two-layers/",
+			"lines": [
+				{
+					"assembly": "hex-frame-bottom",
+					"qty": 1
+				},
+				{
+					"assembly": "chute",
+					"qty": 1
+				},
+				{
+					"part": "bin-retainer-left",
+					"qty": 6
+				},
+				{
+					"part": "bin-retainer-right",
+					"qty": 6
+				},
+				{
+					"part": "scr-m5-16-shcs",
+					"qty": 36
+				}
+			],
+			"connections": [
+				{
+					"from": "bin-retainer-left",
+					"to": "hex-frame-bottom",
+					"via": "scr-m5-16-shcs",
+					"qty": 12,
+					"method": "tnut",
+					"through_mm": 12.8,
+					"note": "Two per retainer, into the 4 T-nuts per A/G extrusion the hex frame pre-installs. Same joint as on a regular distribution layer."
+				},
+				{
+					"from": "bin-retainer-right",
+					"to": "hex-frame-bottom",
+					"via": "scr-m5-16-shcs",
+					"qty": 12,
+					"method": "tnut",
+					"through_mm": 12.8,
+					"note": "Mirror of the left retainer's joint, same bore and same screw."
+				}
+			]
+		},
+		{
 			"id": "layer",
 			"uid": "mnpn",
 			"version": "3",
@@ -2712,23 +2863,25 @@
 		},
 		{
 			"id": "bottom-interface",
-			"uid": "67uq",
-			"version": "1",
+			"uid": "oob0",
+			"version": "2",
 			"name": "Bottom interface",
-			"description": "The bottom interface / lazy Susan level. The chute above it is one of the machine's N regular chutes, already counted there; this assembly only adds the layer connector that bridges down to it.",
+			"description": "The bottom interface / lazy Susan level. It hangs underneath the lowest bin layer and has no hexagonal frame of its own.",
 			"docs": "/hardware/assembly/distribution/bin-frame/bottom-interface/",
 			"lines": [
 				{
-					"assembly": "layer-frame",
-					"qty": 1
-				},
-				{
 					"assembly": "lazy-susan",
 					"qty": 1
-				},
+				}
+			],
+			"versions": [
 				{
-					"assembly": "layer-connector",
-					"qty": 1
+					"version": "2",
+					"uid": "oob0",
+					"date": "2026-09-05",
+					"breaking": false,
+					"message": "Dropped the layer-frame: the bottom interface hangs under the lowest bin layer's frame and does not get a hexagon of its own (bottom two layers, step 6). Dropped the layer connector too: the spare one belongs to the top interface, which slides onto the external bracket on that hex ring. No physical change.",
+					"commit": null
 				}
 			]
 		},
@@ -13702,7 +13855,7 @@
 			"folder": "layer-connectors",
 			"variant_group": null,
 			"variant_name": null,
-			"description": "Layer connector. 1 per layer + 1 per bottom interface.",
+			"description": "Layer connector. 1 per layer + 1 for the top interface, which slides onto the external bracket on that hex ring.",
 			"version": "1",
 			"created_at": "2026-06-27",
 			"updated_at": "2026-06-27",
@@ -13835,7 +13988,7 @@
 			"folder": "layer-connectors",
 			"variant_group": null,
 			"variant_name": null,
-			"description": "Layer connector. 1 per layer + 1 per bottom interface.",
+			"description": "Layer connector. 1 per layer + 1 for the top interface, which slides onto the external bracket on that hex ring.",
 			"version": "1",
 			"created_at": "2026-06-27",
 			"updated_at": "2026-06-27",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1360,12 +1360,44 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "ywb3",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"part": "top-plate",
+							"qty": 1,
+							"uid": "1g22"
+						},
+						{
+							"assembly": "interface",
+							"qty": 1,
+							"uid": "vhrk"
+						},
+						{
+							"assembly": "layer",
+							"qty": "middle-layers",
+							"uid": "mnpn"
+						},
+						{
+							"assembly": "bottom-interface",
+							"qty": 1,
+							"uid": "67uq"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 6,
+							"uid": "2e0s"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "t2t9",
 					"date": "2026-09-05",
 					"breaking": false,
 					"message": "The stack is n bin layers plus one top interface, not n - 2 layers between two interfaces. The layer node now runs non-bottom-layers (n - 1) and the new bottom-layer node runs once, because the lowest layer carries foot covers instead of bracket covers and bottom verticals. Brings the tree onto the same counts the 3D-parts and framing models already used: n + 1 hexagons, 12n bin retainers, 6 foot covers. No physical change.",
-					"commit": null
+					"commit": "36826f49"
 				}
 			]
 		},
@@ -2876,12 +2908,34 @@
 			],
 			"versions": [
 				{
+					"version": "1",
+					"uid": "67uq",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"assembly": "layer-frame",
+							"qty": 1,
+							"uid": "yq92"
+						},
+						{
+							"assembly": "lazy-susan",
+							"qty": 1,
+							"uid": "v6ss"
+						},
+						{
+							"assembly": "layer-connector",
+							"qty": 1,
+							"uid": "6m38"
+						}
+					]
+				},
+				{
 					"version": "2",
 					"uid": "oob0",
 					"date": "2026-09-05",
 					"breaking": false,
 					"message": "Dropped the layer-frame: the bottom interface hangs under the lowest bin layer's frame and does not get a hexagon of its own (bottom two layers, step 6). Dropped the layer connector too: the spare one belongs to the top interface, which slides onto the external bracket on that hex ring. No physical change.",
-					"commit": null
+					"commit": "36826f49"
 				}
 			]
 		},

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -47,13 +47,15 @@ export type Folder = { id: string; name: string; description?: string };
 
 /** One BOM line of an assembly: a child part or sub-assembly with a quantity.
  *  qty 'per-layer' multiplies by the total configured layer count;
- *  'middle-layers' by (count − 2) — the layers between the two interfaces. */
+ *  'non-bottom-layers' by (count − 1) — every bin layer but the lowest, which
+ *  is built differently; 'middle-layers' by (count − 2). The first two mirror
+ *  the 'all' / 'non-bottom' halves of a part's `layer_scope`. */
 export type AssemblyLine = {
 	part?: string;
 	assembly?: string;
 	param?: string; // a slot: filled by the instantiation's args, else the param's default
 	args?: Record<string, string>; // passed to a sub-assembly; '$x' forwards this assembly's own param
-	qty: number | 'per-layer' | 'middle-layers';
+	qty: number | 'per-layer' | 'non-bottom-layers' | 'middle-layers';
 };
 
 /** A parameterized slot an assembly declares: instantiations may pass a
@@ -637,9 +639,11 @@ export function concreteLines(
 }
 
 /** Resolve an assembly line's quantity. Total layer count n includes the top
- *  and bottom interface levels; 'middle-layers' is the n−2 between them. */
+ *  and bottom interface levels; 'non-bottom-layers' is every bin layer but the
+ *  lowest one, and 'middle-layers' is the n−2 between them. */
 export function lineQty(line: AssemblyLine, layers: number): number {
 	if (line.qty === 'per-layer') return layers;
+	if (line.qty === 'non-bottom-layers') return Math.max(0, layers - 1);
 	if (line.qty === 'middle-layers') return Math.max(0, layers - 2);
 	return line.qty;
 }

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -1419,6 +1419,7 @@
 				</button>
 				<span class="text-xs tabular-nums text-text-muted">
 					{#if qty === 'per-layer'}×{layers} (1 per layer)
+					{:else if qty === 'non-bottom-layers'}×{Math.max(0, layers - 1)} (every bin layer but the lowest)
 					{:else if qty === 'middle-layers'}×{Math.max(0, layers - 2)} (layers between the interfaces)
 					{:else if qty !== 1}×{qty}{/if}
 				</span>


### PR DESCRIPTION
The assembly tree counted `n − 2` bin layers while the printed-parts and framing models both counted `n`, so every build's hardware totals were short. This makes the tree agree with them.

**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1545685109615759371/1545694727955808316): "Ok, let's push this through as a screw length change. Then make a new one for the layer count issue:"** She found it by [checking the M5 × 16 total](https://discord.com/channels/1430279849171222682/1545685109615759371/1545692007920312390) on #544's preview, [corrected my reading of the bracket covers](https://discord.com/channels/1430279849171222682/1545685109615759371/1545699166347333742) ("For external bracket covers you need n x6. They get used in the top interface"), and [settled the last open question](https://discord.com/channels/1430279849171222682/1545685109615759371/1545712373074104341): "you could say the top interface owns the spare layer connector. As it slides onto the external bracket, on that hex ring." She had already caught the same defect from the frame side [on 26 August](https://discord.com/channels/1430279849171222682/1542146533968052367/1542160152768028823) with a build photo showing 6 hex frames on a 5 layer machine.

## The shape of the machine

**n bin layers plus one top interface, so n + 1 hexagons.** The lowest bin layer carries foot covers in place of the bracket covers and bottom verticals every other frame uses, and the bottom interface hangs underneath it with no hexagon of its own — [bottom two layers, step 6](https://docs.basically.website/hardware/assembly/distribution/bin-frame/bottom-two-layers/): *"It does not share piece D's legs and it does not get a hex frame of its own."*

## Changes

- **`filament.ts`: new `non-bottom-layers` quantity**, `max(0, n − 1)`. It mirrors the `non-bottom` half of a part's existing `layer_scope`, which is what the printed-parts side already uses to say the same thing. Without it the tree cannot express "every bin layer but the lowest", and flipping `layer` to `per-layer` alone would put the bracket covers at 6(n + 1) instead of 6n.
- **Four new assemblies** for the lowest layer: `external-bracket-with-foot` (side + foot cover, same 2 screws the bottom vertical uses), `outer-hex-frame-bottom`, `hex-frame-bottom`, `bottom-layer`.
- **`superstructure` v2**: `layer` runs `non-bottom-layers`, plus one `bottom-layer`.
- **`bottom-interface` v2**: drops its `layer-frame` and its `layer-connector`.
- **Layer connector descriptions** corrected from "1 per bottom interface" to the top interface, matching their `quantities` and her call.

Both version entries are `breaking: false`: nothing physical changed, only how many of each the tree says a machine has.

## Verification

The other two models are independent oracles, and the tree now lands on both **exactly, at every layer count from 2 to 8**:

| | before | after |
|---|---|---|
| printed frame/layer parts disagreeing with the 3D-parts tab | 8 | **0** |
| `ext-2020-ag`, `ext-2020-bh` vs `framing.ts` A+G, B+H at n=3 | 18 vs 24 | **24 vs 24** |
| same at n=5 | 30 vs 36 | **36 vs 36** |

Specifically, `ext-bracket-foot-cover` goes from appearing in **no assembly at all** to 6, the bin retainers from 12(n−2) to 12n, and Frame 90° bracket / crossbeam / External bracket — side pick up the missing hexagon.

**M5 × 16 rises by 96** at every layer count: 163 → 259 at n = 3, 283 → 379 at n = 5. That is the shortfall being corrected, not new hardware. My earlier "at least 72" was a floor counting only the retainers and the missing ring; the rest is that ring's brackets and the second layer's flange screws.

`npm run check` 0 errors 0 warnings, `npm run build` clean, and `check_connections` / `check_versioning` / `check_generated_pins` all pass.

## Confirmed on a build

BrickCycleAlice, [from Discord](https://discord.com/channels/1430279849171222682/1545685109615759371/1545716605349134467), after reading the diagnosis: *"that's what happened to me, I printed, cut and ordered then went to build and the count of the hardware didn't match. But the prints and cuts did."*

That is the failure this PR predicts, from the outside: the 3D-parts and framing models fed her prints and her cut list correctly, and only the tree-derived hardware order came up short. Her machine is 5 layers ([76 M5 × 12 on the old catalog](https://discord.com/channels/1430279849171222682/1545685109615759371/1545692007920312390) pins it), so the shortfall she hit is the 96 M5 × 16 above, plus 6 foot covers she had printed and had no screws listed for.

## Not covered

Bins and funnels are in no assembly either, so they still read 0 through the tree. That is a separate gap and out of scope here.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1545685109615759371/1545694727955808316
request: https://discord.com/channels/1430279849171222682/1545685109615759371/1545712373074104341
request: https://discord.com/channels/1430279849171222682/1545685109615759371/1545699166347333742
request: https://discord.com/channels/1430279849171222682/1545685109615759371/1545716605349134467
preview: /assembly
-->

