### PR TITLE
docs: add an Install the bins page

### DIFF
--- a/docs/src/content/hardware/assembly/index.md
+++ b/docs/src/content/hardware/assembly/index.md
@@ -19,4 +19,5 @@ A few names recur across these sections and are worth fixing here, once: the fee
 1. **[Distribution]({{ '/hardware/assembly/distribution/' | relative_url }})** — bin frame, top interface, and chute. The interface layer is built as part of distribution.
 2. **[Feeder]({{ '/hardware/assembly/feeder/' | relative_url }})** — the C-channel stages that meter parts in.
 3. **[Electronics]({{ '/hardware/electronics/' | relative_url }})** — boards, wiring, and steppers.
-4. **[Software setup]({{ '/hardware/assembly/software-setup/' | relative_url }})** — flash and configure. Hands off to the [Sorter]({{ '/sorter/' | relative_url }}) section.
+4. **[Install the bins]({{ '/hardware/assembly/install-bins/' | relative_url }})** — printed or laser cut, dropped into the finished tower.
+5. **[Software setup]({{ '/hardware/assembly/software-setup/' | relative_url }})** — flash and configure. Hands off to the [Sorter]({{ '/sorter/' | relative_url }}) section.

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -28,7 +28,7 @@ parts_needed:
 
 Bins go in last, once the tower is standing, the chutes are in and the feeder is on. Nothing here is fastened: each bin drops into its bay and is held by the [bin retainers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) that are already bolted to the frame.
 
-The list above is per layer, and a layer takes **one** of the two sets, not both. Which one is decided by that layer's funnel, in step 1.
+The list above is per layer, and a layer takes **one** of the two sets, not both. Which set depends on the size you chose for that layer, which is step 1.
 
 <div class="img-row">
   <figure>
@@ -41,14 +41,16 @@ The list above is per layer, and a layer takes **one** of the two sets, not both
   </figure>
 </div>
 
-{% include step.html n="1" title="Match the bin size to the layer's funnel" %}
+{% include step.html n="1" title="Check which set each layer takes" %}
 
-The funnel and the bin set are a matched pair, chosen per layer rather than once for the whole machine, so a five layer machine can mix them. See [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}), which is where the choice is made before printing.
+You made this choice per layer when you printed the funnels: each layer is either half size or third size, a machine can mix them, and the funnel and the bin set are a matched pair. So a layer takes whichever set matches the funnel already on it.
 
-- **Funnel (half size)** → **12 bins** on that layer: 6 Bin (half, left) and 6 Bin (half, right).
-- **Funnel (third size)** → **18 bins** on that layer: 6 each of Bin (third, left), Bin (third, center) and Bin (third, right-back).
+- **A half-size layer** takes **12 bins**: 6 Bin (half, left) and 6 Bin (half, right).
+- **A third-size layer** takes **18 bins**: 6 each of Bin (third, left), Bin (third, center) and Bin (third, right-back).
 
