### PR TITLE
docs: the camera lamp assembly

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -11,7 +11,7 @@ author: spencer
 contributors: [barthel, brickcyclealice, christoph]
 warning: >-
   **Steps 1 to 5 come from a build**, the order of operations and the photographs are
-  BrickCycleAlice's. Step 6, the light post, is still an AI-generated first draft written
+  BrickCycleAlice's. Step 6, the camera lamp, is still an AI-generated first draft written
   from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=c-channel) and has
   not been checked against a machine. Correct it as you build.
@@ -52,7 +52,7 @@ The parts list above is **all four channels' worth** — the count is fixed for 
 
 - **Build 4 per machine**, three in the feeder and one for the classification channel. It is the same build four times over, and the rotor is the only thing that changes.
 - **One rotor per unit, and only one of the two.** The three feeder channels take the Rotor (faceted); the classification channel takes the Rotor (finned), the one with the fins in the photographs below. The list above already splits them the way a real machine needs them: three faceted, one finned. Colour changes with the rotor too: the feeder parts are charcoal, the classification-channel ones ash grey.
-- Two of the four channels also carry a light post, whose screws belong to the light post rather than to the list above.
+- Every channel also carries a [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), whose parts and screws belong to that page rather than to the list above.
 
 {% include step.html n="1" title="Preparation" %}
 
@@ -124,15 +124,10 @@ Turn the stage by hand before wiring it. The train should run without a tight sp
   <figcaption>The finished stage, here the classification one with the finned rotor. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
-{% include step.html n="6" title="Fit the light post, on the channels that take one" %}
+{% include step.html n="6" title="Hang the camera lamp over the channel" %}
 
-Two of the C-channels carry a light post, which bolts to this unit's NEMA bracket with 2 {% include fastener.html size="M3" variant="countersunk" length="20" %} screws that thread straight into the printed post.
+Every channel carries a camera lamp: an arm mounted to the channel, a shaded lamp on the end of it and a camera looking down through the middle. It has its own page, [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), and none of its screws are in the list above.
 
-The post, its cap, the cap adapter and the COB plate have their own page: [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}).
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>The C-channel COB light boards need a current-limiting resistor.</b> <b>220&#8486;, 1/4 W, in series, one per board.</b> Wired straight to 24V a 50 mm COB plate pulls about 0.5A and melts its printed mount. A board fed from a basically board v1.3 LED header already has one on the board. Full detail: <a href="{{ '/hardware/electronics/#43--leds-from-basically-board-v13' | relative_url }}">LEDs, on the wire harness page</a>.</p>
-</div>
+The light post and the overhead camera mount that used to do this job were retired on 2026-09-02. Their pages are still up for machines already built that way.
 
 Once all four are built, see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for how they sit together.

