### PR TITLE
Mark the unused M5 length-TBD placeholder for deletion

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -378,6 +378,18 @@
       }
     },
     {
+      "id": "delete-unused-m5-shcs-tbd-placeholder",
+      "name": "Delete the unused M5 socket/button head length-TBD placeholder",
+      "priority": "P4",
+      "condition": "retired",
+      "description": "This placeholder is not used anywhere in the machine. It stood in for an unmeasured M5 joint: first the three electronics mounts that bolt to the frame, which resolved to real parts in PR #428, and after that the two screws fastening the Chute stepper support block. That block was removed from the machine on 2026-08-31 (sorter-v2#489, closing sorter-v2#483) once the NEMA 23 chute stepper mount was confirmed to work without it, so its two screws went with it, and the length was never measured so there is nothing to resolve it to. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #563, alongside #453, #454, #478 and #536 for the other four.",
+      "targets": {
+        "hardware": [
+          "scr-m5-shcs-tbd"
+        ]
+      }
+    },
+    {
       "id": "unconfirmed-servo-adapter-heat-insert",
       "name": "Servo adapter's 4x M3S heat inserts are unconfirmed against the current CAD",
       "priority": "P2",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -392,6 +392,18 @@
 			}
 		},
 		{
+			"id": "delete-unused-m5-shcs-tbd-placeholder",
+			"name": "Delete the unused M5 socket/button head length-TBD placeholder",
+			"priority": "P4",
+			"condition": "retired",
+			"description": "This placeholder is not used anywhere in the machine. It stood in for an unmeasured M5 joint: first the three electronics mounts that bolt to the frame, which resolved to real parts in PR #428, and after that the two screws fastening the Chute stepper support block. That block was removed from the machine on 2026-08-31 (sorter-v2#489, closing sorter-v2#483) once the NEMA 23 chute stepper mount was confirmed to work without it, so its two screws went with it, and the length was never measured so there is nothing to resolve it to. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #563, alongside #453, #454, #478 and #536 for the other four.",
+			"targets": {
+				"hardware": [
+					"scr-m5-shcs-tbd"
+				]
+			}
+		},
+		{
 			"id": "unconfirmed-servo-adapter-heat-insert",
 			"name": "Servo adapter's 4x M3S heat inserts are unconfirmed against the current CAD",
 			"priority": "P2",


### PR DESCRIPTION
Marks `scr-m5-shcs-tbd` for deletion, which was the one entry of the five still unmarked.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1545685109615759371/1546032913164804168): "All the TBD screws and the washer should be marked as 'to be deleted' and for all of those a github issue for deleton should be created."**

## Four of the five were already done

Checked before changing anything:

| part | marked | issue |
|---|---|---|
| `scr-m3-tbd` | `delete-unused-m3-tbd-placeholder` P4 | #453 |
| `scr-m3-shcs-tbd` | `delete-unused-m3-shcs-tbd-placeholder` P4 | #454 |
| `washer-m3-15` | `delete-unused-m3-15-washer` P4 | #478 |
| `scr-m3-8-shcs` | `delete-unused-m3-8-shcs-screw` P4 | #536 |
| `scr-m5-shcs-tbd` | **this PR** | **#563** |

So this is one `changes` entry, P4, `condition: retired`, matching the four above. No part is deleted: a minted uid has to stay resolvable and `check_generated_pins.py` enforces it, which is what the issues are for.

## Two rows read qty TBD and should NOT be marked

Both were on the list I gave in the thread, and neither is a dead part:

- **`scr-m2-8-shcs`** is a live joint — 4 per module into the IMX415 classification camera post, in `camera-extension-assembly` and on the [classification chamber page](https://docs.basically.website/hardware/assembly/feeder/classification-chamber/)'s parts list. It reads TBD only because that assembly is not reachable from the `machine` root, which is a separate gap in the tree, not grounds for deletion.
- **`scr-m3-16-shcs`** is called for by [top interface](https://docs.basically.website/hardware/assembly/distribution/top-interface/) step 12, 2 into the roller-lever limit switch housing's inserts, and it is on that page's parts list. Its own catalog note says the `limit-switch` assembly records M3 × 12 button heads for the same joint and that one of the two is wrong. That is a bench question to settle, and deleting the part would answer it by accident.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1545685109615759371/1546032913164804168
preview: /changes
-->
