### PR TITLE
docs: stop naming Spencer in body copy

### DIFF
--- a/docs/src/content/getting-started.md
+++ b/docs/src/content/getting-started.md
@@ -46,7 +46,7 @@ Python 3.12+, Node.js 20+, pnpm. The install script handles dependencies on Debi
 
 ## Pick a contribution track
 
-- **Mechanical / CAD** — The project uses [Onshape](https://www.onshape.com/) (free, web-based, collaborative). DM Spencer your email for document access. Start by browsing the V2 CAD and checking open bounties for mechanical tasks.
+- **Mechanical / CAD** — The project uses [Onshape](https://www.onshape.com/) (free, web-based, collaborative). Every V2 document is public and listed in the repo's `mechanical/README.md`; the folder holding them is private, so ask in the [Discord](https://discord.gg/6PZtqkwtaS) to be added to it. Start by browsing the V2 CAD and checking open bounties for mechanical tasks.
 - **Electronics** — PCB schematics are in KiCad. Active work on feeder and distribution board reviews. Background in EE or PCB layout is valuable.
 - **Software** — Python backend + SvelteKit frontend. See the [Sorter install guide]({{ '/sorter/installation/' | relative_url }}).
 - **ML / Vision** — Classification research, training data collection, model optimization. See [Classification research]({{ '/lab/classification-research/' | relative_url }}) and [Object detection research]({{ '/lab/object-detection/' | relative_url }}).
@@ -67,5 +67,5 @@ Python 3.12+, Node.js 20+, pnpm. The install script handles dependencies on Debi
 - **Contributions** go through pull requests on GitHub. Branch protection is enabled on main.
 - **Bounties** are posted on the Discord bounty board for discrete, high-priority tasks. Claim one if you can deliver within the posted timeline.
 - **Communication** happens on Discord. Engineering sync calls happen periodically and are recorded for async viewing.
-- **CAD collaboration** uses Onshape shared documents. Request access by DMing Spencer your Onshape email.
+- **CAD collaboration** uses Onshape shared documents. The individual documents are public; for the shared folder, ask in the Discord with your Onshape email.
 - **Design reviews** are scheduled for electronics and mechanical changes before merging.

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -16,7 +16,7 @@ Wire IDs match the schedule tables. Open items are in section 7.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>These electronics pages are working notes right now, not finished documentation.</b> The harness is actively being specced, so parts of this change week to week and some of it contradicts what a machine already built looks like. Anything still undecided is written down as an open item in section 7 rather than smoothed over. Started from what Spencer had on July 12th 2026; treat it as the current thinking, not the final state.</p>
+  <p><b>These electronics pages are working notes right now, not finished documentation.</b> The harness is actively being specced, so parts of this change week to week and some of it contradicts what a machine already built looks like. Anything still undecided is written down as an open item in section 7 rather than smoothed over. Started from Basically's own working notes as of July 12th 2026; treat it as the current thinking, not the final state.</p>
 </div>
 
 This page is the wiring. Where the PSU, the control board and the Orange Pi physically mount is [Installing the electronics]({{ '/hardware/electronics/installation/' | relative_url }}).
@@ -199,12 +199,12 @@ Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC j
 </div>
 
 <dl class="spec-list">
-  <dt>Fit your own</dt><dd><b>220&#8486;</b>, <b>1/4 W</b>, in series, one per COB board. That is what Spencer settled on for the C-channel plates and the classification chamber, and what Jon recommends. <b>200&#8486;</b> is the ballpark given to people whose lights are overheating</dd>
+  <dt>Fit your own</dt><dd><b>220&#8486;</b>, <b>1/4 W</b>, in series, one per COB board. That is what Basically settled on for the C-channel plates and the classification chamber, and what Jon recommends. <b>200&#8486;</b> is the ballpark given to people whose lights are overheating</dd>
   <dt>On basically board v1.3</dt><dd>Already fitted, so a COB board fed from the board needs nothing added. <b>180&#8486;</b>, 1206, 250 mW, 1% (LCSC C17924) in series with the +24V feed to each of the four LED headers: R21 on J8, R22 on J9, R27 on J10, R28 on J11. Each has a solder jumper next to it (JP1-JP4) that bridges the resistor out. On the strip channel the resistor is not strictly required, and brightness can be trimmed with PWM instead (Jon, 2026-08-19)</dd>
   <dt>Effect</dt><dd>Draw drops from ~0.5A to ~0.1A. Still bright enough for the camera, per the C-channel testing in Feb 2026</dd>
 </dl>
 
-<p>Sources, since this has been asked several times: Spencer in #c-channels 2026-02-13 (&ldquo;went for 220ohm resistor&rdquo;), in the classification chamber thread 2026-03-22 (&ldquo;220 ohm&rdquo;), and in #machine-setup-help 2026-05-13 (&ldquo;They need resistor. Ballpark of 200ohm is good&rdquo;, in series, 1/4 W) after a builder's C-channel COB mount started melting after a minute; Jon in #electronics 2026-08-17 and 2026-08-19.</p>
+<p>Sources, since this has been asked several times: #c-channels 2026-02-13 (&ldquo;went for 220ohm resistor&rdquo;), the classification chamber thread 2026-03-22 (&ldquo;220 ohm&rdquo;), and #machine-setup-help 2026-05-13 (&ldquo;They need resistor. Ballpark of 200ohm is good&rdquo;, in series, 1/4 W) after a builder's C-channel COB mount started melting after a minute; Jon in #electronics 2026-08-17 and 2026-08-19.</p>
 
 ### 4.4 &nbsp; Sensors and steppers (from basically board v1.3)
 

--- a/docs/src/content/lab/feeder-experiments/index.md
+++ b/docs/src/content/lab/feeder-experiments/index.md
@@ -54,7 +54,7 @@ Linear vibratory feeders with compression springs (ISO 10243 die springs from 3D
 
 ## Chute drop tests
 
-Spencer tested piece drop accuracy at three heights to validate the bin distribution system.
+Piece drop accuracy was tested at three heights to validate the bin distribution system.
 
 | Height | Success rate | Failures | Primary failure modes |
 |--------|-------------|----------|----------------------|


### PR DESCRIPTION
Takes Spencer's name out of the docs body copy, asked for by [BrickCycleAlice](https://discord.com/channels/1430279849171222682/1545748719784427580/1545763065939894292) and then by [barthel](https://discord.com/channels/1430279849171222682/1545748719784427580/1545764392233082983) as its own PR. The same fix on the new install-bins page is in #549.

**Six references, three pages**

- `hardware/electronics/index.md`
  - Working-notes banner: "Started from what Spencer had on July 12th 2026" → "Started from Basically's own working notes as of July 12th 2026".
  - LED resistors: "That is what Spencer settled on" → "That is what Basically settled on". Jon's name stays, the ask was about Spencer.
  - The sources line under it drops the name and keeps the citation itself: channel, date and quote are all still there, so the claim is still checkable.
- `getting-started.md`, both Onshape lines. "DM Spencer your email for document access" cannot just lose the name, or nobody can get CAD access, so it now says what this repo's own `mechanical/README.md` says: every V2 document is public and listed there, the folder holding them is private, ask in the Discord to be added.
- `lab/feeder-experiments/index.md`: "Spencer tested piece drop accuracy at three heights" → "Piece drop accuracy was tested at three heights".

**Deliberately not touched**

- **Photo, video and render credits** (`<cite>Photo: Spencer.</cite>`, ~25 of them). These are attribution, required per image by `docs/AGENTS.md` and enforced by `scripts/validate_credits.py`.
- **`author:` / `contributors:` front matter**, which renders as the byline. `validate_frontmatter.py` requires one on every page under `hardware/`.
- **Two quote attributions in the lab notes** (`lab/c-channel-singulation`, `lab/software-architecture-decisions`). Both are quotations, and the first sits directly above a quote attributed to Marc, so dropping one name and keeping the other would read worse than leaving them.
- **`spencer_pi5_hailo` and `spencer_pi_cpu_parallel_20260406.json`** in the object-detection pages. Those are literal paths in runnable commands and in a data filename; renaming them in the copy would break the commands.

Say the word and any of those four groups can follow in another PR.

`validate_frontmatter.py`, `validate_credits.py` and `validate_images.py` all show only the failures that are already on main.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545764392233082983
request: https://discord.com/channels/1430279849171222682/1545748719784427580/1545763065939894292
preview: /hardware/electronics/
-->
