### PR TITLE
docs: chute screws are listed on the page that drives them

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -22,7 +22,7 @@ parts_needed:
 
 The chute is what steers a part into the right bin. Build one per layer, N for an N-layer machine. The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) doesn't add any extra chutes of its own, it's a mounting stage the bottommost chute sits on, bridged to it by a [layer connector]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
 
-The fasteners and quantities are in the parts list above and are called out inline at each step.
+The heat inserts are in the parts list above. The screws that hold the four sub-assemblies on are on their own pages, listed where they are driven.
 
 {% include fastener-legend.html %}
 
@@ -33,7 +33,7 @@ One chute is the chute core plus four things that bolt onto it:
 - **Layer connector A** and **Layer connector B**, one of each. See [Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
 - **Layer adapter board**, one per chute. See [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}).
 
-Every screw on this page lands in one of the chute core's own M3 heat inserts. Nothing here taps into bare plastic.
+Every screw that fastens one of them to the core lands in one of the core's own M3 heat inserts. Nothing on the chute taps into bare plastic.
 
 {% include step.html n="1" title="Preparation" %}
 
@@ -62,14 +62,14 @@ Press the heat inserts into the chute core before you mount anything else onto i
 
 {% include step.html n="2" title="Bolt the four sub-assemblies on" %}
 
-Fit them in this order: the funnel brackets, the door module, the layer connectors, then the layer adapter board. Each has its own page for the procedure, and each carries its own screws in its own parts list. What follows is the one thing those pages do not repeat, which screw goes into which insert, worked out from the STLs by comparing each mating part's wall thickness at its screw hole against the core's blind 5.70 mm pockets.
+Fit them in this order, each on its own page, and each with its own screws in its own parts list:
 
-- **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**, left and right: 4 × {% include fastener.html size="M3" variant="countersunk" length="12" %}, 2 per bracket. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the insert and an 8 mm one would not reach it at all.
-- **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**, bolted on as a unit: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, 2 per cover into 5.00 mm of wall, plus 2 × {% include fastener.html size="M3" variant="countersunk" length="12" %} for the servo bracket arms. (The 12 mm figure is inferred by elimination, not measured: no STL exists for that joint, so check fit before committing.)
-- **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** A and B: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %}, 2 per connector. The strap is 3.78 mm thick, so an 8 mm screw reaches 4.22 mm in and stops 1.5 mm short of the pocket bottom, while a 12 mm screw would bottom out before the head seated.
-- **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**: 4 × {% include fastener.html size="M3" variant="socket-button" length="6" %} on the four inserts in the rear face, the only ones of this head type on the chute.
+- **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**, left and right
+- **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**, bolted on as a unit
+- **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** A and B
+- **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**
 
-That is 14 countersunk screws across the four pages, 6 twelves and 8 eights, plus the board's 4 button head. All 18 land in the inserts you pressed in at step 1, which is why the inserts are on this page and the screws are not.
+Every insert you pressed in at step 1 takes a screw from one of those four pages. That is why the inserts are listed here and the screws are not.
 
 <div class="img-placeholder">Photo of a finished chute core with all four sub-assemblies bolted on: funnel brackets, door module, layer connectors and layer adapter board.</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -18,10 +18,6 @@ parts_needed:
     qty: 1
   - part: hsi-m3
     qty: 18
-  - part: scr-m3-12-cs
-    qty: 6
-  - part: scr-m3-8-cs
-    qty: 8
 ---
 
 The chute is what steers a part into the right bin. Build one per layer, N for an N-layer machine. The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) doesn't add any extra chutes of its own, it's a mounting stage the bottommost chute sits on, bridged to it by a [layer connector]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
@@ -66,14 +62,14 @@ Press the heat inserts into the chute core before you mount anything else onto i
 
 {% include step.html n="2" title="Bolt the four sub-assemblies on" %}
 