--- a/docs/src/content/hardware/assembly/feeder/camera-lamp.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-lamp.md
@@ -83,7 +83,7 @@ It replaces the [light post]({{ '/hardware/assembly/feeder/light-post/' | relati
     <p><strong>Colours.</strong> The <strong>Lamp inner reflector</strong> and its six <strong>LED hooks</strong> print ivory white, and that is not cosmetic: they are the reflector. The <strong>Lamp outer cover</strong> is ash grey. The arm, the mount, both brackets, the ring and both clasp halves follow the channel colour like the rest of that channel's parts.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-side-full-2a681306f3a9.png" alt="CAD render of the camera lamp in profile: the disc-shaped lamp overhanging at the top, carried on an arm that steps down at an angle to the C-channel arm mount, with a bracket along each joint">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-render-side-full-2a681306f3a9.png" alt="CAD render of the camera lamp in profile: the disc-shaped lamp overhanging at the top, carried on an arm that steps down at an angle to the C-channel arm mount, with a bracket along each joint">
     <figcaption>The whole thing in profile. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
   </figure>
 </div>
@@ -150,7 +150,7 @@ Six **Inner reflector LED hooks** friction-fit into the rim of the **Lamp inner 
 The **Lamp outer cover** friction-fits down over the reflector, and that is the whole joint: it has no screw hole anywhere in its geometry. The reflector is 150 mm across, the cover 153 mm, and the cover stands about 1.5 mm proud of the reflector at the top so the camera clasp sits recessed in the opening at its centre.
 
 <figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-underside-full-0e2b1e5a0fb9.png" alt="CAD render of the camera lamp seen from below: the inside of the cover with the reflector dome, the LED hooks spaced around the rim, the camera at the centre, and the arm reaching up into it">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-render-underside-full-0e2b1e5a0fb9.png" alt="CAD render of the camera lamp seen from below: the inside of the cover with the reflector dome, the LED hooks spaced around the rim, the camera at the centre, and the arm reaching up into it">
   <figcaption>From below, with the reflector inside the cover and the hooks around the rim. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
 </figure>
 
@@ -161,7 +161,7 @@ Plug the clasped camera into the ring, then set the lamp on top. **The lamp is n
 Order matters here in one place only: the camera has to be in the clasp and the clasp in the ring before the cover goes over the top, because the cover closes around the clasp.
 
 <figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-top-full-edc4616e7088.png" alt="CAD render of the assembled camera lamp from above: the grey cover with the camera clasp and board in the central opening, a slot near the rim, and the arm coming in from the lower left">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-render-top-full-edc4616e7088.png" alt="CAD render of the assembled camera lamp from above: the grey cover with the camera clasp and board in the central opening, a slot near the rim, and the arm coming in from the lower left">
   <figcaption>Assembled, from above. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
 </figure>
 

--- a/docs/src/content/hardware/assembly/feeder/camera-lamp.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-lamp.md
@@ -104,7 +104,9 @@ The arm and the mount butt together end to end, and brackets A and B hold the jo
 
 **The two brackets share their screw holes.** The mount and the arm each carry two 2.8 mm pilot holes that run 19.8 mm straight through the joint, so bracket A's screw enters one end and bracket B's the other, and eight screws go into four holes. Both pairs are 20 mm apart along the joint.
 
-Drive all 8 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, four per bracket, seated flush in the countersinks. A 12 mm countersunk leaves about 7.5 mm of thread inside a 19.8 mm hole, so two screws coming from opposite ends stop roughly 5 mm short of each other. Stop as soon as each head seats: you are cutting a thread in plastic, and the far half of the hole is somebody else's screw.
+Drive all 8 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, four per bracket, seated flush in the countersinks. Stop as soon as each head seats: you are cutting a thread in plastic, and the far half of the hole is somebody else's screw.
+
+**12 mm is the length, and it is the only one that fits.** A countersunk screw's length is measured over its head, so 12 mm through a 4.5 mm bracket leaves about 7.5 mm of thread in the 19.8 mm hole and two screws coming from opposite ends stop roughly 5 mm short of each other. A 16 would put 11.5 mm in from each end, 23 mm of screw in a 19.8 mm hole, and the two would meet before either seated. ReveryX confirmed the M3 × 12 on an assembled arm, 2026-09-05.
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-mounted-wide-w1600-247fb837f4f8.jpg" alt="A wider view of a camera lamp on the machine, showing the full length of the arm from the lamp down to the C-channel, with a bracket screwed along the joint and the LED leads cable-tied along the arm">
@@ -125,7 +127,7 @@ The two {% include fastener.html size="M3" variant="countersunk" length="8" %} s
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>Two screws, not four.</b> The parts calculator lists 4 × M3 × 8 here and flags the count as unconfirmed. There are only two screw positions in either STL. An M3 × 8 countersunk gets about 2 mm of thread into the top half, which is not much, so do not overtighten and check the halves close flush on the board.</p>
+  <p><b>Two screws, not four, and the length is the one thing here still worth checking.</b> The parts calculator lists 4 × M3 × 8 and flags the count as unconfirmed; there are only two screw positions in either STL. On the lengths: the bottom half is 6 mm thick, so an M3 × 8 countersunk reaches about 2 mm into the top half's 5 mm pilot, and an M3 × 10 would give 4 mm and still stop 2 mm short of the top face. Nobody has confirmed either against a build. Do not overtighten, and check the halves close flush on the board.</p>
 </div>
 
 The clasp is what carries the camera into the lamp: its two halves form a 4 mm spigot on the diagonal, which plugs into a 4.2 mm socket in the camera lamp ring. The ring has two of those sockets at the same radius; which one is intended, and whether the module is meant to come out again, is not recorded. <span class="fastener-todo">fastener not recorded</span>

--- a/docs/src/content/hardware/assembly/feeder/camera-lamp.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-lamp.md
@@ -1,0 +1,174 @@
+---
+layout: default
+title: Camera lamp
+type: how-to
+section: hardware
+slug: assembly-camera-lamp
+kicker: Feeder — Camera lamp
+lede: The arm, the shaded lamp and the camera that hang over a C-channel.
+permalink: /hardware/assembly/feeder/camera-lamp/
+author: reveryx
+contributors: [spencer]
+og_image: https://assets.basically.website/sorter-docs/camera-lamp-on-channel-w1600-8d957377d671.jpg
+warning: >-
+  **AI-generated first draft, and the order of operations is a guess.** The parts, the
+  joints and Spencer's photographs are real, from the [parts
+  calculator](https://parts-calculator.basically.website/assembly?focus=camera-lamp); every
+  hole diameter and screw count below is measured off the published STLs. What is missing is
+  a build: nobody has written down how the arm mount attaches to the C-channel, which LED
+  strip goes on the hooks, or how any of it is wired. Fill those in as you build.
+parts_needed:
+  - part: c-channel-arm-mount
+    qty: 1
+  - part: camera-lamp-arm
+    qty: 1
+  - part: arm-bracket-a
+    qty: 1
+  - part: arm-bracket-b
+    qty: 1
+  - part: camera-lamp-ring
+    qty: 1
+  - part: camera-clasp-bottom
+    qty: 1
+  - part: camera-clasp-top
+    qty: 1
+  - part: cam-ov9732
+    qty: 1
+  - part: lamp-inner-reflector
+    qty: 1
+  - part: inner-reflector-led-hook
+    qty: 6
+  - part: lamp-outer-cover
+    qty: 1
+  - part: scr-m3-12-cs
+    qty: 12
+  - part: scr-m3-8-cs
+    qty: 2
+---
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Build a <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">C-channel</a> before you start.</strong> The lamp hangs over one, on an arm that mounts to it. This page builds the lamp, not the channel.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+    <figcaption>A finished C-channel, from the C-channel page. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+The camera lamp is one arm carrying one light and one camera over a channel. The light is a ring of LED strip inside a white reflector, under a grey cover, so what reaches the parts is bounced rather than aimed straight at them, and the camera looks straight down through the hole in the middle of the reflector.
+
+It replaces the [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and the [overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}), which were the previous side-light-plus-rod-arm arrangement and are retired.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-on-channel-w1600-8d957377d671.jpg" alt="A camera lamp on the machine: a grey disc-shaped lamp on an angled arm hanging over the open top of a C-channel, the white reflector lit inside it, with the black bulk bucket behind">
+  <figcaption>The finished thing, over a channel, lit. <cite>Photo: Spencer.</cite></figcaption>
+</figure>
+
+**The parts list above is one lamp's worth.** The catalog gives one to each of the four channels, so a machine takes four of everything on it: C1, C2 and C3 with the OV9732, and the classification channel with the [IMX415]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}) 4K module instead. Everything else is identical between the four.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>Whether C1 really takes a camera is an open question.</b> The parts list gives C1 a full lamp including an OV9732, but the software has no C1 camera role at all: the crop zones are the second channel, the third channel and the classification channel, and nothing reads vision off the bulk channel. The lamp itself is not in doubt on any channel. If you are buying rather than printing, the third OV9732 is the one to hold off on (raised by BrickCycleAlice, 2026-09-05, unanswered).</p>
+</div>
+
+{% include fastener-legend.html %}
+
+{% include step.html n="1" title="Preparation" %}
+
+**No heat inserts anywhere on this assembly.** Every screw is self-tapping into printed plastic. Measured across all seven printed parts, the holes come in exactly two sizes: 2.8 mm, which is the thread-forming pilot, and 3.5 mm, which is clearance for a screw on its way into one of those pilots. There is nothing in the 4.2 mm range an insert would need.
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Colours.</strong> The <strong>Lamp inner reflector</strong> and its six <strong>LED hooks</strong> print ivory white, and that is not cosmetic: they are the reflector. The <strong>Lamp outer cover</strong> is ash grey. The arm, the mount, both brackets, the ring and both clasp halves follow the channel colour like the rest of that channel's parts.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-side-full-2a681306f3a9.png" alt="CAD render of the camera lamp in profile: the disc-shaped lamp overhanging at the top, carried on an arm that steps down at an angle to the C-channel arm mount, with a bracket along each joint">
+    <figcaption>The whole thing in profile. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Print counts, if you are printing for the whole machine:</strong> 4 each of the mount, arm, bracket A, bracket B, ring, both clasp halves, reflector and cover, and <strong>24</strong> LED hooks, six per lamp. The hooks are the ones people come up short on.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <div class="img-placeholder">Image coming</div>
+  </figure>
+</div>
+
+{% include step.html n="2" title="Bracket the arm to the C-channel arm mount" %}
+
+The arm and the mount butt together end to end, and brackets A and B hold the joint, one on each face. Each bracket has four 3.5 mm clearance holes in a 4.5 mm plate, two over the mount and two over the arm.
+
+**The two brackets share their screw holes.** The mount and the arm each carry two 2.8 mm pilot holes that run 19.8 mm straight through the joint, so bracket A's screw enters one end and bracket B's the other, and eight screws go into four holes. Both pairs are 20 mm apart along the joint.
+
+Drive all 8 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, four per bracket, seated flush in the countersinks. A 12 mm countersunk leaves about 7.5 mm of thread inside a 19.8 mm hole, so two screws coming from opposite ends stop roughly 5 mm short of each other. Stop as soon as each head seats: you are cutting a thread in plastic, and the far half of the hole is somebody else's screw.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-mounted-wide-w1600-247fb837f4f8.jpg" alt="A wider view of a camera lamp on the machine, showing the full length of the arm from the lamp down to the C-channel, with a bracket screwed along the joint and the LED leads cable-tied along the arm">
+  <figcaption>The arm on the machine, bracket along the joint, leads running down it. <cite>Photo: Spencer.</cite></figcaption>
+</figure>
+
+{% include step.html n="3" title="Screw the camera lamp ring onto the arm" %}
+
+The ring goes on the far end of the arm and is what the lamp and the camera hang from. It works the same way as the joint below it: four 3.5 mm clearance holes in the ring, two 2.8 mm pilot holes through the end of the arm, so the remaining 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws go two per side into the same two holes. The ring straddles the arm.
+
+That is all 12 of the M3 × 12 in the parts list: 8 at the mount joint, 4 here.
+
+{% include step.html n="4" title="Clasp the camera between the two halves" %}
+
+The camera board is held between the **Camera clasp bottom** and the **Camera clasp top**, which are both 6 mm plates that meet face to face with the board between them.
+
+The two {% include fastener.html size="M3" variant="countersunk" length="8" %} screws go **up through the bottom half into the top half**: 3.5 mm clearance with a countersink on the underside of the bottom, 2.8 mm pilot 5 mm deep in the top. The two positions are on a diagonal, 43.2 mm apart.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><b>Two screws, not four.</b> The parts calculator lists 4 × M3 × 8 here and flags the count as unconfirmed. There are only two screw positions in either STL. An M3 × 8 countersunk gets about 2 mm of thread into the top half, which is not much, so do not overtighten and check the halves close flush on the board.</p>
+</div>
+
+The clasp is what carries the camera into the lamp: its two halves form a 4 mm spigot on the diagonal, which plugs into a 4.2 mm socket in the camera lamp ring. The ring has two of those sockets at the same radius; which one is intended, and whether the module is meant to come out again, is not recorded. <span class="fastener-todo">fastener not recorded</span>
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-camera-seated-w1600-eede61656118.jpg" alt="Looking down on the top of an assembled camera lamp: the grey cover with a circular opening at its centre, the camera board seated in the clasp inside it, its lead plugged in and running off to one side">
+  <figcaption>The camera sits at the centre of the lamp, looking straight down through the reflector. <cite>Photo: Spencer.</cite></figcaption>
+</figure>
+
+{% include step.html n="5" title="Hook the LED strip onto the reflector" %}
+
+Six **Inner reflector LED hooks** friction-fit into the rim of the **Lamp inner reflector**, evenly spaced 60° apart, one per 2.7 mm socket around its outside. Each hook retains the LED strip against the reflector. No screws.
+
+**Not recorded:** which LED strip, how much of it, how it is joined and how it is wired back to the board. None of that is in the catalog yet, and the strip is not a part in the machine's list. What the photograph shows is strip run in a ring around the inside of the reflector, retained by the hooks, with the leads coming out and down the arm.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-lit-from-below-w1600-bb9d54f4f43e.jpg" alt="The lamp lit, photographed from underneath: a ring of LED strip glowing around the outside of the white reflector, the reflector's central funnel in the middle, and the arm behind it">
+  <figcaption>Lit, from below. The strip rings the reflector and the light reaches the parts off the white. <cite>Photo: Spencer.</cite></figcaption>
+</figure>
+
+{% include step.html n="6" title="Cover the reflector" %}
+
+The **Lamp outer cover** friction-fits down over the reflector, and that is the whole joint: it has no screw hole anywhere in its geometry. The reflector is 150 mm across, the cover 153 mm, and the cover stands about 1.5 mm proud of the reflector at the top so the camera clasp sits recessed in the opening at its centre.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-underside-full-0e2b1e5a0fb9.png" alt="CAD render of the camera lamp seen from below: the inside of the cover with the reflector dome, the LED hooks spaced around the rim, the camera at the centre, and the arm reaching up into it">
+  <figcaption>From below, with the reflector inside the cover and the hooks around the rim. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
+</figure>
+
+{% include step.html n="7" title="Bring the three together" %}
+
+Plug the clasped camera into the ring, then set the lamp on top. **The lamp is not fastened to the arm at all.** It sits on it under its own weight, which is how it is recorded and how it comes apart again for a print change.
+
+Order matters here in one place only: the camera has to be in the clasp and the clasp in the ring before the cover goes over the top, because the cover closes around the clasp.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-top-full-edc4616e7088.png" alt="CAD render of the assembled camera lamp from above: the grey cover with the camera clasp and board in the central opening, a slot near the rim, and the arm coming in from the lower left">
+  <figcaption>Assembled, from above. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
+</figure>
+
+{% include step.html n="8" title="Mount the arm on the C-channel" %}
+
+**Not recorded, and not in the CAD either.** The C-channel arm mount carries exactly two holes, the pair the brackets use, and nothing that would fasten it to a channel, so how it is held there is a real gap rather than a missing sentence. The mount is 83 mm long and stands off the channel wall; the photographs show it against the outside of the channel with the arm rising over the rim. <span class="fastener-todo">fastener not recorded</span>
+
+Write down what you did, and where the lamp ended up relative to the channel: height and overhang both change what the camera sees, and the [camera calibration]({{ '/sorter/camera-calibration/' | relative_url }}) step afterwards is software, not a way to fix a lamp in the wrong place.
+
+Wiring, for both the LED strip and the camera, is on the [electronics]({{ '/hardware/electronics/' | relative_url }}) page. Build the other three lamps the same way, and see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for how the channels themselves sit together.

--- a/docs/src/content/hardware/assembly/feeder/camera-lamp.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-lamp.md
@@ -14,8 +14,9 @@ warning: >-
   **AI-generated first draft, and the order of operations is a guess.** The parts, the
   joints and Spencer's photographs are real, from the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=camera-lamp); every
-  hole diameter and screw count below is measured off the published STLs. What is missing is
-  a build: nobody has written down how the arm mount attaches to the C-channel, which LED
+  hole diameter and screw count below is measured off the published STLs, and the 12 screws
+  into 6 holes in Steps 2 and 3 are confirmed by ReveryX, who has the parts. What is missing
+  is a build: nobody has written down how the arm mount attaches to the C-channel, which LED
   strip goes on the hooks, or how any of it is wired. Fill those in as you build.
 parts_needed:
   - part: c-channel-arm-mount
@@ -114,7 +115,7 @@ Drive all 8 {% include fastener.html size="M3" variant="countersunk" length="12"
 
 The ring goes on the far end of the arm and is what the lamp and the camera hang from. It works the same way as the joint below it: four 3.5 mm clearance holes in the ring, two 2.8 mm pilot holes through the end of the arm, so the remaining 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws go two per side into the same two holes. The ring straddles the arm.
 
-That is all 12 of the M3 × 12 in the parts list: 8 at the mount joint, 4 here.
+That is all 12 of the M3 × 12 in the parts list: 8 at the mount joint, 4 here. **Six holes, a screw into each end of every one of them.** ReveryX confirmed that count against the parts on 2026-09-05; everything else about these two steps is off the STLs.
 
 {% include step.html n="4" title="Clasp the camera between the two halves" %}
 

--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -30,6 +30,11 @@ parts_needed:
     qty: 3
 ---
 
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">&#9888;</span>
+  <p><b>This part is retired.</b> It was replaced on 2026-09-02 by the <a href="{{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}">camera lamp</a>, one per channel, which carries both the light and the camera. This page is kept for machines already built this way. Do not print or buy these parts for a new build.</p>
+</div>
+
 <div class="prep-item">
   <div class="prep-item-body">
     <p><strong>Build a <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">C-channel</a> before you start.</strong> It's a required component of this page, not optional or covered here — Step 2 clamps the rod mounts onto one, it doesn't build one.</p>

--- a/docs/src/content/hardware/assembly/feeder/index.md
+++ b/docs/src/content/hardware/assembly/feeder/index.md
@@ -13,11 +13,12 @@ author: spencer
 The feeder takes unsorted parts from the bulk input and, through four C-channel stages, spaces them out one at a time and carries each through the classification chamber before it drops to the distribution system below. Each channel meters parts by rotation; only after a part is imaged in the classification chamber does the software know where it should go next. Build the pages below roughly in order: the C-channel itself (built four times), then what mounts on it, then how the four are arranged and heighted relative to one another.
 
 1. **[C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }})**, the C-channel stage itself. Build four.
-2. **[Classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }})**, where parts are imaged for classification.
-3. **[Light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }})**, the side light on C2 and C3.
-4. **[Overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }})**, the rod arm that hangs a detection camera over a channel.
-5. **[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }})**, the bucket and cap that feed C1.
-6. **[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }})**, the handovers between channels.
-7. **[Arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }})**, the stand, the heights, and how the four sit together.
+2. **[Camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }})**, the arm, light and camera over a channel. One per channel.
+3. **[Classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }})**, where parts are imaged for classification.
+4. **[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }})**, the bucket and cap that feed C1.
+5. **[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }})**, the handovers between channels.
+6. **[Arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }})**, the stand, the heights, and how the four sit together.
 
 Everything after the C-channel page is an AI-generated first draft: the parts are recorded, the steps and the photographs are not. Each page says at the top what is missing from it.