-Either way it is one set per bay, six bays around the hexagon. A layer built with third bins gives you more, smaller destinations; the tradeoff is that the funnel opening is smaller too, which limits the size of piece that layer can take.
+Either way it is one set per bay, six bays around the hexagon.
+
+Changing a layer's mind at this point means a new funnel as well as new bins, so it is worth knowing what the choice was about: 12 wider bins against 18 narrower ones, and the funnel mouth is what limits the piece size that layer can take. The full comparison, and what to pick if you are still deciding, is on [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
 
 {% include step.html n="2" title="Get the bins: print them or cut them" %}
 

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: Install the bins
+type: how-to
+section: hardware
+slug: assembly-install-bins
+kicker: Assembly — Install the bins
+lede: The bins that catch what the chutes drop, and the two ways to get them.
+permalink: /hardware/assembly/install-bins/
+author: spencer
+contributors: [brickcyclealice]
+warning: >-
+  **AI-generated first draft.** Written from the parts catalog, the bin generator and
+  what builders have posted, not from an actual build. No step here has been checked
+  against a machine. Correct it as you build.
+parts_needed:
+  - part: bin-half-left
+    qty: 6
+  - part: bin-half-right
+    qty: 6
+  - part: bin-third-left
+    qty: 6
+  - part: bin-third-center
+    qty: 6
+  - part: bin-third-rightback
+    qty: 6
+---
+
+Bins go in last, once the tower is standing, the chutes are in and the feeder is on. Nothing here is fastened: each bin drops into its bay and is held by the [bin retainers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}) that are already bolted to the frame.
+
+The list above is per layer, and a layer takes **one** of the two sets, not both. Which one is decided by that layer's funnel, in step 1.
+
+<div class="img-placeholder">A finished machine with all bins installed.</div>
+
+{% include step.html n="1" title="Match the bin size to the layer's funnel" %}
+
+The funnel and the bin set are a matched pair, chosen per layer rather than once for the whole machine, so a five layer machine can mix them. See [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}), which is where the choice is made before printing.
+
+- **Funnel (half size)** → **12 bins** on that layer: 6 Bin (half, left) and 6 Bin (half, right).
+- **Funnel (third size)** → **18 bins** on that layer: 6 each of Bin (third, left), Bin (third, center) and Bin (third, right-back).
+
+Either way it is one set per bay, six bays around the hexagon. A layer built with third bins gives you more, smaller destinations; the tradeoff is that the funnel opening is smaller too, which limits the size of piece that layer can take.
+
+{% include step.html n="2" title="Get the bins: print them or cut them" %}
+
+Both are real options and the machine holds them identically. Printed bins are in the parts catalog and need nothing but a printer and time; cut bins are cardboard, need a laser, and are what Spencer runs.
+
+**Printed.** The five parts above, on the [parts calculator](https://parts-calculator.basically.website/), STLs and all. Budget for them: a half set is about 2.1 kg of filament and 55 hours of printing per layer, a third set about 2.1 kg and 60 hours, so a five layer machine is roughly 10 kg and ten days of printer time in bins alone. That is the single biggest print on the machine.
+
+**Laser cut cardboard.** The bins were designed to be cut flat and folded, for cost and because pre-made boxes in the sizes needed ship mostly air. Cut them with [the bin generator](https://bin-gen.basically.website/), which turns a bin into a foldable flat pattern for LightBurn:
+
+- It ships **built-in bins**, so you do not need a CAD file to use it. Drag in your own `.step` only if you have modified a bin.
+- Set **thickness** to your stock. 1/8 inch cardboard is 3.175 mm, which is the default.
+- Leave **kerf compensation** on, so the finger joints come out the size they were drawn.
+- The pattern comes out in three line colours, and the order you cut them in matters: **green first, then blue, then red**. Green is the fold score and only goes through the first outside wall of the corrugation, so it has to be cut while the sheet is still whole, and the green side has to be face up. Blue perforations and red outlines are both full through cuts.
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Glue the corners of a cardboard bin. The folded finger joints on their own do not hold in corrugated stock: most of the volume is air, so a finger usually lands on two paper walls with nothing between them. Hot glue is what Spencer uses.</p>
+</div>
+
+{% include step.html n="3" title="Drop them in" %}
+
+Work around one layer at a time. Each bin sits in its bay with the wide open mouth facing outward and the narrow end toward the middle of the machine, resting on the frame, with its front edge behind the Bin retainer (left) and Bin retainer (right) on the front face of that bay's A/G extrusion. The retainers bolt to the frame and not to the bin, which is why cardboard and printed bins are held the same way and why swapping one for the other later costs nothing.
+
+If the retainers are not on the frame yet, they go on first: 6 of each per layer, 2 {% include fastener.html size="M5" variant="socket-button" length="16" %} each, into T-nuts the hex frame already carries. That step is on [Regular layers]({{ '/hardware/assembly/distribution/bin-frame/regular-layers/' | relative_url }}).
+
+{% include step.html n="4" title="Check the funnel clears every bin" %}
+
+The funnel lands right at the bin entrances by design, so there is very little gap for a piece to escape through, and very little room for a bin that is sitting proud of its bay. Before running the machine, turn the chute stack by hand through a full revolution and watch that nothing touches. A bin that is not pushed fully back is the one the funnel will hit.
+
+With the bins in, the hardware is finished. Continue to [Software setup]({{ '/hardware/assembly/software-setup/' | relative_url }}), which is where the machine is told how many bins each layer has and where they are.

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -36,8 +36,8 @@ The list above is per layer, and a layer takes **one** of the two sets, not both
     <figcaption>Printed bins, two layers of a tower. <cite>Photo: Daddy-O's Bricks - Bill.</cite></figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/install-bins-cardboard-bins-machine-full-2d117575836e.jpg" alt="A whole machine on castors, five layers of folded cardboard bins in the tower with sorted LEGO in them">
-    <figcaption>Laser cut cardboard bins, five layers of a machine. <cite>Photo: Basically.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/install-bins-cardboard-bins-tower-full-97d68e720775.jpg" alt="A bin tower on castors under its plywood deck, five layers of folded cardboard bins with sorted LEGO in them">
+    <figcaption>Laser cut cardboard bins, five layers of a tower. <cite>Photo: Basically.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -36,8 +36,8 @@ The list above is per layer, and a layer takes **one** of the two sets, not both
     <figcaption>Printed bins, two layers of a tower. <cite>Photo: Daddy-O's Bricks - Bill.</cite></figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/install-bins-cardboard-bins-in-frame-w1600-e85d2a93cc70.jpg" alt="A layer seen from floor level, filled with folded cardboard bins radiating out from the chute in the middle">
-    <figcaption>Laser cut cardboard bins, one layer. Photographed on an early build, so the frame around them is an older revision. <cite>Photo: Spencer.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/install-bins-cardboard-bins-machine-full-2d117575836e.jpg" alt="A whole machine on castors, five layers of folded cardboard bins in the tower with sorted LEGO in them">
+    <figcaption>Laser cut cardboard bins, five layers of a machine. <cite>Photo: Basically.</cite></figcaption>
   </figure>
 </div>
 
@@ -71,6 +71,11 @@ Both are real options and the machine holds them identically. Printed bins are i
 </div>
 
 {% include step.html n="3" title="Drop them in" %}
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/install-bins-cardboard-bins-in-frame-w1600-e85d2a93cc70.jpg" alt="A layer seen from floor level, filled with folded cardboard bins radiating out from the chute in the middle">
+  <figcaption>A finished layer, seen from below. Photographed on an early build, so the frame around the bins is an older revision. <cite>Photo: Spencer.</cite></figcaption>
+</figure>
 
 Work around one layer at a time. Each bin sits in its bay with the wide open mouth facing outward and the narrow end toward the middle of the machine, resting on the frame, with its front edge behind the Bin retainer (left) and Bin retainer (right) on the front face of that bay's A/G extrusion. The retainers bolt to the frame and not to the bin, which is why cardboard and printed bins are held the same way and why swapping one for the other later costs nothing.
 

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -43,7 +43,7 @@ Either way it is one set per bay, six bays around the hexagon. A layer built wit
 
 {% include step.html n="2" title="Get the bins: print them or cut them" %}
 
-Both are real options and the machine holds them identically. Printed bins are in the parts catalog and need nothing but a printer and time; cut bins are cardboard, need a laser, and are what Spencer runs.
+Both are real options and the machine holds them identically. Printed bins are in the parts catalog and need nothing but a printer and time; cut bins are cardboard, need a laser, and are what the machine was designed around.
 
 **Printed.** The five parts above, on the [parts calculator](https://parts-calculator.basically.website/), STLs and all. Budget for them: a half set is about 2.1 kg of filament and 55 hours of printing per layer, a third set about 2.1 kg and 60 hours, so a five layer machine is roughly 10 kg and ten days of printer time in bins alone. That is the single biggest print on the machine.
 
@@ -56,7 +56,7 @@ Both are real options and the machine holds them identically. Printed bins are i
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Glue the corners of a cardboard bin. The folded finger joints on their own do not hold in corrugated stock: most of the volume is air, so a finger usually lands on two paper walls with nothing between them. Hot glue is what Spencer uses.</p>
+  <p>Glue the corners of a cardboard bin. The folded finger joints on their own do not hold in corrugated stock: most of the volume is air, so a finger usually lands on two paper walls with nothing between them. Hot glue is what the bins at Basically are held together with.</p>
 </div>
 
 {% include step.html n="3" title="Drop them in" %}

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -50,7 +50,7 @@ You made this choice per layer when you printed the funnels: each layer is eithe
 
 Either way it is one set per bay, six bays around the hexagon.
 
-Changing a layer's mind at this point means a new funnel as well as new bins, so it is worth knowing what the choice was about: 12 wider bins against 18 narrower ones, and the funnel mouth is what limits the piece size that layer can take. The full comparison, and what to pick if you are still deciding, is on [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
+Switching a layer to the other size at this point means printing a new funnel as well as new bins, so it is worth knowing what the choice was about: 12 wider bins against 18 narrower ones, and the funnel mouth is what limits the piece size that layer can take. The full comparison, and what to pick if you are still deciding, is on [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
 
 {% include step.html n="2" title="Get the bins: print them or cut them" %}
 

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -47,7 +47,7 @@ Both are real options and the machine holds them identically. Printed bins are i
 
 **Printed.** The five parts above, on the [parts calculator](https://parts-calculator.basically.website/), STLs and all. Budget for them: a half set is about 2.1 kg of filament and 55 hours of printing per layer, a third set about 2.1 kg and 60 hours, so a five layer machine is roughly 10 kg and ten days of printer time in bins alone. That is the single biggest print on the machine.
 
-**Laser cut cardboard.** The bins were designed to be cut flat and folded, for cost and because pre-made boxes in the sizes needed ship mostly air. Cut them with [the bin generator](https://bin-gen.basically.website/), which turns a bin into a foldable flat pattern for LightBurn:
+**Laser cut cardboard.** The bins were designed to be cut flat and folded, for cost and because pre-made boxes in the sizes needed ship mostly air. Cut them with the [laser cut bin generator](https://bin-gen.basically.website/), which turns a bin into a foldable flat pattern for LightBurn:
 
 - It ships **built-in bins**, so you do not need a CAD file to use it. Drag in your own `.step` only if you have modified a bin.
 - Set **thickness** to your stock. 1/8 inch cardboard is 3.175 mm, which is the default.

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -8,7 +8,7 @@ kicker: Assembly — Install the bins
 lede: The bins that catch what the chutes drop, and the two ways to get them.
 permalink: /hardware/assembly/install-bins/
 author: spencer
-contributors: [brickcyclealice]
+contributors: [brickcyclealice, daddyosbricksbill]
 warning: >-
   **AI-generated first draft.** Written from the parts catalog, the bin generator and
   what builders have posted, not from an actual build. No step here has been checked
@@ -30,7 +30,16 @@ Bins go in last, once the tower is standing, the chutes are in and the feeder is
 
 The list above is per layer, and a layer takes **one** of the two sets, not both. Which one is decided by that layer's funnel, in step 1.
 
-<div class="img-placeholder">A finished machine with all bins installed.</div>
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/install-bins-printed-bins-in-frame-full-8c3d3cc8736c.jpg" alt="Two layers of a bin tower filled with blue 3D printed bins, each sitting behind the black retainer rail on the front of the frame">
+    <figcaption>Printed bins, two layers of a tower. <cite>Photo: Daddy-O's Bricks - Bill.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/install-bins-cardboard-bins-in-frame-w1600-e85d2a93cc70.jpg" alt="A layer seen from floor level, filled with folded cardboard bins radiating out from the chute in the middle">
+    <figcaption>Laser cut cardboard bins, one layer. Photographed on an early build, so the frame around them is an older revision. <cite>Photo: Spencer.</cite></figcaption>
+  </figure>
+</div>
 
 {% include step.html n="1" title="Match the bin size to the layer's funnel" %}
 

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -45,12 +45,14 @@ The list above is per layer, and a layer takes **one** of the two sets, not both
 
 You made this choice per layer when you printed the funnels: each layer is either half size or third size, a machine can mix them, and the funnel and the bin set are a matched pair. So a layer takes whichever set matches the funnel already on it.
 
-- **A half-size layer** takes **12 bins**: 6 Bin (half, left) and 6 Bin (half, right).
-- **A third-size layer** takes **18 bins**: 6 each of Bin (third, left), Bin (third, center) and Bin (third, right-back).
+- **A half-size layer** takes **12 bins**: 6 Bin (half, left) and 6 Bin (half, right). Its funnel mouth is the wider of the two, so this is the layer that takes the biggest pieces the machine can sort. The cost is twelve destinations rather than eighteen.
+- **A third-size layer** takes **18 bins**: 6 each of Bin (third, left), Bin (third, center) and Bin (third, right-back). Half again as many destinations, which is what the small parts that make up most of a pile need. The cost is a narrower mouth, and the mouth is what limits the piece size that layer can take.
 
-Either way it is one set per bay, six bays around the hexagon.
+Either way it is one set per bay, six bays around the hexagon, and the two work out about the same to print.
 
-Switching a layer to the other size at this point means printing a new funnel as well as new bins, so it is worth knowing what the choice was about: 12 wider bins against 18 narrower ones, and the funnel mouth is what limits the piece size that layer can take. The full comparison, and what to pick if you are still deciding, is on [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
+**If you are still deciding:** two third-size layers and one half-size is what the [parts calculator](https://parts-calculator.basically.website/) starts a fresh machine at, and it is a sensible default. Most LEGO is small, so most of your destinations should be, but you want at least one layer that can take the big pieces. Nothing ties a size to a particular height, so which level carries the half-size layer is yours to choose.
+
+Switching a layer to the other size at this point means printing a new funnel as well as new bins. [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}) is where that choice is made, and has the same comparison in full.
 
 {% include step.html n="2" title="Get the bins: print them or cut them" %}
 

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -68,6 +68,8 @@ sections:
                 url: /hardware/assembly/feeder/output-guides/
               - title: Arranging C-channels
                 url: /hardware/assembly/feeder/arranging-c-channels/
+          - title: Install the bins
+            url: /hardware/assembly/install-bins/
           - title: Software setup
             url: /hardware/assembly/software-setup/
       - title: Electronics


### PR DESCRIPTION
Adds `/hardware/assembly/install-bins/`, the last assembly step before software setup, asked for by BrickCycleAlice in [#balloon-does-docs](https://discord.com/channels/1430279849171222682/1536088194557419660/1545748719784427580).

**What the page covers**

1. Match the bin size to that layer's funnel (half → 12 bins, third → 18), which is the choice the [funnel page](https://docs.basically.website/hardware/assembly/distribution/chute/funnel/) already makes before printing.
2. Get the bins, printed or laser cut, both given equal space.
3. Drop them in behind the bin retainers, which bolt to the frame and not to the bin, so either kind is held the same way.
4. Turn the chute through a revolution by hand and check the funnel clears every bin.

**Sources**

- Bin sets and quantities: `parts-calculator/catalog/parts.json` (`bin-half-*`, `bin-third-*`, 6 per layer of each, marked optional).
- Print cost: the catalog's own sliced numbers. Half set 12 × 171.5 g / 4.6 h; third set 6 × (121.8 + 112.2 + 121.7 g) and 6 × (3.4 + 3.2 + 3.4 h). Both land near 2.1 kg and 55 to 60 hours a layer.
- Cardboard bins are the design intent for cost and shipping (design proposal meeting, 2025-11-11), and the current tool is [bin-gen.basically.website](https://bin-gen.basically.website/), which `parts-calculator/src/routes/lasercut/+page.svelte` already links as the Laser Cut Bin Generator. Settings named on the page were read off the live tool.
- Cut order (green score, then blue perforations, then red outlines, green side face up) and the hot glue note: [spencerhubert in #distribution](https://discord.com/channels/1430279849171222682/1437144782819426537/1514123416402264199).
- Retainers, 6 of each per layer and 2 × M5 × 16 each: [Regular layers](https://docs.basically.website/hardware/assembly/distribution/bin-frame/regular-layers/).
- "The funnel lands right at the bin entrances": daddyosbricksbill, #distribution, 2026-09-02.

**Update**

BrickCycleAlice asked that the docs not refer to Spencer by name, so both prose mentions on this page are gone: "what Spencer runs" is now "what the machine was designed around", and "hot glue is what Spencer uses" is now "hot glue is what the bins at Basically are held together with". The photo credit lines and `author:` bylines elsewhere on the site are attribution, required by `docs/AGENTS.md` and checked by `validate_credits.py`, and are untouched here.

**Photos**

barthel asked for one machine with printed bins and one with cut bins in place of the placeholder, and both are in now, uploaded to the asset service and credited:

- **Printed:** a crop of daddyosbricksbill's tower photo (2026-09-02), taken from the part of the frame his red annotation does not cover. The marks themselves are opaque where they cross the bins and cannot be removed.
- **Cut:** a whole machine with five layers of cardboard bins in it, cropped from the V2 video thumbnail on `basically.website/sorter-v2`, which BrickCycleAlice pointed at. Cropped below the plywood deck at her request: the head above it on that machine is the superseded carousel classification, so the figure stops at the deck underside. That replaced the January 2026 layer photo I had first, which was the only cut-bin photo still resolving in the Discord archive; it now sits in step 3 instead, where a layer seen from below is what the step is about, with its early-build caveat in the caption.

Marked as an AI first draft, like the other pages written from the catalog rather than from a build.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545748719784427580
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545763065939894292
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545763342424084560
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545763827411460146
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545765809706631238
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545766760094113812
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545774550384513114
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545774963225661441
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545775576646946846
preview: /hardware/assembly/install-bins/
-->








