### PR TITLE
docs: bin retainers get their own page, T-nuts move to the step that uses them

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bin-retainers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bin-retainers.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Bin retainers
+type: how-to
+section: hardware
+slug: assembly-bin-retainers
+kicker: Bin frame — Bin retainers
+lede: The pair of rails on each face of a layer that a bin slides into. Same on every bin layer.
+permalink: /hardware/assembly/distribution/bin-frame/bin-retainers/
+author: barthel
+contributors: [zed0, brickcyclealice]
+warning: >-
+  **Split out of Regular layers and Bottom two layers, which described this
+  twice, not yet reviewed by a builder in this form.** The step itself is
+  unchanged from those pages. Correct it as you build.
+parts_needed:
+  - part: bin-retainer-left
+    qty: 6
+  - part: bin-retainer-right
+    qty: 6
+  - part: scr-m5-16-shcs
+    qty: 24
+  - part: tnut-m5-2020
+    qty: 24
+tools_needed: [Hex key]
+---
+
+Every bin layer gets the same twelve retainers: a Bin retainer (left) and a Bin retainer (right) on the front face of each of the six A/G extrusions, so each of the six faces has a pair that a bin slides down between. The quantities above are **for one layer**. [Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) and [Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}) both send you here.
+
+**Do this after the layer's External bracket — covers are on.** The retainers run right out to the corners, so leave them off until the corner is finished.
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Put four T-nuts in each face" %}
+
+Drop 4 {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} into the outward-facing slot of each A/G extrusion, two per retainer. They do not have to be positioned accurately: slide them along to meet the retainer's holes once it is held in place.
+
+The T-nuts specified for the machine are the roll-in kind, so they go into the slot here, at this step, with the frame already built. See [Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }}) if you bought a different style, because slide-in nuts have to go in much earlier.
+
+{% include step.html n="2" title="Fasten the retainers" %}
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-regular-layers-bin-retainers-installed-w1600-31bf32089e71.png" alt="Bin retainers fastened to the outer faces of the hexagon frame">
+  <figcaption><cite>Photo: zed0.</cite></figcaption>
+</figure>
+
+On each side of the hexagon, hold both the Bin retainer (left) and the Bin retainer (right) against the front face of A/G (Outer horizontal / Horizontal interface frame). The rib along the back of each one drops into the extrusion's slot and sets the height for you; the hook at the top sits on the top face of the extrusion. Fasten each retainer with 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the T-nuts.
+
+Each retainer's bore is 12.8 mm deep, so a shorter M5 reaches the extrusion face with nothing left to bite in the T-nut. Use a socket head rather than a button head here: the flat the head lands on stops 4.1 mm below the hole, which a button head overhangs, and a washer will not sit flat on it at all.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -244,7 +244,7 @@ Three Lazy Susan extrusion mounts carry the bearing assembly's weight; a hold in
 
 The screw between the extrusion mount and the hold in place is an {% include fastener.html size="M5" variant="socket-button" length="16" %}.
 
-Each mount then bolts up into the B/H spoke (158mm) already in place in the bottom layer's frame, through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion.
+Each mount then bolts up into the B/H spoke (158mm) already in place in the bottom layer's frame, through two more 5.5 mm M5 clearance holes, 30 mm apart, into a T-nut in the extrusion. See [Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }}) if you are not sure which style you have.
 
 That's two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws per mount, 6 more on top of the 3 between mount and hold in place.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -84,7 +84,7 @@ You should already have two [hex frames]({{ '/hardware/assembly/distribution/bin
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>Get the bottom interface's 6 T-nuts into the bottom layer's spokes before the ring closes.</strong> Two each into 3 of the 6 B/H spokes, alternating around the ring. <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}#step-4">Bottom interface, step 4</a> bolts its Lazy Susan extrusion mounts up into them from underneath, so they go in this frame's extrusion, not a frame of its own. Roll-in T-nuts can go in later; slide-in ones cannot.</p>
+  <p><strong>Get the bottom interface's 6 T-nuts into the bottom layer's spokes before the ring closes.</strong> Two each into 3 of the 6 B/H spokes, alternating around the ring. <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}#step-4">Bottom interface, step 4</a> bolts its Lazy Susan extrusion mounts up into them from underneath, so they go in this frame's extrusion, not a frame of its own. Roll-in T-nuts can go in later; slide-in ones cannot, see <a href="{{ '/hardware/helpers/t-nuts/' | relative_url }}">Fitting T-nuts</a>.</p>
 </div>
 
 {% include step.html n="2" title="Run the foot extensions through both layers" %}

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -20,10 +20,6 @@ parts_needed:
     qty: 6
   - part: ext-bracket-foot-cover
     qty: 6
-  - part: bin-retainer-left
-    qty: 12
-  - part: bin-retainer-right
-    qty: 12
   - part: ext-2020-d
     qty: 6
   - part: foot-connector-2020-m6
@@ -31,7 +27,7 @@ parts_needed:
   - part: caster-wheel-m6
     qty: 6
   - part: scr-m5-16-shcs
-    qty: 96
+    qty: 48
 tools_needed: [Hex key, Tape measure]
 ---
 
@@ -83,7 +79,8 @@ Here's where the {% include fastener.html size="M5" variant="socket-button" leng
 - **24** for the foot extensions, 4 per corner (step 2 below), two into each layer
 - **12** for the second layer's External bracket — bottom verticals, 2 per corner (step 3 below)
 - **12** for the bottom layer's External bracket — foot covers, 2 per corner (step 3 below), the same as the bottom vertical it replaces
-- **48** for the bin retainers (step 5 below), 24 per layer, so 48 across both
+
+The bin retainers in step 5 are not in that count: they and their fasteners are listed on their own page.
 
 You should already have two [hex frames]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) built, one for each layer. The verticals are the part that differs here, and they are step 2 below.
 
@@ -169,7 +166,7 @@ Screw a **swivel stem caster (M6 × 15 mm)** into the connector's M6 thread. The
 
 {% include step.html n="5" title="Add the bin retainers" %}
 
