### PR TITLE
parts-calculator: cable cage bracket (cable mount) v2, barthel's fix for the ribbon clamp mismatch (#403)

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1586,18 +1586,29 @@
     },
     {
       "id": "interface-cage-bracket-cable",
-      "uid": "cy58",
+      "uid": "nu2n",
       "name": "Cable cage bracket (cable mount)",
       "description": "Cable cage bracket with the cable mount. 1 needed.",
-      "internal_notes": "1 per interface; the cage bracket variant with a cable mount. Frame color.",
-      "version": "1",
+      "internal_notes": "1 per interface; the cage bracket variant with a cable mount. Frame color. v2 (2026-09-07): barthel's proposed geometry for the ribbon-cable-clamp mismatch (sorter-v2 #403) -- the underside near the heat-insert boss moved from Z 210.0 to Z 212.0 and the mounting foot widened from X +-15 to X +-22, measured against the v1 master STL in this part's own export frame. Not confirmed to close #403; that's still tracked separately in the P1 changes entry.",
+      "version": "2",
       "created_at": "2026-06-27",
-      "updated_at": "2026-06-27",
+      "updated_at": "2026-09-07",
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-09-07",
+          "message": "barthel's proposed fix for the ribbon-cable-clamp foot/lip mismatch (#403): the underside near the heat-insert boss raised ~2mm (Z 210.0 -> 212.0) and the mounting foot widened from +-15 to +-22 in X. Mounting bolt pattern and insert bore unchanged, so an old print still bolts in the same place.",
+          "breaking": false,
+          "commit": null,
+          "onshape_version": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/v/b0b87904579c8becc296a460/e/5e3340c2e9170c356be9cfb9"
+        }
+      ],
       "quantities": {
         "interface": 1
       },
       "assembly": "cable-cage",
-      "stl_hash": "081da7a95e53340f4f27219a224c0015905f176707c84f82c2f69bd72da85530",
+      "stl_hash": "0dad6ad3b408d51771212d81c465973dee0d4f0f41be46ac8f0ba92fbc1e7567",
+      "onshape_version": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/v/b0b87904579c8becc296a460/e/5e3340c2e9170c356be9cfb9",
       "color": {
         "role": "frame"
       },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -1595,11 +1595,17 @@
       "updated_at": "2026-09-07",
       "versions": [
         {
+          "version": "1",
+          "uid": "cy58",
+          "message": "As recorded before the first stamped change.",
+          "stl_hash": "081da7a95e53340f4f27219a224c0015905f176707c84f82c2f69bd72da85530"
+        },
+        {
           "version": "2",
           "date": "2026-09-07",
           "message": "barthel's proposed fix for the ribbon-cable-clamp foot/lip mismatch (#403): the underside near the heat-insert boss raised ~2mm (Z 210.0 -> 212.0) and the mounting foot widened from +-15 to +-22 in X. Mounting bolt pattern and insert bore unchanged, so an old print still bolts in the same place.",
           "breaking": false,
-          "commit": null,
+          "commit": "6e02bf71",
           "onshape_version": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/v/b0b87904579c8becc296a460/e/5e3340c2e9170c356be9cfb9"
         }
       ],
@@ -8669,7 +8675,7 @@
           "date": "2026-09-05",
           "message": "The screw through the servo bracket's side arm into the chute core is an M3 × 8, not an M3 × 12. Measured off the STL: that ear is 5.00 mm thick, the same as the bearing covers', so an 8 reaches 3.00 mm into the core's blind 5.70 mm insert and a 12 bottoms out in it. The lower arm's ear is 8.40 mm and keeps its 12. One screw moves from the 12 column to the 8; no part changed.",
           "breaking": false,
-          "commit": null
+          "commit": "18236142"
         }
       ],
       "name": "Chute",
@@ -9218,7 +9224,7 @@
           "date": "2026-09-01",
           "message": "Recording correction: the idler gear's axle screw is 1 x M3 x 20 countersunk, not M3 x 35. It self-taps into the printed NEMA 23 bracket and never reaches the plywood Top plate, measured on BrickCycleAlice's build (sorter-v2#458). No physical change.",
           "breaking": false,
