### PR TITLE
docs: regular layers is builder-verified, drop the warning

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/regular-layers.md
@@ -9,11 +9,6 @@ lede: The repeating bin layers above the base. Build N−2 for an N-layer machin
 permalink: /hardware/assembly/distribution/bin-frame/regular-layers/
 author: zed0
 contributors: [brickcyclealice, barthel]
-warning: >-
-  **Reorganized to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
-  instead of describing frame construction inline, not yet reviewed by a
-  builder.** The old steps 1-2 (outer ring, spokes) are gone; build a hex
-  frame on that page first. Correct it as you build.
 parts_needed:
   - part: ext-bracket-bottom-vertical
     qty: 6


### PR DESCRIPTION
barthel built a regular layer from the live page and approved it, so the "not yet reviewed by a builder" banner comes off. Same treatment the hex frame page got in #546 after his build there.

The banner also carried the caveat that the page had been reorganized to send you to [Build the hex frame](https://docs.basically.website/hardware/assembly/distribution/bin-frame/hex-frame/) instead of describing the ring inline. That is exactly the shape he built to, so it goes with the rest of the note rather than being softened, per the convention that a page verified against a real build loses the note entirely.

No other change: the body copy, the steps, the fastener counts and `parts_needed` are untouched.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1545864535435640895):** "https://docs.basically.website/hardware/assembly/distribution/bin-frame/regular-layers/ approved. I just built a regular layers based on this documentation."

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545864535435640895
preview: /hardware/assembly/distribution/bin-frame/regular-layers/
-->
