### PR TITLE
parts-calculator: a part the slicer cannot slice keeps its committed numbers, or ships with none

### DIFF
--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -414,8 +414,8 @@ export type PartDetail = {
 	stl?: string;
 	version?: string;
 	updated_at?: string;
-	grams?: number;
-	print_seconds?: number;
+	grams?: number | null; // null when no slicer could slice the part
+	print_seconds?: number | null;
 	onshape?: string;
 	low_tolerance?: boolean;
 	low_tolerance_note?: string;

--- a/parts-calculator/00000.log
+++ b/parts-calculator/00000.log
@@ -1,3 +1,161 @@
-error_code 65540, description: Invalid OpenGL version 3.4
-Failed to create GLFW window; skipping thumbnail rendering for CLI export
-OpenGL context unavailable; skip thumbnail generating
+cli mode, Current OrcaSlicer Version 2.4.0
+Will start to read model file now, file count :1
+allow_multicolor_oneplate 1, allow_rotations 1 skip_modified_gcodes 0 avoid_extrusion_cali_region 0 loaded_filament_ids size 0, clone_objects size 0, skip_useless_pick 0, allow_newer_file 0, allow_mix_temp 0
+plate_to_slice=0, normative_check=1, use_first_fila_as_default=0
+read model file:catalog/build/masters/camera-lamp-arm.stl
+TriangleMesh::repair() started
+TriangleMesh::repair() finished
+object camera-lamp-arm.stl, id :5, from stl or other 3mf
+run:before load settings, file count=2
+operator():load setting file catalog/build/profiles/machine.json, with rule 1
+no substitutions performed from file catalog/build/profiles/machine.json
+loaded machine config catalog/build/profiles/machine.json, type Bambu Lab A1 0.4 nozzle, name system, inherits Bambu Lab A1 0.4 nozzle, printer_model_id 
+operator():load setting file catalog/build/profiles/process_support.json, with rule 1
+no substitutions performed from file catalog/build/profiles/process_support.json
+loaded process config catalog/build/profiles/process_support.json, type sorter process, name system, inherits sorter process
+operator():load setting file catalog/build/profiles/filament.json, with rule 1
+no substitutions performed from file catalog/build/profiles/filament.json
+loaded filament 1 from file catalog/build/profiles/filament.json, type system, name sorter filament, inherits 
+current printer , new printer Bambu Lab A1 0.4 nozzle, current process , new process sorter process
+current printer inherits , new printer inherits Bambu Lab A1 0.4 nozzle, current process inherits , new process inherits sorter process
+index 0, new print compatible printer Bambu Lab A1 0.4 nozzle
+new printer Bambu Lab A1 0.4 nozzle, inherited from Bambu Lab A1 0.4 nozzle, new process sorter process, inherited from sorter process ,compatible 1
+update printer config to newest, different size 0, different_settings: 
+update_full_config: config keys count 40
+load a new printer, update all the keys, different_settings: 
+check printer cli safe params, current_printer_name , new_printer_name Bambu Lab A1 0.4 nozzle, printer_model Bambu Lab A1
+line 2877 , will parse file /Applications/OrcaSlicer.app/Contents/Resources/profiles/BBL/cli_config.json
+can not find key machine_max_acceleration_e in config
+can not find key machine_max_acceleration_retracting in config
+can not find key machine_max_acceleration_travel in config
+set key machine_max_acceleration_x  index 0, from 12000  to 6000
+set key machine_max_acceleration_x  index 1, from 12000  to 6000
+set key machine_max_acceleration_y  index 0, from 12000  to 6000
+set key machine_max_acceleration_y  index 1, from 12000  to 6000
+can not find key machine_max_jerk_x in config
+can not find key machine_max_jerk_y in config
+can not find key machine_max_jerk_z in config
+can not find key machine_max_speed_e in config
+can not find key machine_max_speed_x in config
+can not find key machine_max_speed_y in config
+update process config to newest, different size 0, different_settings: 
+update_full_config: config keys count 132
+load a new process, update all the keys, different_settings: 
+update filament 1's config to newest, different size 0, name sorter filament, different_settings 
+no filament colors found in projects
+total 1 models, 0 objects
+3657, remove_wrapping_detect 0, old value 0
+set_index: plate_id update from 0 to 0
+set_index: plate_id update from 1807646064 to 1
+translate_old 0, shrink_to_new_bed 0, old bed size {600, 600, 600}
+reset_size:before size: plate_width 0, plate_depth 0, plate_height 0
+reset_size:after size: plate_width 600, plate_depth 600, plate_height 600
+set_pos_and_size: plate_id 0, before, origin {0,0,0}, plate_width 0, plate_depth 0, plate_height 0
+set_pos_and_size: with_instance_move 0, after, origin {0,0,0}, plate_width 600, plate_depth 600, plate_height 600
+update_slice_result_valid_state: plate 0 , update slice result from 0 to 0
+set_pos_and_size: plate_id 1, before, origin {0,0,0}, plate_width 0, plate_depth 0, plate_height 0
+set_pos_and_size: with_instance_move 0, after, origin {720,0,0}, plate_width 600, plate_depth 600, plate_height 600
+update_slice_result_valid_state: plate 1 , update slice result from 0 to 0
+update_slice_result_valid_state: plate 0 , update slice result from 0 to 0
+update_slice_result_valid_state: plate 1 , update slice result from 0 to 0
+will start transforms, commands count 2
+process transform orient
+object camera-lamp-arm.stl, id :5, no need to orient when setting orient to 0
+orient_option 0
+process transform arrange
+finished model pre-process commands
+Before process command, no need to orient, object id :5
+before arrange, need_arrange=1, duplicate_count 0, filament_color_changed 0
+preprocess_arrange_polygon: not in any plates, bed_idx 0, translation(x) 0, (y) 0
+arrange bedpts:1000000 1000000, 599000000   1000000, 599000000 599000000,   1000000 599000000
+Arrange full params: {"min_obj_distance":0,"accuracy":1.000000,"parallel":1,"allow_rotations":1,"do_final_align":1,"allow_multi_materials_on_same_plate":1,"avoid_extrusion_cali_region":0,"is_seq_print":0,"bed_shrink_x":1.000000,"bed_shrink_y":1.000000,"brim_skirt_distance":0.000000,"clearance_height_to_rod":25.000000,"clearance_height_to_lid":256.000000,"clearance_radius":73.000000,"printable_height":600.000000,
+arrange: items selected before arranging: 1
+arrange: items unselected before arranging: 0
+start 1 th arranging...
+arrange progress: initial order: camera-lamp-arm.stl, p=0, bed_temp=35, height=130, area=4.39133e+15
+arrange progress: camera-lamp-arm.stl bed_id=0,score=0.200000, score_all_plates=0.200000
+arrange camera-lamp-arm.stl succeed!, plate id=0, pos=622.455,727.32, temp_type=1
+finished 1 th arranging...
+update_slice_result_valid_state: plate 0 , update slice result from 0 to 0
+update_slice_result_valid_state: plate 1 , update slice result from 0 to 0
+postprocess_bed_index_for_selected: bed_idx 0, locked_plate -1, translation(x) 379.066, (y) 465.216
+postprocess_bed_index_for_selected:found in plate_index 0, bed_idx 0
+postprocess_arrange_polygon: bed_idx 0, selected 1, translation(x) 379.066, (y) 465.216
+rebuild_plates_after_arrangement:before rebuild, plates count 1, recycle_plates 1
+update_slice_result_valid_state: plate 0 , update slice result from 0 to 0
+update_slice_result_valid_state: plate 1 , update slice result from 0 to 0
+reload_all_objects: m_model->objects.size() is 1
+add_instance: plate_id 0, add instance obj_id 0, instance_id 0, move_position 0
+add_instance: plate 0 , m_ready_for_slice changes to 1
+reload_all_objects: found plate_id 0, for obj_id 0, instance_id 0
+rebuild_plates_after_arrangement:after rebuild, plates count 1
+Need to slice for plate 0, total plate count 1 partplates!
+Plate 1: pre_check 1, start
+BuildVolume printable_area clasified as: Rectangle
+update_print_volume_state, print_volume {0, 0, 0} to {600, 600, 600}, got 1 printable istances
+volume triangle count 3744, total 3744
+plate 1: load cached data success, go on.
+apply, Line 1120: enter
+apply, has_scarf_joint_seam:false
+apply, got print_diff 73, object_diff 19, region_diff 29, set status to APPLY_STATUS_CHANGED
+apply 1260: found full_config_diff changed.
+apply 1590: found print object changed.
+apply, got new_changed_keys, size=1
+apply, i=0, key=enable_prime_tower
+apply 1787: finished,  this 0xaf791c000, m_modified_count 1, apply_status 1, m_support_used 1
+set no_check to 0:
+printer_model_string: Bambu Lab A1, is_bbl_vendor_preset 1
+start Print::process for partplate 1
+set print's callback to default_status_callback.
+process: this=0xaf791c000, enter, use_cache=0, object size=1
+process: total object counts 1 in current print, need to slice 1
+Starting the slicing process. Resident memory: 48MB; Peak memory usage: 48MB
+default_status_callback: percent=5, warning_step=-1, message=Slicing mesh, message_type=0
+Slicing volumes... Resident memory: 48MB; Peak memory usage: 48MB
+slice_mesh to polygons
+Slicing volumes - removing top empty layers
+Make overhang printable...
+angle 0.959931 maxHoleArea 0 tan_angle 1.42815
+layer_thickness 0.2 max_dist_from_lower_layer 0.28563
+Slicing volumes - make_slices in parallel - begin
+Slicing volumes - make_slices in parallel - end
+default_status_callback: percent=15, warning_step=-1, message=Generating walls, message_type=0
+Generating walls... Resident memory: 89MB; Peak memory usage: 89MB
+Generating perimeters in parallel - start
+Generating perimeters in parallel - end
+SupportSpotsGenerator: applying filament type: PLA
+default_status_callback: percent=25, warning_step=-1, message=Generating infill regions, message_type=0
+Detecting solid surfaces... Resident memory: 90MB; Peak memory usage: 90MB
+Detecting solid surfaces for region 0 in parallel - start
+Detecting solid surfaces for region 0 - clipping in parallel - start
+Detecting solid surfaces for region 0 - clipping in parallel - end
+Preparing fill surfaces... Resident memory: 90MB; Peak memory usage: 90MB
+Discovering vertical shells... Resident memory: 90MB; Peak memory usage: 90MB
+Discovering vertical shells for region 0 in parallel - start : cache top / bottom
+Discovering vertical shells for region 0 in parallel - end : cache top / bottom
+Discovering vertical shells for region 0 in parallel - start : ensure vertical wall thickness
+Discovering vertical shells for region 0 in parallel - end
+Processing external surfaces... Resident memory: 91MB; Peak memory usage: 91MB
+Processing external surfaces for region 0 in parallel - start
+Processing external surfaces for region 0 in parallel - end
+Bridge over infill - Start Resident memory: 91MB; Peak memory usage: 91MB
+Bridge over infill - Directions and expanded surfaces computed Resident memory: 92MB; Peak memory usage: 92MB
+Bridge over infill - End Resident memory: 92MB; Peak memory usage: 92MB
+default_status_callback: percent=35, warning_step=-1, message=Generating infill toolpath, message_type=0
+Filling layers in parallel - start
+Filling layers in parallel - end
+Ironing in parallel - start
+Ironing in parallel - end
+default_status_callback: percent=50, warning_step=-1, message=Generating support, message_type=0
+Support generator - Start
+Support generator - Creating top contacts
+PrintObjectSupportMaterial::top_contact_layers() in parallel - start
+PrintObjectSupportMaterial::top_contact_layers() in parallel - end
+default_status_callback: percent=71, warning_step=-1, message=Detect overhangs for auto-lift, message_type=0
+default_status_callback: percent=70, warning_step=-1, message=Generating skirt & brim, message_type=0
+found slicing or export error for partplate 1
+update_slice_result_valid_state: plate 0 , update slice result from 0 to 0
+update_slice_result_valid_state: plate 0 , update slice result from 0 to 0
+~PrintObject: this=0x10bb7b930, m_shared_object 0x0
+update_slice_result_valid_state: plate 1 , update slice result from 0 to 0
+update_slice_result_valid_state: plate 1 , update slice result from 0 to 0

--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -1194,8 +1194,13 @@ def main():
             if info is not None:
                 kept_numbers.append(p["id"])
         if info is None:
+            # No slicer could do it and nothing committed to fall back on. The
+            # part still ships, with its numbers empty: an entry with no weight
+            # is a part the site can show and say so, a missing entry is a
+            # broken build and a red check for whoever touched the catalog.
             failed.append(p["id"])
-            continue
+            info = {"grams": None, "support_grams": None, "support_used": False,
+                    "print_seconds": None}
 
         png = os.path.join(RENDERS_OUT, p["id"] + ".png")
         try:
@@ -1273,9 +1278,9 @@ def main():
         })
         sup = " +support" if info["support_used"] else ""
         mark = f"  stamp: {', '.join(v['face'] for v in stamped)}" if stamped else "  (no stamp fits)"
