### PR TITLE
parts-calculator: mark the two chute bearing holders as one part

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -413,8 +413,9 @@
     {
       "id": "merge-bearing-holders",
       "name": "Merge the two chute bearing holders into one part",
-      "priority": "P3",
-      "description": "The chute door module's two bearing holders are the same geometry, so the machine can print one part twice instead of two parts once each. Measured off the two master STLs: a proper rotation of exactly 180.000 degrees about the flange face normal (0, 0.906, 0.423) maps one onto the other with a maximum deviation of 0.065 mm and a mean of 0.004 mm, and the transform's determinant is +1, so no handedness is involved. The only asymmetry in either part is 0.05 mm, between two of the three M3 insert pockets, at 17.35 mm and 17.40 mm from the bore centre. The two ids are interchangeable as they stand and nothing about the assembly changes. Which id survives, and what a single holder should be called, are open questions. Tracked as sorter-v2 issue #569, with the catalog side in #570.",
+      "priority": "P1",
+      "condition": "broken",
+      "description": "The chute door module asks for two different printed parts, a left bearing holder and a right one, where one part printed twice does the whole job. They are the same geometry. Measured off the two master STLs: a proper rotation of exactly 180.000 degrees about the flange face normal (0, 0.906, 0.423) maps one onto the other with a maximum deviation of 0.065 mm and a mean of 0.004 mm, and the transform's determinant is +1, so no handedness is involved. The only asymmetry in either part is 0.05 mm, between two of the three M3 insert pockets, at 17.35 mm and 17.40 mm from the bore centre. The machine should carry one holder and print it twice, which drops the printed part count by one. Nothing about the assembly changes: the two bearing seats face outward either way. The two ids are interchangeable as they stand. Which id survives, and what a single holder should be called, are open questions. Tracked as sorter-v2 issue #569, with the catalog side in #570.",
       "targets": {
         "parts": [
           "bearing-holder-left",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -409,6 +409,18 @@
           "camera-clasp-bottom"
         ]
       }
+    },
+    {
+      "id": "merge-bearing-holders",
+      "name": "Merge the two chute bearing holders into one part",
+      "priority": "P3",
+      "description": "The chute door module's two bearing holders are the same geometry, so the machine can print one part twice instead of two parts once each. Measured off the two master STLs: a proper rotation of exactly 180.000 degrees about the flange face normal (0, 0.906, 0.423) maps one onto the other with a maximum deviation of 0.065 mm and a mean of 0.004 mm, and the transform's determinant is +1, so no handedness is involved. The only asymmetry in either part is 0.05 mm, between two of the three M3 insert pockets, at 17.35 mm and 17.40 mm from the bore centre. The two ids are interchangeable as they stand and nothing about the assembly changes. Which id survives, and what a single holder should be called, are open questions. Tracked as sorter-v2 issue #569, with the catalog side in #570.",
+      "targets": {
+        "parts": [
+          "bearing-holder-left",
+          "bearing-holder-right"
+        ]
+      }
     }
   ],
   "folders": [
@@ -1887,8 +1899,8 @@
       "id": "bearing-holder-left",
       "uid": "gybh",
       "name": "Bearing holder (left)",
-      "description": "Bearing holder, left.",
-      "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to the chute-core role (ivory white); confirm.",
+      "description": "Bearing holder, left. The same part as the right holder, turned 180 degrees about its flange face.",
+      "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to the chute-core role (ivory white); confirm. Same geometry as bearing-holder-right: a proper rotation of exactly 180.000 degrees about the flange face normal (0, 0.906, 0.423) maps one onto the other, max deviation 0.065 mm, mean 0.004 mm, determinant +1 rather than -1, so it is a rotation and not a reflection. NOT a handed pair; earlier notes that said so came from testing only axis-aligned rotations, which cannot answer the question. See sorter-v2#569.",
       "version": "1",
       "created_at": "2026-06-27",
       "updated_at": "2026-06-27",
@@ -1907,14 +1919,20 @@
           "part": "hsi-m3",
           "qty": 3
         }