-Both layers take bin retainers, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 2: on each side of each hexagon, a Bin retainer (left) and a Bin retainer (right) on the front face of the A/G extrusion, 4 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into T-nuts.
+Both layers take a full set of retainers, so do **[Bin retainers]({{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }}) twice**, once for each hexagon. That page's parts list is per layer; double every quantity on it here.
 
 {% include step.html n="6" title="Attach the bottom interface" %}
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-two-layers.md
@@ -14,8 +14,6 @@ warning: >-
   Daddy-O's Bricks - Bill; no other step here has been checked against a
   machine. Correct it as you build.
 parts_needed:
-  - part: ext-bracket-cover
-    qty: 6
   - part: ext-bracket-bottom-vertical
     qty: 6
   - part: ext-bracket-foot-cover
@@ -101,7 +99,7 @@ The corner itself is the same as on any layer. Only the vertical changes: one pi
 On each of the six corners, working on the second layer first:
 
 <ol class="numbered-steps">
-  <li>Slot an External bracket — cover onto the second layer's External bracket — side, and the External bracket — foot cover onto the bottom layer's, before either extrusion goes in. Both take 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws and are awkward to fit afterwards.</li>
+  <li>The second layer's External bracket — cover is already on, fitted with its <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}#step-9">hex frame</a>, and it takes no screws. Slot an External bracket — foot cover onto the bottom layer's External bracket — side now, before either extrusion goes in: it does take 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws, and it is awkward to fit afterwards.</li>
   <li>Partially thread the 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws that will clamp each collar onto piece D, at both the second layer's bracket and the bottom layer's, so they are started but not yet tight.</li>
   <li>Slide a piece D down through the second layer's bracket and on down through the matching corner of the bottom layer, so one piece passes through both.</li>
   <li>Measure from the bottom before tightening anything, to check how far the exposed end will stand proud once the corner is clamped.</li>
@@ -149,7 +147,7 @@ The two layers are now one rigid unit and their spacing is set by the bracket po
 
 The bottom layer does not get an External bracket — bottom vertical or an External bracket — cover. It gets an **External bracket — foot cover** instead, one per corner, which is the single printed part that replaces both of them. It is shorter than the pair it replaces, on purpose, so the extrusion stands out past it far enough for the foot connector in step 4.
 
-The foot cover fastens the same way the bottom vertical it replaces would: 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes into the External bracket — side. Mount it before the extrusion goes in, at the same point as the second layer's cover in step 2.
+The foot cover fastens the same way the bottom vertical it replaces would: 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes into the External bracket — side. Mount it before the extrusion goes in, at the point in step 2 where the corner is still open.
 
 The second layer's corners are ordinary, exactly as in [regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) step 1: an External bracket — bottom vertical slid onto piece D with its angles aligned at the bottom, 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws through its outer holes.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -175,7 +175,7 @@ Push an External bracket — cover onto each of the six External bracket — sid
 This is the easy moment to do it. Once a vertical extrusion is standing in a collar, the cover is difficult to slide on past it.
 
 <div class="callout">
-  <p><strong>Building the bottom layer's frame?</strong> That one takes no covers. <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}">Bottom two layers</a> fits it with External bracket — foot covers instead, one printed part in place of the cover and the External bracket — bottom vertical together. Every other frame takes all six, the top interface's included.</p>
+  <p><strong>Building the bottom layer's frame?</strong> That one takes no External bracket — covers. <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}">Bottom two layers</a> fits it with External bracket — foot covers instead, one printed part in place of the cover and the External bracket — bottom vertical together. Every other frame takes all six, the top interface's included.</p>
 </div>
 
 A hex frame is now complete. Build as many as your machine needs (see the note at the top of this page), then move on to [Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}), [Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}), [Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) or [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) to turn one into the layer you need.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -14,6 +14,8 @@ parts_needed:
     qty: 6
   - part: ext-bracket-left
     qty: 6
+  - part: ext-bracket-cover
+    qty: 6
   - part: ext-2020-bh
     qty: 6
   - part: frame-crossbeam
@@ -170,5 +172,15 @@ Double-check that every Frame 90° bracket is still fully seated in its slot. A 
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/hex-frame-finished-top-down-full-c6abfb4dad6e.jpg" alt="A finished hex frame from above, the alternating grey spoke and teal crossbeam pieces forming the inner ring inside the aluminum outer hexagon">
   <figcaption><cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
+
+{% include step.html n="9" title="Fit the External bracket — covers" %}
+
+Push an External bracket — cover onto each of the six External bracket — sides. It takes no fasteners of its own, it is held by the fit; the side and the cover together form the collar that a layer's vertical extrusion later stands in.
+
+This is the easy moment to do it. Once a vertical extrusion is standing in a collar, the cover is difficult to slide on past it.
+
+<div class="callout">
+  <p><strong>Building the bottom layer's frame?</strong> That one takes no covers. <a href="{{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}">Bottom two layers</a> fits it with External bracket — foot covers instead, one printed part in place of the cover and the External bracket — bottom vertical together. Every other frame takes all six, the top interface's included.</p>
+</div>
 
 A hex frame is now complete. Build as many as your machine needs (see the note at the top of this page), then move on to [Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}), [Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }}), [Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) or [Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) to turn one into the layer you need.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -22,8 +22,6 @@ parts_needed:
     qty: 12
   - part: scr-m5-16-shcs
     qty: 12
-  - part: tnut-m5-2020
-    qty: 24
 tools_needed: [Hex key, Mallet or hammer with a cloth to protect the brackets]
 ---
 
@@ -31,9 +29,9 @@ This guide builds one hexagonal frame: the outer ring of A/G extrusion and Exter
 
 An N-layer machine needs **N + 1 of these**: one per planned layer, plus one for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}). The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) does not get a frame of its own — it hangs underneath the bottom layer's frame, off the same six spokes.
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions. Each frame uses 6 A/G (320mm) and 6 B/H (158mm). The 24 T-nuts in the list above aren't used by anything in this guide — they're pre-installed in step 1 while the extrusion ends are still accessible, for the bin retainers a later page attaches to the outer ring.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions. Each frame uses 6 A/G (320mm) and 6 B/H (158mm).
 