-Fit them in this order: the funnel brackets, the door module, the layer connectors, then the layer adapter board. Each has its own page for the procedure. What follows is the one thing those pages do not repeat, which screw goes into which insert, worked out from the STLs by comparing each mating part's wall thickness at its screw hole against the core's blind 5.70 mm pockets.
+Fit them in this order: the funnel brackets, the door module, the layer connectors, then the layer adapter board. Each has its own page for the procedure, and each carries its own screws in its own parts list. What follows is the one thing those pages do not repeat, which screw goes into which insert, worked out from the STLs by comparing each mating part's wall thickness at its screw hole against the core's blind 5.70 mm pockets.
 
 - **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**, left and right: 4 × {% include fastener.html size="M3" variant="countersunk" length="12" %}, 2 per bracket. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the insert and an 8 mm one would not reach it at all.
 - **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**, bolted on as a unit: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, 2 per cover into 5.00 mm of wall, plus 2 × {% include fastener.html size="M3" variant="countersunk" length="12" %} for the servo bracket arms. (The 12 mm figure is inferred by elimination, not measured: no STL exists for that joint, so check fit before committing.)
 - **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** A and B: 4 × {% include fastener.html size="M3" variant="countersunk" length="8" %}, 2 per connector. The strap is 3.78 mm thick, so an 8 mm screw reaches 4.22 mm in and stops 1.5 mm short of the pocket bottom, while a 12 mm screw would bottom out before the head seated.
-- **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**: 4 × {% include fastener.html size="M3" variant="socket-button" length="6" %} on the four inserts in the rear face, the only ones of this head type on the chute. They are in that page's parts list, not this one.
+- **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**: 4 × {% include fastener.html size="M3" variant="socket-button" length="6" %} on the four inserts in the rear face, the only ones of this head type on the chute.
 
-That accounts for all 14 countersunk screws in the list above, 6 twelves and 8 eights.
+That is 14 countersunk screws across the four pages, 6 twelves and 8 eights, plus the board's 4 button head. All 18 land in the inserts you pressed in at step 1, which is why the inserts are on this page and the screws are not.
 
 <div class="img-placeholder">Photo of a finished chute core with all four sub-assemblies bolted on: funnel brackets, door module, layer connectors and layer adapter board.</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -165,10 +165,10 @@ Fit the lower arm and the side arm to the housing and fasten them with the 4 {% 
 
 Six of the core's 18 inserts are for this module, and the screws for them are in the list above:
 
-- **2 bearing covers**, 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} in total, 2 per cover.
+- **2 bearing covers**, 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} in total, 2 per cover, into 5.00 mm of wall.
 - **Servo bracket arms**, 2 {% include fastener.html size="M3" variant="countersunk" length="12" %}.
 
-Why each of these is the length it is, measured off the STLs, is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, which is the one place it is written down. The 12 mm figure for the arms is inferred rather than measured, so check the fit before committing.
+The cover screws are 8 mm because that reaches 3.00 mm into the core's blind 5.70 mm insert, measured off the STLs. The arms' 12 mm is inferred by elimination rather than measured, since no STL exists for that joint, so check the fit before committing.
 
 The servo output then couples to the door through the two-piece servo adapter, servo side and flap side.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -50,9 +50,9 @@ parts_needed:
   - part: hsi-m3
     qty: 16
   - part: scr-m3-12-cs
-    qty: 4
+    qty: 6
   - part: scr-m3-8-cs
-    qty: 16
+    qty: 20
 ---
 
 The door module is the moving half of the chute. Build it on the bench as one unit, then bolt it to the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}). One per chute, so one per layer.
@@ -77,7 +77,7 @@ Four things make it up:
 - **Bearing assembly, its own:** 10 {% include fastener.html size="M3" variant="heat-insert" %} (4 in the race, 3 in each holder) and 10 {% include fastener.html size="M3" variant="countersunk" length="8" %}. Six hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each. The two 6704-2RS bearings are sealed on both sides (that's what "2RS" means), so they're symmetric: there's no wrong way round to seat them. The covers are thin printed plastic, so snug their screws down evenly rather than fully tightening one before the others.
 - **Servo adapter, its own:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %}, no heat inserts. They hold the servo-side and flap-side halves together with the MG995 Servo Horn clasped between them.
 - **Servo bracket, its own:** 6 {% include fastener.html size="M3" variant="heat-insert" %} in the housing, 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} for the arms, and 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the servo's mounting ears.
