### PR TITLE
hive: default AI model to GLM 5.3, refresh the OpenRouter roster

### DIFF
--- a/software/hive/backend/app/config.py
+++ b/software/hive/backend/app/config.py
@@ -86,9 +86,10 @@ class Settings(BaseSettings):
     # server-health page (server_storage_cache). The walk lists every S3 key so
     # it's slow; a few hours is plenty. Clamped to a 5min floor in the worker.
     SERVER_STORAGE_REFRESH_INTERVAL_MINUTES: int = 180
-    # Best intelligence-per-dollar on OpenRouter as of 2026-07 (~$0.7/M in,
-    # ~$2.2/M out). Frontend settings page mirrors this in aiModelGroups.
-    DEFAULT_AI_MODEL: str = "z-ai/glm-5.2"
+    # Newest full-size GLM as of 2026-09: ~$1.4/M in, ~$4.4/M out, roughly half
+    # of Sonnet 5 on the blended cost factor. The settings page reads this from
+    # GET /api/ai/models rather than hardcoding it.
+    DEFAULT_AI_MODEL: str = "z-ai/glm-5.3"
     PROFILE_AI_PROMPT_CACHE_ENABLED: bool = True
     PROFILE_AI_PROMPT_CACHE_TTL: str | None = None
     SECRET_ENCRYPTION_KEY: str | None = None

--- a/software/hive/backend/app/services/openrouter_catalog.py
+++ b/software/hive/backend/app/services/openrouter_catalog.py
@@ -29,21 +29,29 @@ CACHE_TTL_SECONDS = 6 * 60 * 60
 # Curated roster. Order within a group is the order shown. Every id must exist on
 # OpenRouter; ids that 404 out of the catalog are dropped at serve time rather
 # than shown as broken options.
+#
+# Prices and names are live (fetched below), but WHICH models appear is this
+# hand-picked list and it goes stale as vendors ship. Last refreshed against
+# https://openrouter.ai/api/v1/models on 2026-09-06.
 CURATED_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "Recommended",
         (
-            "z-ai/glm-5.2",
+            "z-ai/glm-5.3",
+            "z-ai/glm-5.3-flash",
             "anthropic/claude-sonnet-5",
-            "openai/gpt-5.4",
-            "deepseek/deepseek-v4-pro",
-            "google/gemini-3.6-flash",
+            "google/gemini-3.8-flash",
+            "deepseek/deepseek-v4-pro-0813",
+            "openai/gpt-5.6-sol",
         ),
     ),
     (
         "Anthropic",
         (
+            "anthropic/claude-fable-5.1",
             "anthropic/claude-fable-5",
+            "anthropic/claude-opus-5",
+            "anthropic/claude-opus-4.8",
             "anthropic/claude-opus-4.7",
             "anthropic/claude-sonnet-5",
             "anthropic/claude-sonnet-4.6",
@@ -53,28 +61,36 @@ CURATED_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "OpenAI",
         (
+            "openai/gpt-6-astra-pro",
+            "openai/gpt-6-astra",
+            "openai/gpt-5.6-terra",
+            "openai/gpt-5.6-sol",
+            "openai/gpt-5.6-luna",
             "openai/gpt-5.5-pro",
             "openai/gpt-5.5",
             "openai/gpt-5.4-pro",
             "openai/gpt-5.4",
             "openai/gpt-5.4-mini",
-            "openai/gpt-5.6-terra",
-            "openai/gpt-5.6-luna",
+            "openai/gpt-5.4-nano",
         ),
     ),
     (
         "Google",
         (
+            "google/gemini-3.8-flash",
+            "google/gemini-3.7-flash",
             "google/gemini-3.6-flash",
             "google/gemini-3.5-flash",
+            "google/gemini-3.5-flash-lite",
             "google/gemini-3.1-pro-preview",
-            "google/gemini-3-flash-preview",
             "google/gemini-3.1-flash-lite",
         ),
     ),
     (
         "Z.ai (GLM)",
         (
+            "z-ai/glm-5.3",
+            "z-ai/glm-5.3-flash",
             "z-ai/glm-5.2",
             "z-ai/glm-5.1",
             "z-ai/glm-5",
@@ -86,7 +102,9 @@ CURATED_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "DeepSeek",
         (
+            "deepseek/deepseek-v4-pro-0813",
             "deepseek/deepseek-v4-pro",
+            "deepseek/deepseek-v4-flash-0731",
             "deepseek/deepseek-v4-flash",
             "deepseek/deepseek-v3.2",
         ),
@@ -94,9 +112,10 @@ CURATED_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "Qwen",
         (
+            "qwen/qwen3.8-max-0902",
+            "qwen/qwen3.8-flash",
             "qwen/qwen3.7-max",
-            "qwen/qwen3.6-max-preview",
-            "qwen/qwen3-max",
+            "qwen/qwen3.7-plus",
             "qwen/qwen3-vl-235b-a22b-instruct",
         ),
     ),
@@ -104,6 +123,7 @@ CURATED_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
         "Moonshot (Kimi)",
         (
             "moonshotai/kimi-k3",
+            "moonshotai/kimi-k2.7-code",
             "moonshotai/kimi-k2.6",
             "moonshotai/kimi-k2-thinking",
         ),
@@ -119,6 +139,7 @@ CURATED_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "xAI (Grok)",
         (
+            "x-ai/grok-4.6",
             "x-ai/grok-4.5",
             "x-ai/grok-4.3",
         ),


### PR DESCRIPTION
## What

- `DEFAULT_AI_MODEL` moves from `z-ai/glm-5.2` (~0.37x Sonnet 5) to `z-ai/glm-5.3` (~0.54x), the newest full-size GLM.
- The curated OpenRouter roster in `openrouter_catalog.py` is refreshed. Prices and names were already live, but which models appear is a hand-written list that had not been touched since 2026-07-29 and was missing GLM 5.3 / 5.3 Flash, Gemini 3.7 / 3.8 Flash, Opus 5, Fable 5.1, GPT-6 Astra, GPT-5.6 Sol, Qwen 3.8, Grok 4.6, Kimi K2.7, and the August DeepSeek V4 builds. Three superseded previews are dropped. A source comment now says the list is manual and when it was last checked.
- GLM 5.3 Flash (~0.03x) is in Recommended as the cheap option but is not the default; it has not been run against the tool loop.

## Why

Spencer's account was on Sonnet 4.6 at ~1.5x. The default is the cheap-but-capable path for everyone else, and the picker had drifted far enough that the current GLM was not selectable at all.

## Verification

- Every id in the roster resolves on `https://openrouter.ai/api/v1/models` as of 2026-09-06, and the default is served by `GET /api/ai/models`.
- `pytest tests/test_profiles.py tests/test_ai_usage.py`: 16 passed.

Note: the default only applies to accounts with no saved `preferred_ai_model`. Existing accounts keep whatever they last saved until they pick again in Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)