-This frame's fastener total is fixed: 12 M5x16 screws (one per extrusion end, so two per bracket) and 24 T-nuts, all installed in step 1. Steps 2 through 8 use none. Regular layers and bottom two layers reuse these same 24 T-nuts for their bin retainers, so don't count them twice.
+This frame's fastener total is fixed: 12 M5x16 screws, one per extrusion end and so two per bracket, all driven in step 1. Steps 2 through 8 use none, and the frame needs no T-nuts of its own. The bin retainers that later bolt to this ring do use T-nuts, but with the roll-in T-nuts this machine specifies those go into the slot on the [Bin retainers]({{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }}) page, at the step that uses them.
 
 {% include fastener-legend.html %}
 
@@ -54,15 +52,15 @@ Slide piece A/G (Outer horizontal / Horizontal interface frame, 320mm) of alumin
 
 **Standard:** use an {% include fastener.html size="M5" variant="socket-button" length="16" %} screw to tap directly through the outer of the two adjacent holes on the External bracket — side (the smaller of the pair), bracing it against the extrusion.
 
-**Option:** if you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes (the larger of the pair) to fasten into them instead. These need T-nuts of their own; the 24 in the parts list are for the bin retainers.
+**Option:** if you would rather not tap and brace, place T-nuts in the extrusion and use the inner holes (the larger of the pair) to fasten into them instead. That is 12 more {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} per frame, on top of the parts list above.
 
 The bracket carries other holes that neither method uses, including one on its inward-facing side further along the extrusion. Leave those empty.
 
-If you are using slide-in T-nuts rather than drop-in or roll-in T-nuts, insert 4 into the outermost section of the extrusion before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible.
+If you are using slide-in T-nuts rather than the roll-in ones this machine specifies, insert 4 into the outermost section of the extrusion before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible. Those 4 are for the [bin retainers]({{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }}), and [Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }}) lists every other place the same applies. With roll-in T-nuts there is nothing to do here.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Before you watch: the video below still shows 2 inner T-nuts fitted partway along the extrusion. Skip those, only the 4 outer T-nuts per extrusion are needed, for the bin retainers added on a later page.</p>
+  <p>Before you watch: the video fits T-nuts into the extrusion, and none of them belong to this page. The 4 outer ones per extrusion are for the <a href="{{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }}">bin retainers</a>, fitted on that page unless you are using slide-in T-nuts; the 2 inner ones partway along the extrusion are not needed at all.</p>
 </div>
 
 <figure class="video-figure">

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/hex-frame.md
@@ -60,11 +60,6 @@ The bracket carries other holes that neither method uses, including one on its i
 
 If you are using slide-in T-nuts rather than the roll-in ones this machine specifies, insert 4 into the outermost section of the extrusion before connecting the next External bracket — side, as this is the last time the ends of the extrusion are accessible. Those 4 are for the [bin retainers]({{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }}), and [Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }}) lists every other place the same applies. With roll-in T-nuts there is nothing to do here.
 
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Before you watch: the video fits T-nuts into the extrusion, and none of them belong to this page. The 4 outer ones per extrusion are for the <a href="{{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }}">bin retainers</a>, fitted on that page unless you are using slide-in T-nuts; the 2 inner ones partway along the extrusion are not needed at all.</p>
-</div>
-
 <figure class="video-figure">
   <div class="video-embed video-embed-wide">
     <iframe

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/index.md
@@ -16,4 +16,5 @@ The bin frame is the stack of hexagonal layers that makes up the body of the mac
 2. **[Bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }})** — the Lazy Susan stage, slung under the bottom layer's spokes.
 3. **[Bottom two layers]({{ '/hardware/assembly/distribution/bin-frame/bottom-two-layers/' | relative_url }})** — the paired base layers on the long vertical extrusions.
 4. **[Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }})** — build N−2 of these, one per remaining layer.
-5. **[Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})** — outside this section, but takes one of the hex frames from step 1 and caps the stack.
+5. **[Bin retainers]({{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }})** — the same twelve rails on every bin layer. Steps 3 and 4 both send you here, once per layer.
+6. **[Top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})** — outside this section, but takes one of the hex frames from step 1 and caps the stack.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -37,7 +37,7 @@ This guide covers creating a regular layer. It's also the basis for creating the
   </figure>
 </div>
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. The bin retainers in step 2 are the only thing on this layer that takes {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %}, and they carry their own parts on their own page, so neither the retainers nor their fasteners are in the list above.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. The bin retainers in step 2 are the only thing on this layer that takes {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %}, and they carry their own parts on their own page, so neither the retainers nor their fasteners are in the list above. [Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }}) covers the nuts themselves.
 
 {% include fastener-legend.html %}
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -19,14 +19,10 @@ parts_needed:
     qty: 6
   - part: ext-bracket-bottom-vertical
     qty: 6
-  - part: bin-retainer-left
-    qty: 6
-  - part: bin-retainer-right
-    qty: 6
   - part: ext-2020-c
     qty: 6
   - part: scr-m5-16-shcs
-    qty: 60
+    qty: 36
 ---
 
 Each layer holds one chute-and-bin pair (built separately) that catches pieces routed to it; a regular layer's job is simply to repeat the same hexagonal ring, vertical supports, and flange joint as the layer below it, so the stack can go as tall as the machine needs.
@@ -43,7 +39,7 @@ This guide covers creating a regular layer. It's also the basis for creating the
   </figure>
 </div>
 
-The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. This page needs no {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %} of its own: the bin retainers in step 2 use the 4 T-nuts per A/G extrusion that [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) already pre-installs for exactly this purpose.
+The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. The bin retainers in step 2 are the only thing on this layer that takes {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %}, and they carry their own parts on their own page, so neither the retainers nor their fasteners are in the list above.
 
 {% include fastener-legend.html %}
 
