### PR TITLE
docs: mark the chute pages builder-verified

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -9,10 +9,7 @@ lede: The chute assembly. Build one per layer.
 permalink: /hardware/assembly/distribution/chute/chute-core/
 author: spencer
 contributors: [barthel]
-warning: >-
-  **AI-generated first draft.** Written from the machine assembly tree in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=chute), not from an
-  actual build. No step here has been checked against a machine. Correct it as you build.
+last_verified: 2026-09-07
 parts_needed:
   - part: chute-core
     qty: 1

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -9,14 +9,7 @@ lede: The per-layer door mechanism that releases parts into a bin.
 permalink: /hardware/assembly/distribution/chute/door-module/
 author: spencer
 contributors: [barthel]
-last_verified: 2026-09-05
-warning: >-
-  **AI-generated first draft, apart from the servo bracket.** Written from the machine assembly
-  tree in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=flap-module), not from
-  an actual build. Steps 2 and 3 are a builder's account, corrected against a real machine on
-  2026-09-05, and the video below is Basically's own. Step 4 is derived from the parts'
-  geometry, not from anyone who has built one. Correct it as you build.
+last_verified: 2026-09-07
 parts_needed:
   - part: chute-door
     qty: 1
@@ -190,11 +183,6 @@ The shaft is captured at both ends once this is together, so there is only one o
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bearing-assembly-blue-full-1cb33257bd5a.png" alt="Two renders, one above the other: on top the chute door with its shaft, the bearing race over the shaft, and the two bearing holders drawn out along the shaft with a blue bearing in each; below, the same parts pushed together so the holders sit on the ends of the race">
   <figcaption>The holders, with their bearings in blue, going onto the ends of the shaft and down onto the race. The covers are not shown. <cite>Rendered from the parts' own geometry in assembly position, not from a build. Render: Balloon.</cite></figcaption>
 </figure>
-
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>This order is derived from the parts rather than from a build: the bores, the shaft and the race line up in the CAD and only fit together one way. The fits quoted are measured off the STLs. Nobody has reported building it, so correct this step if it does not go together as described.</p>
-</div>
 
 {% include step.html n="5" title="Bolt the flap assembly to the chute core" %}
 

--- a/docs/src/content/hardware/assembly/distribution/chute/funnel.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/funnel.md
@@ -9,7 +9,7 @@ lede: The two brackets that hang off the chute core, and the funnel that snaps i
 permalink: /hardware/assembly/distribution/chute/funnel/
 author: spencer
 contributors: [barthel]
-last_verified: 2026-09-05
+last_verified: 2026-09-07
 parts_needed:
   - part: funnel-half
   - part: funnel-third

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -10,11 +10,6 @@ permalink: /hardware/assembly/distribution/chute/
 author: spencer
 contributors: [alex, brickcyclealice, barthel]
 last_verified: 2026-09-07
-warning: >-
-  **The install order below is one builder's account.** Steps 2 to 4 are how alex built his
-  machine, written down from what he described in Discord; nobody else has said whether they
-  did it the same way. The pages themselves have been built from. Correct the order as you
-  build.
 ---
 
 The chute is one per layer. Build the core first, since everything else bolts into its heat inserts.

--- a/docs/src/content/hardware/assembly/distribution/chute/index.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/index.md
@@ -8,14 +8,13 @@ kicker: Distribution — Chute
 lede: The rotating chute that aims parts at the correct bin.
 permalink: /hardware/assembly/distribution/chute/
 author: spencer
-contributors: [alex, brickcyclealice]
+contributors: [alex, brickcyclealice, barthel]
+last_verified: 2026-09-07
 warning: >-
-  **Part AI-generated, part one builder's account.** The list of pages comes from the machine
-  assembly tree in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=chute), not from an
-  actual build. The install order below is how alex built his machine, written down from what
-  he described in Discord; nobody else has said whether they did it the same way. Each page
-  carries its own note. Correct them as you build.
+  **The install order below is one builder's account.** Steps 2 to 4 are how alex built his
+  machine, written down from what he described in Discord; nobody else has said whether they
+  did it the same way. The pages themselves have been built from. Correct the order as you
+  build.
 ---
 
 The chute is one per layer. Build the core first, since everything else bolts into its heat inserts.

--- a/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/layer-connectors.md
@@ -9,11 +9,7 @@ lede: The connectors that chain layers together.
 permalink: /hardware/assembly/distribution/chute/layer-connectors/
 author: spencer
 contributors: [barthel]
-warning: >-
-  **AI-generated first draft.** Written from the machine assembly tree in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=layer-connector), not
-  from an actual build. No step here has been checked against a machine. Correct it as you
-  build.
+last_verified: 2026-09-07
 parts_needed:
   - part: layer-connector-1
     qty: 1

--- a/docs/src/content/hardware/assembly/distribution/chute/pcb.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/pcb.md
@@ -9,10 +9,7 @@ lede: The board that drives the servo.
 permalink: /hardware/assembly/distribution/chute/pcb/
 author: spencer
 contributors: [barthel]
-warning: >-
-  **AI-generated first draft.** Written from the machine assembly tree in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=chute-pcb), not from
-  an actual build. No step here has been checked against a machine. Correct it as you build.
+last_verified: 2026-09-07
 parts_needed:
   - part: layer-adapter-board-basically
     qty: 1


### PR DESCRIPTION
**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1546559519260409867): "Documentation https://docs.basically.website/hardware/assembly/distribution/chute/ approved. I successfully built the Chute, including the individual modules, following the instructions."** And, [in the same thread](https://discord.com/channels/1430279849171222682/1546559519260409867/1546561101523722281): "Remove warning "he install order below is one builder's account." from chute page."

He built a chute and its modules from the pages as written, so they stop being drafts.

## What changed

**The `warning:` banner comes off all five how-to pages and the landing page** (`chute-core.md`, `door-module.md`, `layer-connectors.md`, `pcb.md`, and `index.md`). Per the convention set on the funnel page in #557, a page verified against a build loses the note entirely rather than softening it.

`index.md`'s banner was narrowed first, to the install order in steps 2 to 4 (still [alex's account](https://docs.basically.website/hardware/assembly/distribution/chute/) of how he built his machine), then removed outright when barthel asked for it in the thread.

**`last_verified: 2026-09-07` on all six pages.** `funnel.md` and `door-module.md` already carried `2026-09-05` from #572 and #559; both move to the date barthel approved the section. It renders as *Last verified* in the page footer, overriding the site-wide `2026-04-08` default in `docs/src/lib/server/content.ts`.

**One stale callout removed**, on `door-module.md` step 4: it said the bearing order was derived from the parts and "Nobody has reported building it, so correct this step if it does not go together as described". Somebody has now.

**barthel added to `contributors:` on `index.md`**, where he was not listed.

## What was deliberately kept

**Every other callout stays.** They are build instructions rather than caveats about the page: the 180 degree servo travel warning on `door-module.md`, and the static-handling caution on `pcb.md`.

**Step 3 of `index.md` keeps its line** that nobody has said yet when the funnels should go on. That is an open question about the machine build order, not a caveat about the page, and nothing in this report settles it.

No page bodies, parts lists or permalinks changed.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1546559519260409867
request: https://discord.com/channels/1430279849171222682/1546559519260409867/1546561101523722281
preview: /hardware/assembly/distribution/chute/
preview: /hardware/assembly/distribution/chute/chute-core/
preview: /hardware/assembly/distribution/chute/door-module/
-->