+
+Two pages are kept for machines already built to the older arrangement and are not part of the build above: the **[light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }})** and the **[overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }})**, both replaced by the camera lamp on 2026-09-02.

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -29,6 +29,11 @@ parts_needed:
     qty: 2
 ---
 
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">&#9888;</span>
+  <p><b>This part is retired.</b> It was replaced on 2026-09-02 by the <a href="{{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}">camera lamp</a>, one per channel, which carries both the light and the camera. This page is kept for machines already built this way. Do not print or buy these parts for a new build.</p>
+</div>
+
 <div class="prep-item">
   <div class="prep-item-body">
     <p><strong>Build a <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">C-channel</a> before you start.</strong> It's a required component of this page, not optional or covered here — Step 4 bolts the post onto one's NEMA bracket, it doesn't build one.</p>

--- a/docs/src/liquid/_data/authors.yml
+++ b/docs/src/liquid/_data/authors.yml
@@ -36,3 +36,6 @@ jgadling:
 
 alex:
   name: alex
+
+reveryx:
+  name: ReveryX

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -56,11 +56,13 @@ sections:
             children:
               - title: C-channel
                 url: /hardware/assembly/feeder/c-channel/
+              - title: Camera lamp
+                url: /hardware/assembly/feeder/camera-lamp/
               - title: Classification chamber
                 url: /hardware/assembly/feeder/classification-chamber/