@@ -89,9 +85,7 @@ Matching parts from the same print run are embossed with a shared set code (e.g.
   <figcaption><cite>Photo: zed0.</cite></figcaption>
 </figure>
 
-On each side of the hexagon, attach both the Bin retainer (left) and Bin retainer (right) to the front face of A/G (Outer horizontal / Horizontal interface frame) using 4 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the T-nuts your hex frame already has installed there.
-
-Each retainer's bore is 12.8 mm deep, so a shorter M5 reaches the extrusion face with nothing left to bite in the T-nut. Use a socket head rather than a button head here: the flat the head lands on stops 4.1 mm below the hole, which a button head overhangs, and a washer will not sit flat on it at all.
+Twelve retainers go on each layer, six pairs, one pair per face of the hexagon. They are the same on every bin layer, so the step is on its own page: **[Bin retainers]({{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }})**, including the T-nuts they fasten into. Do it now, with the covers on and before the layer goes onto the stack, so you are still working on a frame you can turn around.
 
 A regular layer is now complete.
 

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -15,8 +15,6 @@ warning: >-
   builder.** The old steps 1-2 (outer ring, spokes) are gone; build a hex
   frame on that page first. Correct it as you build.
 parts_needed:
-  - part: ext-bracket-cover
-    qty: 6
   - part: ext-bracket-bottom-vertical
     qty: 6
   - part: ext-2020-c
@@ -56,9 +54,8 @@ The aluminum extrusion is cut to length; the [framing cut list](https://parts-ca
   </figure>
 </div>
 
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Fit the External bracket — cover onto the External bracket — side now, at each corner of your hexagon. It's difficult to slide on once piece C is in place.</p>
+<div class="callout">
+  <p>The External bracket — covers are already on, fitted in <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}#step-9">Build the hex frame, step 9</a>. If a corner is missing one, put it on before you stand piece C in it, because it is difficult to slide on afterwards.</p>
 </div>
 
 Slot piece C (Layer vertical support) of aluminum extrusion between the External bracket — cover and the External bracket — side. At typical cut length, piece C sits about 3 mm short of both the top and bottom of the bracket run. Position it so that 3 mm gap is at the bottom, leaving the extrusion flush (or nearly flush) at the top. Use 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws tapped through the holes near the bottom of the External bracket — side to secure the extrusion.

--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -39,6 +39,14 @@ This guide covers creating a regular layer. It's also the basis for creating the
 
 The aluminum extrusion is cut to length; the [framing cut list](https://parts-calculator.basically.website/framing) has the exact dimensions for piece C. The bin retainers in step 2 are the only thing on this layer that takes {% include fastener.html size="M5" variant="t-nut" text="M5 T-nuts" %}, and they carry their own parts on their own page, so neither the retainers nor their fasteners are in the list above. [Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }}) covers the nuts themselves.
 
+The 36 {% include fastener.html size="M5" variant="socket-button" length="16" %} in the list above are three pairs at each of the six corners, and nothing else on this page takes a screw:
+
+- **12** clamping the External bracket — side onto piece C, 2 per corner (step 1)
+- **12** through the External bracket — bottom vertical's outer holes onto the same extrusion, 2 per corner (step 1)
+- **12** up through that flange into the layer above, 2 per corner (step 3)
+
+The hex frame's own 12 are on [its page]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}), and the bin retainers' 24 are on [theirs]({{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }}), so a complete layer is 72.
+
 {% include fastener-legend.html %}
 
 {% include step.html n="1" title="Install the verticals" %}

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -350,7 +350,7 @@ These six brackets are what the vertical extrusion legs (piece F, step 13) will 
 
 Align an Interface bracket with piece E (Interface spoke, long) of aluminum extrusion.
 
-Place T-nuts in the extrusion, lined up with the 4 holes on the side of the Interface bracket.
+Place T-nuts in the extrusion, lined up with the 4 holes on the side of the Interface bracket. See [Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }}) for how they go in.
 
 Slide the extrusion into the Interface bracket, careful not to dislodge the T-nuts, and drive four {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into them.
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -66,8 +66,6 @@ parts_needed:
     qty: 1
   - part: ribbon-cable-clamp
     qty: 1
-  - part: ext-bracket-cover
-    qty: 6
   - part: extrusion-e
     qty: 6
   - part: extrusion-f

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -163,7 +163,7 @@ Press the plunger on the lid. You should hear the button click.
 The two clamp bosses go onto the 2020 extrusion on 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into 2 {% include fastener.html size="M5" variant="t-nut" text="T-nuts" %} in the extrusion slot. It goes on the [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) belonging to the top interface; the [layout render]({{ '/hardware/electronics/installation/' | relative_url }}) on the installation overview shows where it sits relative to the chute stepper.
 
 <div class="callout">
-  <p><b>No problem if you forgot them.</b> The {% include fastener.html size="M5" variant="t-nut" text="T-nut" %} this build specifies is the spring-loaded roll-in kind, which drops into the slot anywhere along its length, so it can still go in now without taking the frame apart.</p>
+  <p><b>No problem if you forgot them.</b> The {% include fastener.html size="M5" variant="t-nut" text="T-nut" %} this build specifies is the spring-loaded roll-in kind, which drops into the slot anywhere along its length, so it can still go in now without taking the frame apart. See <a href="{{ '/hardware/helpers/t-nuts/' | relative_url }}">Fitting T-nuts</a>.</p>
 </div>
 
 <div class="img-row">

--- a/docs/src/content/hardware/electronics/installation/index.md
+++ b/docs/src/content/hardware/electronics/installation/index.md
@@ -26,7 +26,7 @@ Each of the three printed enclosures bolts to the 2020 frame with 2 M5 screws in
 The six T-nuts go into the hex frame while the top interface is built, at [step 13]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}#step-13) of that page.
 
 <div class="callout">
-  <p><b>No problem if you forgot them.</b> The {% include fastener.html size="M5" variant="t-nut" text="T-nut" %} this build specifies is the spring-loaded roll-in kind, which drops into the slot anywhere along its length, so it can still go in now without taking the frame apart.</p>
+  <p><b>No problem if you forgot them.</b> The {% include fastener.html size="M5" variant="t-nut" text="T-nut" %} this build specifies is the spring-loaded roll-in kind, which drops into the slot anywhere along its length, so it can still go in now without taking the frame apart. See <a href="{{ '/hardware/helpers/t-nuts/' | relative_url }}">Fitting T-nuts</a>.</p>
 </div>
 
 All three go on the same plane: the [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) that belongs to the top interface, the one lowered onto the interface assembly at [step 13]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}#step-13) of the top interface build. The render below is that frame seen from above, and the chute stepper is the landmark to place the three enclosures against.

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -76,7 +76,7 @@ Screw the 4 M3 standoffs into the inserts. Sit the Pi on them and fasten it down
 The mount hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into 2 {% include fastener.html size="M5" variant="t-nut" text="T-nuts" %} in the extrusion slot. It goes on the [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) belonging to the top interface; the [layout render]({{ '/hardware/electronics/installation/' | relative_url }}) on the installation overview shows where it sits relative to the chute stepper.
 
 <div class="callout">
