### PR TITLE
docs: move Layer connectors to the end of the Chute section

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -29,9 +29,9 @@ The heat inserts are in the parts list above. The screws that hold the four sub-
 One chute is the chute core plus four things that bolt onto it:
 
 - **Door module**, one per chute: the door, the bearing assembly, the servo adapter and the servo in its bracket, built as a unit. See [Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }}).
-- **Layer connector A** and **Layer connector B**, one of each. See [Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
 - **Layer adapter board**, one per chute. See [Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}).
 - **Funnel bracket (left)** and **Funnel bracket (right)**, one of each. See [Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }}).
+- **Layer connector A** and **Layer connector B**, one of each. See [Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
 
 Every screw that fastens one of them to the core lands in one of the core's own M3 heat inserts. Nothing on the chute taps into bare plastic.
 
@@ -65,12 +65,12 @@ Press the heat inserts into the chute core before you mount anything else onto i
 Fit them in this order, each on its own page, and each with its own screws in its own parts list:
 
 - **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**, bolted on as a unit
-- **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** A and B
 - **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**
 - **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**, left and right
+- **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})** A and B
 
 Every insert you pressed in at step 1 takes a screw from one of those four pages. That is why the inserts are listed here and the screws are not.
 
-<div class="img-placeholder">Photo of a finished chute core with all four sub-assemblies bolted on: door module, layer connectors, layer adapter board and funnel brackets.</div>
+<div class="img-placeholder">Photo of a finished chute core with all four sub-assemblies bolted on: door module, layer adapter board, funnel brackets and layer connectors.</div>
 
 The chute is complete when all four are on. Repeat for every layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -24,9 +24,9 @@ The whole chute stack rotates as one unit, on the [top interface]({{ '/hardware/
 
 1. **[Chute core]({{ '/hardware/assembly/distribution/chute/chute-core/' | relative_url }})**. The printed body everything else mounts to, and the 18 heat inserts that hold it all together.
 2. **[Door module]({{ '/hardware/assembly/distribution/chute/door-module/' | relative_url }})**. The door itself, the bearing assembly it swings on, the servo adapter, and the MG995 servo that drives it. Built as a unit, then bolted on.
-3. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})**. The pair that joins this layer's chute to the one below.
-4. **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**. The board that drives the servo.
-5. **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**. The two brackets that go on last, and the funnel that snaps into them. You choose one of two funnel sizes for each layer, which sets that layer's funnel and its bin set together, so make the choice before printing either.
+3. **[Layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }})**. The board that drives the servo.
+4. **[Funnel brackets]({{ '/hardware/assembly/distribution/chute/funnel/' | relative_url }})**. The two brackets that hang off the core, and the funnel that snaps into them. You choose one of two funnel sizes for each layer, which sets that layer's funnel and its bin set together, so make the choice before printing either.
+5. **[Layer connectors]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }})**. The pair that joins this layer's chute to the one below.
 
 ## Installing the chutes in the machine
 

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -47,12 +47,12 @@ sections:
                     url: /hardware/assembly/distribution/chute/chute-core/
                   - title: Door module
                     url: /hardware/assembly/distribution/chute/door-module/
-                  - title: Layer connectors
-                    url: /hardware/assembly/distribution/chute/layer-connectors/
                   - title: Layer adapter board
                     url: /hardware/assembly/distribution/chute/pcb/
                   - title: Funnel brackets
                     url: /hardware/assembly/distribution/chute/funnel/
+                  - title: Layer connectors
+                    url: /hardware/assembly/distribution/chute/layer-connectors/
           - title: Feeder
             url: /hardware/assembly/feeder/
             children:


### PR DESCRIPTION
barthel asked for the **Layer connectors** page to sit at the end of the Chute section, right after **Funnel brackets**.

The chute order is now **Chute core, Door module, Layer adapter board, Funnel brackets, Layer connectors**, changed in the three places that carry it:

- `docs/src/liquid/_data/nav.yml`, the sidebar order.
- `chute/index.md`, the numbered install list. Item 4 no longer says the funnel brackets "go on last", since they are not last any more.
- `chute-core.md`, both link lists (the four sub-assemblies, and step 2's "fit them in this order") plus the photo placeholder caption that names them in order.

No permalink changed, so no `_redirects` entry is needed. The `chute` assembly in `parts-calculator/catalog/parts.json` still lists the connectors in its own order and was deliberately left alone, the same as in #572.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1546410972439126108
preview: /hardware/assembly/distribution/chute/
-->