-              - title: Light post
+              - title: Light post (retired)
                 url: /hardware/assembly/feeder/light-post/
-              - title: Overhead camera mount
+              - title: Overhead camera mount (retired)
                 url: /hardware/assembly/feeder/camera-mount/
               - title: Bulk input
                 url: /hardware/assembly/feeder/bulk-input/

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -368,6 +368,21 @@
           "servo-adapter"
         ]
       }
+    },
+    {
+      "id": "camera-clasp-screw-count",
+      "name": "Adapted camera module: the clasp takes 2 screws, not 4",
+      "priority": "P3",
+      "description": "The Adapted camera module lists 4x M3 x 8 countersunk and marks the count as not confirmed at the bench. The published STLs have only two screw positions: the Camera clasp bottom has two 3.50 mm clearance holes with a countersink on its underside, the Camera clasp top has the two matching 2.80 mm self-tapping pilots 5.00 mm deep, and the pair sits on the diagonal 43.2 mm apart. There is no third or fourth hole in either half. Changing the line is an assembly revision and has to be stamped as a new version, so the count is left as authored until somebody does that with a build in front of them. Note also that an M3 x 8 countersunk only reaches about 2 mm into the top half through the 6 mm bottom half, so the length is worth checking at the same time. Measured 2026-09-05 while writing the camera lamp assembly docs page.",
+      "targets": {
+        "assemblies": [
+          "adapted-camera-module"
+        ],
+        "parts": [
+          "camera-clasp-top",
+          "camera-clasp-bottom"
+        ]
+      }
     }
   ],
   "folders": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -382,6 +382,21 @@
 					"servo-adapter"
 				]
 			}
