### PR TITLE
docs: hex frame is builder-verified, drop both warnings

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -9,10 +9,6 @@ lede: The hexagonal aluminum-and-bracket ring shared by every layer. Build one p
 permalink: /hardware/assembly/distribution/bin-frame/hex-frame/
 author: barthel
 contributors: [brickcyclealice, zed0]
-warning: >-
-  **Reorganized from a Discord build walkthrough, not yet reviewed by a
-  builder.** This page has not been checked step-by-step against a build.
-  Correct it as you go.
 parts_needed:
   - part: ext-2020-ag
     qty: 6
@@ -179,8 +175,3 @@ Double-check that every Frame 90° bracket is still fully seated in its slot. A 
 </figure>
 
 A hex frame is now complete. Build as many as your machine needs (see the note at the top of this page), then move on to [Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}), [Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}), [Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) or [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) to turn one into the layer you need.
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>This page still hasn't been reconciled against the parts calculator's assembly groupings, which don't currently line up with hex-frame-first construction — see <a href="https://discord.com/channels/1430279849171222682/1542862600935702619/1542885792177983488">the open discussion in Discord</a> before treating that side as final.</p>
-</div>

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -113,8 +113,7 @@ Slide a B/H spoke (158mm) and a Frame crossbeam together. For easy assembly, sta
 
 Repeat step 2 around the hexagon until you have used **6 Frame crossbeams and 5 B/H spokes (158mm)**. Deliberately hold the 6th spoke back — it closes the loop later, in step 7.
 
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
+<div class="callout">
   <p>Building the <strong>bottom layer's</strong> frame? The <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}">bottom interface</a> hangs off it, and its three Lazy Susan extrusion mounts each bolt into a T-nut in a B/H spoke, on 3 of the 6 spokes alternating around the ring. If you're using slide-in T-nuts, slide 2 into each of those 3 spokes as you build them here in steps 2-3, since this is the last time their ends are open; drop-in or roll-in T-nuts can go in any time before the ring closes in step 7. Every other layer's frame needs none of this.</p>
 </div>
 


### PR DESCRIPTION
barthel built a hex frame straight from this page and it worked, so the two warnings on it are no longer true and both come off.

**Removed the `warning:` frontmatter banner.** It said the page was "reorganized from a Discord build walkthrough, not yet reviewed by a builder". It has now been checked step-by-step against a build, and the convention is that a page verified against a build loses the note entirely rather than softening it.

**Removed the closing callout** about the page not being reconciled against the parts calculator's assembly groupings. barthel reconciled it by hand: the calculator's `Outer hex frame` node lists `External bracket — cover` and `External bracket — bottom vertical` (they come in via the `External bracket with support` sub-assembly), and those two are not fitted during this build, they go on in [Regular layers](https://docs.basically.website/hardware/assembly/distribution/bin-frame/regular-layers/) and the other layer pages. His call is that this is fine and that the individual element counts match the page, so there is nothing left for the callout to warn about.

**Second ask, same thread:** the "Building the bottom layer's frame?" callout in step 3 is now an information note rather than a warning, at barthel's request. That is a bare `<div class="callout">`, which is how the site already writes a neutral note (`bottom-two-layers.md`, `top-interface.md`); the yellow bar and the warning icon are gone, the text is unchanged.

**Not touched:**

- The other two callouts on the page stay, as build instructions rather than caveats about the page: the T-nut count in zed0's video, and the extra spoke T-nuts a bottom layer needs for the bottom interface.
- No change to `parts-calculator/catalog/parts.json`. The grouping barthel flagged is the recorded one and he approved it as is.
- `regular-layers.md` keeps its own reorganization warning. Nobody has built from that page since the reorg, so it is still unreviewed.

Verified by barthel's build, reported in #balloon-does-docs.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545710825430323200
request: https://discord.com/channels/1430279849171222682/1545710825430323200/1545712978303914055
preview: /hardware/assembly/distribution/bin-frame/hex-frame/
-->

