### PR TITLE
parts-calculator: generate.py runs the instant checks itself

### DIFF
--- a/parts-calculator/CLAUDE.md
+++ b/parts-calculator/CLAUDE.md
@@ -54,12 +54,15 @@ build. Two halves:
   render as derived forms, made by the service's worker on the same pinned
   profile. So no machine needs OrcaSlicer to change parts data, and a branch
   preview is correct from the first push, because the data rode in with it.
-  `.github/workflows/check-parts.yml` guards every PR and push: the generated
-  data must agree with the source pins (`check_generated_pins.py`), every
-  URL the site ships must serve real bytes (`check_asset_urls.py`), and
-  revisions must follow the versioning discipline — breaking bits declared,
-  assembly line changes stamped (`check_versioning.py`, per `VERSIONING.md`).
-  Pure checks, about a minute; nothing commits onto your branch.
+  `generate.py` checks its own work: at the end of every run it runs
+  `check_generated_pins.py` (generated data agrees with the source pins),
+  `check_versioning.py` (breaking bits declared, assembly line changes
+  stamped, per `VERSIONING.md`) and `check_connections.py`, and exits
+  non-zero if one fails, so an inconsistent result never gets committed.
+  Do not run those by hand. `.github/workflows/check-parts.yml` runs the
+  same three on every PR and push as the backstop, plus the one that does
+  not belong in a regen: `check_asset_urls.py`, which fetches every URL the
+  site ships. Never run that one locally. Nothing commits onto your branch.
 - **`src/`** — the app. Reads generated JSON, does all math in the browser.
   Fully static.
 

--- a/parts-calculator/catalog/generate.py
+++ b/parts-calculator/catalog/generate.py
@@ -344,6 +344,24 @@ def why_unsliceable(stl_abs, tried):
     return f"{why}; tried {tried}"
 
 
+# The instant checks CI runs on every parts PR (check-parts.yml), run here at
+# the end of every regeneration so an inconsistent result never gets committed
+# and "regenerate" is the one command. The URL check stays in CI: a thousand
+# fetches is a job for a runner, not for every regen.
+CHECKS = ("check_generated_pins", "check_versioning", "check_connections")
+
+
+def run_checks():
+    sys.stdout.flush()   # the checks write straight to the fd; keep the log in order
+    root = os.path.dirname(REPO)
+    failed = [name for name in CHECKS
+              if subprocess.run([sys.executable, os.path.join(REPO, "scripts", name + ".py")],
+                                cwd=root).returncode != 0]
+    if failed:
+        sys.exit(f"regenerated, but {', '.join(failed)} failed (see above) -- "
+                 "fix the source and run again; do not commit this")
+
+
 def unchanged_slice(prev, stl):
     """The committed slice numbers of `prev`, reusable when the bytes are the
     same -- for a part every slicing attempt refused this run. The asset
@@ -1150,6 +1168,7 @@ def main():
         data["tags"] = manifest.get("tags", [])
         json.dump(data, open(DATA_OUT, "w"), indent="\t")
         print(f"refreshed authored metadata in {DATA_OUT}")
+        run_checks()
         return
     if os.path.exists(ORCA) and os.path.isdir(PROFILES):
         profiles, density, cost_per_kg = build_profiles()
@@ -1395,6 +1414,7 @@ def main():
     if args.strict and (failed or not out_parts):
         sys.exit(f"strict mode: {len(failed)} part(s) failed, "
                  f"{len(out_parts)} produced -- refusing to bless this output")
+    run_checks()
 
 
 def process_plates(manifest):


### PR DESCRIPTION
The three checks that are pure functions of the two catalog files (`check_generated_pins`, `check_versioning`, `check_connections`) now run at the end of every `generate.py` run and fail it non-zero, so an inconsistent result never gets committed and "regenerate" is the one command a contributor or a bot has to run.

Balloon had been pre-running the whole CI suite by hand before every commit, including `check_asset_urls.py`, which fetches every asset link in the catalog. That one stays in CI. Directions in `parts-calculator/CLAUDE.md` updated to match.

Verified: a local regeneration runs the three checks at the end and passes, zero diff against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