+		},
+		{
+			"id": "camera-clasp-screw-count",
+			"name": "Adapted camera module: the clasp takes 2 screws, not 4",
+			"priority": "P3",
+			"description": "The Adapted camera module lists 4x M3 x 8 countersunk and marks the count as not confirmed at the bench. The published STLs have only two screw positions: the Camera clasp bottom has two 3.50 mm clearance holes with a countersink on its underside, the Camera clasp top has the two matching 2.80 mm self-tapping pilots 5.00 mm deep, and the pair sits on the diagonal 43.2 mm apart. There is no third or fourth hole in either half. Changing the line is an assembly revision and has to be stamped as a new version, so the count is left as authored until somebody does that with a build in front of them. Note also that an M3 x 8 countersunk only reaches about 2 mm into the top half through the 6 mm bottom half, so the length is worth checking at the same time. Measured 2026-09-05 while writing the camera lamp assembly docs page.",
+			"targets": {
+				"assemblies": [
+					"adapted-camera-module"
+				],
+				"parts": [
+					"camera-clasp-top",
+					"camera-clasp-bottom"
+				]
+			}
 		}
 	],
 	"folders": [


### PR DESCRIPTION
Adds the camera lamp to the assembly docs. ReveryX asked for it in `#c-channels` after barthel pointed out that the lamp's assembly only existed in the parts calculator.

**New page:** `/hardware/assembly/feeder/camera-lamp/`, the arm, the shaded lamp and the camera that hang over a C-channel. Written from the [catalog's assembly tree](https://parts-calculator.basically.website/assembly?focus=camera-lamp), Spencer's photographs (from the `camera-lamp` catalog entry, re-uploaded to `sorter-docs` with their EXIF rotation baked in so they are not sideways on the page), and measurements taken off the published STLs.

### What the STLs settle

- **The 12 M3 × 12 go into 6 holes.** The C-channel arm mount and the arm each carry Ø2.8 mm pilot holes running 19.8 mm straight through the joint; brackets A and B sit on opposite faces (Ø3.5 mm clearance in a 4.5 mm plate) and screw into the same hole from either end. The camera lamp ring does the same at the far end: 4 screws, 2 holes. A 12 mm countersunk leaves ~7.5 mm of thread in a 19.8 mm hole, so two screws nose to nose still have ~5 mm between them.
- **No heat inserts anywhere.** Every hole across the seven printed parts is Ø2.8 (self-tap) or Ø3.5 (clearance). Nothing in the 4.2 mm range an insert would need.
- **The camera clasp has two screw positions, not four**, 43.2 mm apart on the diagonal: Ø3.5 clearance with a countersink on the underside of the bottom half, Ø2.8 × 5 mm pilots in the top. The catalog lists 4 × M3 × 8 and already flags the count as unconfirmed at the bench.
- **How the arm mount attaches to the C-channel is not in the CAD.** The mount has exactly two holes and both belong to the brackets. The page marks it not recorded rather than inventing a fixing.
- The reflector is 150 mm across and the cover 153 mm, friction fit, no fastener anywhere in the cover's geometry; the six LED hooks friction-fit into Ø2.7 sockets 60° apart around the reflector's rim.

### The clasp screw count

Recorded as a **P3 in `changes`** (`camera-clasp-screw-count`) rather than edited in place. Changing an assembly's `lines` is a revision that has to be stamped as a new version per `VERSIONING.md`, and that is a call for somebody with a build in front of them, not something to fold into a docs PR. The docs page states the measurement and the discrepancy in a callout. `catalog.generated.json` regenerated with `generate.py --metadata-only` in the same commit.

### The two retired pages

The light post and the overhead camera mount were retired by #534 on 2026-09-02. Both now open with a callout saying so and pointing here, both are labelled `(retired)` in the sidebar, and they come out of the feeder build order (kept for machines already built that way). C-channel step 6 points at the camera lamp instead of the light post, and its "two of the four channels carry a light post" bullet becomes the camera lamp.

### Open, and deliberately left open on the page

- **Whether C1 takes a camera.** The catalog gives all four channels a full lamp, the software has no C1 camera role, and BrickCycleAlice asked Spencer to double-check on 2026-09-05. The page carries that as a warning callout so nobody buys a third OV9732 on the strength of a docs page.
- **The LED strip.** Which strip, how much, how it is joined and how it is wired are not catalog lines yet. Said so rather than guessed.
- **The order of operations.** Nobody has built one from instructions; the warning at the top says so.

Sources: #534 (the C-channel overhaul), `parts-calculator/catalog/parts.json`, and the STLs at `assets.basically.website/sorter-parts/`.

### Builder confirmation

ReveryX, who has the parts, confirmed the Step 2 / Step 3 arrangement: six pilot holes, a screw driven into each end of every one, twelve M3 × 12 in total. That count was measured off the STLs when the page was written and is now checked against real parts, so the page says so and the top warning no longer claims every count is geometry only (`f817f5f`).

barthel asked for the sizes to be checked so nothing is left as an undefined screw. Every screw on the page carries a size already; `3eb7528` records why each is the length it is:

- **M3 × 12** at both joints. 4.5 mm of bracket leaves 7.5 mm of thread in the 19.8 mm hole, and because a screw enters from each end, a 16 would put 23 mm of screw into a 19.8 mm hole and the two would meet before either seated. ReveryX confirmed the 12 on an arm he assembled.
- **M3 × 8** at the camera clasp is the one length nobody has checked against a build: through the 6 mm bottom half it reaches about 2 mm into the top half's 5 mm pilot, where an M3 × 10 would give 4 mm and still stop 2 mm short of the top face. The callout says so rather than quietly changing the authored part.

The two `fastener not recorded` marks left on the page are not screws: the clasp-to-ring joint is a spigot in a socket, and the arm mount has no fastener to the C-channel anywhere in its geometry.

### Where the images are served from

barthel asked for the lamp's photos to live with the documentation rather than the parts calculator. Every image on the page now comes from the `sorter-docs` namespace: the four photographs were re-uploaded when the page was written (with their EXIF rotation baked into the pixels, since the derived rungs drop the flag and they render sideways otherwise), and the three renders followed in `e8ae887`. So the page does not depend on the `camera-lamp` catalog entry keeping its `images`.

Nothing is removed from the calculator in this PR. Spencer added those seven images to the assembly three days ago in #534 and people are using that page to see the build, so whether the entry keeps them is his call rather than something to fold into a docs change.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1460692585881534579/1545741984172605571
request: https://discord.com/channels/1430279849171222682/1460692585881534579/1545728036672905216
request: https://discord.com/channels/1430279849171222682/1545741984172605571/1545743151669715141
request: https://discord.com/channels/1430279849171222682/1545741984172605571/1545745184028098650
request: https://discord.com/channels/1430279849171222682/1545741984172605571/1545746273456619571
preview: /hardware/assembly/feeder/camera-lamp/
-->