-  <p><b>No problem if you forgot them.</b> The {% include fastener.html size="M5" variant="t-nut" text="T-nut" %} this build specifies is the spring-loaded roll-in kind, which drops into the slot anywhere along its length, so it can still go in now without taking the frame apart.</p>
+  <p><b>No problem if you forgot them.</b> The {% include fastener.html size="M5" variant="t-nut" text="T-nut" %} this build specifies is the spring-loaded roll-in kind, which drops into the slot anywhere along its length, so it can still go in now without taking the frame apart. See <a href="{{ '/hardware/helpers/t-nuts/' | relative_url }}">Fitting T-nuts</a>.</p>
 </div>
 
 <div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/electronics/installation/psu-box.md
+++ b/docs/src/content/hardware/electronics/installation/psu-box.md
@@ -91,7 +91,7 @@ Fit the cap. It carries no screws of its own — its STL has no case-screw holes
 The box hangs off the 2020 frame on 2 {% include fastener.html size="M5" variant="socket-button" length="12" %} screws into 2 {% include fastener.html size="M5" variant="t-nut" text="T-nuts" %} in the extrusion slot. It goes on the [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}) belonging to the top interface; the [layout render]({{ '/hardware/electronics/installation/' | relative_url }}) on the installation overview shows where it sits relative to the chute stepper.
 
 <div class="callout">
-  <p><b>No problem if you forgot them.</b> The {% include fastener.html size="M5" variant="t-nut" text="T-nut" %} this build specifies is the spring-loaded roll-in kind, which drops into the slot anywhere along its length, so it can still go in now without taking the frame apart.</p>
+  <p><b>No problem if you forgot them.</b> The {% include fastener.html size="M5" variant="t-nut" text="T-nut" %} this build specifies is the spring-loaded roll-in kind, which drops into the slot anywhere along its length, so it can still go in now without taking the frame apart. See <a href="{{ '/hardware/helpers/t-nuts/' | relative_url }}">Fitting T-nuts</a>.</p>
 </div>
 
 <div class="img-placeholder">Image coming</div>

--- a/docs/src/content/hardware/helpers/index.md
+++ b/docs/src/content/hardware/helpers/index.md
@@ -15,3 +15,4 @@ contributors: [barthel]
 - **[Preparing the 20-tooth timing pulley]({{ '/hardware/helpers/pulley-gear-mod/' | relative_url }})**
 - **[Soldering Pico headers]({{ '/hardware/helpers/pico-headers/' | relative_url }})**
 - **[Installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }})**
+- **[Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }})**

--- a/docs/src/content/hardware/helpers/t-nuts.md
+++ b/docs/src/content/hardware/helpers/t-nuts.md
@@ -27,13 +27,13 @@ Two things follow, and they are why the machine specifies this style:
 <figure class="video-figure">
   <div class="video-embed video-embed-wide">
     <iframe
-      src="https://www.youtube.com/embed/bGmanrPj7s0?start=73"
+      src="https://www.youtube.com/embed/bGmanrPj7s0?start=68"
       title="How roll-in T-nuts go into extrusion"
       allow="encrypted-media; picture-in-picture; web-share"
       allowfullscreen
       loading="lazy"></iframe>
   </div>
-  <figcaption>How the nut rolls in and locks. <cite>Video linked by Marc.</cite></figcaption>
+  <figcaption>Starts at 1:08, where the roll-in T-nut comes up. The four variants it then shows (set screw, flex handle, ball spring, spring leaf) are all roll-in; this machine's is a spring one. <cite>Video: 80/20, linked by Marc.</cite></figcaption>
 </figure>
 
 ## If you have a different style

--- a/docs/src/content/hardware/helpers/t-nuts.md
+++ b/docs/src/content/hardware/helpers/t-nuts.md
@@ -27,13 +27,13 @@ Two things follow, and they are why the machine specifies this style:
 <figure class="video-figure">
   <div class="video-embed video-embed-wide">
     <iframe
-      src="https://www.youtube.com/embed/bGmanrPj7s0?start=68"
+      src="https://www.youtube.com/embed/bGmanrPj7s0?start=73"
       title="How roll-in T-nuts go into extrusion"
       allow="encrypted-media; picture-in-picture; web-share"
       allowfullscreen
       loading="lazy"></iframe>
   </div>
-  <figcaption>Starts at 1:08, where the roll-in T-nut comes up. The four variants it then shows (set screw, flex handle, ball spring, spring leaf) are all roll-in; this machine's is a spring one. <cite>Video: 80/20, linked by Marc.</cite></figcaption>
+  <figcaption>Starts at 1:13, where the roll-in T-nut comes up. The four variants it then shows (set screw, flex handle, ball spring, spring leaf) are all roll-in; this machine's is a spring one. <cite>Video: 80/20, linked by Marc.</cite></figcaption>
 </figure>
 
 ## If you have a different style