-- **Holding the finished module to the chute core:** not in the list above at all. Those screws come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s own set and are counted on that page.
+- **Holding the finished module to the chute core:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers and 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} through the servo bracket arms, step 4. They go into the core's own heat inserts, so there is nothing to press in here for them.
 
 {% include step.html n="1" title="Preparation" %}
 
@@ -163,12 +163,12 @@ Fit the lower arm and the side arm to the housing and fasten them with the 4 {% 
 
 {% include step.html n="4" title="Fit the module to the chute core" %}
 
-Six of the core's 18 inserts are for this module, and the screws come out of the core's own set rather than being extra:
+Six of the core's 18 inserts are for this module, and the screws for them are in the list above:
 
 - **2 bearing covers**, 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} in total, 2 per cover.
 - **Servo bracket arms**, 2 {% include fastener.html size="M3" variant="countersunk" length="12" %}.
 
-The full split across the core's 14 countersunk screws is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, which is the one place it is written down.
+Why each of these is the length it is, measured off the STLs, is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, which is the one place it is written down. The 12 mm figure for the arms is inferred rather than measured, so check the fit before committing.
 
 The servo output then couples to the door through the two-piece servo adapter, servo side and flap side.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -59,7 +59,7 @@ The calculator takes a size per layer and totals the print for whatever mix you 
 
 Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, which are pressed in on that page.
 
-Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. Why 12 mm and not 8 is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, along with the rest of the split.
+Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the core's blind 5.70 mm insert and an 8 mm one would not reach it at all.
 
 <div class="img-placeholder">Photo of both funnel brackets fitted to the chute core.</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -21,6 +21,8 @@ parts_needed:
     qty: 1
   - part: funnel-bracket-right
     qty: 1
+  - part: scr-m3-12-cs
+    qty: 4
 ---
 
 The funnel catches what the door releases and guides it into the bin below. It hangs off two printed brackets that are part of the chute.
@@ -31,7 +33,7 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 - **One funnel per layer**, in one of two sizes, and it is your choice which. Step 1 is that decision.
 - The brackets screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, so there is nothing to tap.
-- The 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} they take come out of the core's set of 6 and are not extra, so they are on that page's parts list rather than this one.
+- The 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} they take are in the list above, and they go into the core's inserts rather than into anything on this page.
 
 {% include step.html n="1" title="Pick the funnel size for the layer" %}
 
@@ -55,7 +57,7 @@ The calculator takes a size per layer and totals the print for whatever mix you 
 
 {% include step.html n="2" title="Fit the funnel brackets to the chute core" %}
 
-Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, using screws from the chute's set.
+Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, which are pressed in on that page.
 
 Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. Why 12 mm and not 8 is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page, along with the rest of the split.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -39,7 +39,7 @@ Both connectors fasten to the [chute core]({{ '/hardware/assembly/distribution/c
 
 Each connector takes 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flat strap between its two end blocks, but don't fully tighten them yet: step 2 covers checking the alignment first.
 
-The strap is countersunk 90° on its outer face, so the head sits flush. Why 8 mm and not 12 is on the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }}) page with the rest of the split.
+The strap is countersunk 90° on its outer face, so the head sits flush. It is 3.78 mm thick, so an 8 mm screw reaches 4.22 mm into the core's blind 5.70 mm insert and stops 1.5 mm short of the bottom, while a 12 mm one would bottom out before the head seated.
 
 <div class="img-placeholder">Photo of both layer connectors screwed to the chute core.</div>
 

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -19,6 +19,8 @@ parts_needed:
     qty: 1
   - part: layer-connector-2
     qty: 1
+  - part: scr-m3-8-cs
+    qty: 4
 ---
 
 The layer connectors are a pair of printed parts, Layer connector A and Layer connector B, that join one layer's chute to the next one down so parts pass from chute to chute without a gap.