+      ],
+      "attributes": [
+        {
+          "label": "Interchangeable with",
+          "value": "Bearing holder (right)"
+        }
       ]
     },
     {
       "id": "bearing-holder-right",
       "uid": "rnog",
       "name": "Bearing holder (right)",
-      "description": "Bearing holder, right.",
-      "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to the chute-core role (ivory white); confirm.",
+      "description": "Bearing holder, right. The same part as the left holder, turned 180 degrees about its flange face.",
+      "internal_notes": "Chute-core assembly part. COLOR UNSPECIFIED by Spencer - defaulted to the chute-core role (ivory white); confirm. Same geometry as bearing-holder-left: a proper rotation of exactly 180.000 degrees about the flange face normal (0, 0.906, 0.423) maps one onto the other, max deviation 0.065 mm, mean 0.004 mm, determinant +1 rather than -1, so it is a rotation and not a reflection. NOT a handed pair; earlier notes that said so came from testing only axis-aligned rotations, which cannot answer the question. See sorter-v2#569.",
       "version": "1",
       "created_at": "2026-06-27",
       "updated_at": "2026-06-27",
@@ -1932,6 +1950,12 @@
         {
           "part": "hsi-m3",
           "qty": 3
+        }
+      ],
+      "attributes": [
+        {
+          "label": "Interchangeable with",
+          "value": "Bearing holder (left)"
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -427,8 +427,9 @@
 		{
 			"id": "merge-bearing-holders",
 			"name": "Merge the two chute bearing holders into one part",
-			"priority": "P3",
-			"description": "The chute door module's two bearing holders are the same geometry, so the machine can print one part twice instead of two parts once each. Measured off the two master STLs: a proper rotation of exactly 180.000 degrees about the flange face normal (0, 0.906, 0.423) maps one onto the other with a maximum deviation of 0.065 mm and a mean of 0.004 mm, and the transform's determinant is +1, so no handedness is involved. The only asymmetry in either part is 0.05 mm, between two of the three M3 insert pockets, at 17.35 mm and 17.40 mm from the bore centre. The two ids are interchangeable as they stand and nothing about the assembly changes. Which id survives, and what a single holder should be called, are open questions. Tracked as sorter-v2 issue #569, with the catalog side in #570.",
+			"priority": "P1",
+			"condition": "broken",
+			"description": "The chute door module asks for two different printed parts, a left bearing holder and a right one, where one part printed twice does the whole job. They are the same geometry. Measured off the two master STLs: a proper rotation of exactly 180.000 degrees about the flange face normal (0, 0.906, 0.423) maps one onto the other with a maximum deviation of 0.065 mm and a mean of 0.004 mm, and the transform's determinant is +1, so no handedness is involved. The only asymmetry in either part is 0.05 mm, between two of the three M3 insert pockets, at 17.35 mm and 17.40 mm from the bore centre. The machine should carry one holder and print it twice, which drops the printed part count by one. Nothing about the assembly changes: the two bearing seats face outward either way. The two ids are interchangeable as they stand. Which id survives, and what a single holder should be called, are open questions. Tracked as sorter-v2 issue #569, with the catalog side in #570.",
 			"targets": {
 				"parts": [
 					"bearing-holder-left",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -423,6 +423,18 @@
 					"camera-clasp-bottom"
 				]
 			}
+		},
+		{
+			"id": "merge-bearing-holders",
+			"name": "Merge the two chute bearing holders into one part",
+			"priority": "P3",
+			"description": "The chute door module's two bearing holders are the same geometry, so the machine can print one part twice instead of two parts once each. Measured off the two master STLs: a proper rotation of exactly 180.000 degrees about the flange face normal (0, 0.906, 0.423) maps one onto the other with a maximum deviation of 0.065 mm and a mean of 0.004 mm, and the transform's determinant is +1, so no handedness is involved. The only asymmetry in either part is 0.05 mm, between two of the three M3 insert pockets, at 17.35 mm and 17.40 mm from the bore centre. The two ids are interchangeable as they stand and nothing about the assembly changes. Which id survives, and what a single holder should be called, are open questions. Tracked as sorter-v2 issue #569, with the catalog side in #570.",
+			"targets": {
+				"parts": [
+					"bearing-holder-left",
+					"bearing-holder-right"
+				]
+			}
 		}
 	],
 	"folders": [
@@ -11514,7 +11526,7 @@
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
-			"description": "Bearing holder, left.",
+			"description": "Bearing holder, left. The same part as the right holder, turned 180 degrees about its flange face.",
 			"version": "1",
 			"created_at": "2026-06-27",
 			"updated_at": "2026-06-27",
@@ -11530,7 +11542,12 @@
 					"grams": 7.95
 				}
 			],