--- a/docs/src/content/hardware/helpers/t-nuts.md
+++ b/docs/src/content/hardware/helpers/t-nuts.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Fitting T-nuts
+type: how-to
+section: hardware
+slug: helper-t-nuts
+kicker: Helpers — T-nuts
+lede: How the machine's roll-in T-nuts go into the extrusion, and what changes if you buy a different style.
+permalink: /hardware/helpers/t-nuts/
+author: barthel
+parts_needed:
+  - part: tnut-m5-2020
+tools_needed: [Hex key]
+---
+
+Every M5 screw that fastens a printed part to aluminum extrusion, rather than tapping into plastic, lands in one of these. The parts list calls for a **spring-loaded roll-in T-nut** for 2020 extrusion, and that choice is what lets the assembly pages ask for T-nuts at the step that uses them instead of making you plan them in advance.
+
+## Roll-in
+
+A roll-in T-nut goes into the slot **anywhere along its length**. Hold it so its long axis lines up with the slot opening, push it in, then turn it a quarter turn so the ends sit under the lips of the slot. A spring leaf or a spring-loaded ball on the back then holds it where you put it, so it stays in position while you line the part up and it does not fall out if you take the screw back out later.
+
+Two things follow, and they are why the machine specifies this style:
+
+- **You never have to fit one early.** No frame has to come apart, and no extrusion end has to be left open, to add a T-nut to a slot that is already built into the machine.
+- **You can undo a joint without losing the nut.** Take the screws out, lift the part off, and the T-nuts are still sitting in the slot where they were.
+
+<figure class="video-figure">
+  <div class="video-embed video-embed-wide">
+    <iframe
+      src="https://www.youtube.com/embed/bGmanrPj7s0?start=73"
+      title="How roll-in T-nuts go into extrusion"
+      allow="encrypted-media; picture-in-picture; web-share"
+      allowfullscreen
+      loading="lazy"></iframe>
+  </div>
+  <figcaption>How the nut rolls in and locks. <cite>Video linked by Marc.</cite></figcaption>
+</figure>
+
+## If you have a different style
+
+Cheaper T-nuts are usually **slide-in**: a plain rectangular block with no spring, which can only be loaded from an open end of the extrusion and then slid along to where it is needed. They work, but they change the order you have to build in, because a slot that has a bracket on both ends can no longer take one.
+
+If that is what you have, fit these before the frames close around them:
+
+- **4 per A/G extrusion** on each [hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}), toward the outer end of the extrusion, for the [bin retainers]({{ '/hardware/assembly/distribution/bin-frame/bin-retainers/' | relative_url }}).
+- **2 each into 3 of the 6 B/H spokes** of the bottom layer's frame, alternating around the ring, for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }})'s Lazy Susan mounts.
+
+Slide-in nuts also do not hold their position on their own, so a nut you fitted early can drift along the slot before you get to the part that uses it. Fitting the part in the same session is easier than trying to line up a nut you cannot see.

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -36,6 +36,8 @@ sections:
                     url: /hardware/assembly/distribution/bin-frame/bottom-two-layers/
                   - title: Regular layers
                     url: /hardware/assembly/distribution/bin-frame/regular-layers/
+                  - title: Bin retainers
+                    url: /hardware/assembly/distribution/bin-frame/bin-retainers/
               - title: Top interface
                 url: /hardware/assembly/distribution/top-interface/
               - title: Chute
@@ -103,6 +105,8 @@ sections:
             url: /hardware/helpers/pico-headers/
           - title: Installing heat inserts
             url: /hardware/helpers/heat-inserts/
+          - title: Fitting T-nuts
+            url: /hardware/helpers/t-nuts/
       - title: Parts
         url: /hardware/parts/
         children:

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7940,7 +7940,7 @@
     {
       "id": "layer",
       "uid": "mnpn",
-      "version": "3",
+      "version": "4",
       "name": "Distribution layer",
       "description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins.",
       "docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
@@ -7964,6 +7964,10 @@
         {
           "part": "scr-m5-16-shcs",
           "qty": 36
+        },
+        {
+          "part": "tnut-m5-2020",
+          "qty": 24
         }
       ],
       "connections": [
@@ -7974,7 +7978,7 @@
           "qty": 12,
           "method": "tnut",
           "through_mm": 12.8,
-          "note": "Two per retainer, into the 4 T-nuts per A/G extrusion the hex frame pre-installs. Measured off the STL: 12.00 mm of plastic between the head face and the face that sits on the extrusion, plus a 0.8 mm locating rib that drops into the slot, so the bore the screw crosses is 12.8 mm. An M5 x 12 stops level with the extrusion face with no thread in the nut; an M5 x 20 stands 8 mm into a slot about 5.9 mm deep and bottoms out before it clamps."
+          "note": "Two per retainer, into the 4 T-nuts per A/G extrusion, which go into the slot at this step. Measured off the STL: 12.00 mm of plastic between the head face and the face that sits on the extrusion, plus a 0.8 mm locating rib that drops into the slot, so the bore the screw crosses is 12.8 mm. An M5 x 12 stops level with the extrusion face with no thread in the nut; an M5 x 20 stands 8 mm into a slot about 5.9 mm deep and bottoms out before it clamps."
         },
         {
           "from": "bin-retainer-right",
@@ -8069,6 +8073,12 @@
           "breaking": false,
           "message": "The 24 bin-retainer screws are M5 x 16, not M5 x 12: the retainer's bore is 12.8 mm, so an M5 x 12 reaches the extrusion face with nothing left for the T-nut. Reported by BrickCycleAlice, who tried them on a build; confirmed by measuring the STL. Merged into the existing scr-m5-16-shcs line, 12 + 24 = 36, and the joint recorded in connections with its measured through_mm.",
           "commit": "1ce549ec"
+        },
+        {
+          "version": "4",
+          "date": "2026-09-05",
+          "message": "Restored tnut-m5-2020 qty 24 for the bin retainers. v2 dropped them here as \"the hex frame's own pre-installed T-nuts\", and hex-frame v2 then dropped the same 24 on 2026-08-31 as part of the Inner/Outer restructure, so they fell out of the machine entirely and no hardware list has carried them since. They belong on this node, alongside the 24 scr-m5-16-shcs that go through them. No physical change.",
+          "breaking": false
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2577,7 +2577,7 @@
 		{
 			"id": "layer",
 			"uid": "mnpn",
-			"version": "3",
+			"version": "4",
 			"name": "Distribution layer",
 			"description": "One distribution layer between the interfaces: frame, chute, bin retainers, funnels, bins.",
 			"docs": "/hardware/assembly/distribution/bin-frame/regular-layers/",
@@ -2601,6 +2601,10 @@
 				{
 					"part": "scr-m5-16-shcs",
 					"qty": 36
+				},
+				{
+					"part": "tnut-m5-2020",
+					"qty": 24
 				}
 			],
 			"connections": [
@@ -2611,7 +2615,7 @@
 					"qty": 12,
 					"method": "tnut",
 					"through_mm": 12.8,
-					"note": "Two per retainer, into the 4 T-nuts per A/G extrusion the hex frame pre-installs. Measured off the STL: 12.00 mm of plastic between the head face and the face that sits on the extrusion, plus a 0.8 mm locating rib that drops into the slot, so the bore the screw crosses is 12.8 mm. An M5 x 12 stops level with the extrusion face with no thread in the nut; an M5 x 20 stands 8 mm into a slot about 5.9 mm deep and bottoms out before it clamps."
+					"note": "Two per retainer, into the 4 T-nuts per A/G extrusion, which go into the slot at this step. Measured off the STL: 12.00 mm of plastic between the head face and the face that sits on the extrusion, plus a 0.8 mm locating rib that drops into the slot, so the bore the screw crosses is 12.8 mm. An M5 x 12 stops level with the extrusion face with no thread in the nut; an M5 x 20 stands 8 mm into a slot about 5.9 mm deep and bottoms out before it clamps."
 				},
 				{
 					"from": "bin-retainer-right",
@@ -2702,11 +2706,17 @@
 				},
 				{
 					"version": "3",
-					"uid": "mnpn",
 					"date": "2026-09-05",
 					"breaking": false,
 					"message": "The 24 bin-retainer screws are M5 x 16, not M5 x 12: the retainer's bore is 12.8 mm, so an M5 x 12 reaches the extrusion face with nothing left for the T-nut. Reported by BrickCycleAlice, who tried them on a build; confirmed by measuring the STL. Merged into the existing scr-m5-16-shcs line, 12 + 24 = 36, and the joint recorded in connections with its measured through_mm.",
 					"commit": "1ce549ec"
+				},
+				{
+					"version": "4",
+					"uid": "mnpn",
+					"date": "2026-09-05",
+					"message": "Restored tnut-m5-2020 qty 24 for the bin retainers. v2 dropped them here as \"the hex frame's own pre-installed T-nuts\", and hex-frame v2 then dropped the same 24 on 2026-08-31 as part of the Inner/Outer restructure, so they fell out of the machine entirely and no hardware list has carried them since. They belong on this node, alongside the 24 scr-m5-16-shcs that go through them. No physical change.",
+					"breaking": false
 				}
 			]
 		},