-          "commit": null
+          "commit": "5195cedc"
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -12,8 +12,8 @@
 		"cost_per_kg": 24.99,
 		"commit_base_url": "https://github.com/basicallysource/sorter-v2/commit/",
 		"engrave": "33d9fa246b1a",
-		"all_parts_zip": "https://assets.basically.website/sorter-parts/all-parts-b9de86b7d2b1.zip",
-		"all_parts_plain_zip": "https://assets.basically.website/sorter-parts/all-parts-plain-3a0441932286.zip"
+		"all_parts_zip": "https://assets.basically.website/sorter-parts/all-parts-b69ef395e79f.zip",
+		"all_parts_plain_zip": "https://assets.basically.website/sorter-parts/all-parts-plain-d17d1486022f.zip"
 	},
 	"sections": [
 		{
@@ -3266,7 +3266,7 @@
 					"date": "2026-09-05",
 					"message": "The screw through the servo bracket's side arm into the chute core is an M3 \u00d7 8, not an M3 \u00d7 12. Measured off the STL: that ear is 5.00 mm thick, the same as the bearing covers', so an 8 reaches 3.00 mm into the core's blind 5.70 mm insert and a 12 bottoms out in it. The lower arm's ear is 8.40 mm and keeps its 12. One screw moves from the 12 column to the 8; no part changed.",
 					"breaking": false,
-					"commit": null
+					"commit": "18236142"
 				}
 			],
 			"name": "Chute",
@@ -3819,7 +3819,7 @@
 					"date": "2026-09-01",
 					"message": "Recording correction: the idler gear's axle screw is 1 x M3 x 20 countersunk, not M3 x 35. It self-taps into the printed NEMA 23 bracket and never reaches the plywood Top plate, measured on BrickCycleAlice's build (sorter-v2#458). No physical change.",
 					"breaking": false,
-					"commit": null
+					"commit": "5195cedc"
 				}
 			]
 		},
