### PR TITLE
parts-calculator: a part no slicer could slice says why, as slice_failed

### DIFF
--- a/docs/src/lib/server/content.ts
+++ b/docs/src/lib/server/content.ts
@@ -140,6 +140,7 @@ for (const [path, raw] of Object.entries(dataFiles)) {
 				updated_at: pt.updated_at,
 				grams: pt.grams,
 				print_seconds: pt.print_seconds,
+				slice_failed: pt.slice_failed,
 				onshape: pt.versions?.[pt.versions.length - 1]?.onshape_version ?? pt.onshape,
 				info: pt.info,
 				low_tolerance: pt.low_tolerance,
@@ -416,6 +417,7 @@ export type PartDetail = {
 	updated_at?: string;
 	grams?: number | null; // null when no slicer could slice the part
 	print_seconds?: number | null;
+	slice_failed?: string; // present when no slicer could slice the part: why, and what was tried
 	onshape?: string;
 	low_tolerance?: boolean;
 	low_tolerance_note?: string;

--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -322,6 +322,28 @@ def unchanged_render(prev, stl, part):
     return None
 
 
+def why_unsliceable(stl_abs, tried):
+    """A reason to put on the data when no slicer would slice a part.
+    OrcaSlicer's own log for these says nothing ("Errors / run found error")
+    and the asset service reports only that its worker failed, so this looks
+    at the mesh for the two things that reliably stop a slicer, and otherwise
+    says so. `tried` is what was attempted, for the same reader."""
+    import trimesh
+    m = trimesh.load(stl_abs, force="mesh", process=True)
+    if not m.is_watertight:
+        why = "the mesh is not a closed solid"
+    else:
+        z0 = m.bounds[0][2]
+        n, c = m.face_normals, m.triangles_center
+        on_bed = m.area_faces[(n[:, 2] < -0.95) & (c[:, 2] < z0 + 0.2)].sum()
+        if on_bed < 1.0:
+            why = ("it rests on an edge or a corner in its export orientation, "
+                   "so the first layer is empty")
+        else:
+            why = "OrcaSlicer refused it and its log gives no reason"
+    return f"{why}; tried {tried}"
+
+
 def unchanged_slice(prev, stl):
     """The committed slice numbers of `prev`, reusable when the bytes are the
     same -- for a part every slicing attempt refused this run. The asset
@@ -1199,8 +1221,11 @@ def main():
             # is a part the site can show and say so, a missing entry is a
             # broken build and a red check for whoever touched the catalog.
             failed.append(p["id"])
+            tried = ("the asset service's slicer, flat, with and without supports"
+                     if profiles is None else
+                     "flat, with supports, and auto-oriented with supports")
             info = {"grams": None, "support_grams": None, "support_used": False,
-                    "print_seconds": None}
+                    "print_seconds": None, "failed": why_unsliceable(stl_abs, tried)}
 
         png = os.path.join(RENDERS_OUT, p["id"] + ".png")
         try:
@@ -1261,6 +1286,10 @@ def main():
             # may force support on other parts just to slice, but that isn't surfaced.
             "support_intentional": bool(p.get("support", False)),
             "print_seconds": info["print_seconds"],
+            # Present only when the numbers above are empty: says why, so a
+            # reader of the data does not have to guess between "not sliced"
+            # and "never measured".
+            **({"slice_failed": info["failed"]} if info.get("failed") else {}),
             "color": p.get("color", {"any": True}),
             "optional": p.get("optional", False),
             "onshape": p.get("onshape"),

--- a/parts-calculator/src/lib/components/AssemblyDetail.svelte
+++ b/parts-calculator/src/lib/components/AssemblyDetail.svelte
@@ -150,7 +150,7 @@
 					{part.name} <Badge variant="neutral">3D printed</Badge>
 					<ChangeStatus kind="parts" id={part.id} name={part.name} />
 				</span>
-				<span class="ad-meta">{part.grams != null ? `${part.grams.toFixed(0)} g each` : 'not sliced'} · {part.uid}</span>
+				<span class="ad-meta" title={part.slice_failed ? `Not sliced: ${part.slice_failed}` : undefined}>{part.slice_failed ? 'not sliced' : `${(part.grams ?? 0).toFixed(0)} g each`} · {part.uid}</span>
 			</span>
 			<span class="ad-qty">×{each}</span>
 			<ArrowRight size={14} class="ad-go" />

--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -394,6 +394,7 @@ export type Part = {
 	support_used: boolean; // slicer used support to slice this (may be auto-forced)
 	support_intentional?: boolean; // the part *opts into* support in the manifest (vs. auto-forced)
 	print_seconds: number | null; // null when no slicer could do it
+	slice_failed?: string; // present when no slicer could slice this geometry (the three above are null): why, and what was tried
 	color: ColorSpec;
 	optional: boolean;
 	onshape?: string | null; // link to the source Onshape document, if known

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -706,10 +706,10 @@
 							{#if sw.length > 1}{s.qty}× {/if}{s.color?.name ?? 'any'}
 						</span>
 					{/each}
-					{#if p.print_seconds != null}
+					{#if p.slice_failed}
+						<span title="Not sliced: {p.slice_failed}. Weight and print time are unknown.">· not sliced</span>
+					{:else if p.print_seconds != null}
 						<span title="Print time for one {p.name}">· {duration(p.print_seconds)}</span>
-					{:else}
-						<span title="No slicer could slice this part; weight and print time are unknown">· not sliced</span>
 					{/if}
 				</span>
 				{#if p.support_intentional}

--- a/parts-calculator/src/routes/assembly/+page.svelte
+++ b/parts-calculator/src/routes/assembly/+page.svelte
@@ -923,7 +923,7 @@
 									>3D printed</span>
 								{#if line.part}{@render tagChips(line.part)}{/if}
 							</div>
-							<div class="text-xs text-text-muted">{part.grams != null ? `${part.grams.toFixed(0)} g each` : 'not sliced'}</div>
+							<div class="text-xs text-text-muted">{part.slice_failed ? 'not sliced' : `${(part.grams ?? 0).toFixed(0)} g each`}</div>
 						</div>
 						<div class="text-right text-xs tabular-nums text-text">
 							<div class="font-semibold">×{lineQty(line, layers)}</div>
@@ -1056,7 +1056,7 @@
 						{#if p.version}<span class="text-xs text-text-muted">· v{p.version}</span>{/if}
 					</div>
 					{#if typeof p.grams === 'number'}
-						<div class="text-xs text-text-muted">{p.grams != null ? `${p.grams.toFixed(0)} g each` : 'not sliced'}</div>
+						<div class="text-xs text-text-muted">{p.slice_failed ? 'not sliced' : `${(p.grams ?? 0).toFixed(0)} g each`}</div>
 					{/if}
 				</div>
 				{#if p.stl}

--- a/parts-calculator/src/routes/updates/+page.svelte
+++ b/parts-calculator/src/routes/updates/+page.svelte
@@ -174,7 +174,7 @@
 				>
 					<Download size={14} /> STL
 				</a>
-				<span class="text-[11px] text-text-muted">{u.part.grams != null ? grams(u.part.grams * Math.max(qty, 1)) : 'not sliced'} · {u.part.print_seconds != null ? duration(u.part.print_seconds * Math.max(qty, 1)) : '—'}</span>
+				<span class="text-[11px] text-text-muted">{#if u.part.slice_failed}not sliced{:else}{grams((u.part.grams ?? 0) * Math.max(qty, 1))} · {duration((u.part.print_seconds ?? 0) * Math.max(qty, 1))}{/if}</span>
 			{:else}
 				<a href="/part/{u.part.id}" class="text-xs text-primary hover:text-primary-hover">Open part</a>
 			{/if}


### PR DESCRIPTION
Follow-up to #585. A part nothing can slice now carries `slice_failed: "<reason>; tried <attempts>"` beside its empty numbers, present only when it applies. Not an alarm, a note on the data.

The slicer itself gives nothing usable (Orca's log says "Errors / run found error"; the service reports only a status), so the generator looks at the mesh for the two things that reliably stop a slicer and otherwise says the slicer refused it:

- `the mesh is not a closed solid`
- `it rests on an edge or a corner in its export orientation, so the first layer is empty` (the camera lamp arm's actual cause)
- `OrcaSlicer refused it and its log gives no reason`

plus `tried flat, with supports, and auto-oriented with supports` locally or `tried the asset service's slicer, flat, with and without supports` through the service.

Both sites key "not sliced" off the flag and show the reason on hover. Type-checked clean on both; a service-backed regen against main is a zero diff (nothing currently fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