### PR DESCRIPTION
**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1545727470026883232):** *"I'd like us to give more consideration to this feature of the T-nuts and install them right at the step where they're needed. That way, they wouldn't be scattered throughout the entire documentation and would be easier to locate. ... Ideally, I'd like to dedicate a separate, short page to attaching the bin retainers, since this is described in several places."* He opened the topic [here](https://discord.com/channels/1430279849171222682/1536088194557419660/1545721430682108068), noting that the bin retainers are what drives the screw and T-nut count per layer.

The catalog part is `tnut-m5-2020`, "M5 roll-in T-nut, 2020", spring-loaded roll-in. A roll-in nut goes into the slot anywhere along its length, so nothing has to be pre-fitted while an extrusion end is still open. The hex frame page was written as if the opposite were true. The style was chosen for exactly this property, in [#distribution on 2026-03-07](https://discord.com/channels/1430279849171222682/1437144782819426537/1479944747765334220): *"i like these ones a lot because you can take them out and insert them anywhere in the aluminum profile"*.

## New page: Bin retainers

`docs/src/content/hardware/assembly/distribution/bin-frame/bin-retainers.md`, authored to barthel.

The step was written out twice, in [Regular layers](https://docs.basically.website/hardware/assembly/distribution/bin-frame/regular-layers/) step 2 and [Bottom two layers](https://docs.basically.website/hardware/assembly/distribution/bin-frame/bottom-two-layers/) step 5, with the second telling you to follow the first. It is now one page that both call, carrying the retainers, their 24 screws and their 24 T-nuts. Both callers drop those parts from their own `parts_needed` and link instead, the same pattern the hex frame split used.

It is a bin-layer page, not a hex frame page. You build N+1 hex frames and only N of them hold bins: the top interface's frame takes no retainers.

## New page: Fitting T-nuts

`docs/src/content/hardware/helpers/t-nuts.md`, a helper page, authored to barthel. What a roll-in nut is, how it goes in, and the two consequences that matter (fit it at the step that uses it; you can undo a joint without losing the nut). The video is Marc's, [posted in #distribution](https://discord.com/channels/1430279849171222682/1437144782819426537/1479945463192092763) in the thread where the style was decided, embedded from his own timestamp of 1:13.

The page also collects the two places a **slide-in** nut has to be fitted early, so that constraint lives in one place instead of being repeated as a conditional on every page.

## Hex frame page: the 24 T-nuts come off

`hex-frame.md` carried them in four places: `parts_needed`, the intro paragraph, the fastener-total paragraph, and the callout above zed0's video. All four now point at the bin retainers page. What stays is the slide-in exception in step 1, which is the only case where something really does have to happen at this stage, and it now links to the helper page.

The frame's own fastener total is unchanged: 12 M5 x 16, no T-nuts. Step 1's T-nut *option* for the inner holes is unchanged too, and it is now stated as 12 more nuts per frame rather than being netted against the 24.

## Catalog: the retainer T-nuts were missing from the machine entirely

`parts-calculator/catalog/parts.json`, `layer` v3 to v4, `breaking: false`. This is a real BOM bug and it is how the docs and the catalog got out of step, so it goes in with the rest.

The 24 T-nuts the bin retainers bolt into were dropped twice, each time on the assumption that the other node still carried them:

- `layer` v2, 2026-08-29: *"Dropped tnut-m5-2020 qty 24 -- those are the hex frame's own pre-installed T-nuts (bin retainers reuse them, not new ones)"*.
- `hex-frame` v2, 2026-08-31: *"the 24 T-nuts are dropped"*, as part of the Inner/Outer hex frame restructure.

After the second one no assembly in the tree listed them, so no hardware list has included them since. They are restored on `layer`, alongside the 24 `scr-m5-16-shcs` that pass through them, which is also where they now sit in the docs. The `bin-retainer-left` connection note is corrected to match. `catalog.generated.json` regenerated with `generate.py --metadata-only`.

**Not fixed here**, both pre-existing and both worth their own change:

- `layer` is instantiated `max(0, layers - 2)` times in the machine tree while the 3D-printed-parts tab multiplies the same section by the full layer count, so every per-layer fastener on this node reads two layers short. Same defect as the M5 x 16 shortfall in #544.
- `bottom-two-layers.md` lists 6 `ext-bracket-cover` for two layers where the two collars look like they want 12.

Checks: `check_versioning.py` clean, `check_generated_pins.py` clean, `check_docs_refs.py` warns only that `layer` was revised (expected) plus the pre-existing set. Docs build clean on Node 22.

## The External bracket — cover moves to the hex frame page

**Asked by barthel [in the same thread](https://discord.com/channels/1430279849171222682/1545727470026883232/1545731282288517161):** *"why don't we attach the external bracket cover when we're building the hex frame? Does that make a later step in the build more complicated?"* It does not, so it moves. He then [pointed at the page's own words](https://discord.com/channels/1430279849171222682/1545727470026883232/1545731654914678835) as the argument for it: *"Auf der regular layer seite steht sogar: 'Fit the External bracket — cover onto the External bracket — side now, at each corner of your hexagon. It's difficult to slide on once piece C is in place.'"* That warning is the sentence this change removes, because the frame build is a strictly earlier moment than the one it was protecting.

`hex-frame.md` gains 6 `ext-bracket-cover` and a step 9 that fits them; `regular-layers.md`, `bottom-two-layers.md` and `top-interface.md` drop them from their own `parts_needed`, and Regular layers' warning about fitting the cover before piece C becomes a note pointing back at that step. The machine total is unchanged: 6 per frame across N+1 frames, less the bottom layer's frame, is 6N, which is what the pages added up to before.

**The bottom layer's frame is the exception and step 9 says so.** It takes `ext-bracket-foot-cover`, one printed part in place of the cover and the External bracket — bottom vertical together, per `bottom-two-layers.md` step 3.

**`ext-bracket-cover` has no fastener holes**, so this moves no screws. Measured on the STL: silhouette taken along +z, radially inward, and both 45° diagonals, then flood-filled from the border to find voids fully enclosed by material. The cover returns **zero** enclosed voids in every direction. The same pass over `ext-bracket-foot-cover` returns its 28.8 × 29.2 mm bore plus **two 5.6 × 5.6 mm holes at (±20.7, −356.6)**, which are the Ø5.5 clearance pair its step already documents, so the method finds holes where holes exist.

That corrects `bottom-two-layers.md` step 2, which said the cover and the foot cover "both take 2 M5 × 16 screws". Only the foot cover does. Step 3's description of the foot cover's own pair was already right.

**Not fixed here:** `ext-bracket-foot-cover` appears in no assembly's `lines` at all, so the catalog gives every corner of every layer a cover and no machine BOM contains a foot cover. Modelling the bottom layer as its own node is a bigger change than this PR.

## Follow-ups from the same thread

**Regular layers now shows where its 36 M5 × 16 come from.** [Asked for here](https://discord.com/channels/1430279849171222682/1545727470026883232/1545754280391217262): *"Check the screw count on the sides, where bin retainer was described before."* Both pages check out and the split conserved the totals: Regular layers 60 → 36 + 24 on the retainer page, Bottom two layers 96 → 48 + 48, and the machine's M5 × 16 across these pages is 72N − 12 either way. Regular layers had no breakdown of its number (Bottom two layers already had one), so it now lists the three pairs per corner that make up the 36.

**The catalog is a different story and is not touched here.** It carries 60 M5 × 16 per layer against the docs' 72. The missing 12 is one of the two bracket pairs at each corner: `external-bracket-with-support` lists 2 screws where the corner takes 4 (Spencer's own description of the part is *"Has 4 screws. Two that hold the bottom to the top and two that hold the vertical extrusion"*, and the `external-bracket` helper node already says 4). Bumping it is not the fix, because that node sits inside `hex-frame`, which the top interface also uses and which has no External bracket — bottom vertical at all. The bottom vertical and its screws belong to the layer standing on the frame, not to the frame, which is the shape the docs now describe. That is the same structural knot as the `middle-layers` n − 2 count and belongs in its own change. Previously flagged in #373.

**The video starts at 1:13.** barthel [confirmed that timestamp](https://discord.com/channels/1430279849171222682/1545727470026883232/1545735780595408947): *"1:13 is the correct timestamp."* I had briefly moved it to 1:08 off a transcript estimate; his reading of the video wins, so it is back to Marc's original `?start=73`.

**Fitting T-nuts is now linked from every page that calls for T-nuts.** [Asked for here](https://discord.com/channels/1430279849171222682/1545727470026883232/1545736402820669491): *"Please add a link to the 'fiiting t-nuts' page"*. Added on Bottom interface, Bottom two layers, Regular layers, Top interface, PSU box, Control board housing, Orange Pi mount and the electronics installation overview, at each page's own first T-nut mention. Hex frame and Bin retainers already linked it. Same shape as the heat inserts helper: the procedure lives in one place and the steps point at it.

**The T-nut warning above the hex frame video is gone.** [Asked for here](https://discord.com/channels/1430279849171222682/1545727470026883232/1545734093520502895): *"I think we need the video ... and the photo below it showing the four T-nuts, but we no longer need the warning above the video."* The video and the photo stay; the callout telling you which of the T-nuts in them belonged to this page is no longer needed now that none of them do.

**On the cover being on every hex frame** ([barthel](https://discord.com/channels/1430279849171222682/1545727470026883232/1545732952409776268)): every frame except the bottom layer's, which `bottom-two-layers.md` gives External bracket — foot covers instead. Step 9 carries that exception, and after barthel's [“the foot cover is a cover too”](https://discord.com/channels/1430279849171222682/1545727470026883232/1545745199790039120) it says that frame takes no *External bracket — covers* rather than "no covers", which was contradicting the next sentence.


<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545727470026883232
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545721430682108068
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545730969368268881
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545731282288517161
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545731654914678835
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545732952409776268
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545735780595408947
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545736402820669491
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545734093520502895
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545745199790039120
request: https://discord.com/channels/1430279849171222682/1545727470026883232/1545754280391217262
preview: /hardware/assembly/distribution/bin-frame/bin-retainers/
-->







