### PR TITLE
Count the bottom layer's 24 bin-retainer T-nuts

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -8112,8 +8112,8 @@
     },
     {
       "id": "bottom-layer",
-      "uid": "sqsi",
-      "version": "1",
+      "uid": "7dq2",
+      "version": "2",
       "name": "Bottom distribution layer",
       "description": "The lowest bin layer. Identical to a distribution layer except that its frame carries foot covers instead of bracket covers and bottom verticals, and the bottom interface hangs underneath it.",
       "docs": "/hardware/assembly/distribution/bin-frame/bottom-two-layers/",
@@ -8137,6 +8137,10 @@
         {
           "part": "scr-m5-16-shcs",
           "qty": 36
+        },
+        {
+          "part": "tnut-m5-2020",
+          "qty": 24
         }
       ],
       "connections": [
@@ -8157,6 +8161,47 @@
           "method": "tnut",
           "through_mm": 12.8,
           "note": "Mirror of the left retainer's joint, same bore and same screw."
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "uid": "sqsi",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "assembly": "hex-frame-bottom",
+              "qty": 1,
+              "uid": "5l36"
+            },
+            {
+              "assembly": "chute",
+              "qty": 1,
+              "uid": "axlb"
+            },
+            {
+              "part": "bin-retainer-left",
+              "qty": 6,
+              "uid": "hqz0"
+            },
+            {
+              "part": "bin-retainer-right",
+              "qty": 6,
+              "uid": "ybpv"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 36,
+              "uid": "2e0s"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-09-06",
+          "breaking": false,
+          "message": "Added tnut-m5-2020 qty 24 for the bin retainers, matching layer v4. That restore landed on the regular layer node while this one was still in review, so the lowest bin layer was left as the only frame in the machine whose retainer T-nuts were not counted. No physical change.",
+          "commit": "46fb3bb8"
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2750,8 +2750,8 @@
 		},
 		{
 			"id": "bottom-layer",
-			"uid": "sqsi",
-			"version": "1",
+			"uid": "7dq2",
+			"version": "2",
 			"name": "Bottom distribution layer",
 			"description": "The lowest bin layer. Identical to a distribution layer except that its frame carries foot covers instead of bracket covers and bottom verticals, and the bottom interface hangs underneath it.",
 			"docs": "/hardware/assembly/distribution/bin-frame/bottom-two-layers/",
@@ -2775,6 +2775,10 @@
 				{
 					"part": "scr-m5-16-shcs",
 					"qty": 36
+				},
+				{
+					"part": "tnut-m5-2020",
+					"qty": 24
 				}
 			],
 			"connections": [
@@ -2795,6 +2799,48 @@
 					"method": "tnut",
 					"through_mm": 12.8,
 					"note": "Mirror of the left retainer's joint, same bore and same screw."
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "sqsi",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"assembly": "hex-frame-bottom",
+							"qty": 1,
+							"uid": "5l36"
+						},
+						{
+							"assembly": "chute",
+							"qty": 1,
+							"uid": "axlb"
+						},
+						{
+							"part": "bin-retainer-left",
+							"qty": 6,
+							"uid": "hqz0"
+						},
+						{
+							"part": "bin-retainer-right",
+							"qty": 6,
+							"uid": "ybpv"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 36,
+							"uid": "2e0s"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "7dq2",
+					"date": "2026-09-06",
+					"breaking": false,
+					"message": "Added tnut-m5-2020 qty 24 for the bin retainers, matching layer v4. That restore landed on the regular layer node while this one was still in review, so the lowest bin layer was left as the only frame in the machine whose retainer T-nuts were not counted. No physical change.",
+					"commit": "46fb3bb8"
 				}
 			]
 		},


### PR DESCRIPTION
The lowest bin layer is the only frame in the machine whose bin-retainer T-nuts are not counted. This adds its 24.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545685109615759371/1546032913164804168): "This should be fixed in the seperate bin retainer side."** Raised by BrickCycleAlice mid-build, [from Discord](https://discord.com/channels/1430279849171222682/1545685109615759371/1545719833893670922): "are the t-nuts listed as a count hardware here?" — they were not.

## Most of this was already fixed

[`layer` v4](https://github.com/basicallysource/sorter-v2/commits/main/parts-calculator/catalog/parts.json) restored `tnut-m5-2020` qty 24 on the regular layer node on 2026-09-05, while [#545](https://github.com/basicallysource/sorter-v2/pull/545) was still in review. `bottom-layer` was created by that PR and so never got the same line. The result on `main` today is `68 + 24(n − 1)` — every bin layer's retainer T-nuts counted **except the lowest one's**.

So this is 24 T-nuts, not the 120 I quoted in the thread before checking the current state.

## The change

One line on `bottom-layer`, `tnut-m5-2020` qty 24, in the same place `layer` carries its own — on the layer node alongside the 24 `scr-m5-16-shcs` that pass through them, which is where `layer` v4 decided they belong. Stamped v1 → v2, `breaking: false`; nothing physical changes.

Totals go to **`68 + 24n`** at every layer count, one T-nut per retainer screw:

| layers | before | after |
|---|---|---|
| 2 | 92 | 116 |
| 3 | 116 | 140 |
| 5 | 164 | **188** |
| 8 | 236 | 260 |

`check_connections`, `check_versioning` and `check_generated_pins` all pass.

## Two things found on the way, not fixed here

- **`layer` v4 was authored without minting a new uid.** VERSIONING.md says a new version is a new uid, and `stamp_versions.py` assumes it — run it today and it writes `uid: jog7` onto v3, which is already v2's uid, and `generate.py` then refuses the file with `duplicate uid(s): ['jog7']`. Worth a fresh uid on that entry.
- **`check_connections.py` cannot see this class of bug at all.** Four edges carry `method: "tnut"` and, until `layer` v4, none of their assemblies had a `tnut-m5-2020` line, so the assembly page rendered a "T-NUT" label over a nut nothing counted. An anchor-kind edge (`tnut`, `nut`, `insert`) whose assembly has no line for that anchor is always a bug and could be a check. That file is the PR gate, so it is not mine to change.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1545685109615759371/1546032913164804168
request: https://discord.com/channels/1430279849171222682/1545685109615759371/1545719833893670922
preview: /assembly
-->