-			"attributes": [],
+			"attributes": [
+				{
+					"label": "Interchangeable with",
+					"value": "Bearing holder (right)"
+				}
+			],
 			"grams": 7.95,
 			"support_grams": 0.0,
 			"support_used": false,
@@ -11652,7 +11669,7 @@
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
-			"description": "Bearing holder, right.",
+			"description": "Bearing holder, right. The same part as the left holder, turned 180 degrees about its flange face.",
 			"version": "1",
 			"created_at": "2026-06-27",
 			"updated_at": "2026-06-27",
@@ -11668,7 +11685,12 @@
 					"grams": 7.98
 				}
 			],
-			"attributes": [],
+			"attributes": [
+				{
+					"label": "Interchangeable with",
+					"value": "Bearing holder (left)"
+				}
+			],
 			"grams": 7.98,
 			"support_grams": 0.0,
 			"support_used": false,


### PR DESCRIPTION
Asked by **barthel** in Discord: [could we use it as one part and reduce the printed-part count by one?](https://discord.com/channels/1430279849171222682/1546045981294985287/1546054980639785061)

Yes. `bearing-holder-left` and `bearing-holder-right` in the chute door module are the same geometry, so the machine can print one part twice instead of two parts once each.

**What this PR does is mark that, and nothing else.** No part is removed and no quantity changes; retiring an id is a stamped catalog revision plus a rename, which is #570, and the CAD side is #569.

## The measurement

From the two master STLs pinned in `catalog/parts.json`:

- A **proper rotation** of exactly **180.000 degrees** about the axis `(0, 0.90631, 0.42261)` maps the left holder onto the right one. That axis is the **flange face normal** to within 0.05 degrees, so in the hand it is "lay it flange down and spin it half a turn".
- **Determinant +1.** A reflection would be -1, so there is no handedness.
- Max deviation **0.065 mm**, mean **0.004 mm**, over all 3013 unique vertices, point-to-surface in both directions.
- The only asymmetry in either part is **0.05 mm**, between two of the three M3 insert pockets, at 17.35 mm and 17.40 mm from the bore centre.

![Four renders of the bearing holder from one camera. Top left the left holder as printed, top right the same part turned 180 degrees about its flange, bottom left the right holder as printed which is the same image again, bottom right both holders with the bearing race between them showing the two bearing seats facing outward](https://assets.basically.website/sorter-parts/bearing-holders-one-part-full-2d451d042546.png)

Top right and bottom left are the same image: the left holder turned, and the right holder untouched, from one camera.

## The changes

- A **P1 `changes` entry with `condition: "broken"`**, `merge-bearing-holders`, targeting both parts, so the calculator shows the warning on either part page. Opened as P3 with no condition; barthel asked for P1 + broken, on the reading that the defect is the catalog asking for two different printed parts where one printed twice does the job. The description leads with that.
- An **`Interchangeable with`** attribute on each part.
- Both **descriptions** say it, since that is the line a builder actually reads.
- `internal_notes` on both carry the numbers and the reason the earlier "handed pair" claim was wrong.

`catalog.generated.json` regenerated with `generate.py --metadata-only` in the same commit. `check_generated_pins`, `check_versioning`, `check_connections` all pass locally; `check_docs_refs` reports its 23 pre-existing warnings and none of them is a bearing holder.

Closes nothing. Tracked in #569 and #570.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1546045981294985287/1546054980639785061
preview: /part/bearing-holder-left
-->