+        weight = f"{info['grams']:7.1f} g/ea" if info["grams"] is not None else "   not sliced"
         # [n/total] makes mid-run CI log pings read as real progress
-        print(f"  [{i}/{len(printed)}] {p['name']:<26} {info['grams']:7.1f} g/ea{sup}{mark}",
-              flush=True)
+        print(f"  [{i}/{len(printed)}] {p['name']:<26} {weight}{sup}{mark}", flush=True)
 
     archive_versions({p["id"]: p for p in printed}, out_parts,
                      profiles, hexmap, role_defaults, args.force, prev_parts)
@@ -1355,7 +1360,8 @@ def main():
         print(f"  ~ {len(kept_numbers)} part(s) the slicer refused this run; kept the committed "
               f"numbers, same bytes: {', '.join(kept_numbers)}")
     if failed:
-        print(f"  ! {len(failed)} part(s) FAILED to slice: {', '.join(failed)}")
+        print(f"  ! {len(failed)} part(s) could not be sliced and ship with no weight or "
+              f"print time: {', '.join(failed)}")
 
     if args.strict and (failed or not out_parts):
         sys.exit(f"strict mode: {len(failed)} part(s) failed, "

--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -322,6 +322,20 @@ def unchanged_render(prev, stl, part):
     return None
 
 
+def unchanged_slice(prev, stl):
+    """The committed slice numbers of `prev`, reusable when the bytes are the
+    same -- for a part every slicing attempt refused this run. The asset
+    service's worker cannot slice the camera lamp arm at all (a local Orca
+    only manages it auto-oriented), and dropping a part whose numbers were
+    measured from these very bytes is worse than keeping them. A NEW or
+    changed part has no `prev` and still fails loudly."""
+    if prev and prev.get("stl") == stl and prev.get("grams") is not None:
+        return {"grams": prev["grams"], "support_grams": prev.get("support_grams", 0.0),
+                "support_used": bool(prev.get("support_used")),
+                "print_seconds": prev.get("print_seconds", 0)}
+    return None
+
+
 def unchanged_stamps(prev, stl, uid):
     """The committed stamps of `prev`, reusable only if they were cut into
     the same bytes with the same uid -- the STL URL carries the hash -- and
@@ -1149,6 +1163,7 @@ def main():
     zip_members = []      # the all-parts bundle: each part's default stamped variant
     plain_members = []    # the same parts unstamped, for whoever unticks "engrave"
     failed = []
+    kept_numbers = []
     forced_support = []
     forced_orient = []
     printed = [p for p in manifest["parts"] if p.get("kind", "printed") == "printed"]
@@ -1173,12 +1188,16 @@ def main():
                               orient=True)
             if info is not None:
                 forced_orient.append(p["id"])
+        live_stl = stl_url(p["id"], p["stl_hash"])
+        if info is None:
+            info = unchanged_slice(prev_parts.get(p["id"]), live_stl)
+            if info is not None:
+                kept_numbers.append(p["id"])
         if info is None:
             failed.append(p["id"])
             continue
 
         png = os.path.join(RENDERS_OUT, p["id"] + ".png")
-        live_stl = stl_url(p["id"], p["stl_hash"])
         try:
             render_url = render_url_for(stl_abs, default_hex(p, role_defaults, hexmap),
                                         png, args.force,
@@ -1332,6 +1351,9 @@ def main():
     if forced_orient:
         print(f"  ~ {len(forced_orient)} part(s) could not slice in modeled orientation at "
               f"all; auto-oriented WITH support for the weight: {', '.join(forced_orient)}")
+    if kept_numbers:
+        print(f"  ~ {len(kept_numbers)} part(s) the slicer refused this run; kept the committed "
+              f"numbers, same bytes: {', '.join(kept_numbers)}")
     if failed:
         print(f"  ! {len(failed)} part(s) FAILED to slice: {', '.join(failed)}")
 

--- a/parts-calculator/catalog/requirements.txt
+++ b/parts-calculator/catalog/requirements.txt
@@ -9,6 +9,8 @@ trimesh==4.8.3
 shapely==2.1.2
 manifold3d==3.5.2
 scipy==1.17.1
+# trimesh's spatial index; generate.py cannot import without it
+rtree==1.4.1
 # scripts/mesh_report.py and mesh_repair.py: finding the places an export is not
 # a closed solid, and drawing them (meshfig.py rasterises with numpy + Pillow,
 # since a build box has no GL context)

--- a/parts-calculator/src/lib/components/AssemblyDetail.svelte
+++ b/parts-calculator/src/lib/components/AssemblyDetail.svelte
@@ -150,7 +150,7 @@
 					{part.name} <Badge variant="neutral">3D printed</Badge>
 					<ChangeStatus kind="parts" id={part.id} name={part.name} />
 				</span>
-				<span class="ad-meta">{part.grams.toFixed(0)} g each · {part.uid}</span>
+				<span class="ad-meta">{part.grams != null ? `${part.grams.toFixed(0)} g each` : 'not sliced'} · {part.uid}</span>
 			</span>
 			<span class="ad-qty">×{each}</span>
 			<ArrowRight size={14} class="ad-go" />

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -389,11 +389,11 @@ export type Part = {
 	candidates?: PartCandidate[]; // revisions under test for this slot, oldest first
 	images?: CatalogImage[]; // extra pictures beyond the render
 	attributes?: { label: string; value: string }[]; // variant characteristics shown in the app
-	grams: number; // total incl. any support
-	support_grams: number; // the support portion of `grams`
+	grams: number | null; // total incl. any support; null when no slicer could do it
+	support_grams: number | null; // the support portion of `grams`; null with it
 	support_used: boolean; // slicer used support to slice this (may be auto-forced)
 	support_intentional?: boolean; // the part *opts into* support in the manifest (vs. auto-forced)
-	print_seconds: number;
+	print_seconds: number | null; // null when no slicer could do it
 	color: ColorSpec;
 	optional: boolean;
 	onshape?: string | null; // link to the source Onshape document, if known
@@ -946,7 +946,10 @@ export type BuyLine = {
 
 /** Grams counted for a part: total when its support is included, else object-only. */
 export function effectiveGrams(part: Part, inclSupport: boolean): number {
-	return inclSupport ? part.grams : part.grams - part.support_grams;
+	// A part no slicer could slice weighs nothing here: it is listed, and the
+	// page says it is not sliced, but it cannot contribute to a spool count.
+	if (part.grams == null) return 0;
+	return inclSupport ? part.grams : part.grams - (part.support_grams ?? 0);
 }
 
 /** Group the SELECTED parts' filament by resolved color, with bulk-tier pricing.

--- a/parts-calculator/src/lib/parts-csv.ts
+++ b/parts-calculator/src/lib/parts-csv.ts
@@ -82,9 +82,9 @@ export function partsCsv(
 			c.qty,
 			+each.toFixed(1),
 			+(each * c.qty).toFixed(1),
-			+p.support_grams.toFixed(1),
+			p.support_grams == null ? '' : +p.support_grams.toFixed(1),
 			p.support_intentional ? 'yes' : 'no',
-			Math.round(p.print_seconds / 60),
+			p.print_seconds == null ? '' : Math.round(p.print_seconds / 60),
 			c.name,
 			p.version,
 			p.updated_at,
@@ -172,7 +172,7 @@ export function assemblyCsv(root: string, spec: ExportSpec): string {
 				each,
 				total,
 				'',
-				part ? +part.grams.toFixed(1) : '',
+				part?.grams != null ? +part.grams.toFixed(1) : '',
 				part?.stl ?? (lc ? absolute(lc.dxf) : ''),
 				hw?.description ?? part?.description ?? lc?.description ?? ''
 			]);

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -313,7 +313,7 @@
 	// theoretical total print time: every included part printed alone, sequentially,
 	// on one printer (one part per plate — no batching)
 	const totalPrintSeconds = $derived(
-		PARTS.reduce((sum, p) => sum + p.print_seconds * qtyOf(p.id), 0)
+		PARTS.reduce((sum, p) => sum + (p.print_seconds ?? 0) * qtyOf(p.id), 0)
 	);
 
 	const sectionRows = $derived(
@@ -706,12 +706,16 @@
 							{#if sw.length > 1}{s.qty}× {/if}{s.color?.name ?? 'any'}
 						</span>
 					{/each}
-					<span title="Print time for one {p.name}">· {duration(p.print_seconds)}</span>
+					{#if p.print_seconds != null}
+						<span title="Print time for one {p.name}">· {duration(p.print_seconds)}</span>
+					{:else}
+						<span title="No slicer could slice this part; weight and print time are unknown">· not sliced</span>
+					{/if}
 				</span>
 				{#if p.support_intentional}
 					<label class="pl-support">
 						<input class="setup-toggle h-3.5 w-3.5" type="checkbox" bind:checked={inclSupport[p.id]} />
-						total {p.grams.toFixed(0)} g · support {p.support_grams.toFixed(0)} g
+						total {p.grams?.toFixed(0) ?? '—'} g · support {p.support_grams?.toFixed(0) ?? '—'} g
 						<span class="opacity-70">({inclSupport[p.id] ? 'included' : 'excluded'})</span>
 					</label>
 				{/if}

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -923,7 +923,7 @@
 									>3D printed</span>
 								{#if line.part}{@render tagChips(line.part)}{/if}
 							</div>
-							<div class="text-xs text-text-muted">{part.grams.toFixed(0)} g each</div>
+							<div class="text-xs text-text-muted">{part.grams != null ? `${part.grams.toFixed(0)} g each` : 'not sliced'}</div>
 						</div>
 						<div class="text-right text-xs tabular-nums text-text">
 							<div class="font-semibold">×{lineQty(line, layers)}</div>
@@ -983,7 +983,7 @@
 						{/if}
 					</div>
 					{#if part && typeof (pv?.grams ?? part.grams) === 'number'}
-						<div class="text-xs text-text-muted">{(pv?.grams ?? part.grams).toFixed(0)} g each</div>
+						<div class="text-xs text-text-muted">{(pv?.grams ?? part.grams ?? 0).toFixed(0)} g each</div>
 					{/if}
 				</div>
 				{#if stl}
@@ -1056,7 +1056,7 @@
 						{#if p.version}<span class="text-xs text-text-muted">· v{p.version}</span>{/if}
 					</div>
 					{#if typeof p.grams === 'number'}
-						<div class="text-xs text-text-muted">{p.grams.toFixed(0)} g each</div>
+						<div class="text-xs text-text-muted">{p.grams != null ? `${p.grams.toFixed(0)} g each` : 'not sliced'}</div>
 					{/if}
 				</div>
 				{#if p.stl}

--- a/parts-calculator/src/routes/updates/+page.svelte
+++ b/parts-calculator/src/routes/updates/+page.svelte
@@ -85,10 +85,10 @@
 	// at the current layer count. A size for the diff, not an instruction.
 	const changed = $derived([...added, ...revised]);
 	const changedGrams = $derived(
-		changed.reduce((sum, u) => sum + u.part.grams * machineQty(u.part, layers), 0)
+		changed.reduce((sum, u) => sum + (u.part.grams ?? 0) * machineQty(u.part, layers), 0)
 	);
 	const changedSeconds = $derived(
-		changed.reduce((sum, u) => sum + u.part.print_seconds * machineQty(u.part, layers), 0)
+		changed.reduce((sum, u) => sum + (u.part.print_seconds ?? 0) * machineQty(u.part, layers), 0)
 	);
 
 	const presets = [
@@ -174,7 +174,7 @@
 				>
 					<Download size={14} /> STL
 				</a>
-				<span class="text-[11px] text-text-muted">{grams(u.part.grams * Math.max(qty, 1))} · {duration(u.part.print_seconds * Math.max(qty, 1))}</span>
+				<span class="text-[11px] text-text-muted">{u.part.grams != null ? grams(u.part.grams * Math.max(qty, 1)) : 'not sliced'} · {u.part.print_seconds != null ? duration(u.part.print_seconds * Math.max(qty, 1)) : '—'}</span>
 			{:else}
 				<a href="/part/{u.part.id}" class="text-xs text-primary hover:text-primary-hover">Open part</a>
 			{/if}


### PR DESCRIPTION
Follow-up to #582, and the last thing stopping a balloon turn from finishing a catalog change on its own.

**Problem.** The asset service's worker cannot slice `camera-lamp-arm` (its master is exported in machine coordinates and rests on a corner, so its first layer is empty; a local OrcaSlicer only manages it auto-oriented, which the service never tries). `generate.py` dropped a part it could not slice, so every service-backed regeneration, which is every balloon regeneration, produced a catalog without that part and failed `check_generated_pins`. One unsliceable part took the whole pipeline down.

**Change, in two layers:**

1. **Unchanged bytes keep their committed numbers.** When every slicing attempt fails for a part whose master is the one the committed numbers were measured from, reuse grams, support and print time (`unchanged_slice()`), and list the part at the end of the run. Same shape as the thumbnail and stamp fallbacks.
2. **Otherwise the part ships with empty numbers.** A new or changed part nothing can slice stays in the catalog with `grams`, `support_grams` and `print_seconds` null; the run names it; `--strict` still makes that fatal for anyone who wants it. Both sites show "not sliced" for such a part and leave it out of spool counts and print-time totals.

Also pins `rtree` in `requirements.txt`; `generate.py` cannot import without it and the bot had to discover that at runtime.

**Verified:** a regeneration through the service backend on a checkout of main keeps `camera-lamp-arm`, reports it, and produces a zero diff; `check_generated_pins` and `check_versioning` pass; `svelte-check` is clean for both the calculator and the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
