### PR TITLE
docs: funnel page reordered, the snap documented, and builder-verified

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -9,11 +9,7 @@ lede: The funnel that guides parts through the door.
 permalink: /hardware/assembly/distribution/chute/funnel/
 author: spencer
 contributors: [barthel]
-warning: >-
-  **Step 3 comes from a builder's report**, how the funnel snaps into its brackets. The rest is
-  an **AI-generated first draft**, written from the machine assembly tree and parts registry in
-  the [parts calculator](https://parts-calculator.basically.website/assembly?focus=chute), not
-  from an actual build, and has not been checked against a machine. Correct it as you build.
+last_verified: 2026-09-05
 parts_needed:
   - part: funnel-half
   - part: funnel-third

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -10,10 +10,10 @@ permalink: /hardware/assembly/distribution/chute/funnel/
 author: spencer
 contributors: [barthel]
 warning: >-
-  **AI-generated first draft.** Written from the machine assembly tree and parts registry in
+  **Step 3 comes from a builder's report**, how the funnel snaps into its brackets. The rest is
+  an **AI-generated first draft**, written from the machine assembly tree and parts registry in
   the [parts calculator](https://parts-calculator.basically.website/assembly?focus=chute), not
-  from an actual build. No step here has been checked against a machine. Correct it as you
-  build.
+  from an actual build, and has not been checked against a machine. Correct it as you build.
 parts_needed:
   - part: funnel-half
   - part: funnel-third
@@ -31,11 +31,25 @@ The fasteners and quantities are in the parts list above and are called out inli
 
 {% include fastener-legend.html %}
 
-- **One funnel per layer**, in one of two sizes, and it is your choice which. Step 1 is that decision.
+- **One funnel per layer**, in one of two sizes, and it is your choice which. Step 2 is that decision; the brackets are the same either way, so they go on before you have made it.
 - The brackets screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, so there is nothing to tap.
 - The 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} they take are in the list above, and they go into the core's inserts rather than into anything on this page.
+- **The funnel itself takes no fasteners.** It snaps into the brackets, which is step 3.
 
-{% include step.html n="1" title="Pick the funnel size for the layer" %}
+{% include step.html n="1" title="Fit the funnel brackets to the chute core" %}
+
+Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, which are pressed in on that page.
+
+Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the core's blind 5.70 mm insert and an 8 mm one would not reach it at all.
+
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/chute-core-funnel-brackets-full-36040ab587fd.png" alt="Render of one long side of the chute core with the two heat inserts a funnel bracket screws into circled in red">
+  <figcaption>The two inserts one funnel bracket screws into, at the lower end of one long side of the chute core. The other long side carries the mirror pair for the second bracket. <cite>Render: Balloon.</cite></figcaption>
+</figure>
+
+<div class="img-placeholder">Photo of both funnel brackets fitted to the chute core.</div>
+
+{% include step.html n="2" title="Pick the funnel size for the layer" %}
 
 **This is a builder's decision, taken once per layer.** What you are choosing is how finely that layer divides its ring: into 12 bins or into 18. The funnel and the bin set are a matched pair, so the size you pick decides both at once, and a machine can mix sizes from layer to layer. Decide before you print either part.
 
@@ -55,14 +69,10 @@ Neither is cheaper to build: a layer's bins come to roughly 2.1 kg of filament a
 
 The calculator takes a size per layer and totals the print for whatever mix you pick.
 
-{% include step.html n="2" title="Fit the funnel brackets to the chute core" %}
-
-Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of each. They screw into the [chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})'s M3 heat inserts, which are pressed in on that page.
-
-Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the core's blind 5.70 mm insert and an 8 mm one would not reach it at all.
-
-<div class="img-placeholder">Photo of both funnel brackets fitted to the chute core.</div>
-
 {% include step.html n="3" title="Hang the funnel" %}
 
-The funnel's connection to the brackets isn't documented yet. There's no confirmed fastener or clip method. If you get this far, please share how yours attaches so this step can be filled in.
+**Nothing is screwed or glued here.** Each bracket has two arms: the one with the two countersunk holes is the one that went onto the core in step 1, and the plain arm is a sprung slide. The funnel has a rail down each side that runs into that arm. Push the funnel onto the pair of brackets, the arm flexes to let the rail past, and it springs back and holds the funnel there.
+
+It should feel like it has landed. If the funnel can be lifted straight back off without the arm flexing, it has not gone far enough in.
+
+<div class="img-placeholder">Photo of a funnel snapped into its two brackets.</div>


