### PR TITLE
parts-calculator: stamp the three new version entries with the commit on main

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -8318,7 +8318,7 @@
           "date": "2026-09-06",
           "message": "The 24 bin retainer T-nuts and the 6 piece D foot extensions this layer was created without. The T-nuts are the same 24 the layer node carries, one per retainer screw; this node was added after them and never got a line, so the machine read 164 T-nuts where it should read 188 at 5 layers. Piece D replaces this layer's piece C and was reaching the Hardware tab from an old BOM-sheet hand count rather than from the tree. No physical change.",
           "breaking": false,
-          "commit": "970249dd"
+          "commit": "a5ebc2ca"
         }
       ]
     },
@@ -8507,7 +8507,7 @@
           "date": "2026-09-06",
           "message": "Piece C (Layer vertical support), 6 per layer. The layer carries the extrusion that spans up to the ring above it, so 6 on a node that runs non-bottom-layers times is the framing cut list's 6(n-1) exactly. It was in no assembly, so the Hardware tab had nothing to count it from and rendered qty TBD. No physical change.",
           "breaking": false,
-          "commit": "970249dd"
+          "commit": "a5ebc2ca"
         }
       ]
     },
@@ -9861,7 +9861,7 @@
           "date": "2026-09-06",
           "message": "Pieces E and F, the interface spoke and the interface vertical support this bracket is bolted onto, 1 each. The node's own description already named both; neither was in any assembly, so both read qty TBD on the Hardware tab while the framing cut list knew them. 6 of each per machine, which is what framing.ts says. No physical change.",
           "breaking": false,
-          "commit": "970249dd"
+          "commit": "a5ebc2ca"
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -2948,7 +2948,7 @@
 					"date": "2026-09-06",
 					"message": "The 24 bin retainer T-nuts and the 6 piece D foot extensions this layer was created without. The T-nuts are the same 24 the layer node carries, one per retainer screw; this node was added after them and never got a line, so the machine read 164 T-nuts where it should read 188 at 5 layers. Piece D replaces this layer's piece C and was reaching the Hardware tab from an old BOM-sheet hand count rather than from the tree. No physical change.",
 					"breaking": false,
-					"commit": "970249dd"
+					"commit": "a5ebc2ca"
 				}
 			]
 		},
@@ -3138,7 +3138,7 @@
 					"date": "2026-09-06",
 					"message": "Piece C (Layer vertical support), 6 per layer. The layer carries the extrusion that spans up to the ring above it, so 6 on a node that runs non-bottom-layers times is the framing cut list's 6(n-1) exactly. It was in no assembly, so the Hardware tab had nothing to count it from and rendered qty TBD. No physical change.",
 					"breaking": false,
-					"commit": "970249dd"
+					"commit": "a5ebc2ca"
 				}
 			]
 		},
@@ -4503,7 +4503,7 @@
 					"date": "2026-09-06",
 					"message": "Pieces E and F, the interface spoke and the interface vertical support this bracket is bolted onto, 1 each. The node's own description already named both; neither was in any assembly, so both read qty TBD on the Hardware tab while the framing cut list knew them. 6 of each per machine, which is what framing.ts says. No physical change.",
 					"breaking": false,
-					"commit": "970249dd"
+					"commit": "a5ebc2ca"
 				}
 			]
 		},


### PR DESCRIPTION
Asked for by zed0 in `#balloon-does-docs`, after he spotted `a5ebc2ca` and `4f17cc8b` failing `Cloudflare Pages: parts-calculator`: https://discord.com/channels/1430279849171222682/1536088194557419660/1546475477781450762

### What was broken

`#561` stamped three new version entries with `"commit": "970249dd"`, which was its own branch head at the time. The branch (`balloon/extrusions-and-bottom-layer-tnuts`) was rebased before merge and now points at `61f2919e`, so `970249dd` is an ancestor of nothing: it is orphaned, no clone can fetch it, and only a working checkout that predates the force-push still holds the object.

`scripts/version-snapshots.mjs` (which is `prebuild`, so it runs before Vite) reads `src/lib/data/catalog.generated.json` at `<successor commit>~` for every superseded version and calls `process.exit(1)` on any it cannot read. So the Pages build has failed on every `parts-calculator` commit on `main` since `a5ebc2ca`, with no compile error anywhere in the log, and `parts-calculator.basically.website` has been serving `4f5bcebf`'s build since 2026-09-06.

`4f17cc8b` (#564) is innocent; it fails only because it carries the same `parts.json`.

### The change

The three stamps (`bottom-layer` v1, `layer` v4, `interface-bracket-mount` v2) become `a5ebc2ca`, the squash commit that carries the change on `main`, regenerated into the generated catalog with `generate.py --metadata-only`. `a5ebc2ca~` is `4f5bcebf`, the last state of those versions' reign, which is what VERSIONING.md defines a version's moment to be.

### Verification

- Fresh clone at `4f17cc8b` with every origin branch fetched: `node scripts/version-snapshots.mjs` fails on exactly `970249dd~` for those three entries, exit 1.
- Same clone at `4f5bcebf` (last green commit on `main`): exit 0, with the other stamps resolving fine, which rules out the older not-on-`main` stamps as the cause.
- Same clone at this branch: **36 snapshots written, exit 0** (`4f17cc8b` managed 33 plus 3 failures).
- `check_generated_pins`, `check_versioning`, `check_connections` and `check_asset_urls` all pass locally; `npm ci && npm run build` on Node 22 is clean.

### Not in this change

Ten other stamped moments resolve only through branches that still exist (`a2c66436`, `36826f49`, `1ce549ec`, `9ff8a1e3`, `9708a416`). They are readable today and untouched here, but each one dies the day its branch is deleted. Worth moving to their `main` commits deliberately, in their own change.

A CI check that catches this class before merge is written and posted in the thread; it cannot come from me, because pushing `.github/workflows/` needs a token scope this account does not have.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1546475477781450762
request: https://discord.com/channels/1430279849171222682/1546475477781450762/1546478299230773319
preview: /assembly
-->