@@ -28,7 +30,7 @@ The fasteners and quantities are in the parts list above and are called out inli
 {% include fastener-legend.html %}
 
 - **How many:** 1 of each per distribution layer, plus 1 of each for the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) and 1 of each for the [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}). For an N-layer machine, that's N + 2 pairs total.
-- **Screws:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per connector, 4 for the pair. They come out of the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s set of 8 and are not extra, so they are on that page's parts list rather than this one.
+- **Screws:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per connector, 4 for the pair, in the list above. They go into the core's inserts rather than into anything on this page.
 - Both connectors go into the chute core's M3 heat inserts.
 
 {% include step.html n="1" title="Fit the connectors to the chute core" %}


### PR DESCRIPTION
Every screw the chute section calls for now sits in the Needed Parts of the page where you actually drive it, and Chute core no longer repeats them. Before this, the funnel brackets, the door module and the layer connectors all pushed their mounting screws up onto the Chute core page, each with a line explaining that they "come out of the core's set and are not extra", while the Layer adapter board page carried its own four. So three pages listed screws they never mention driving, and one page listed 14 screws none of whose steps are on it.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1545873599217401998):** "Why are screws listed here under "Needed Parts" when the process of screwing components in place is described on the respective subpages?", scoped [in the thread](https://discord.com/channels/1430279849171222682/1545873599217401998/1545877500620578927) to "I mean the chute subpages only. All pages in chute section.", then [extended](https://discord.com/channels/1430279849171222682/1545873599217401998/1545882679029796904) to Chute core step 2 itself: "Now that we've moved the required screws to their respective subpages, there's no need to list them again in Step 2. That would only increase the maintenance effort when changes are made."

## What moved

- **Chute core**: drops 6 × `scr-m3-12-cs` and 8 × `scr-m3-8-cs`. It keeps the core and all 18 `hsi-m3`, because every one of those inserts is pressed in at its own step 1.
- **Funnel**: gains 4 × `scr-m3-12-cs`, the pair of brackets at its step 2.
- **Layer connectors**: gains 4 × `scr-m3-8-cs`, the pair at its step 1.
- **Door module**: 4 → 6 × `scr-m3-12-cs` and 16 → 20 × `scr-m3-8-cs`, adding the 4 through the bearing covers and the 2 through the servo bracket arms that its step 4 drives. Its "What each fastener is for" split now closes on the full totals instead of pointing elsewhere for the last row.
- **Layer adapter board**: unchanged. It was already doing this.

## Step 2 stops repeating them

Step 2 was listing every sub-assembly's screw count and length a second time, next to the link to the page that also lists them. That is the duplication barthel asked to remove, and it is now four links and nothing else.

The measurements behind each length were only written down in step 2, so rather than delete them they moved onto the page that uses each one: the funnel bracket's 8.16 mm wall onto Funnel, the layer connector strap's 3.78 mm onto Layer connectors, and the bearing cover's 5.00 mm plus the servo arms' inferred 12 mm onto Door module. Each number now sits beside the screw it explains, and no page points at another page for it. The servo bracket arms' 12 mm is still inferred by elimination rather than measured, because no STL exists for that joint, and the Door module page now says so at the point it is used.

Totals are conserved: 4 + 2 = 6 twelves and 4 + 4 = 8 eights, the same set the `chute` assembly declares in `parts-calculator/catalog/parts.json`. Nothing is added to or removed from the machine, so no catalog change and no regeneration.

This follows the pattern the rest of the assembly docs already use: the bin retainers took their own screws and T-nuts onto their own page in #547, and the hex frame split the same way.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545873599217401998
request: https://discord.com/channels/1430279849171222682/1545873599217401998/1545877500620578927
request: https://discord.com/channels/1430279849171222682/1545873599217401998/1545881296285204610
request: https://discord.com/channels/1430279849171222682/1545873599217401998/1545882679029796904
preview: /hardware/assembly/distribution/chute/chute-core/
preview: /hardware/assembly/distribution/chute/funnel/
preview: /hardware/assembly/distribution/chute/layer-connectors/
preview: /hardware/assembly/distribution/chute/door-module/
-->