### PR DESCRIPTION
Four changes to [/hardware/assembly/distribution/chute/funnel/](https://docs.basically.website/hardware/assembly/distribution/chute/funnel/), all of them from barthel reading the #556 preview.

**1. The size decision moves to step 2.**

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1545883365444419664): "The funnel brackets can be screwed on separately from the actual funnel or the bin divider. In my opinion, the decision to “Pick the funnel size for the layer” can be moved before “Hang the funnel.”"**

The brackets are the same left/right pair whichever size the layer ends up being, and they bolt into the chute core's M3 heat inserts, so nothing about fitting them waits on the size decision. Step 1 is now *Fit the funnel brackets to the chute core*, step 2 is *Pick the funnel size for the layer* (text unchanged from #551), step 3 is *Hang the funnel*. The size choice still has to be made before the funnel or that layer's bins are printed, which the step says in its first paragraph.

**2. Step 3 says how the funnel attaches.**

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545883365444419664/1545883773969891388): "The funnel brackets have a kind of spring mechanism (the arm without holes) that allows the funnel itself to snap into place and stay secure."**

That step previously said the connection was not documented and asked whoever got there to report back. It now describes the snap: the plain arm is a sprung slide, the funnel has a rail down each side that runs into it, and the arm flexes and springs back to hold the funnel.

The catalog agrees with the report: `funnel-bracket-left` and `-right` in `parts-calculator/catalog/parts.json` are both sourced from `snap_in_funnel_bracket - <side>_funnel_slide.stl` and their internal note reads "Snap-in funnel bracket". Rendering the two published STLs shows the same thing: the bracket's plain arm carries a slot running its length with a stepped catch at the tip, and the funnel has a matching rail on each side.

Front matter changed with it at the time, following the shape `feeder/c-channel.md` uses. Change 4 below then takes the whole note off the page.

Nothing else on the page moves, and no fastener counts change.

**3. Where the brackets bolt onto the core.**

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545873599217401998/1545885687625285834):** "Take a look at each subpage of the Chute Core section and see if there's an illustration showing how the individual elements are attached to the Chute Core... mark with red circles where the parts should be screwed onto the Chute Core." That work is #558 for the other three subpages; the funnel view lands here instead, [because barthel pointed out this PR already edits the page](https://discord.com/channels/1430279849171222682/1545873599217401998/1545886135170109460).

Step 1 gains a render of one long side of the chute core with the two inserts a bracket screws into circled. Same renderer, camera and marker style as the three heat-insert views on the [Chute core](https://docs.basically.website/hardware/assembly/distribution/chute/chute-core/) page, so the pages read as one set, and no letter or colour key, which was taken back out of those views in #406. The insert positions are the measured ones; running the same camera with all 18 circled reproduces that page's own counts exactly, 8 on one long side and 6 on the other.

The photo placeholder stays: a render of the bare core is not a substitute for a photo of the finished joint.

**4. The AI warning comes off and the page is marked verified.**

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545883365444419664/1545895385762111538): "Remove AI warning and mark as approved by builder."**

The `warning:` front matter is deleted outright rather than softened, which is what a page checked against a build gets here (#546 on the hex frame, #554 on regular layers). "Approved by builder" is recorded as `last_verified: 2026-09-05`, which the page footer renders in place of the site-wide `2026-04-08` default from `docs/src/lib/server/content.ts`; barthel is already in `contributors:`.

## Rebased, not stacked

This was based on `balloon/chute-screws-on-their-own-pages`, which squash-merged as #556 while the branch was open, leaving the base pointing at a dead branch. Retargeting to `main` alone gave CONFLICTING and four changed files, because the squash means those commits are not ancestors of `main`. So the branch was rebuilt on current `main` and force-pushed, and it is now one file and one commit. **The force-push resets any votes the board had recorded.**

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1545883365444419664
request: https://discord.com/channels/1430279849171222682/1545883365444419664/1545883773969891388
request: https://discord.com/channels/1430279849171222682/1545873599217401998/1545885687625285834
request: https://discord.com/channels/1430279849171222682/1545873599217401998/1545886135170109460
request: https://discord.com/channels/1430279849171222682/1545883365444419664/1545895385762111538
preview: /hardware/assembly/distribution/chute/funnel/
-->


