### PR TITLE
docs: show where each chute sub-assembly bolts onto the core

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -170,6 +170,17 @@ Six of the core's 18 inserts are for this module, and the screws for them are in
 
 The cover screws are 8 mm because that reaches 3.00 mm into the core's blind 5.70 mm insert, measured off the STLs. The arms' 12 mm is inferred by elimination rather than measured, since no STL exists for that joint, so check the fit before committing.
 
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/chute-core-door-module-side-4-full-f61ab38ed984.png" alt="Render of the servo side of the chute core with four heat inserts circled in red">
+    <figcaption>The long side the servo sits on: two inserts for that side's bearing cover, two for the servo bracket arms. <cite>Render: Balloon.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/chute-core-door-module-side-2-full-c9afd2f336aa.png" alt="Render of the other long side of the chute core with two heat inserts circled in red">
+    <figcaption>The other long side: two inserts, both for the second bearing cover. <cite>Render: Balloon.</cite></figcaption>
+  </figure>
+</div>
+
 The servo output then couples to the door through the two-piece servo adapter, servo side and flap side.
 
 <div class="callout callout-warning">

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -61,6 +61,11 @@ Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of
 
 Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the core's blind 5.70 mm insert and an 8 mm one would not reach it at all.
 
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/chute-core-funnel-brackets-full-36040ab587fd.png" alt="Render of one long side of the chute core with the two heat inserts a funnel bracket screws into circled in red">
+  <figcaption>The two inserts one funnel bracket screws into, at the lower end of one long side of the chute core. The other long side carries the mirror pair for the second bracket. <cite>Render: Balloon.</cite></figcaption>
+</figure>
+
 <div class="img-placeholder">Photo of both funnel brackets fitted to the chute core.</div>
 
 {% include step.html n="3" title="Hang the funnel" %}

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -61,11 +61,6 @@ Every chute carries a Funnel bracket (left) and a Funnel bracket (right), one of
 
 Each bracket takes 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws, 4 for the pair. The bracket is 8.16 mm thick at the screw, so a 12 mm screw reaches 3.84 mm into the core's blind 5.70 mm insert and an 8 mm one would not reach it at all.
 
-<figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/chute-core-funnel-brackets-full-36040ab587fd.png" alt="Render of one long side of the chute core with the two heat inserts a funnel bracket screws into circled in red">
-  <figcaption>The two inserts one funnel bracket screws into, at the lower end of one long side of the chute core. The other long side carries the mirror pair for the second bracket. <cite>Render: Balloon.</cite></figcaption>
-</figure>
-
 <div class="img-placeholder">Photo of both funnel brackets fitted to the chute core.</div>
 
 {% include step.html n="3" title="Hang the funnel" %}

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -41,6 +41,11 @@ Each connector takes 2 {% include fastener.html size="M3" variant="countersunk" 
 
 The strap is countersunk 90° on its outer face, so the head sits flush. It is 3.78 mm thick, so an 8 mm screw reaches 4.22 mm into the core's blind 5.70 mm insert and stops 1.5 mm short of the bottom, while a 12 mm one would bottom out before the head seated.
 
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/chute-core-layer-connectors-full-2092b04f9864.png" alt="Render of one long side of the chute core with the two heat inserts a layer connector screws into circled in red">
+  <figcaption>The two inserts one layer connector screws into, one near each end of a long side of the chute core. The other long side carries the mirror pair for the second connector. <cite>Render: Balloon.</cite></figcaption>
+</figure>
+
 <div class="img-placeholder">Photo of both layer connectors screwed to the chute core.</div>
 
 {% include step.html n="2" title="Check the alignment against the layer below" %}

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -42,6 +42,11 @@ Nothing to press in here. The four inserts the board sits on are pressed into th
 
 Seat it over the four inserts and fasten it with 4 {% include fastener.html size="M3" variant="socket-button" length="6" %} screws. Do not overtighten, the board is standing on printed plastic, not a metal standoff.
 
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-rear-full-ad4c2cc7869c.png" alt="Close render of the rear end of the chute core with the four heat inserts the layer adapter board screws into circled in red">
+  <figcaption>The four inserts the board sits on, all on the panel at the top end of the chute core's rear face. <cite>Render: Balloon.</cite></figcaption>
+</figure>
+
 <div class="img-placeholder">Photo of the layer adapter board seated on its four inserts and screwed to the chute core.</div>
 
 {% include step.html n="3" title="Connect the ribbon cable" %}


### PR DESCRIPTION
Three of the four chute sub-assembly pages now show where their part bolts onto the chute core. **The funnel view is in #557 instead**, which already edits that page, [as barthel pointed out](https://discord.com/channels/1430279849171222682/1545873599217401998/1545886135170109460). None of them had an illustration of that joint: Funnel, Layer connectors and Layer adapter board carried only a placeholder for a photo nobody has taken, and Door module had renders of its own parts' heat inserts but nothing of it going onto the core.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545873599217401998/1545885687625285834):** "Take a look at each subpage of the Chute Core section and see if there's an illustration showing how the individual elements are attached to the Chute Core. If there are no illustrations, find suitable photos or use one or more of the renderings (without the red circles) from the Chute Core page in the Preparation section, copy them to the relevant subpage, and mark with red circles where the parts should be screwed onto the Chute Core." Follows #556, which moved the screws themselves onto these pages. The funnel's own view is on #557.

## The views

Same renderer, camera and marker style as the three heat-insert views already on the [Chute core](https://docs.basically.website/hardware/assembly/distribution/chute/chute-core/) page, so the pages read as one set: light background, thin orange ring, no fill, camera about 18° off the face so a blind pocket shades as a crescent.

- **Layer connectors** — the 2 inserts one connector screws into, one near each end of a long side. Its mirror pair takes the second connector.
- **Door module** — a pair of views, because the two sides differ: the servo side has 4 (its bearing cover plus the two servo bracket arms), the other has 2.
- **Layer adapter board** — reuses the existing `chute-core-inserts-v3-rear` render unchanged. Those 4 circles were already exactly the board's 4 inserts, so nothing new was rendered for it.

No page gained a letter or colour key tying a circle to a part, because that was taken back out of the Chute core views in #406 at barthel's request.

The photo placeholders stay where they are: a render of the bare core is not a substitute for a photo of the finished joint, and those are still wanted.

## Positive control

The insert positions come from the measured map in the knowledge base rather than from eyeballing the render. Before cutting the four views, the same camera was run with **all 18 inserts circled**, and it reproduces the Chute core page's own counts exactly: 8 on one long side, 6 on the other, 4 on the rear face, every ring landing on a visible pocket. The subsets below are slices of that same list.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1545873599217401998/1545885687625285834
request: https://discord.com/channels/1430279849171222682/1545873599217401998/1545886135170109460
preview: /hardware/assembly/distribution/chute/layer-connectors/
preview: /hardware/assembly/distribution/chute/door-module/
preview: /hardware/assembly/distribution/chute/pcb/
-->