@@ -9674,7 +9674,7 @@
 		},
 		{
 			"id": "interface-cage-bracket-cable",
-			"uid": "cy58",
+			"uid": "nu2n",
 			"name": "Cable cage bracket (cable mount)",
 			"quantities": {
 				"interface": 1
@@ -9684,23 +9684,34 @@
 			"variant_group": null,
 			"variant_name": null,
 			"description": "Cable cage bracket with the cable mount. 1 needed.",
-			"version": "1",
+			"version": "2",
 			"created_at": "2026-06-27",
-			"updated_at": "2026-06-27",
+			"updated_at": "2026-09-07",
 			"versions": [
 				{
 					"version": "1",
 					"uid": "cy58",
-					"date": "2026-06-27",
-					"message": "Initial version.",
-					"commit": null,
-					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-081da7a95e53.stl",
+					"message": "As recorded before the first stamped change.",
+					"stl_hash": "081da7a95e53340f4f27219a224c0015905f176707c84f82c2f69bd72da85530",
 					"render": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-full-1f0901ff1415.png",
+					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-081da7a95e53.stl",
 					"grams": 15.88
+				},
+				{
+					"version": "2",
+					"uid": "nu2n",
+					"date": "2026-09-07",
+					"message": "barthel's proposed fix for the ribbon-cable-clamp foot/lip mismatch (#403): the underside near the heat-insert boss raised ~2mm (Z 210.0 -> 212.0) and the mounting foot widened from +-15 to +-22 in X. Mounting bolt pattern and insert bore unchanged, so an old print still bolts in the same place.",
+					"breaking": false,
+					"commit": "6e02bf71",
+					"onshape_version": "https://cad.onshape.com/documents/36d65973fe08f685f790dc8b/v/b0b87904579c8becc296a460/e/5e3340c2e9170c356be9cfb9",
+					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-0dad6ad3b408.stl",
+					"render": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-full-de4012cabecf.png",
+					"grams": 15.97
 				}
 			],
 			"attributes": [],
-			"grams": 15.88,
+			"grams": 15.97,
 			"support_grams": 0.0,
 			"support_used": false,
 			"support_intentional": false,
@@ -9723,52 +9734,52 @@
 			"caption": null,
 			"docs_page": null,
 			"conflicts": null,
-			"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-081da7a95e53.stl",
-			"render": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-full-1f0901ff1415.png",
+			"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-0dad6ad3b408.stl",
+			"render": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-full-de4012cabecf.png",
 			"stamped": [
 				{
 					"face": "bottom",
-					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-cy58-stamped-bottom-b6605bfc6e08.stl",
+					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-nu2n-stamped-bottom-44c710173b32.stl",
 					"normal": [
 						-0.0,
 						-0.0,
 						-1.0
 					],
 					"center": [
-						11.31,
-						199.63,
-						210.0
+						11.34,
+						199.68,
+						212.0
 					],
 					"size": [
-						3.63,
-						12.27
+						3.56,
+						12.17
 					],
 					"cap": 3.5,
 					"depth": 0.6
 				},
 				{
 					"face": "+x side",
-					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-cy58-stamped-plus-x-side-2cc81fb6c305.stl",
+					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-nu2n-stamped-plus-x-side-18dbe4e22ee7.stl",
 					"normal": [
 						1.0,
 						0.0,
-						-0.0
+						0.0
 					],
 					"center": [
 						15.0,
-						199.63,
-						213.69
+						199.68,
+						215.66
 					],
 					"size": [
-						12.27,
-						3.63
+						12.17,
+						3.56
 					],
 					"cap": 3.5,
 					"depth": 0.6
 				},
 				{
 					"face": "-x side",
-					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-cy58-stamped-minus-x-side-b8aa422d5223.stl",
+					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-nu2n-stamped-minus-x-side-60759d3b7395.stl",
 					"normal": [
 						-1.0,
 						0.0,
@@ -9776,32 +9787,32 @@
 					],
 					"center": [
 						-15.0,
-						199.63,
-						213.69
+						199.68,
+						215.66
 					],
 					"size": [
-						12.27,
-						3.63
+						12.17,
+						3.56
 					],
 					"cap": 3.5,
 					"depth": 0.6
 				},
 				{
-					"face": "+y side",
-					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-cy58-stamped-plus-y-side-de41c5fadf3d.stl",
+					"face": "-y side",
+					"stl": "https://assets.basically.website/sorter-parts/interface-cage-bracket-cable-nu2n-stamped-minus-y-side-f089237f82f8.stl",
 					"normal": [
-						0.0,
-						1.0,
-						0.0
+						-0.0,
+						-1.0,
+						-0.0
 					],
 					"center": [
-						6.99,
-						207.64,
-						213.69
+						-14.55,
+						162.14,
+						217.66
 					],
 					"size": [
-						12.27,
-						3.63
+						12.17,
+						3.56
 					],
 					"cap": 3.5,
 					"depth": 0.6


### PR DESCRIPTION
The new version of the cable-mount cage bracket barthel posted for #403, replacing v1 in the catalog.

- `interface-cage-bracket-cable` is now **v2**, uid `nu2n`, master `0dad6ad3b408` (already on the asset service). The underside near the heat-insert boss rises ~2 mm (Z 210 → 212) and the mounting foot widens from ±15 to ±22 mm in X, measured against the v1 master in its own export frame. Bolt pattern and insert bore are unchanged, so an old print still bolts in the same place. Not yet confirmed to close #403.
- v1 (uid `cy58`) is recorded as the superseded version with its pinned hash, so the uid on existing prints keeps resolving.
- `stamp_versions.py` also stamped two entries that were still pending on main (chute v2, chute-stepper-gearing v2).
- Regenerated with the local slicer: 16.0 g, four stamp faces, new bundles. Nothing else in the catalog moved.

This is the change balloon started this morning and could not finish; the reason is fixed in #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
