### PR TITLE
docs: top interface piece F protrusion, and steps 13 and 14 builder-verified

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -670,7 +670,7 @@ Insert an extrusion piece F (Interface vertical support) into each of the Interf
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Do not push piece F all the way through the bracket. Leave its end roughly 20 mm short of the far end of the channel: that is far enough in to cover both pairs of T-nut screws, and it leaves enough of the extrusion standing out to reach past the screws at the base of the layer's External bracket — side later in this step. <a href="{{ '/hardware/assembly/distribution/top-interface/' | relative_url }}#step-14">Step 14</a> shows the whole corner in section.</p>
+  <p>Do not push piece F all the way through the bracket. Leave its end roughly 20 mm short of the far end of the channel: that is far enough in to cover both pairs of T-nut screws, and it leaves enough of the extrusion standing out to reach past the screws at the base of the layer's External bracket — side later in this step. <b>166 mm of the extrusion should stand out of the bracket</b>, measured from the edge of the bracket where the extrusion exits to the free end of the piece. <a href="{{ '/hardware/assembly/distribution/top-interface/' | relative_url }}#step-14">Step 14</a> shows the whole corner in section.</p>
 </div>
 
 <figure>

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -664,7 +664,7 @@ Insert an extrusion piece F (Interface vertical support) into each of the Interf
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>Do not push piece F all the way through the bracket. Leave its end roughly 20 mm short of the far end of the channel: that is far enough in to cover both pairs of T-nut screws, and it leaves enough of the extrusion standing out to reach past the screws at the base of the layer's External bracket — side later in this step. <b>166 mm of the extrusion should stand out of the bracket</b>, measured from the edge of the bracket where the extrusion exits to the free end of the piece. <a href="{{ '/hardware/assembly/distribution/top-interface/' | relative_url }}#step-14">Step 14</a> shows the whole corner in section.</p>
+  <p>Do not push piece F all the way through the bracket. Leave its end about 11 mm short of the far end of the channel: that is far enough in to cover both pairs of T-nut screws, and it leaves enough of the extrusion standing out to reach past the screws at the base of the layer's External bracket — side later in this step. <b>165 mm of the extrusion should stand out of the bracket</b>, measured from the edge of the bracket where the extrusion exits to the free end of the piece. <a href="{{ '/hardware/assembly/distribution/top-interface/' | relative_url }}#step-14">Step 14</a> shows the whole corner in section.</p>
 </div>
 
 <figure>
@@ -722,7 +722,7 @@ The numbers on the photo and the drawing:
   <li class="key-screw"><strong>Two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws</strong> at the base of that bracket brace it against the extrusion, the same screws and holes a layer's own vertical gets. Nothing else fastens the interface to the layer.</li>
 </ol>
 
-**Piece F does not reach the top of the Interface bracket, and it comes nowhere near the top plate.** How deep it goes is not stated anywhere in the build, but it is fixed at both ends by what has to be screwed: the lower end has to reach past the two screws at the base of the layer's bracket, and the upper end has to cover the bracket's second pair of T-nut screws, whose bosses sit about 90 mm above the bracket's underside. A 274 mm piece cannot do both and also reach the top of a 120 mm bracket, so it stands about 6 mm past the upper screws and stops roughly 23 mm short of the top of the bracket. That is what the drawing shows.
+**Piece F does not reach the top of the Interface bracket, and it comes nowhere near the top plate.** How deep it goes is not stated anywhere in the build, but it is fixed at both ends by what has to be screwed: the lower end has to reach past the two screws at the base of the layer's bracket, and the upper end has to cover the bracket's second pair of T-nut screws, whose bosses sit about 90 mm above the bracket's underside. A 274 mm piece cannot do both and also reach the top of a 120 mm bracket. On a built machine it stands about 20 mm past the upper screws and stops about 11 mm short of the top of the bracket. The drawing is made from the part geometry rather than from a build, and its inferred heights seat the extrusion around 12 mm shallower than that.
 
 <div class="clear-float"></div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -9,12 +9,6 @@ lede: The interface between the feeder and the bin tower.
 permalink: /hardware/assembly/distribution/top-interface/
 author: zed0
 contributors: [barthel, brickcyclealice]
-warning: >-
-  **Steps 13 and 14 were rewritten to reference [Build the hex frame]({{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }})
-  and to describe the interface-to-layer joint from CAD geometry, and neither
-  has been checked against a build yet.** If something doesn't match what you
-  see, treat it as unverified and flag it rather than assuming it's your
-  mistake. The rest of the page is unaffected.
 parts_needed:
   - part: interface-upper-fixed-section
     qty: 1


### PR DESCRIPTION
**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1545869135966244884): "Great interface. Please add the following information to the warning "Do not push piece F all the way through the bracket. Leave its end roughly 20 mm short of the far end of the channel": The extrusion profile should protrude 16.6 cm from the bracket. Measure from the edge of the bracket where the profile exits to the end of the profile."**

**And [from Discord](https://discord.com/channels/1430279849171222682/1545869135966244884/1545870186727346329): "Step 13 and 14 are approved by a build."**

**And, correcting the figure to 165 mm, [from Discord](https://discord.com/channels/1430279849171222682/1545869135966244884/1545872191906779227): "165mm".**

Three commits on the [Top interface](https://docs.basically.website/hardware/assembly/distribution/top-interface/) page, all off barthel's build of the interface.

### 1. The measured protrusion, in step 13's warning

**165 mm of the extrusion should stand out of the bracket**, measured from the edge of the bracket where the extrusion exits to the free end of the piece. Written in mm rather than 16.5 cm so it matches every other length on the page.

### 2. The unverified banner comes off

The `warning:` front matter said steps 13 and 14 "were rewritten ... from CAD geometry, and neither has been checked against a build yet". A build has now checked both, so per the house rule a verified page loses the note entirely rather than softening it. Nothing else in the front matter changed.

### 3. The two derived clearances now follow the build

Measured off the parts, 165 mm standing out is 109 mm engaged in the bracket:

- the Interface bracket's channel is 120 mm long and open at both ends, and the two pairs of T-nut screw bosses sit 25 mm and 89 mm above its underside (all three measured off the `interface-bracket` v2 STL);
- piece F is cut to 274 mm ([`parts-calculator/src/lib/framing.ts`](https://github.com/basicallysource/sorter-v2/blob/main/parts-calculator/src/lib/framing.ts), 280 mm CAD minus the 6 mm clearance trim).

So the two places that carried the older CAD stack-up are updated to match:

- step 13's warning, "roughly 20 mm short of the far end of the channel" becomes **about 11 mm short**;
- step 14's closing paragraph, "about 6 mm past the upper screws and stops roughly 23 mm short of the top of the bracket" becomes **about 20 mm past the upper screws and about 11 mm short of the top**.

**The section drawing in step 14 is unchanged and now differs from the text on purpose.** It is rendered from the part geometry, and as its caption already says, the interface parts are not exported in a shared frame with the layer parts, so their heights come from seating each part on the one below. That inferred stack-up puts piece F about 12 mm shallower than the build does. Rather than leave the picture silently contradicting the words, the paragraph now says which is which. Redrawing the section to the built depth is a separate job.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545869135966244884
request: https://discord.com/channels/1430279849171222682/1545869135966244884/1545870186727346329
request: https://discord.com/channels/1430279849171222682/1545869135966244884/1545872191906779227
preview: /hardware/assembly/distribution/top-interface/
-->
