### PR TITLE
docs: move funnel brackets last in the chute tree and rename the page

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -29,19 +29,19 @@ The heat inserts are in the parts list above. The screws that hold the four sub-
 One chute is the chute core plus four things that bolt onto it:
 
 - **Door module**, one per chute: the door, the bearing assembly, the servo adapter and the servo in its bracket, built as a unit. See [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}).
-- **Funnel bracket (left)** and **Funnel bracket (right)**, one of each. See [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
 - **Layer connector A** and **Layer connector B**, one of each. See [Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
 - **Layer adapter board**, one per chute. See [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}).
+- **Funnel bracket (left)** and **Funnel bracket (right)**, one of each. See [Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
 
 Every screw that fastens one of them to the core lands in one of the core's own M3 heat inserts. Nothing on the chute taps into bare plastic.
 
 {% include step.html n="1" title="Preparation" %}
 
-Press the heat inserts into the chute core before you mount anything else onto it. Once the funnel brackets and the door module are on, several of the insert positions are hard to reach with an iron. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
+Press the heat inserts into the chute core before you mount anything else onto it. Once the door module and the funnel brackets are on, several of the insert positions are hard to reach with an iron. See [installing heat inserts]({{ '/hardware/helpers/heat-inserts/' | relative_url }}) for the technique.
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page: 4 for the funnel brackets, 6 for the door module (4 for its two bearing covers, 2 for the servo bracket arms), 4 for the layer connectors, and 4 for the layer adapter board. This is separate from the bearing assembly's own 10 inserts, which live in the bearing race and holders themselves.</p>
+    <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page: 6 for the door module (4 for its two bearing covers, 2 for the servo bracket arms), 4 for the layer connectors, 4 for the layer adapter board, and 4 for the funnel brackets. This is separate from the bearing assembly's own 10 inserts, which live in the bearing race and holders themselves.</p>
     <p>All 18 are the same pocket, Ø4.2 mm and blind, 5.7 mm deep, split <strong>8 + 6 + 4</strong> across three faces. The views are rendered from the chute core STL, turned slightly off each face so the pockets shade as holes, and circle only the pockets visible in that view.</p>
   </div>
   <div class="prep-item-figure prep-item-figure-split">
@@ -64,13 +64,13 @@ Press the heat inserts into the chute core before you mount anything else onto i
 
 Fit them in this order, each on its own page, and each with its own screws in its own parts list:
 
-- **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**, left and right
 - **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**, bolted on as a unit
 - **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** A and B
 - **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**
+- **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**, left and right
 
 Every insert you pressed in at step 1 takes a screw from one of those four pages. That is why the inserts are listed here and the screws are not.
 
-<div class="img-placeholder">Photo of a finished chute core with all four sub-assemblies bolted on: funnel brackets, door module, layer connectors and layer adapter board.</div>
+<div class="img-placeholder">Photo of a finished chute core with all four sub-assemblies bolted on: door module, layer connectors, layer adapter board and funnel brackets.</div>
 
 The chute is complete when all four are on. Repeat for every layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Funnel
+title: Funnel brackets
 type: how-to
 section: hardware
 slug: assembly-funnel
-kicker: Chute — Funnel
-lede: The funnel that guides parts through the door.
+kicker: Chute — Funnel brackets
+lede: The two brackets that hang off the chute core, and the funnel that snaps into them.
 permalink: /hardware/assembly/distribution/chute/funnel/
 author: spencer
 contributors: [barthel]

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -23,10 +23,10 @@ The chute is one per layer. Build the core first, since everything else bolts in
 The whole chute stack rotates as one unit, on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s Lazy Susan, driven by the stepper motor and gear train described there. The bins themselves don't move; each chute's door opens for a moment once it's rotated into position over the correct bin, dropping the part in. See [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}) and [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) for how that opening is driven and timed.
 
 1. **[Chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})**. The printed body everything else mounts to, and the 18 heat inserts that hold it all together.
-2. **[Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**. The funnel that guides parts into the bin, and the two brackets it hangs from. You choose one of two sizes for each layer, which sets that layer's funnel and its bin set together, so make the choice before printing either.
-3. **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**. The door itself, the bearing assembly it swings on, the servo adapter, and the MG995 servo that drives it. Built as a unit, then bolted on.
-4. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})**. The pair that joins this layer's chute to the one below.
-5. **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**. The board that drives the servo.
+2. **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**. The door itself, the bearing assembly it swings on, the servo adapter, and the MG995 servo that drives it. Built as a unit, then bolted on.
+3. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})**. The pair that joins this layer's chute to the one below.
+4. **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**. The board that drives the servo.
+5. **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**. The two brackets that go on last, and the funnel that snaps into them. You choose one of two funnel sizes for each layer, which sets that layer's funnel and its bin set together, so make the choice before printing either.
 
 ## Installing the chutes in the machine
 

--- a/docs/src/content/hardware/assembly/install-bins.md
+++ b/docs/src/content/hardware/assembly/install-bins.md
@@ -52,7 +52,7 @@ Either way it is one set per bay, six bays around the hexagon, and the two work 
 
 **If you are still deciding:** two third-size layers and one half-size is what the [parts calculator](https://parts-calculator.basically.website/) starts a fresh machine at, and it is a sensible default. Most LEGO is small, so most of your destinations should be, but you want at least one layer that can take the big pieces. Nothing ties a size to a particular height, so which level carries the half-size layer is yours to choose.
 
-Switching a layer to the other size at this point means printing a new funnel as well as new bins. [Funnel]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}) is where that choice is made, and has the same comparison in full.
+Switching a layer to the other size at this point means printing a new funnel as well as new bins. [Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}) is where that choice is made, and has the same comparison in full.
 
 {% include step.html n="2" title="Get the bins: print them or cut them" %}
 

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -45,14 +45,14 @@ sections:
                 children:
                   - title: Chute core
                     url: /hardware/assembly/distribution/chute/chute-core/
-                  - title: Funnel
-                    url: /hardware/assembly/distribution/chute/funnel/
                   - title: Door module
                     url: /hardware/assembly/distribution/chute/door-module/
                   - title: Layer connectors
                     url: /hardware/assembly/distribution/chute/layer-connectors/
                   - title: Layer adapter board
                     url: /hardware/assembly/distribution/chute/pcb/
+                  - title: Funnel brackets
+                    url: /hardware/assembly/distribution/chute/funnel/
           - title: Feeder
             url: /hardware/assembly/feeder/
             children:


### PR DESCRIPTION
Requested by **barthel** in #balloon-does-docs: https://discord.com/channels/1430279849171222682/1536088194557419660/1546056405738594304

**Funnel brackets now come last in the chute.** The order in the sidebar (`nav.yml`), on the chute landing page and in both link lists on the chute core page is now Chute core, Door module, Layer connectors, Layer adapter board, Funnel brackets.

**The page is renamed "Funnel brackets".** Title, kicker, and every link to it across the site. Its lede now covers both parts (the brackets and the funnel that snaps into them).

**The URL is unchanged**, `/hardware/assembly/distribution/chute/funnel/`, so no redirect is needed and no bookmark breaks.

Also reordered to match, on the chute core page: the heat-insert split sentence in step 1, the "hard to reach with an iron" sentence, and the caption of the finished-core photo placeholder.

Not touched: the `chute` assembly in `parts-calculator/catalog/parts.json` still lists the funnel brackets third. Say the word if the calculator's tree should match.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1546056405738594304
preview: /hardware/assembly/distribution/chute/
-->
