### PR TITLE
feeder: B1 belt-feeder topology (cleated conveyor replaces C1+C2)

### DIFF
--- a/software/machine.example.toml
+++ b/software/machine.example.toml
@@ -153,3 +153,18 @@ c_channel_3 = 4
 
 [stepper_direction_inverts]
 carousel = true
+
+# B1 belt feeder (machine_setup = "belt_feeder" pairs [feeder] mode = "belt_rev01").
+# Every key is tunable live under Settings > Tuning > B1 Belt Feeder.
+# [feeder_belt]
+# belt_speed_usteps_per_s = 2000   # base speed while C3 wants pieces
+# forward_direction_sign = 1       # -1 if the belt motor is wired the other way
+# c3_full_speed_pieces = 1         # at/below this many pieces in C3: full speed
+# c3_stop_pieces = 3               # at/above: belt stops (linear ramp in between)
+# speed_update_interval_ms = 250
+# jam_timeout_s = 45.0             # no new C3 piece for this long -> incident; 0 = off
+# enable_belt = true
+
+# Per-channel detector confidence overrides (read once at backend start).
+# [perception.conf_thresholds]
+# 4 = 0.25

--- a/software/sorter/backend/global_config.py
+++ b/software/sorter/backend/global_config.py
@@ -111,6 +111,9 @@ class GlobalConfig:
         # main.py after camera startup. Not an env-toggle: the mode config
         # determines whether this is non-None.
         self.perception_service = None
+        # B1 belt feeder live status: one dict BeltFeeding updates in place,
+        # read by the tuning router. None until a BELT_REV01 feeder has run.
+        self.belt_feeder_status: "dict | None" = None
 
         # Standalone training-image grabber. Runs regardless of machine mode;
         # set in main.py after camera startup. See sample_collector.py.

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -41,6 +41,23 @@ class FeederMode(enum.Enum):
     # channel's drop zone occupied; for C3, a piece at the exit edge while the
     # classification channel is busy/not ready).
     CONSTANT_MOVEMENT_REV01 = "constant_movement_rev01"
+    # B1 belt topology: a cleated conveyor (continuous velocity via
+    # move_at_speed, throttled by C3's perception fill level) replaces the
+    # C1/C2 pulsing entirely; C3 keeps the pulse-perception exit metering.
+    # Pairs with machine_setup "belt_feeder". See subsystems/feeder/belt/.
+    BELT_REV01 = "belt_rev01"
+
+
+# Feeder modes that read ChannelState from the rev04 perception service
+# (perception owns detection; legacy VisionManager paths stay off).
+PERCEPTION_NATIVE_FEEDER_MODES = frozenset(
+    {
+        FeederMode.GO_TO_ANGLE_REV01,
+        FeederMode.PULSE_PERCEPTION_REV01,
+        FeederMode.CONSTANT_MOVEMENT_REV01,
+        FeederMode.BELT_REV01,
+    }
+)
 
 from global_config import GlobalConfig
 from hardware.bus import MCUBus, MCUBusError
@@ -626,6 +643,8 @@ class IRLInterface:
     c_channel_1_rotor_stepper: "StepperMotor"
     c_channel_2_rotor_stepper: "StepperMotor"
     c_channel_3_rotor_stepper: "StepperMotor"
+    # belt_feeder setups: alias for the C1 rotor stepper driving the B1 belt.
+    belt_stepper: "StepperMotor"
     fifth_stepper: "StepperMotor"
     servos: "list[ServoMotor]"
     chute: "Chute"
@@ -1085,13 +1104,13 @@ def mkIRLConfig(machine_params: dict[str, object] | None = None) -> IRLConfig:
         classification_channel_source = cameras_section.get("classification_channel")
         carousel_source = (
             classification_channel_source
-            if machine_setup.key == "classification_channel"
+            if machine_setup.uses_classification_channel
             and classification_channel_source is not None
             else cameras_section.get("carousel")
         )
         aux_camera_role = (
             "classification_channel"
-            if machine_setup.key == "classification_channel"
+            if machine_setup.uses_classification_channel
             else "carousel"
         )
 
@@ -1254,7 +1273,11 @@ def mkIRLConfig(machine_params: dict[str, object] | None = None) -> IRLConfig:
             color_profile=_color_profile("classification_top"),
         )
     
-    classification_channel_setup = machine_setup.key == "classification_channel"
+    # Capability, not key: any setup driving the classification C-channel off
+    # the carousel port (classification_channel, belt_feeder) needs the fast
+    # rotor profile — the key check silently left belt_feeder at 16 µsteps /
+    # 1000 µsteps/s, i.e. an ~8x slower C4.
+    classification_channel_setup = machine_setup.uses_classification_channel
     carousel_microsteps = 8 if classification_channel_setup else 16
     carousel_speed = 4000 if classification_channel_setup else 1000
     irl_config.carousel_stepper = mkStepperConfig(
@@ -1280,7 +1303,11 @@ def _requiredCanonicalStepperNames(
     stepper_binding_overrides: dict[str, str],
 ) -> list[str]:
     logical_required: list[str] = ["chute"]
-    if machine_setup.automatic_feeder:
+    if machine_setup.uses_belt_feeder:
+        # The belt motor lives on the C1 rotor port; C2 has no motor in this
+        # topology.
+        logical_required.extend(["c_channel_1", "c_channel_3"])
+    elif machine_setup.automatic_feeder:
         logical_required.extend(["c_channel_1", "c_channel_2", "c_channel_3"])
     if machine_setup.uses_carousel_transport:
         logical_required.append("carousel")
@@ -1487,6 +1514,11 @@ def mkIRLInterface(config: IRLConfig, gc: GlobalConfig) -> IRLInterface:
         irl_interface.c_channel_4_rotor_stepper = irl_interface.carousel_stepper
         if config.machine_setup.uses_classification_channel:
             irl_interface.classification_channel_rotor_stepper = irl_interface.carousel_stepper
+
+    if config.machine_setup.uses_belt_feeder and hasattr(
+        irl_interface, "c_channel_1_rotor_stepper"
+    ):
+        irl_interface.belt_stepper = irl_interface.c_channel_1_rotor_stepper
 
     _apply_stepper_software_disable(gc, irl_interface)
 

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -1095,6 +1095,21 @@ def mkIRLConfig(machine_params: dict[str, object] | None = None) -> IRLConfig:
                     f"Invalid feeder.mode={feeder_mode_raw!r} in machine.toml; valid values: {valid}"
                 )
 
+    # The belt topology and the belt feeder mode only work as a pair: the belt
+    # flow needs the belt_stepper this setup binds, and every other feeder mode
+    # drives the C2 rotor this setup does not have.
+    feeder_mode = irl_config.feeder_config.mode
+    if machine_setup.uses_belt_feeder and feeder_mode != FeederMode.BELT_REV01:
+        raise ValueError(
+            f"machine_setup {machine_setup.key!r} requires feeder.mode = "
+            f"{FeederMode.BELT_REV01.value!r}, got {feeder_mode.value!r}"
+        )
+    if feeder_mode == FeederMode.BELT_REV01 and not machine_setup.uses_belt_feeder:
+        raise ValueError(
+            f"feeder.mode = {FeederMode.BELT_REV01.value!r} needs the belt_feeder "
+            f"machine setup, not {machine_setup.key!r}"
+        )
+
     if camera_layout_type == "split_feeder":
         # split_feeder: per-channel cameras from TOML, no single feeder or classification
         cameras_section = cast(dict[str, object], raw_toml.get("cameras", {})) if isinstance(raw_toml, dict) else {}

--- a/software/sorter/backend/machine_platform/machine_profile.py
+++ b/software/sorter/backend/machine_platform/machine_profile.py
@@ -27,6 +27,7 @@ class MachineCapabilities:
     automatic_feeder: bool
     carousel_transport: bool
     classification_channel: bool
+    belt_feeder: bool
     carousel_endstop_required: bool
     runtime_supported: bool
 
@@ -83,6 +84,7 @@ def build_machine_profile(
             automatic_feeder=machine_setup_definition.automatic_feeder,
             carousel_transport=machine_setup_definition.uses_carousel_transport,
             classification_channel=machine_setup_definition.uses_classification_channel,
+            belt_feeder=machine_setup_definition.uses_belt_feeder,
             carousel_endstop_required=machine_setup_definition.requires_carousel_endstop,
             runtime_supported=machine_setup_definition.runtime_supported,
         ),

--- a/software/sorter/backend/machine_runtime/__init__.py
+++ b/software/sorter/backend/machine_runtime/__init__.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 from machine_runtime.base import MachineRuntime
 from machine_runtime.classification_channel import ClassificationChannelRuntime
 from machine_runtime.standard_carousel import StandardCarouselRuntime
-from machine_setup import (
-    CLASSIFICATION_CHANNEL_SETUP,
-    get_machine_setup_definition,
-)
+from machine_setup import get_machine_setup_definition
 
 
 def build_machine_runtime(machine_setup_key: object) -> MachineRuntime:
     definition = get_machine_setup_definition(machine_setup_key)
-    if definition.key == CLASSIFICATION_CHANNEL_SETUP:
+    # Capability, not key: belt_feeder also runs the classification C-channel.
+    if definition.uses_classification_channel:
         return ClassificationChannelRuntime(definition)
     return StandardCarouselRuntime(definition)

--- a/software/sorter/backend/machine_setup.py
+++ b/software/sorter/backend/machine_setup.py
@@ -6,6 +6,7 @@ from typing import Any
 STANDARD_CAROUSEL_SETUP = "standard_carousel"
 CLASSIFICATION_CHANNEL_SETUP = "classification_channel"
 MANUAL_CAROUSEL_SETUP = "manual_carousel"
+BELT_FEEDER_SETUP = "belt_feeder"
 
 DEFAULT_MACHINE_SETUP = CLASSIFICATION_CHANNEL_SETUP
 
@@ -25,6 +26,10 @@ class MachineSetupDefinition:
     homes_chute: bool
     requires_carousel_endstop: bool
     runtime_supported: bool
+    # B1 belt topology: a cleated inclined conveyor replaces both the C1 bulk
+    # bucket and the C2 buffer channel. The belt motor plugs into the freed C1
+    # rotor port; C3 keeps doing the final singulation into C4.
+    uses_belt_feeder: bool = False
 
     @property
     def manual_feed_mode(self) -> bool:
@@ -45,6 +50,7 @@ class MachineSetupDefinition:
             "homes_chute": self.homes_chute,
             "requires_carousel_endstop": self.requires_carousel_endstop,
             "runtime_supported": self.runtime_supported,
+            "uses_belt_feeder": self.uses_belt_feeder,
         }
 
 
@@ -102,6 +108,27 @@ MACHINE_SETUPS: dict[str, MachineSetupDefinition] = {
         homes_chute=True,
         requires_carousel_endstop=True,
         runtime_supported=True,
+    ),
+    BELT_FEEDER_SETUP: MachineSetupDefinition(
+        key=BELT_FEEDER_SETUP,
+        label="B1 Belt Feeder + C3 + Classification Channel",
+        description=(
+            "Cleated inclined conveyor (B1) replaces the C1 bulk bucket and the C2 buffer "
+            "channel: the belt meters bulk parts directly into C3, which keeps doing the "
+            "final singulation into the classification C-channel. The belt motor plugs "
+            "into the C1 rotor port."
+        ),
+        feeding_mode="auto_channels",
+        automatic_feeder=True,
+        uses_carousel_transport=False,
+        uses_classification_chamber=False,
+        uses_classification_channel=True,
+        runs_reverse_pulse_calibration=False,
+        homes_carousel=False,
+        homes_chute=True,
+        requires_carousel_endstop=False,
+        runtime_supported=True,
+        uses_belt_feeder=True,
     ),
 }
 

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -43,6 +43,7 @@ from defs.events import RuntimeStatsEvent, RuntimeStatsData
 from irl.config import (
     ClassificationChannelMode,
     FeederMode,
+    PERCEPTION_NATIVE_FEEDER_MODES,
     mkIRLConfig,
     mkIRLInterface,
 )
@@ -123,21 +124,16 @@ def _noPowerModeActive(gc: GlobalConfig) -> bool:
 
 def _perceptionModeActive(irl_config) -> bool:
     """Rev04 perception stack: a perception-native feeder mode
-    (GO_TO_ANGLE_REV01, PULSE_PERCEPTION_REV01 or CONSTANT_MOVEMENT_REV01)
-    paired with the SIMPLE_STATE_MACHINE_REV01 classification channel. The
-    perception package owns detection for these pairs only; every other mode
-    pair keeps using the legacy VisionManager paths."""
+    (see PERCEPTION_NATIVE_FEEDER_MODES) paired with the
+    SIMPLE_STATE_MACHINE_REV01 classification channel. The perception package
+    owns detection for these pairs only; every other mode pair keeps using the
+    legacy VisionManager paths."""
     feeder_mode = getattr(getattr(irl_config, "feeder_config", None), "mode", None)
     cc_mode = getattr(
         getattr(irl_config, "classification_channel_config", None), "mode", None
     )
     return (
-        feeder_mode
-        in (
-            FeederMode.GO_TO_ANGLE_REV01,
-            FeederMode.PULSE_PERCEPTION_REV01,
-            FeederMode.CONSTANT_MOVEMENT_REV01,
-        )
+        feeder_mode in PERCEPTION_NATIVE_FEEDER_MODES
         and cc_mode
         in (
             ClassificationChannelMode.SIMPLE_STATE_MACHINE_REV01,
@@ -149,8 +145,8 @@ def _perceptionModeActive(irl_config) -> bool:
 def _maybeStartPerception(gc: GlobalConfig, irl_config, camera_service) -> None:
     if not _perceptionModeActive(irl_config):
         gc.logger.info(
-            "Perception (rev04) inactive: mode pair is not "
-            "(GO_TO_ANGLE_REV01, SIMPLE_STATE_MACHINE_REV01). Legacy vision owns detection."
+            "Perception (rev04) inactive: feeder mode is not perception-native "
+            "or classification mode is not a REV01 state machine. Legacy vision owns detection."
         )
         return
 

--- a/software/sorter/backend/perception/service.py
+++ b/software/sorter/backend/perception/service.py
@@ -82,6 +82,21 @@ _DEFAULT_CONF_THRESHOLDS: dict[int, float] = {
 }
 
 
+def _conf_thresholds_from_toml() -> dict[int, float]:
+    """Per-channel detector confidence overrides from machine TOML
+    (``[perception.conf_thresholds]``, see toml_config.getPerceptionConfThresholds).
+
+    A too-low threshold on an empty channel makes the detector flicker on
+    platter texture, which the C4 state machine then chases as a phantom
+    piece (capture cycle -> MOVING_TO_PRECISE timeout loop)."""
+    try:
+        from toml_config import getPerceptionConfThresholds
+
+        return getPerceptionConfThresholds()
+    except Exception:
+        return {}
+
+
 class PerceptionService:
     """Owns the perception workers, slots, and channel defs.
 
@@ -850,6 +865,7 @@ def build(
     permanently strands a slow camera anymore.
     """
     resolved_conf: Dict[int, float] = dict(_DEFAULT_CONF_THRESHOLDS)
+    resolved_conf.update(_conf_thresholds_from_toml())
     if conf_thresholds:
         resolved_conf.update(conf_thresholds)
     ctx = _ReconcileContext(

--- a/software/sorter/backend/server/routers/detection.py
+++ b/software/sorter/backend/server/routers/detection.py
@@ -41,6 +41,7 @@ from server import shared_state
 from server.classification_training import getClassificationTrainingManager
 from server.machine_naming import display_name_from_hostname, random_display_name
 from server.routers.tailscale import current_hostname
+from subsystems.feeder.incidents import BELT_FEEDER_STALLED_INCIDENT_KIND
 from vision.detection_registry import (
     detection_algorithm_definition,
     detection_algorithm_options,
@@ -2416,6 +2417,19 @@ def feeder_bulk_feed_incident_clear(
 
     runtime_stats.clearActiveIncident(kind=BULK_FEEDER_STALLED_INCIDENT_KIND, resolved_by="operator")
     return {"ok": True, "cleared": True, "channel": "c1"}
+
+
+@router.post("/api/feeder/belt-feed-incident/clear")
+def feeder_belt_feed_incident_clear() -> Dict[str, Any]:
+    """B1 topology: the operator checked the boat / belt and wants to resume."""
+    runtime_stats = _runtime_stats_or_503()
+    active = runtime_stats.activeIncident() if hasattr(runtime_stats, "activeIncident") else None
+    if not isinstance(active, dict) or active.get("kind") != BELT_FEEDER_STALLED_INCIDENT_KIND:
+        runtime_stats.clearActiveIncident(kind=BELT_FEEDER_STALLED_INCIDENT_KIND)
+        return {"ok": True, "cleared": False, "reason": "no_active_incident"}
+
+    runtime_stats.clearActiveIncident(kind=BELT_FEEDER_STALLED_INCIDENT_KIND, resolved_by="operator")
+    return {"ok": True, "cleared": True, "channel": "b1"}
 
 
 @router.post("/api/feeder/detection-incident/clear")

--- a/software/sorter/backend/server/routers/setup.py
+++ b/software/sorter/backend/server/routers/setup.py
@@ -64,7 +64,7 @@ class FeedingModePayload(BaseModel):
 
 
 class MachineSetupPayload(BaseModel):
-    setup: Literal["classification_channel", "manual_carousel"]
+    setup: Literal["classification_channel", "manual_carousel", "belt_feeder"]
 
 
 class ClassificationChannelModePayload(BaseModel):
@@ -123,12 +123,19 @@ def _camera_assignments_from_config(config: Dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _camera_assignments_complete(camera_assignments: dict[str, Any]) -> bool:
+def _camera_assignments_complete(
+    camera_assignments: dict[str, Any], machine_setup_key: str | None = None
+) -> bool:
     layout = camera_assignments.get("layout")
     if layout not in {"default", "split_feeder"}:
         return False
     if layout == "split_feeder":
-        return all(camera_assignments.get(role) is not None for role in ("c_channel_2", "c_channel_3")) and (
+        # The belt topology has no C2 channel, so no C2 camera is required.
+        uses_belt = bool(
+            get_machine_setup_definition(machine_setup_key).uses_belt_feeder
+        )
+        feeder_roles = ("c_channel_3",) if uses_belt else ("c_channel_2", "c_channel_3")
+        return all(camera_assignments.get(role) is not None for role in feeder_roles) and (
             camera_assignments.get("classification_channel") is not None
             or camera_assignments.get("carousel") is not None
         )
@@ -181,6 +188,18 @@ def _persist_machine_setup(config: Dict[str, Any], setup_key: str) -> Dict[str, 
         **feeding,
         "mode": definition.feeding_mode,
     }
+
+    # The belt topology only works with the belt feeder subsystem (and vice
+    # versa: the belt flow needs the belt_stepper this setup binds), so keep
+    # the pair in lock-step when switching TO belt_feeder — and never leave a
+    # stale belt_rev01 behind when switching away.
+    feeder = config.get("feeder", {})
+    if not isinstance(feeder, dict):
+        feeder = {}
+    if definition.uses_belt_feeder:
+        config["feeder"] = {**feeder, "mode": FeederMode.BELT_REV01.value}
+    elif feeder.get("mode") == FeederMode.BELT_REV01.value:
+        config["feeder"] = {**feeder, "mode": FeederMode.PULSE_PERCEPTION_REV01.value}
     return config
 
 
@@ -193,11 +212,16 @@ def _current_stepper_direction_payload() -> list[dict[str, Any]]:
     active_irl = shared_state.getActiveIRL()
     entries: list[dict[str, Any]] = []
     logical_names = list(LOGICAL_STEPPER_BINDING_BASES.keys())
-    if _machine_setup_key_from_config(config) == CLASSIFICATION_CHANNEL_SETUP:
+    definition = get_machine_setup_definition(_machine_setup_key_from_config(config))
+    if definition.uses_classification_channel:
         logical_names = [
             C4_LOGICAL_STEPPER if name == C4_BACKING_STEPPER else name
             for name in logical_names
         ]
+    labels = dict(STEPPER_LABELS)
+    if definition.uses_belt_feeder:
+        # The belt motor plugs into the freed C1 rotor port.
+        labels["c_channel_1"] = "B1 Belt"
 
     for logical_name in logical_names:
         attr_base = _stepper_attr_base(logical_name)
@@ -212,7 +236,7 @@ def _current_stepper_direction_payload() -> list[dict[str, Any]]:
         entries.append(
             {
                 "name": logical_name,
-                "label": STEPPER_LABELS.get(logical_name, logical_name),
+                "label": labels.get(logical_name, logical_name),
                 "inverted": bool(inverts.get(config_key, False)),
                 "live_inverted": live_inverted,
                 "available": stepper is not None,
@@ -607,7 +631,7 @@ def get_setup_wizard_summary() -> Dict[str, Any]:
         "machine_named": bool(getMachineNickname()),
         "boards_detected": len(discovery["boards"]) > 0,
         "camera_layout_selected": camera_assignments["layout"] in {"default", "split_feeder"},
-        "cameras_assigned": _camera_assignments_complete(camera_assignments),
+        "cameras_assigned": _camera_assignments_complete(camera_assignments, machine_setup_key),
         "servo_configured": (
             servo_settings["backend"] == "waveshare"
             or bool(discovery["pca_available"])
@@ -662,7 +686,12 @@ def get_feeding_mode() -> Dict[str, Any]:
 @router.post("/api/feeding-mode")
 def set_feeding_mode(payload: FeedingModePayload) -> Dict[str, Any]:
     params_path, config = _read_machine_params_config()
-    if payload.mode == "manual_carousel":
+    current_setup_key = _machine_setup_key_from_config(config)
+    if get_machine_setup_definition(current_setup_key).feeding_mode == payload.mode:
+        # The current setup already feeds this way (e.g. belt_feeder is also
+        # auto_channels) — don't silently switch topologies.
+        next_setup_key = current_setup_key
+    elif payload.mode == "manual_carousel":
         next_setup_key = MANUAL_CAROUSEL_SETUP
     else:
         next_setup_key = CLASSIFICATION_CHANNEL_SETUP

--- a/software/sorter/backend/server/routers/setup.py
+++ b/software/sorter/backend/server/routers/setup.py
@@ -786,6 +786,20 @@ def set_feeder_subsystem_mode(payload: FeederSubsystemModePayload) -> Dict[str, 
     if payload.mode not in valid:
         raise HTTPException(status_code=400, detail=f"Invalid mode {payload.mode!r}; valid: {sorted(valid)}")
     params_path, config = _read_machine_params_config()
+    # The belt topology and the belt feeder mode only work as a pair (see
+    # mkIRLConfig, which refuses to boot a mismatch).
+    definition = get_machine_setup_definition(_machine_setup_key_from_config(config))
+    wants_belt = payload.mode == FeederMode.BELT_REV01.value
+    if definition.uses_belt_feeder and not wants_belt:
+        raise HTTPException(
+            status_code=409,
+            detail=f"The {definition.key} setup runs the {FeederMode.BELT_REV01.value} feeder only.",
+        )
+    if wants_belt and not definition.uses_belt_feeder:
+        raise HTTPException(
+            status_code=409,
+            detail=f"{FeederMode.BELT_REV01.value} needs the belt_feeder machine setup, not {definition.key}.",
+        )
     section = config.get("feeder", {})
     if not isinstance(section, dict):
         section = {}

--- a/software/sorter/backend/server/routers/tuning.py
+++ b/software/sorter/backend/server/routers/tuning.py
@@ -1,5 +1,6 @@
 """Tuning endpoints for runtime-adjustable parameters."""
 from __future__ import annotations
+from server import shared_state
 
 from typing import Any
 
@@ -16,6 +17,8 @@ from toml_config import (
     setTrackerConfig,
     getPulsePerceptionConfig,
     setPulsePerceptionConfig,
+    getBeltFeederConfig,
+    setBeltFeederConfig,
     getConstantMovementConfig,
     setConstantMovementConfig,
     getClassificationProviders,
@@ -27,6 +30,7 @@ from classification.providers import COLOR_PROVIDER_SPECS, MOLD_PROVIDER_SPECS
 from subsystems.classification_channel.simple_state_machine_rev01.rev01_config import FIELD_META
 from subsystems.feeder.go_to_angle.config import FIELD_META as GO_TO_ANGLE_FIELD_META
 from subsystems.feeder.pulse_perception.config import FIELD_META as PULSE_PERCEPTION_FIELD_META
+from subsystems.feeder.belt.config import FIELD_META as BELT_FEEDER_FIELD_META
 from subsystems.feeder.constant_movement.config import FIELD_META as CONSTANT_MOVEMENT_FIELD_META
 from perception.tracker_config import TRACKER_SPECS
 
@@ -83,6 +87,34 @@ def set_pulse_perception_config(body: dict[str, Any]) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc))
     return {"config": updated}
 
+
+@router.get("/api/tuning/feeder-belt")
+def get_belt_feeder_config() -> dict[str, Any]:
+    return {
+        "config": getBeltFeederConfig(),
+        "fields": BELT_FEEDER_FIELD_META,
+    }
+
+
+@router.post("/api/tuning/feeder-belt")
+def set_belt_feeder_config(body: dict[str, Any]) -> dict[str, Any]:
+    try:
+        updated = setBeltFeederConfig(body)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"config": updated}
+
+
+@router.get("/api/tuning/feeder-belt/status")
+def get_belt_feeder_status() -> dict[str, Any]:
+    """Live introspection of the B1 belt controller: commanded speed, C3 fill
+    level driving the ramp, jam countdown, and why the belt is (not) moving.
+    ``available`` is False until a BELT_REV01 feeder has run at least once."""
+    gc = shared_state.gc_ref
+    status = getattr(gc, "belt_feeder_status", None) if gc is not None else None
+    if not isinstance(status, dict):
+        return {"available": False, "status": None}
+    return {"available": True, "status": dict(status)}
 
 @router.get("/api/tuning/feeder-pulse-perception/autotune")
 def get_pulse_perception_autotune_status() -> dict[str, Any]:

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/moving_to_precise.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/moving_to_precise.py
@@ -8,11 +8,11 @@ from .constants import C4_TRAVEL_SIGN, LOG_TAG
 
 
 class MovingToPrecise(Rev01BaseState):
-    """Reverse closed-loop converge the piece to the PRECISE staging zone.
+    """Forward-only closed-loop converge of the piece to the PRECISE staging zone.
 
-    Drives the leading piece's COM toward the centre of the precise arc with
-    repeated bounded moves (issued REVERSE — negative output degrees — via
-    ``C4_TRAVEL_SIGN``). The Brickognize request spawned at the end of CAPTURING
+    Drives the leading piece's COM toward the precise arc with repeated bounded
+    moves in the platter's travel direction (``C4_TRAVEL_SIGN``); it never
+    backs up. The Brickognize request spawned at the end of CAPTURING
     runs concurrently; we do not block on it here. When the COM is parked in the
     precise band we hand off to AWAITING_DISTRIBUTION, which collects the result
     and waits for the chute. The piece is held short of the fall-off so it cannot
@@ -22,6 +22,7 @@ class MovingToPrecise(Rev01BaseState):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._started_at = 0.0
+        self._last_gap_seen_at = 0.0
 
     def step(self) -> Optional[ClassificationChannelState]:
         perception_service = getattr(self.gc, "perception_service", None)
@@ -48,7 +49,23 @@ class MovingToPrecise(Rev01BaseState):
             return ClassificationChannelState.REV01_AWAITING_DISTRIBUTION
 
         gap = state.exit_com_forward_to_precise_deg
-        within_tol = gap is not None and abs(gap) <= float(cfg.precise_center_tolerance_deg)
+        if gap is not None:
+            lead_to_exit = state.exit_com_forward_deg
+            # comForwardToPreciseEntryDeg wraps to (-180, 180]: a piece far up
+            # the drop zone reads as a small/negative gap when it is really most
+            # of a turn short. Un-wrap when the leading gap-to-exit says so.
+            if (
+                gap <= float(cfg.precise_center_tolerance_deg)
+                and lead_to_exit is not None
+                and lead_to_exit > 180.0
+            ):
+                gap += 360.0
+        # Walled-platter rule: the sectors hold the piece, so any position AT or
+        # PAST the precise entry (gap <= tolerance, including negative/overshot)
+        # counts as parked. C4 never reverses — backing up would carry the
+        # piece's sector across the intake, and forward "corrections" past the
+        # fall-off discharge it prematurely.
+        within_tol = gap is not None and gap <= float(cfg.precise_center_tolerance_deg)
         arrived = bool(state.exit_com_in_precise) or within_tol
 
         if arrived and not moving:
@@ -63,15 +80,29 @@ class MovingToPrecise(Rev01BaseState):
             return None
 
         if gap is None:
-            # No precise reading this frame (piece not detected / no precise arc).
-            # Hold and wait for a frame with a detection rather than nudge blind.
+            # No detection this frame. On the walled platter the piece is
+            # parked wherever its sector is — there is nothing to hunt for, and
+            # blind moves risk carrying the sector over the fall-off. Give
+            # detection a short grace for the piece to re-appear, then simply
+            # proceed: AWAITING collects the result and DISCHARGING owns the
+            # (forward) move to the fall-off.
+            grace_s = float(cfg.precise_blind_grace_ms) / 1000.0
+            blind_since = max(self._last_gap_seen_at, self._started_at)
+            if grace_s > 0 and now - blind_since >= grace_s:
+                self.logger.info(
+                    f"{LOG_TAG} MOVING_TO_PRECISE no detection for "
+                    f"{(now - blind_since):.1f}s — sector holds the piece, "
+                    f"proceeding to AWAITING"
+                )
+                self.stopStepper()
+                return ClassificationChannelState.REV01_AWAITING_DISTRIBUTION
             return None
+        self._last_gap_seen_at = now
 
-        # Sign carries direction: a negative gap (overshot the precise centre
-        # toward the exit) flips C4_TRAVEL_SIGN so the carousel backs up.
-        move = max(-float(cfg.discharge_max_move_output_deg),
-                   min(gap, float(cfg.discharge_max_move_output_deg)))
-        if abs(move) < float(cfg.precise_center_tolerance_deg):
+        # Forward-only: rotate the piece's sector up to the precise band, never
+        # back. Overshoot is handled by the arrived-check above, not by reversing.
+        move = min(gap, float(cfg.discharge_max_move_output_deg))
+        if move < float(cfg.precise_center_tolerance_deg):
             return None
         self.startOutputMove(C4_TRAVEL_SIGN * move, cfg.precise_converge_speed_usteps_per_s)
         return None
@@ -96,3 +127,4 @@ class MovingToPrecise(Rev01BaseState):
         super().cleanup()
         self.stopStepper()
         self._started_at = 0.0
+        self._last_gap_seen_at = 0.0

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/rev01_config.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/rev01_config.py
@@ -24,7 +24,7 @@ class Rev01Config:
     # after this grace without a detection MOVING_TO_PRECISE simply proceeds
     # to AWAITING instead of stalling into the rotate timeout. 0 = wait for
     # the rotate timeout (legacy hold-and-wait).
-    precise_blind_grace_ms: float = 1200.0
+    precise_blind_grace_ms: float = 0.0
     # Legacy fixed discharge kick (only used on the non-perception fallback path).
     # The active perception path closed-loops onto the fall-off centre instead;
     # see ``discharge_*`` fields below.
@@ -125,7 +125,7 @@ FIELD_META: list[dict] = [
     {"key": "capture_at_rest_ms", "label": "Capture-at-rest window (ms)", "type": "float", "default": _DEFAULTS.capture_at_rest_ms, "description": "How long the piece is photographed at rest. The burst ends at this window or the frame ceiling, whichever comes first (~30 fps, so 350 ms fits ~10 frames)."},
     {"key": "precise_converge_speed_usteps_per_s", "label": "Move-to-precise converge speed (µsteps/s)", "type": "int", "default": _DEFAULTS.precise_converge_speed_usteps_per_s, "description": "Motor speed for the reverse converge into the narrow precise staging band. Slower than normal rotation so the approach is gentle."},
     {"key": "precise_center_tolerance_deg", "label": "Move-to-precise: precise-centre tolerance (output deg)", "type": "float", "default": _DEFAULTS.precise_center_tolerance_deg, "description": "How close (in output degrees) the piece must be to the centre of the precise band to count as parked."},
-    {"key": "precise_blind_grace_ms", "label": "Move-to-precise: no-detection grace (ms)", "type": "float", "default": _DEFAULTS.precise_blind_grace_ms, "description": "If the piece is not detected for this long during the converge, proceed to AWAITING — the sector walls hold the piece, there is nothing to hunt for. 0 = wait for the rotate timeout."},
+    {"key": "precise_blind_grace_ms", "label": "Move-to-precise: no-detection grace (ms)", "type": "float", "default": _DEFAULTS.precise_blind_grace_ms, "description": "Walled platter only: if the piece is not detected for this long during the converge, proceed to AWAITING because the sector walls hold it. 0 (default) = wait for the rotate timeout; a detector outage is then never mistaken for a parked piece."},
     {"key": "kick_off_output_deg", "label": "Kick-off move (output deg)", "type": "float", "default": _DEFAULTS.kick_off_output_deg, "description": "Legacy non-perception fallback only: fixed move that shoves the piece off the channel at discharge. The active path closed-loops onto the fall-off centre instead."},
     {"key": "discharge_speed_usteps_per_s", "label": "Discharge speed (µsteps/s)", "type": "int", "default": _DEFAULTS.discharge_speed_usteps_per_s, "description": "Motor speed for discharge moves (driving the piece into the fall-off zone)."},
     {"key": "crop_padding_px", "label": "Crop padding (px)", "type": "int", "default": _DEFAULTS.crop_padding_px, "description": "Extra pixels added around the detected bounding box when cropping the piece image sent to classification."},

--- a/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/rev01_config.py
+++ b/software/sorter/backend/subsystems/classification_channel/simple_state_machine_rev01/rev01_config.py
@@ -14,11 +14,17 @@ class Rev01Config:
     # afterwards which frames are worth sending. The piece does not rotate, so
     # the views are near-identical.
     capture_at_rest_ms: float = 350.0
-    # Reverse converge to the precise staging zone (MOVING_TO_PRECISE). Slower
+    # Forward-only converge to the precise staging zone (MOVING_TO_PRECISE). Slower
     # than the discharge converge so the approach into the narrow precise band is
     # gentle; tolerance is the |gap-to-precise-centre| at which we call it parked.
     precise_converge_speed_usteps_per_s: int = 5000
     precise_center_tolerance_deg: float = 4.0
+    # Walled platter: when the piece is not detected during the converge
+    # (shadowed sector, polygon cut-out), the sector walls hold it in place —
+    # after this grace without a detection MOVING_TO_PRECISE simply proceeds
+    # to AWAITING instead of stalling into the rotate timeout. 0 = wait for
+    # the rotate timeout (legacy hold-and-wait).
+    precise_blind_grace_ms: float = 1200.0
     # Legacy fixed discharge kick (only used on the non-perception fallback path).
     # The active perception path closed-loops onto the fall-off centre instead;
     # see ``discharge_*`` fields below.
@@ -119,6 +125,7 @@ FIELD_META: list[dict] = [
     {"key": "capture_at_rest_ms", "label": "Capture-at-rest window (ms)", "type": "float", "default": _DEFAULTS.capture_at_rest_ms, "description": "How long the piece is photographed at rest. The burst ends at this window or the frame ceiling, whichever comes first (~30 fps, so 350 ms fits ~10 frames)."},
     {"key": "precise_converge_speed_usteps_per_s", "label": "Move-to-precise converge speed (µsteps/s)", "type": "int", "default": _DEFAULTS.precise_converge_speed_usteps_per_s, "description": "Motor speed for the reverse converge into the narrow precise staging band. Slower than normal rotation so the approach is gentle."},
     {"key": "precise_center_tolerance_deg", "label": "Move-to-precise: precise-centre tolerance (output deg)", "type": "float", "default": _DEFAULTS.precise_center_tolerance_deg, "description": "How close (in output degrees) the piece must be to the centre of the precise band to count as parked."},
+    {"key": "precise_blind_grace_ms", "label": "Move-to-precise: no-detection grace (ms)", "type": "float", "default": _DEFAULTS.precise_blind_grace_ms, "description": "If the piece is not detected for this long during the converge, proceed to AWAITING — the sector walls hold the piece, there is nothing to hunt for. 0 = wait for the rotate timeout."},
     {"key": "kick_off_output_deg", "label": "Kick-off move (output deg)", "type": "float", "default": _DEFAULTS.kick_off_output_deg, "description": "Legacy non-perception fallback only: fixed move that shoves the piece off the channel at discharge. The active path closed-loops onto the fall-off centre instead."},
     {"key": "discharge_speed_usteps_per_s", "label": "Discharge speed (µsteps/s)", "type": "int", "default": _DEFAULTS.discharge_speed_usteps_per_s, "description": "Motor speed for discharge moves (driving the piece into the fall-off zone)."},
     {"key": "crop_padding_px", "label": "Crop padding (px)", "type": "int", "default": _DEFAULTS.crop_padding_px, "description": "Extra pixels added around the detected bounding box when cropping the piece image sent to classification."},

--- a/software/sorter/backend/subsystems/feeder/belt/config.py
+++ b/software/sorter/backend/subsystems/feeder/belt/config.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BeltFeederConfig:
+    # Base (100%) belt speed. The controller scales this down as C3 fills up,
+    # so this is the speed the belt runs at while C3 wants more pieces.
+    belt_speed_usteps_per_s: int = 2000
+    # +1 carries the cleats upward toward the drop-off into C3. Flip to -1 if
+    # the belt motor is wired the other way.
+    forward_direction_sign: int = 1
+    # Fill-level controller on C3's perception piece count: at or below
+    # ``c3_full_speed_pieces`` the belt runs at 100%; at or above
+    # ``c3_stop_pieces`` it stops; linear ramp in between. Because the boat at
+    # the belt's foot buffers and the cleats self-meter, this can be lazy —
+    # the belt keeps running through cleat bursts instead of stop/go feeding.
+    c3_full_speed_pieces: int = 1
+    c3_stop_pieces: int = 3
+    # Issue at most one speed change per interval so a flickering piece count
+    # doesn't hammer the serial bus with move_at_speed commands.
+    speed_update_interval_ms: int = 250
+    # No new piece arrived in C3 although the belt has been running at speed
+    # for this long -> boat empty or belt jammed; raise an operator incident.
+    # 0 disables jam detection.
+    jam_timeout_s: float = 45.0
+    enable_belt: bool = True
+
+
+_DEFAULTS = BeltFeederConfig()
+
+# ``section`` groups fields under a denoted subheader in the tuning UI. Order
+# within a section is preserved; sections appear in first-seen order.
+FIELD_META: list[dict] = [
+    {"section": "Belt", "key": "enable_belt", "label": "Enable belt", "type": "bool", "default": _DEFAULTS.enable_belt, "description": "Master switch for the B1 belt motor. Off = the belt never moves; C3 keeps metering whatever is already on it."},
+    {"section": "Belt", "key": "belt_speed_usteps_per_s", "label": "Belt base speed (µsteps/s)", "type": "int", "default": _DEFAULTS.belt_speed_usteps_per_s, "description": "Belt speed while C3 wants more pieces (the 100% point of the fill-level ramp). Cleat spacing × this speed sets the burst cadence into C3."},
+    {"section": "Belt", "key": "forward_direction_sign", "label": "Forward direction sign (+1/-1)", "type": "int", "default": _DEFAULTS.forward_direction_sign, "description": "Which way the motor turns to carry cleats up toward the C3 drop-off. Use -1 only if the belt runs backwards."},
+    {"section": "C3 fill-level control", "key": "c3_full_speed_pieces", "label": "C3 pieces for full speed", "type": "int", "default": _DEFAULTS.c3_full_speed_pieces, "description": "While C3 has at most this many pieces the belt runs at 100% base speed."},
+    {"section": "C3 fill-level control", "key": "c3_stop_pieces", "label": "C3 pieces for full stop", "type": "int", "default": _DEFAULTS.c3_stop_pieces, "description": "Once C3 holds this many pieces (or more) the belt stops. Between the full-speed and stop counts the speed ramps down linearly."},
+    {"section": "C3 fill-level control", "key": "speed_update_interval_ms", "label": "Speed update interval (ms)", "type": "int", "default": _DEFAULTS.speed_update_interval_ms, "description": "Minimum time between belt speed changes, so a flickering piece count doesn't spam the motor."},
+    {"section": "Jam detection", "key": "jam_timeout_s", "label": "Jam timeout (s)", "type": "float", "default": _DEFAULTS.jam_timeout_s, "description": "If the belt has been running this long without a single new piece arriving in C3, raise a belt-stalled incident (boat empty or belt jammed). 0 disables."},
+]
+
+
+def configFromDict(d: dict) -> BeltFeederConfig:
+    cfg = BeltFeederConfig()
+    for meta in FIELD_META:
+        k = meta["key"]
+        if k not in d:
+            continue
+        raw = d[k]
+        try:
+            if meta["type"] == "int":
+                setattr(cfg, k, int(raw))
+            elif meta["type"] == "bool":
+                setattr(cfg, k, bool(raw))
+            else:
+                setattr(cfg, k, float(raw))
+        except (TypeError, ValueError):
+            pass
+    return cfg
+
+
+def configToDict(cfg: BeltFeederConfig) -> dict[str, object]:
+    return {meta["key"]: getattr(cfg, meta["key"]) for meta in FIELD_META}

--- a/software/sorter/backend/subsystems/feeder/belt/config.py
+++ b/software/sorter/backend/subsystems/feeder/belt/config.py
@@ -22,7 +22,27 @@ class BeltFeederConfig:
     # No new piece arrived in C3 although the belt has been running at speed
     # for this long -> boat empty or belt jammed; raise an operator incident.
     # 0 disables jam detection.
-    jam_timeout_s: float = 45.0
+    jam_timeout_s: float = 20.0
+    # Load watch without an encoder: while the belt runs, the TMC2209's
+    # StallGuard result (SG_RESULT, 0..1023, high = free-running, towards 0 =
+    # loaded/blocked) is read every ``load_poll_interval_ms``. Below
+    # ``load_block_sg_threshold`` for ``load_block_samples`` consecutive reads the
+    # belt stops and the operator incident is raised instead of pushing on: on
+    # 2026-09-06 the belt drove 45 s plus three watchdog nudges into a blockage
+    # and sheared its drive shaft. 0 = watch only (values are logged and shown
+    # in the status) until the threshold has been read off the repaired machine.
+    # Perception freshness: a C3 state older than this is not a fill level,
+    # it is a frozen camera; the belt stops rather than run blind.
+    perception_stale_s: float = 2.0
+    # Stuck-watchdog nudge: the belt runs at base speed for this long, once
+    # per stall (further requests are refused so the watchdog escalates to
+    # the operator instead of driving a blocked belt again and again —
+    # 2026-09-06 three nudges into a blockage sheared the drive shaft).
+    nudge_run_ms: int = 1500
+    nudge_max_attempts: int = 1
+    load_block_sg_threshold: int = 0
+    load_block_samples: int = 3
+    load_poll_interval_ms: int = 500
     enable_belt: bool = True
 
 
@@ -38,6 +58,12 @@ FIELD_META: list[dict] = [
     {"section": "C3 fill-level control", "key": "c3_stop_pieces", "label": "C3 pieces for full stop", "type": "int", "default": _DEFAULTS.c3_stop_pieces, "description": "Once C3 holds this many pieces (or more) the belt stops. Between the full-speed and stop counts the speed ramps down linearly."},
     {"section": "C3 fill-level control", "key": "speed_update_interval_ms", "label": "Speed update interval (ms)", "type": "int", "default": _DEFAULTS.speed_update_interval_ms, "description": "Minimum time between belt speed changes, so a flickering piece count doesn't spam the motor."},
     {"section": "Jam detection", "key": "jam_timeout_s", "label": "Jam timeout (s)", "type": "float", "default": _DEFAULTS.jam_timeout_s, "description": "If the belt has been running this long without a single new piece arriving in C3, raise a belt-stalled incident (boat empty or belt jammed). 0 disables."},
+    {"key": "perception_stale_s", "label": "Perception: max C3 state age (s)", "type": "float", "default": _DEFAULTS.perception_stale_s, "description": "If the C3 detection state is older than this the belt stops (reason stale_perception) instead of running on a frozen camera."},
+    {"key": "nudge_run_ms", "label": "Stuck nudge: run time (ms)", "type": "int", "default": _DEFAULTS.nudge_run_ms, "description": "How long the belt runs at base speed for one stuck-watchdog nudge. Bounded: a velocity move would otherwise run until the next fill-level command."},
+    {"key": "nudge_max_attempts", "label": "Stuck nudge: attempts per stall", "type": "int", "default": _DEFAULTS.nudge_max_attempts, "description": "Nudges accepted per stall (reset when a new piece reaches C3). Beyond this the watchdog raises the jam incident instead of driving a possibly blocked belt again."},
+    {"key": "load_block_sg_threshold", "label": "Belt load: SG_RESULT block threshold", "type": "int", "default": _DEFAULTS.load_block_sg_threshold, "description": "StallGuard result below which the running belt counts as blocked (0..1023; high = free-running). 0 = watch only: the value is logged and shown in the status so the threshold can be read off the real machine before enabling."},
+    {"key": "load_block_samples", "label": "Belt load: consecutive blocked reads", "type": "int", "default": _DEFAULTS.load_block_samples, "description": "How many consecutive reads below the threshold stop the belt and raise the incident."},
+    {"key": "load_poll_interval_ms", "label": "Belt load: poll interval (ms)", "type": "int", "default": _DEFAULTS.load_poll_interval_ms, "description": "How often SG_RESULT is read while the belt runs."},
 ]
 
 

--- a/software/sorter/backend/subsystems/feeder/belt/flow.py
+++ b/software/sorter/backend/subsystems/feeder/belt/flow.py
@@ -31,6 +31,34 @@ if TYPE_CHECKING:
     from hardware.sorter_interface import StepperMotor
 
 
+class BeltLoadMonitor:
+    """Blocked-belt detector on the driver's StallGuard result: below the
+    threshold for ``samples`` consecutive reads means blocked. A threshold of 0
+    only records values (watch mode)."""
+
+    def __init__(self, threshold: int, samples: int) -> None:
+        self.threshold = int(threshold)
+        self.samples = max(1, int(samples))
+        self.last_sg: int | None = None
+        self.low_streak = 0
+
+    def observe(self, sg_result: int | None) -> bool:
+        if sg_result is None:
+            return False
+        self.last_sg = int(sg_result)
+        if self.threshold <= 0:
+            self.low_streak = 0
+            return False
+        if self.last_sg < self.threshold:
+            self.low_streak += 1
+        else:
+            self.low_streak = 0
+        return self.low_streak >= self.samples
+
+    def reset(self) -> None:
+        self.low_streak = 0
+
+
 class BeltFeeding(PulsePerceptionFeeding):
     def __init__(
         self,
@@ -60,7 +88,16 @@ class BeltFeeding(PulsePerceptionFeeding):
         # in place every tick and reachable via gc (read by the tuning router).
         self._status: dict = {"reason": "idle", "ts": 0.0}
         self._last_blocked_reason: str | None = None
+        # Stuck-watchdog nudge window (monotonic deadline) and attempts spent
+        # since the last piece reached C3.
+        self._nudge_until: float = 0.0
+        self._nudges_since_arrival: int = 0
+        self._perception_reason: str = "no_perception"
         gc.belt_feeder_status = self._status
+        # Load watch (see BeltLoadMonitor); polled only while the belt runs.
+        self._load = BeltLoadMonitor(self._belt_config.load_block_sg_threshold, self._belt_config.load_block_samples)
+        self._load_next_poll_at: float = 0.0
+        self._load_last_log_at: float = 0.0
 
     def _cfg(self):
         # The C1/C2 rotors don't exist in the belt topology; the inherited C3
@@ -82,16 +119,22 @@ class BeltFeeding(PulsePerceptionFeeding):
 
     def _nudge_belt(self) -> bool:
         """Stuck-watchdog nudge for a piece hung at the belt's drop lip: run
-        the belt at base speed for one update interval, then hand control back
-        to the fill-level controller."""
+        the belt at base speed for ``nudge_run_ms``, then hand control back to
+        the fill-level controller. Bounded in time and in count: after
+        ``nudge_max_attempts`` per stall the request is refused so the watchdog
+        escalates to the operator instead of driving a blocked belt again."""
         stepper: "StepperMotor | None" = getattr(self.irl, "belt_stepper", None)
         cfg = self._belt_cfg()
-        if stepper is None or not cfg.enable_belt:
+        if stepper is None or not cfg.enable_belt or getattr(stepper, "stalled", False):
             return False
-        self._belt_cmd_speed = 0
-        self._belt_next_cmd_at = 0.0
-        self._command_belt_speed(stepper, abs(int(cfg.belt_speed_usteps_per_s)), cfg, time.monotonic())
-        return self._belt_cmd_speed != 0
+        if self._nudges_since_arrival >= max(0, int(cfg.nudge_max_attempts)):
+            self.gc.logger.info(
+                f"BeltFeeding: nudge refused — {self._nudges_since_arrival} already spent on this stall"
+            )
+            return False
+        self._nudges_since_arrival += 1
+        self._nudge_until = time.monotonic() + max(0, int(cfg.nudge_run_ms)) / 1000.0
+        return True
 
     def _belt_cfg(self) -> BeltFeederConfig:
         now = time.monotonic()
@@ -126,23 +169,37 @@ class BeltFeeding(PulsePerceptionFeeding):
             self._publish_status(cfg, 0, None, "chute_move")
             return
 
-        c3_pieces = self._c3_piece_count()
+        c3_pieces = self._c3_piece_count(cfg)
         if c3_pieces is None:
-            # Perception not up yet — never run the belt blind.
+            # Perception not up yet, or its C3 state is stale — never run the
+            # belt blind.
             self._command_belt_speed(stepper, 0, cfg, now)
-            self._publish_status(cfg, 0, None, "no_perception")
+            self._publish_status(cfg, 0, None, self._perception_reason)
             return
 
         if c3_pieces > self._last_c3_pieces:
             self._last_arrival_at = now
+            self._nudges_since_arrival = 0
         self._last_c3_pieces = c3_pieces
 
-        target = self._target_speed(cfg, c3_pieces)
-        self._command_belt_speed(stepper, target, cfg, now)
+        if getattr(stepper, "stalled", False):
+            # DIAG latch from the stall monitor: never keep driving.
+            self._stop_belt("stall latch")
+            self._publish_status(cfg, 0, c3_pieces, "stalled")
+            return
+        if self._check_load(stepper, cfg, now):
+            self._publish_status(cfg, 0, c3_pieces, "blocked")
+            return
+
+        nudging = cfg.enable_belt and now < self._nudge_until
+        target = abs(int(cfg.belt_speed_usteps_per_s)) if nudging else self._target_speed(cfg, c3_pieces)
+        self._command_belt_speed(stepper, target, cfg, now, immediate=nudging)
         self._check_jam(cfg, now)
 
         if not cfg.enable_belt:
             reason = "disabled"
+        elif nudging:
+            reason = "nudging"
         elif target == 0:
             reason = "stopped_c3_full"
         elif target < abs(cfg.belt_speed_usteps_per_s):
@@ -179,6 +236,8 @@ class BeltFeeding(PulsePerceptionFeeding):
                     round(now - self._last_arrival_at, 1) if self._last_arrival_at else None
                 ),
                 "jam_timeout_s": cfg.jam_timeout_s if cfg else None,
+                "sg_result": self._load.last_sg,
+                "load_block_sg_threshold": cfg.load_block_sg_threshold if cfg else None,
                 "jam_countdown_s": (
                     round(max(0.0, cfg.jam_timeout_s - (now - quiet_since)), 1)
                     if cfg and cfg.jam_timeout_s > 0 and self._belt_running_since is not None
@@ -195,14 +254,23 @@ class BeltFeeding(PulsePerceptionFeeding):
             if runtime_stats is not None and hasattr(runtime_stats, "observeBlockedReason"):
                 runtime_stats.observeBlockedReason("belt", reason)
 
-    def _c3_piece_count(self) -> int | None:
+    def _c3_piece_count(self, cfg: BeltFeederConfig) -> int | None:
+        """C3's piece count, or None (with ``_perception_reason`` set) when
+        there is no usable state: perception not up, or its last C3 frame
+        older than ``perception_stale_s`` — a frozen camera keeps the last
+        count forever, and a belt fed by that count would run blind."""
         perception_service = getattr(self.gc, "perception_service", None)
         if perception_service is None:
+            self._perception_reason = "no_perception"
             return None
         from perception.state import EMPTY_STATE, EMPTY_STATE_TS
 
         c3 = perception_service.read_states().get(3, EMPTY_STATE)
         if c3.ts == EMPTY_STATE_TS:
+            self._perception_reason = "no_perception"
+            return None
+        if cfg.perception_stale_s > 0 and time.time() - float(c3.ts) > cfg.perception_stale_s:
+            self._perception_reason = "stale_perception"
             return None
         return c3.n_pieces
 
@@ -225,14 +293,15 @@ class BeltFeeding(PulsePerceptionFeeding):
         target: int,
         cfg: BeltFeederConfig,
         now: float,
+        immediate: bool = False,
     ) -> None:
         sign = 1 if cfg.forward_direction_sign >= 0 else -1
         signed_target = sign * target
         if signed_target == self._belt_cmd_speed and not self._belt_cmd_unacked:
             return
-        # An emergency stop may always go out immediately; speed-ups and
-        # ramp-downs respect the update interval.
-        if target != 0 and now < self._belt_next_cmd_at:
+        # An emergency stop (and a watchdog nudge) may always go out
+        # immediately; speed-ups and ramp-downs respect the update interval.
+        if target != 0 and not immediate and now < self._belt_next_cmd_at:
             return
         if target > self._belt_speed_limit:
             # Never push a zero minimum into firmware: braking clamps to it and
@@ -257,6 +326,45 @@ class BeltFeeding(PulsePerceptionFeeding):
             self._belt_running_since = None
         elif was_stopped:
             self._belt_running_since = now
+
+    def _check_load(self, stepper: "StepperMotor", cfg: BeltFeederConfig, now: float) -> bool:
+        """Read the driver's StallGuard result while the belt runs; stop and
+        raise the incident once it reads blocked. Returns True when blocked."""
+        self._load.threshold = int(cfg.load_block_sg_threshold)
+        self._load.samples = max(1, int(cfg.load_block_samples))
+        if self._belt_cmd_speed == 0 or self._belt_running_since is None:
+            self._load.reset()
+            return False
+        if now - self._belt_running_since < 0.5 or now < self._load_next_poll_at:
+            return False  # SG_RESULT is meaningless below cruise speed / during spin-up
+        self._load_next_poll_at = now + max(100, int(cfg.load_poll_interval_ms)) / 1000.0
+        from tmc_telemetry import REG_SG_RESULT, safeReadRegister
+
+        sg = safeReadRegister(stepper, REG_SG_RESULT)
+        blocked = self._load.observe(sg)
+        if sg is not None and now - self._load_last_log_at >= 10.0:
+            self._load_last_log_at = now
+            self.gc.logger.info(
+                f"BeltFeeding: SG_RESULT={sg} at {abs(self._belt_cmd_speed)} µsteps/s"
+                + (f" (block threshold {self._load.threshold})" if self._load.threshold > 0 else " (watch only)")
+            )
+        if not blocked:
+            return False
+        self.gc.logger.warning(
+            f"BeltFeeding: SG_RESULT {self._load.last_sg} below {self._load.threshold} for "
+            f"{self._load.low_streak} reads — belt blocked, stopping"
+        )
+        self._stop_belt("blocked")
+        from ..incidents import publish_belt_feeder_stalled_incident
+
+        publish_belt_feeder_stalled_incident(
+            self.gc,
+            stalled_ms=int((now - (self._belt_running_since or now)) * 1000),
+            belt_speed_usteps_per_s=abs(int(cfg.belt_speed_usteps_per_s)),
+            jam_timeout_s=cfg.jam_timeout_s,
+        )
+        self._load.reset()
+        return True
 
     def _check_jam(self, cfg: BeltFeederConfig, now: float) -> None:
         if cfg.jam_timeout_s <= 0 or self._belt_running_since is None:

--- a/software/sorter/backend/subsystems/feeder/belt/flow.py
+++ b/software/sorter/backend/subsystems/feeder/belt/flow.py
@@ -1,0 +1,309 @@
+import time
+from typing import Optional, TYPE_CHECKING
+
+from irl.config import IRLInterface, IRLConfig
+from global_config import GlobalConfig
+from subsystems.shared_variables import SharedVariables
+from vision import VisionManager
+
+from ..states import FeederState
+from ..pulse_perception.flow import C3Upstream, PulsePerceptionFeeding, _CONFIG_TTL_S
+from ..constant_movement.flow import FIRMWARE_MIN_SPEED_USTEPS_PER_S
+from .config import BeltFeederConfig
+
+# B1 belt topology (machine_setup "belt_feeder"): a cleated inclined conveyor
+# replaces the C1 bulk bucket AND the C2 buffer channel. The belt lifts a few
+# pieces per cleat out of the boat and drops them into C3; surplus tumbles back
+# into the boat, so the belt self-meters and self-recirculates.
+#
+# Control model — constant-speed feeding instead of stop/go:
+#   - C3 keeps the pulse-perception exit metering unchanged (final singulation
+#     into the classification channel). We inherit that wholesale from
+#     PulsePerceptionFeeding and force ch1/ch2 off — those motors don't exist
+#     in this topology.
+#   - The belt runs CONTINUOUSLY via move_at_speed, scaled by C3's perception
+#     fill level (ChannelState.n_pieces): full speed while C3 wants pieces,
+#     linear ramp down to a stop as C3 fills up. Because the boat buffers and
+#     the cleats self-meter, this controller can be lazy — no per-piece
+#     reactions, just a slow closed loop on channel occupancy.
+
+if TYPE_CHECKING:
+    from hardware.sorter_interface import StepperMotor
+
+
+class BeltFeeding(PulsePerceptionFeeding):
+    def __init__(
+        self,
+        irl: IRLInterface,
+        irl_config: IRLConfig,
+        gc: GlobalConfig,
+        shared: SharedVariables,
+        vision: VisionManager,
+    ):
+        super().__init__(irl, irl_config, gc, shared, vision)
+        self._belt_config: BeltFeederConfig = BeltFeederConfig()
+        self._belt_config_loaded_at: float = 0.0
+        # Last speed actually commanded to the motor (signed, µsteps/s) and the
+        # earliest time we may issue the next change.
+        self._belt_cmd_speed: int = 0
+        self._belt_next_cmd_at: float = 0.0
+        # A command the motor did not acknowledge leaves its real state unknown;
+        # the next command (and any stop) must go out regardless of the cache.
+        self._belt_cmd_unacked: bool = False
+        self._belt_speed_limit: int = 0
+        # Jam detection: the belt has been running since ``_belt_running_since``
+        # and the last new piece appeared in C3 at ``_last_arrival_at``.
+        self._belt_running_since: float | None = None
+        self._last_arrival_at: float = 0.0
+        self._last_c3_pieces: int = 0
+        # Live introspection for the tuning page / debugging: one dict, updated
+        # in place every tick and reachable via gc (read by the tuning router).
+        self._status: dict = {"reason": "idle", "ts": 0.0}
+        self._last_blocked_reason: str | None = None
+        gc.belt_feeder_status = self._status
+
+    def _cfg(self):
+        # The C1/C2 rotors don't exist in the belt topology; the inherited C3
+        # exit metering (and its tuning page) is used unchanged.
+        cfg = super()._cfg()
+        cfg.enable_ch1 = False
+        cfg.enable_ch2 = False
+        return cfg
+
+    def _c3_upstream(self, cfg) -> C3Upstream:
+        belt_cfg = self._belt_cfg()
+        return C3Upstream(
+            label="B1 belt",
+            channel_id=1,
+            stepper=getattr(self.irl, "belt_stepper", None),
+            enabled=bool(belt_cfg.enable_belt),
+            nudge=self._nudge_belt,
+        )
+
+    def _nudge_belt(self) -> bool:
+        """Stuck-watchdog nudge for a piece hung at the belt's drop lip: run
+        the belt at base speed for one update interval, then hand control back
+        to the fill-level controller."""
+        stepper: "StepperMotor | None" = getattr(self.irl, "belt_stepper", None)
+        cfg = self._belt_cfg()
+        if stepper is None or not cfg.enable_belt:
+            return False
+        self._belt_cmd_speed = 0
+        self._belt_next_cmd_at = 0.0
+        self._command_belt_speed(stepper, abs(int(cfg.belt_speed_usteps_per_s)), cfg, time.monotonic())
+        return self._belt_cmd_speed != 0
+
+    def _belt_cfg(self) -> BeltFeederConfig:
+        now = time.monotonic()
+        if now - self._belt_config_loaded_at >= _CONFIG_TTL_S:
+            try:
+                from toml_config import getBeltFeederConfig
+                from .config import configFromDict
+                self._belt_config = configFromDict(getBeltFeederConfig())
+            except Exception as exc:
+                self.gc.logger.warning(f"BeltFeeding: config load failed: {exc}")
+            self._belt_config_loaded_at = now
+        return self._belt_config
+
+    def step(self) -> Optional[FeederState]:
+        next_state = super().step()
+        self._step_belt()
+        return next_state
+
+    def _step_belt(self) -> None:
+        stepper: "StepperMotor | None" = getattr(self.irl, "belt_stepper", None)
+        if stepper is None:
+            self._publish_status(None, 0, None, "no_belt_stepper")
+            return
+        cfg = self._belt_cfg()
+        now = time.monotonic()
+
+        if self.shared.chute_move_in_progress and not (
+            self.gc.rotary_channel_steppers_can_operate_in_parallel
+        ):
+            # Same rule as the rotors: no feeder motion while the chute moves.
+            self._stop_belt("chute move")
+            self._publish_status(cfg, 0, None, "chute_move")
+            return
+
+        c3_pieces = self._c3_piece_count()
+        if c3_pieces is None:
+            # Perception not up yet — never run the belt blind.
+            self._command_belt_speed(stepper, 0, cfg, now)
+            self._publish_status(cfg, 0, None, "no_perception")
+            return
+
+        if c3_pieces > self._last_c3_pieces:
+            self._last_arrival_at = now
+        self._last_c3_pieces = c3_pieces
+
+        target = self._target_speed(cfg, c3_pieces)
+        self._command_belt_speed(stepper, target, cfg, now)
+        self._check_jam(cfg, now)
+
+        if not cfg.enable_belt:
+            reason = "disabled"
+        elif target == 0:
+            reason = "stopped_c3_full"
+        elif target < abs(cfg.belt_speed_usteps_per_s):
+            reason = "throttled"
+        else:
+            reason = "running"
+        self._publish_status(cfg, target, c3_pieces, reason)
+
+    def _publish_status(
+        self,
+        cfg: BeltFeederConfig | None,
+        target: int,
+        c3_pieces: int | None,
+        reason: str,
+    ) -> None:
+        now = time.monotonic()
+        quiet_since = max(self._belt_running_since or 0.0, self._last_arrival_at)
+        self._status.update(
+            {
+                "ts": time.time(),
+                "reason": reason,
+                "commanded_speed_usteps_per_s": self._belt_cmd_speed,
+                "target_speed_usteps_per_s": target,
+                "base_speed_usteps_per_s": cfg.belt_speed_usteps_per_s if cfg else None,
+                "c3_pieces": c3_pieces,
+                "c3_full_speed_pieces": cfg.c3_full_speed_pieces if cfg else None,
+                "c3_stop_pieces": cfg.c3_stop_pieces if cfg else None,
+                "running_for_s": (
+                    round(now - self._belt_running_since, 1)
+                    if self._belt_running_since is not None
+                    else None
+                ),
+                "since_last_arrival_s": (
+                    round(now - self._last_arrival_at, 1) if self._last_arrival_at else None
+                ),
+                "jam_timeout_s": cfg.jam_timeout_s if cfg else None,
+                "jam_countdown_s": (
+                    round(max(0.0, cfg.jam_timeout_s - (now - quiet_since)), 1)
+                    if cfg and cfg.jam_timeout_s > 0 and self._belt_running_since is not None
+                    else None
+                ),
+            }
+        )
+        # Count blocked reasons on the change edge only (not per tick).
+        if reason in ("running", "throttled"):
+            self._last_blocked_reason = None
+        elif reason != self._last_blocked_reason:
+            self._last_blocked_reason = reason
+            runtime_stats = getattr(self.gc, "runtime_stats", None)
+            if runtime_stats is not None and hasattr(runtime_stats, "observeBlockedReason"):
+                runtime_stats.observeBlockedReason("belt", reason)
+
+    def _c3_piece_count(self) -> int | None:
+        perception_service = getattr(self.gc, "perception_service", None)
+        if perception_service is None:
+            return None
+        from perception.state import EMPTY_STATE, EMPTY_STATE_TS
+
+        c3 = perception_service.read_states().get(3, EMPTY_STATE)
+        if c3.ts == EMPTY_STATE_TS:
+            return None
+        return c3.n_pieces
+
+    def _target_speed(self, cfg: BeltFeederConfig, c3_pieces: int) -> int:
+        if not cfg.enable_belt:
+            return 0
+        full = max(0, cfg.c3_full_speed_pieces)
+        stop = max(full + 1, cfg.c3_stop_pieces)
+        if c3_pieces <= full:
+            fraction = 1.0
+        elif c3_pieces >= stop:
+            fraction = 0.0
+        else:
+            fraction = (stop - c3_pieces) / (stop - full)
+        return int(round(abs(cfg.belt_speed_usteps_per_s) * fraction))
+
+    def _command_belt_speed(
+        self,
+        stepper: "StepperMotor",
+        target: int,
+        cfg: BeltFeederConfig,
+        now: float,
+    ) -> None:
+        sign = 1 if cfg.forward_direction_sign >= 0 else -1
+        signed_target = sign * target
+        if signed_target == self._belt_cmd_speed and not self._belt_cmd_unacked:
+            return
+        # An emergency stop may always go out immediately; speed-ups and
+        # ramp-downs respect the update interval.
+        if target != 0 and now < self._belt_next_cmd_at:
+            return
+        if target > self._belt_speed_limit:
+            # Never push a zero minimum into firmware: braking clamps to it and
+            # a later distance move on this port would never finish.
+            try:
+                stepper.set_speed_limits(FIRMWARE_MIN_SPEED_USTEPS_PER_S, target)
+                self._belt_speed_limit = target
+            except Exception as exc:
+                self.gc.logger.warning(f"BeltFeeding: speed limit set failed: {exc}")
+        success = stepper.move_at_speed(signed_target)
+        if not success:
+            self.gc.logger.warning(
+                f"BeltFeeding: move_at_speed({signed_target}) not acknowledged"
+            )
+            self._belt_cmd_unacked = True
+            return
+        self._belt_cmd_unacked = False
+        was_stopped = self._belt_cmd_speed == 0
+        self._belt_cmd_speed = signed_target
+        self._belt_next_cmd_at = now + max(0, cfg.speed_update_interval_ms) / 1000.0
+        if target == 0:
+            self._belt_running_since = None
+        elif was_stopped:
+            self._belt_running_since = now
+
+    def _check_jam(self, cfg: BeltFeederConfig, now: float) -> None:
+        if cfg.jam_timeout_s <= 0 or self._belt_running_since is None:
+            return
+        quiet_since = max(self._belt_running_since, self._last_arrival_at)
+        quiet_s = now - quiet_since
+        if quiet_s < cfg.jam_timeout_s:
+            return
+        from ..incidents import publish_belt_feeder_stalled_incident
+
+        publish_belt_feeder_stalled_incident(
+            self.gc,
+            stalled_ms=int(quiet_s * 1000),
+            belt_speed_usteps_per_s=abs(self._belt_cmd_speed),
+            jam_timeout_s=cfg.jam_timeout_s,
+        )
+        # Re-arm so the incident (or a false alarm on an empty boat) doesn't
+        # re-fire every tick.
+        self._last_arrival_at = now
+
+    def _stop_belt(self, why: str) -> None:
+        """Idempotent: sends the stop only while the belt is commanded to run
+        (or its last command went unacknowledged, so the real state is unknown)."""
+        if self._belt_cmd_speed == 0 and not self._belt_cmd_unacked:
+            return
+        stepper: "StepperMotor | None" = getattr(self.irl, "belt_stepper", None)
+        acked = False
+        if stepper is not None:
+            try:
+                acked = bool(stepper.move_at_speed(0))
+            except Exception as exc:
+                self.gc.logger.warning(f"BeltFeeding: {why} belt stop failed: {exc}")
+        self._belt_cmd_speed = 0
+        self._belt_running_since = None
+        self._belt_cmd_unacked = stepper is not None and not acked
+
+    def hold_motion(self) -> None:
+        """The coordinator stops stepping the feeder during an incident or in
+        manual feed mode and calls this instead. A velocity move never ends on
+        its own, so the belt must be stopped explicitly here."""
+        if self._belt_cmd_speed == 0 and not self._belt_cmd_unacked:
+            return
+        self._stop_belt("hold")
+        self._publish_status(None, 0, None, "held")
+
+    def cleanup(self) -> None:
+        # Leaving FEEDING (pause/stop/incident) must always stop the belt.
+        self._stop_belt("cleanup")
+        self._status.update({"ts": time.time(), "reason": "idle"})
+        super().cleanup()

--- a/software/sorter/backend/subsystems/feeder/incidents.py
+++ b/software/sorter/backend/subsystems/feeder/incidents.py
@@ -13,6 +13,7 @@ from typing import Any
 # raise THIS operator-facing incident.
 FEEDER_JAM_INCIDENT_KIND = "feeder_jam"
 FEEDER_JAM_SOURCE_KIND = "feeder_stuck_watchdog"
+BELT_FEEDER_STALLED_INCIDENT_KIND = "belt_feeder_stalled"
 
 
 def feeder_jam_incident_active(gc: Any, *, channel_label: str | None = None) -> bool:
@@ -172,3 +173,48 @@ def _incident_handling_off(kind: str) -> bool:
         return bool(incidentHandlingOff(kind))
     except Exception:
         return False
+
+
+def publish_belt_feeder_stalled_incident(
+    gc: Any,
+    *,
+    stalled_ms: int,
+    belt_speed_usteps_per_s: int,
+    jam_timeout_s: float,
+) -> bool:
+    """B1 belt topology: the belt ran for the whole jam window without a single
+    new piece arriving in C3 — the boat is empty or the belt is jammed."""
+    if _incident_handling_off(BELT_FEEDER_STALLED_INCIDENT_KIND):
+        return False
+    runtime_stats = getattr(gc, "runtime_stats", None)
+    if runtime_stats is None or not hasattr(runtime_stats, "setActiveIncident"):
+        return False
+
+    active = None
+    if hasattr(runtime_stats, "activeIncident"):
+        try:
+            active = runtime_stats.activeIncident()
+        except Exception:
+            active = None
+    if isinstance(active, dict):
+        return active.get("kind") == BELT_FEEDER_STALLED_INCIDENT_KIND
+
+    runtime_stats.setActiveIncident(
+        {
+            "kind": BELT_FEEDER_STALLED_INCIDENT_KIND,
+            "severity": "warning",
+            "status": "waiting_for_operator",
+            "awaiting_operator": True,
+            "scope": "feeder",
+            "channel": "b1",
+            "role": "belt_feeder",
+            "channel_label": "B1 Belt Feeder",
+            "triggered_at": time.time(),
+            "stalled_ms": int(stalled_ms),
+            "belt_speed_usteps_per_s": int(belt_speed_usteps_per_s),
+            "jam_timeout_s": float(jam_timeout_s),
+            "rule": "belt_ran_without_new_c3_piece_for_timeout",
+            "resolution": "operator_check_boat_or_belt_then_clear_incident",
+        }
+    )
+    return True

--- a/software/sorter/backend/subsystems/feeder/pulse_perception/flow.py
+++ b/software/sorter/backend/subsystems/feeder/pulse_perception/flow.py
@@ -1,6 +1,6 @@
 import time
-from dataclasses import replace
-from typing import Optional, TYPE_CHECKING
+from dataclasses import replace, dataclass
+from typing import Any, Callable, Optional, TYPE_CHECKING
 
 from states.base_state import BaseState
 from subsystems.shared_variables import SharedVariables
@@ -76,6 +76,19 @@ def _wants_advance(action) -> bool:
     from perception.cascade import Action
 
     return action in (Action.ADVANCE, Action.PRECISE)
+
+
+@dataclass(frozen=True)
+class C3Upstream:
+    """Who feeds C3, for the stuck watchdog: the label used in the jam
+    incident, the rotor to nudge (or a topology-specific ``nudge`` callable),
+    and whether nudging is possible at all."""
+
+    label: str
+    channel_id: int
+    stepper: Any
+    enabled: bool
+    nudge: Optional[Callable[[], bool]] = None
 
 
 class PulsePerceptionFeeding(BaseState):
@@ -203,6 +216,16 @@ class PulsePerceptionFeeding(BaseState):
             return replace(state, in_drop=True)
         return state
 
+    def _c3_upstream(self, cfg: PulsePerceptionConfig) -> C3Upstream:
+        """C2 feeds C3 in the C-channel topology. The belt topology overrides
+        this with the belt (there is no C2 to blame or to nudge)."""
+        return C3Upstream(
+            label="C2",
+            channel_id=2,
+            stepper=getattr(self.irl, "c_channel_2_rotor_stepper", None),
+            enabled=bool(cfg.enable_ch2),
+        )
+
     def step(self) -> Optional[FeederState]:
         cfg = self._cfg()
 
@@ -222,7 +245,6 @@ class PulsePerceptionFeeding(BaseState):
         states = perception_service.read_states()
         c2 = states.get(2, EMPTY_STATE)
         c3 = states.get(3, EMPTY_STATE)
-        c4 = states.get(4, EMPTY_STATE)
 
         now_mono = time.monotonic()
         # Hold C2/C3 drop-zone occupancy across brief detector dropouts so the
@@ -247,13 +269,15 @@ class PulsePerceptionFeeding(BaseState):
             )
             # C3 hung at the C2->C3 hand-off: keep C3 from hammering a piece it
             # can't move; nudge C2 (its upstream) to free it, escalate on failure.
+            upstream = self._c3_upstream(cfg)
             self._stuck_watchdog.observe(
                 channel_id=3,
                 channel_label="C3",
-                upstream_label="C2",
-                upstream_channel_id=2,
-                upstream_stepper=self.irl.c_channel_2_rotor_stepper,
-                upstream_enabled=bool(cfg.enable_ch2),
+                upstream_label=upstream.label,
+                upstream_channel_id=upstream.channel_id,
+                upstream_stepper=upstream.stepper,
+                upstream_enabled=upstream.enabled,
+                nudge=upstream.nudge,
                 leading_pos_deg=_leading_com(c3),
                 wants_advance=_wants_advance(action),
                 cfg=cfg,

--- a/software/sorter/backend/subsystems/feeder/pulse_perception/stuck_watchdog.py
+++ b/software/sorter/backend/subsystems/feeder/pulse_perception/stuck_watchdog.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from .config import PulsePerceptionConfig, channelMoveSpeed
 from subsystems.feeder.incidents import (
@@ -79,7 +79,10 @@ class FeederStuckWatchdog:
         wants_advance: bool,
         cfg: PulsePerceptionConfig,
         now: float,
+        nudge: Optional[Callable[[], bool]] = None,
     ) -> None:
+        """``nudge`` replaces the default upstream-rotor pulse for topologies
+        whose upstream is not a C-channel rotor (the B1 belt)."""
         if not cfg.stuck_watchdog_enabled or _handling_off():
             # Feature disabled or the operator set this incident to "off": drop
             # any state and never raise. (An already-raised jam clears the next
@@ -157,7 +160,11 @@ class FeederStuckWatchdog:
         if automatic and upstream_enabled and tracker.nudge_attempts < int(
             cfg.stuck_max_nudge_attempts
         ):
-            moved = self._nudge_upstream(upstream_stepper, upstream_channel_id, cfg)
+            moved = (
+                nudge()
+                if nudge is not None
+                else self._nudge_upstream(upstream_stepper, upstream_channel_id, cfg)
+            )
             if tracker.nudge_attempts == 0:
                 # First nudge of this stall: remember when it started (monotonic)
                 # so an auto-freed jam records its real duration.

--- a/software/sorter/backend/subsystems/feeder/state_machine.py
+++ b/software/sorter/backend/subsystems/feeder/state_machine.py
@@ -72,6 +72,12 @@ class FeederStateMachine(BaseSubsystem):
                 FeederState.IDLE: Idle(irl, gc, shared),
                 FeederState.FEEDING: ConstantMovementFeeding(irl, irl_config, gc, shared, vision),
             }
+        elif self._mode == FeederMode.BELT_REV01:
+            from .belt.flow import BeltFeeding
+            self.states_map = {
+                FeederState.IDLE: Idle(irl, gc, shared),
+                FeederState.FEEDING: BeltFeeding(irl, irl_config, gc, shared, vision),
+            }
         else:
             raise ValueError(f"Unsupported feeder mode: {self._mode}")
         self.gc.profiler.enterState("feeder", self.current_state.value)

--- a/software/sorter/backend/tests/test_belt_feeder.py
+++ b/software/sorter/backend/tests/test_belt_feeder.py
@@ -1,0 +1,141 @@
+"""B1 belt-feeder topology: setup registry, stepper requirements, and the
+fill-level speed controller (pure math — no hardware)."""
+
+import unittest
+from types import SimpleNamespace
+
+from machine_setup import BELT_FEEDER_SETUP, MACHINE_SETUPS
+from irl.config import FeederMode, PERCEPTION_NATIVE_FEEDER_MODES, _requiredCanonicalStepperNames
+from subsystems.feeder.belt.config import BeltFeederConfig, configFromDict, configToDict
+from subsystems.feeder.belt.flow import BeltFeeding
+
+
+class BeltFeederSetupTests(unittest.TestCase):
+    def test_belt_feeder_setup_registered(self) -> None:
+        definition = MACHINE_SETUPS[BELT_FEEDER_SETUP]
+        self.assertTrue(definition.uses_belt_feeder)
+        self.assertTrue(definition.automatic_feeder)
+        self.assertTrue(definition.uses_classification_channel)
+        self.assertFalse(definition.uses_carousel_transport)
+        self.assertFalse(definition.requires_carousel_endstop)
+        self.assertTrue(definition.to_dict()["uses_belt_feeder"])
+
+    def test_other_setups_do_not_use_belt(self) -> None:
+        for key, definition in MACHINE_SETUPS.items():
+            if key == BELT_FEEDER_SETUP:
+                continue
+            self.assertFalse(definition.uses_belt_feeder, key)
+
+    def test_belt_mode_is_perception_native(self) -> None:
+        self.assertIn(FeederMode.BELT_REV01, PERCEPTION_NATIVE_FEEDER_MODES)
+
+    def test_required_steppers_skip_c2(self) -> None:
+        required = _requiredCanonicalStepperNames(MACHINE_SETUPS[BELT_FEEDER_SETUP], {})
+        self.assertIn("c_channel_1_rotor", required)
+        self.assertIn("c_channel_3_rotor", required)
+        self.assertNotIn("c_channel_2_rotor", required)
+        self.assertNotIn("carousel", required)
+
+
+class BeltFeederConfigTests(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        cfg = BeltFeederConfig(belt_speed_usteps_per_s=3200, c3_stop_pieces=5)
+        self.assertEqual(configFromDict(configToDict(cfg)), cfg)
+
+    def test_from_dict_ignores_unknown_and_bad_values(self) -> None:
+        cfg = configFromDict({"belt_speed_usteps_per_s": "1500", "nope": 1, "jam_timeout_s": None})
+        self.assertEqual(cfg.belt_speed_usteps_per_s, 1500)
+        self.assertEqual(cfg.jam_timeout_s, BeltFeederConfig().jam_timeout_s)
+
+
+class BeltTargetSpeedTests(unittest.TestCase):
+    """_target_speed is pure — full speed at/below the full-speed count,
+    linear ramp, stop at/above the stop count."""
+
+    def _speed(self, cfg: BeltFeederConfig, pieces: int) -> int:
+        return BeltFeeding._target_speed(None, cfg, pieces)  # type: ignore[arg-type]
+
+    def test_ramp(self) -> None:
+        cfg = BeltFeederConfig(belt_speed_usteps_per_s=2000, c3_full_speed_pieces=1, c3_stop_pieces=3)
+        self.assertEqual(self._speed(cfg, 0), 2000)
+        self.assertEqual(self._speed(cfg, 1), 2000)
+        self.assertEqual(self._speed(cfg, 2), 1000)
+        self.assertEqual(self._speed(cfg, 3), 0)
+        self.assertEqual(self._speed(cfg, 7), 0)
+
+    def test_disabled_belt_never_moves(self) -> None:
+        cfg = BeltFeederConfig(enable_belt=False)
+        self.assertEqual(self._speed(cfg, 0), 0)
+
+    def test_degenerate_thresholds_still_stop(self) -> None:
+        # stop <= full is clamped to full+1 instead of dividing by zero.
+        cfg = BeltFeederConfig(c3_full_speed_pieces=2, c3_stop_pieces=2)
+        self.assertEqual(self._speed(cfg, 2), BeltFeederConfig().belt_speed_usteps_per_s)
+        self.assertEqual(self._speed(cfg, 3), 0)
+
+
+class BeltHoldMotionTests(unittest.TestCase):
+    """The coordinator calls hold_motion instead of step during incidents /
+    manual feed: a velocity move must be stopped explicitly, once."""
+
+    class _Stepper:
+        def __init__(self) -> None:
+            self.speeds: list[int] = []
+
+        def move_at_speed(self, speed: int) -> bool:
+            self.speeds.append(speed)
+            return True
+
+    def _feeding(self, running_speed: int) -> tuple[BeltFeeding, "_Stepper"]:
+        stepper = self._Stepper()
+        flow = BeltFeeding.__new__(BeltFeeding)
+        flow.irl = SimpleNamespace(belt_stepper=stepper)
+        flow.gc = SimpleNamespace(logger=SimpleNamespace(warning=lambda *a, **k: None))
+        flow._belt_cmd_speed = running_speed
+        flow._belt_cmd_unacked = False
+        flow._belt_running_since = 1.0 if running_speed else None
+        flow._last_arrival_at = 0.0
+        flow._last_blocked_reason = None
+        flow._status = {}
+        return flow, stepper
+
+    def test_hold_stops_a_running_belt_once(self) -> None:
+        flow, stepper = self._feeding(2000)
+        flow.hold_motion()
+        flow.hold_motion()
+        self.assertEqual(stepper.speeds, [0])
+        self.assertEqual(flow._belt_cmd_speed, 0)
+        self.assertIsNone(flow._belt_running_since)
+        self.assertEqual(flow._status["reason"], "held")
+
+    def test_hold_is_a_no_op_while_stopped(self) -> None:
+        flow, stepper = self._feeding(0)
+        flow.hold_motion()
+        self.assertEqual(stepper.speeds, [])
+
+    def test_hold_retries_after_an_unacknowledged_command(self) -> None:
+        flow, stepper = self._feeding(0)
+        flow._belt_cmd_unacked = True
+        flow.hold_motion()
+        self.assertEqual(stepper.speeds, [0])
+        self.assertFalse(flow._belt_cmd_unacked)
+
+
+class BeltUpstreamTests(unittest.TestCase):
+    """The C3 stuck watchdog must blame and nudge the belt, not a C2 that
+    does not exist in this topology."""
+
+    def test_c3_upstream_is_the_belt(self) -> None:
+        flow = BeltFeeding.__new__(BeltFeeding)
+        stepper = object()
+        flow.irl = SimpleNamespace(belt_stepper=stepper)
+        flow._belt_cfg = lambda: BeltFeederConfig(enable_belt=True)
+        upstream = flow._c3_upstream(None)
+        self.assertEqual(upstream.label, "B1 belt")
+        self.assertIs(upstream.stepper, stepper)
+        self.assertTrue(upstream.enabled)
+        self.assertEqual(upstream.nudge, flow._nudge_belt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/sorter/backend/tests/test_belt_feeder.py
+++ b/software/sorter/backend/tests/test_belt_feeder.py
@@ -97,6 +97,10 @@ class BeltHoldMotionTests(unittest.TestCase):
         flow._last_arrival_at = 0.0
         flow._last_blocked_reason = None
         flow._status = {}
+        from subsystems.feeder.belt.flow import BeltLoadMonitor
+        flow._load = BeltLoadMonitor(0, 3)
+        flow._load_next_poll_at = 0.0
+        flow._load_last_log_at = 0.0
         return flow, stepper
 
     def test_hold_stops_a_running_belt_once(self) -> None:
@@ -135,6 +139,163 @@ class BeltUpstreamTests(unittest.TestCase):
         self.assertIs(upstream.stepper, stepper)
         self.assertTrue(upstream.enabled)
         self.assertEqual(upstream.nudge, flow._nudge_belt)
+
+
+class BeltLoadMonitorTests(unittest.TestCase):
+    def test_watch_mode_records_but_never_blocks(self) -> None:
+        from subsystems.feeder.belt.flow import BeltLoadMonitor
+        m = BeltLoadMonitor(threshold=0, samples=3)
+        for sg in (400, 10, 0, 0, 0):
+            self.assertFalse(m.observe(sg))
+        self.assertEqual(m.last_sg, 0)
+
+    def test_blocks_after_consecutive_low_reads_only(self) -> None:
+        from subsystems.feeder.belt.flow import BeltLoadMonitor
+        m = BeltLoadMonitor(threshold=60, samples=3)
+        self.assertFalse(m.observe(500))
+        self.assertFalse(m.observe(30))
+        self.assertFalse(m.observe(20))
+        self.assertFalse(m.observe(300))   # a free read resets the streak
+        self.assertFalse(m.observe(10))
+        self.assertFalse(m.observe(10))
+        self.assertTrue(m.observe(5))
+        self.assertFalse(m.observe(None))  # an unreadable register is not evidence
+
+    def test_defaults_are_watch_only_and_jam_window_is_shorter(self) -> None:
+        cfg = BeltFeederConfig()
+        self.assertEqual(cfg.load_block_sg_threshold, 0)
+        self.assertEqual(cfg.jam_timeout_s, 20.0)
+
+
+class _StepStepper:
+    def __init__(self) -> None:
+        self.speeds: list[int] = []
+        self.limits: list[tuple[int, int]] = []
+        self.stalled = False
+
+    def move_at_speed(self, speed: int) -> bool:
+        self.speeds.append(speed)
+        return True
+
+    def set_speed_limits(self, lo: int, hi: int) -> None:
+        self.limits.append((lo, hi))
+
+
+def _stepFlow(cfg: BeltFeederConfig, c3_pieces: int = 0, state_age_s: float = 0.0):
+    """A BeltFeeding double wired for _step_belt: fake stepper, a perception
+    service whose C3 state is ``state_age_s`` old, no chute move, no incidents."""
+    import time as _time
+    from subsystems.feeder.belt.flow import BeltLoadMonitor
+
+    stepper = _StepStepper()
+    state = SimpleNamespace(ts=_time.time() - state_age_s, n_pieces=c3_pieces)
+    flow = BeltFeeding.__new__(BeltFeeding)
+    flow.irl = SimpleNamespace(belt_stepper=stepper)
+    flow.gc = SimpleNamespace(
+        logger=SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None),
+        perception_service=SimpleNamespace(read_states=lambda: {3: state}),
+        rotary_channel_steppers_can_operate_in_parallel=True,
+    )
+    flow.shared = SimpleNamespace(chute_move_in_progress=False)
+    flow._belt_cfg = lambda: cfg
+    flow._belt_cmd_speed = 0
+    flow._belt_cmd_unacked = False
+    flow._belt_next_cmd_at = 0.0
+    flow._belt_speed_limit = 0
+    flow._belt_running_since = None
+    flow._last_arrival_at = 0.0
+    flow._last_c3_pieces = 0
+    flow._last_blocked_reason = None
+    flow._status = {}
+    flow._load = BeltLoadMonitor(0, 3)
+    flow._load_next_poll_at = 0.0
+    flow._load_last_log_at = 0.0
+    flow._nudge_until = 0.0
+    flow._nudges_since_arrival = 0
+    flow._perception_reason = "no_perception"
+    return flow, stepper, state
+
+
+class BeltStepSafetyTests(unittest.TestCase):
+    """The belt never runs blind, never drives a latched stall, and a watchdog
+    nudge is one bounded run per stall."""
+
+    def test_fresh_state_runs_the_belt(self) -> None:
+        flow, stepper, _ = _stepFlow(BeltFeederConfig(belt_speed_usteps_per_s=2000))
+        flow._step_belt()
+        self.assertEqual(stepper.speeds, [2000])
+        self.assertEqual(flow._status["reason"], "running")
+
+    def test_stale_perception_stops_the_belt(self) -> None:
+        flow, stepper, _ = _stepFlow(BeltFeederConfig(perception_stale_s=2.0), state_age_s=5.0)
+        flow._belt_cmd_speed = 2000
+        flow._belt_running_since = 1.0
+        flow._step_belt()
+        self.assertEqual(stepper.speeds, [0])
+        self.assertEqual(flow._status["reason"], "stale_perception")
+
+    def test_stall_latch_stops_the_belt_before_any_command(self) -> None:
+        flow, stepper, _ = _stepFlow(BeltFeederConfig())
+        flow._belt_cmd_speed = 2000
+        flow._belt_running_since = 1.0
+        stepper.stalled = True
+        flow._step_belt()
+        self.assertEqual(stepper.speeds, [0])
+        self.assertEqual(flow._status["reason"], "stalled")
+
+    def test_nudge_is_one_bounded_run_per_stall(self) -> None:
+        cfg = BeltFeederConfig(belt_speed_usteps_per_s=2000, c3_full_speed_pieces=1, c3_stop_pieces=2,
+                               nudge_run_ms=1500, nudge_max_attempts=1)
+        flow, stepper, state = _stepFlow(cfg, c3_pieces=2)  # C3 full: belt stopped
+        flow._step_belt()
+        self.assertEqual(stepper.speeds, [])
+        self.assertEqual(flow._status["reason"], "stopped_c3_full")
+        self.assertTrue(flow._nudge_belt())
+        flow._step_belt()
+        self.assertEqual(stepper.speeds, [2000])
+        self.assertEqual(flow._status["reason"], "nudging")
+        self.assertFalse(flow._nudge_belt())             # second request on the same stall: refused
+        flow._nudge_until = 0.0                           # the run time elapsed
+        flow._step_belt()
+        self.assertEqual(stepper.speeds, [2000, 0])       # back under the fill-level controller
+        state.n_pieces = 3                                 # a new piece reached C3
+        flow._step_belt()
+        self.assertTrue(flow._nudge_belt())               # a fresh stall gets its one nudge again
+
+    def test_nudge_refused_on_a_latched_stall(self) -> None:
+        flow, stepper, _ = _stepFlow(BeltFeederConfig())
+        stepper.stalled = True
+        self.assertFalse(flow._nudge_belt())
+
+
+class FeederModePairingTests(unittest.TestCase):
+    """belt_feeder <-> belt_rev01 is enforced at the feeder-mode endpoint."""
+
+    def _post(self, monkey, setup_key: str, mode: str):
+        from server.routers import setup as setup_router
+        written: dict = {}
+        monkey.setattr(setup_router, "_read_machine_params_config",
+                       lambda: ("params.toml", {"machine_setup": {"type": setup_key}}))
+        monkey.setattr(setup_router, "_write_machine_params_config",
+                       lambda path, config: written.update(config))
+        return setup_router.set_feeder_subsystem_mode(SimpleNamespace(mode=mode)), written
+
+    def test_pairing(self) -> None:
+        import pytest
+        from fastapi import HTTPException
+        from _pytest.monkeypatch import MonkeyPatch
+        monkey = MonkeyPatch()
+        try:
+            result, written = self._post(monkey, BELT_FEEDER_SETUP, "belt_rev01")
+            self.assertTrue(result["ok"]) ; self.assertEqual(written["feeder"]["mode"], "belt_rev01")
+            with pytest.raises(HTTPException):
+                self._post(monkey, BELT_FEEDER_SETUP, "pulse_perception_rev01")
+            with pytest.raises(HTTPException):
+                self._post(monkey, "classification_channel", "belt_rev01")
+            result, _ = self._post(monkey, "classification_channel", "pulse_perception_rev01")
+            self.assertTrue(result["ok"])
+        finally:
+            monkey.undo()
 
 
 if __name__ == "__main__":

--- a/software/sorter/backend/tests/test_dashboard_config.py
+++ b/software/sorter/backend/tests/test_dashboard_config.py
@@ -31,6 +31,7 @@ class DashboardConfigTests(unittest.TestCase):
         self.assertFalse(config["show_sample_capture"])
         self.assertEqual("automatic", config["incident_handling"]["exit_stuck"])
         self.assertEqual("automatic", config["incident_handling"]["feeder_jam"])
+        self.assertEqual("manual", config["incident_handling"]["belt_feeder_stalled"])
         self.assertEqual("manual", config["incident_handling"]["distribution_chute_jam"])
         self.assertEqual("manual", config["incident_handling"]["distribution_servo_bus_offline"])
         self.assertEqual("manual", config["incident_handling"]["distribution_no_bin_available"])
@@ -39,6 +40,7 @@ class DashboardConfigTests(unittest.TestCase):
             [
                 "exit_stuck",
                 "feeder_jam",
+                "belt_feeder_stalled",
                 "distribution_chute_jam",
                 "distribution_servo_bus_offline",
                 "distribution_no_bin_available",

--- a/software/sorter/backend/toml_config.py
+++ b/software/sorter/backend/toml_config.py
@@ -337,6 +337,56 @@ def setPulsePerceptionConfig(updates: dict[str, Any]) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# B1 belt feeder tuning config
+# ---------------------------------------------------------------------------
+
+
+def getBeltFeederConfig() -> dict[str, Any]:
+    from subsystems.feeder.belt.config import BeltFeederConfig, configToDict
+    config = _read_toml()
+    section = config.get("feeder_belt")
+    defaults = configToDict(BeltFeederConfig())
+    if isinstance(section, dict):
+        return {**defaults, **{k: v for k, v in section.items() if k in defaults}}
+    return defaults
+
+
+def getPerceptionConfThresholds() -> dict[int, float]:
+    """Per-channel detector confidence overrides, read at backend start:
+
+    [perception.conf_thresholds]
+    4 = 0.25
+    """
+    section = _read_toml().get("perception")
+    raw = section.get("conf_thresholds") if isinstance(section, dict) else None
+    result: dict[int, float] = {}
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            try:
+                channel, conf = int(key), float(value)
+            except (TypeError, ValueError):
+                continue
+            if 0.0 < conf <= 1.0:
+                result[channel] = conf
+    return result
+
+
+def setBeltFeederConfig(updates: dict[str, Any]) -> dict[str, Any]:
+    from subsystems.feeder.belt.config import BeltFeederConfig, configToDict
+    defaults = configToDict(BeltFeederConfig())
+    valid = {k: v for k, v in updates.items() if k in defaults}
+
+    def updater(config: dict[str, Any]) -> None:
+        existing = config.get("feeder_belt")
+        base = dict(existing) if isinstance(existing, dict) else {}
+        base.update(valid)
+        config["feeder_belt"] = base
+
+    _update_toml(updater)
+    return getBeltFeederConfig()
+
+
+# ---------------------------------------------------------------------------
 # Feeder constant-movement tuning config
 # ---------------------------------------------------------------------------
 
@@ -465,9 +515,12 @@ _INCIDENT_KIND_ALIASES: dict[str, str] = {
 # classification fallbacks, ...) get no policy row: their publishers never run
 # on the default setup.
 _INCIDENT_FEEDER_JAM = "feeder_jam"
+# B1 belt topology only (BELT_REV01 feeder); the publisher honours "off".
+_INCIDENT_BELT_FEEDER_STALLED = "belt_feeder_stalled"
 _INCIDENT_HANDLING_DEFAULTS: dict[str, str] = {
     _INCIDENT_EXIT_STUCK: _INCIDENT_MODE_AUTOMATIC,
     _INCIDENT_FEEDER_JAM: _INCIDENT_MODE_AUTOMATIC,
+    _INCIDENT_BELT_FEEDER_STALLED: _INCIDENT_MODE_MANUAL,
     "distribution_chute_jam": _INCIDENT_MODE_MANUAL,
     "distribution_servo_bus_offline": _INCIDENT_MODE_MANUAL,
     "distribution_no_bin_available": _INCIDENT_MODE_MANUAL,
@@ -492,6 +545,16 @@ _INCIDENT_DEFINITIONS: tuple[dict[str, Any], ...] = (
         "manual_label": "Call the operator as soon as a channel is stuck",
         "automatic_label": "Nudge the upstream channel to free it, then call the operator",
         "automatic_supported": True,
+    },
+    {
+        "kind": _INCIDENT_BELT_FEEDER_STALLED,
+        "label": "Belt Feed Stalled",
+        "scope": "B1",
+        "description": "The belt ran for the whole jam window without a new piece arriving in C3 — the boat is empty or the belt is jammed.",
+        "off_label": "Do not raise belt-stalled incidents",
+        "manual_label": "Operator checks the boat or belt, then clears",
+        "automatic_label": "Not available",
+        "automatic_supported": False,
     },
     {
         "kind": "distribution_chute_jam",

--- a/software/sorter/backend/vision/camera.py
+++ b/software/sorter/backend/vision/camera.py
@@ -245,8 +245,15 @@ def default_auto_camera_device_settings() -> dict[str, bool]:
 
 def _bool_from_capture_value(key: str, value: float) -> bool:
     if key == "auto_exposure" and platform.system() == "Linux":
+        # V4L2 exposure menus vary per camera: 1 is always Manual Mode, but
+        # "auto" may be 3 (Aperture Priority, the UVC norm), 0 (OBSBOT
+        # "Auto Mode"), or 2 (Shutter Priority). OpenCV additionally
+        # normalizes to 0.25 (manual) / 0.75 (auto). Manual is the only
+        # unambiguous state — everything else counts as auto.
+        if abs(value - 0.25) < 0.05:
+            return False
         rounded = round(value)
-        if abs(value - rounded) < 0.05 and rounded in {1, 3}:
+        if abs(value - rounded) < 0.05:
             return rounded != 1
         return value >= 0.5
     return value >= 0.5
@@ -284,15 +291,23 @@ def _try_v4l2ctl_set(source: int, key: str, value: bool | float) -> bool:
     if entry is None:
         return False
     ctrl_name, fmt = entry
-    try:
-        result = subprocess.run(
-            ["v4l2-ctl", "-d", f"/dev/video{source}", "-c", f"{ctrl_name}={fmt(value)}"],
-            capture_output=True,
-            timeout=2,
-        )
-        return result.returncode == 0
-    except Exception:
-        return False
+    candidates = [fmt(value)]
+    if key == "auto_exposure" and bool(value):
+        # Not every camera has Aperture Priority (3) — OBSBOT-style menus use
+        # 0 for plain Auto Mode. Fall back if the preferred value is rejected.
+        candidates.append("0")
+    for candidate in candidates:
+        try:
+            result = subprocess.run(
+                ["v4l2-ctl", "-d", f"/dev/video{source}", "-c", f"{ctrl_name}={candidate}"],
+                capture_output=True,
+                timeout=2,
+            )
+            if result.returncode == 0:
+                return True
+        except Exception:
+            return False
+    return False
 
 
 # OpenCV's V4L2 backend lies about menu controls (auto_exposure especially) on
@@ -331,7 +346,9 @@ def _try_v4l2ctl_get_bool(source: int, key: str) -> bool | None:
     except Exception:
         return None
     if key == "auto_exposure":
-        return n == 3
+        # 1 = Manual Mode is the only manual state; 0/2/3 are auto variants
+        # (see _bool_from_capture_value).
+        return n != 1
     return n != 0
 
 

--- a/software/sorter/backend/vision/vision_manager.py
+++ b/software/sorter/backend/vision/vision_manager.py
@@ -17,6 +17,7 @@ from irl.config import (
     CameraPictureSettings,
     ClassificationChannelMode,
     FeederMode,
+    PERCEPTION_NATIVE_FEEDER_MODES,
     mkCameraConfig,
 )
 from defs.events import CameraName, FrameEvent, FrameData, FrameResultData
@@ -296,11 +297,7 @@ class VisionManager:
             if uses_classification_channel_setup
             else ("c_channel_2", "c_channel_3")
         )
-        perception_native_feeder = feeder_mode in (
-            FeederMode.GO_TO_ANGLE_REV01,
-            FeederMode.PULSE_PERCEPTION_REV01,
-            FeederMode.CONSTANT_MOVEMENT_REV01,
-        )
+        perception_native_feeder = feeder_mode in PERCEPTION_NATIVE_FEEDER_MODES
         run_auxiliary_detection = (
             not perception_native_feeder
             and classification_mode

--- a/software/sorter/frontend/src/lib/components/settings/GeneralSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/GeneralSection.svelte
@@ -464,7 +464,7 @@
 					<div>
 						<div class="mb-1.5 text-xs font-medium text-text">Feeder Mode</div>
 						<div class="flex flex-wrap gap-2">
-							{#each ['pulse_perception_rev01', 'go_to_angle_rev01', 'constant_movement_rev01'] as mode}
+							{#each machineSetup === 'belt_feeder' ? ['belt_rev01'] : ['pulse_perception_rev01', 'go_to_angle_rev01', 'constant_movement_rev01'] as mode}
 								<button
 									onclick={() => saveFeederMode(mode)}
 									disabled={savingFeederMode}

--- a/software/sorter/frontend/src/lib/components/settings/GeneralSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/GeneralSection.svelte
@@ -4,7 +4,11 @@
 	import type { MachineState } from '$lib/machines/types';
 	import { settings } from '$lib/stores/settings';
 
-	type MachineSetup = 'standard_carousel' | 'classification_channel' | 'manual_carousel';
+	type MachineSetup =
+		| 'standard_carousel'
+		| 'classification_channel'
+		| 'manual_carousel'
+		| 'belt_feeder';
 
 	type MachineSetupCard = {
 		key: MachineSetup;
@@ -20,6 +24,13 @@
 			description: 'C-Channels + Classification Channel',
 			detail:
 				'Replaces the carousel/chamber pair with a dedicated classification C-channel on the former carousel motor port.'
+		},
+		{
+			key: 'belt_feeder',
+			title: 'B1 Belt Feeder',
+			description: 'B1 Belt + C3 + Classification Channel',
+			detail:
+				'Cleated inclined conveyor replaces the C1 bulk bucket and the C2 buffer channel. The belt motor plugs into the C1 rotor port and feeds C3 directly; selecting this also switches the feeder subsystem to belt_rev01.'
 		},
 		{
 			key: 'standard_carousel',
@@ -112,7 +123,7 @@
 	}
 
 	function normalizeMachineSetup(value: unknown): MachineSetup {
-		return value === 'standard_carousel' || value === 'manual_carousel'
+		return value === 'standard_carousel' || value === 'manual_carousel' || value === 'belt_feeder'
 			? value
 			: 'classification_channel';
 	}
@@ -132,7 +143,8 @@
 			go_to_angle_rev01: 'Go to Angle',
 			pulse_perception_rev01: 'Simple Pulse',
 			constant_movement_rev01: 'Constant Movement',
-			drop_zone_reactive_rev01: 'Drop Zone Reactive'
+			drop_zone_reactive_rev01: 'Drop Zone Reactive',
+			belt_rev01: 'B1 Belt'
 		};
 		return labels[mode] ?? mode;
 	}

--- a/software/sorter/frontend/src/lib/components/settings/HiveModelsSection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/HiveModelsSection.svelte
@@ -180,6 +180,9 @@
 	let downloadingModelId = $state<string | null>(null);
 	let deletingLocalId = $state<string | null>(null);
 	let activatingAlgorithmId = $state<string | null>(null);
+	// Tracks which model's activate dropdown is open. Hover alone is unreachable
+	// on the CM5 touch tablet, so the panel toggles open on tap.
+	let openActivateId = $state<string | null>(null);
 	let cleaningUp = $state(false);
 	let actionError = $state<string | null>(null);
 
@@ -495,6 +498,7 @@
 				throw new Error(await readApiError(res, `HTTP ${res.status}`));
 			}
 			await loadActiveAssignments();
+			openActivateId = null;
 		} catch (e: any) {
 			actionError = e?.message ?? 'Failed to activate model.';
 		} finally {
@@ -630,13 +634,22 @@
 		};
 	});
 
+	function handleActivateMenuClickOutside(event: MouseEvent) {
+		if (openActivateId === null) return;
+		const target = event.target;
+		if (target instanceof Element && target.closest('[data-activate-menu]')) return;
+		openActivateId = null;
+	}
+
 	onMount(() => {
 		void (async () => {
 			await loadTargets();
 			await Promise.all([loadInstalled(), loadDownloads(), loadActiveAssignments()]);
 		})();
+		document.addEventListener('click', handleActivateMenuClickOutside);
 		return () => {
 			stopPolling();
+			document.removeEventListener('click', handleActivateMenuClickOutside);
 		};
 	});
 
@@ -1119,11 +1132,15 @@
 												Cannot activate
 											</span>
 										{:else}
-											<!-- Hover-expand activate: assign this model to a single
-											     subsystem at a time, 1:1 with the TOML, no fallback. -->
-											<div class="group relative">
+											<!-- Tap-to-open activate menu: assign this model to a single
+											     subsystem at a time, 1:1 with the TOML, no fallback.
+											     Tap toggles it, a tap anywhere outside closes it (CM5 touch tablet). -->
+											<div class="relative" data-activate-menu>
 												<button
 													type="button"
+													onclick={() =>
+														(openActivateId =
+															openActivateId === algorithmId ? null : algorithmId)}
 													class={`inline-flex items-center gap-1.5 border px-3 py-1.5 text-sm transition-colors ${
 														isActive
 															? 'border-success/40 bg-success/[0.08] text-text'
@@ -1139,7 +1156,11 @@
 													<ChevronDown size={13} class="opacity-70" />
 												</button>
 												<div
-													class="invisible absolute right-0 top-full z-30 mt-px min-w-[16rem] border border-border bg-surface opacity-0 shadow-lg transition-opacity duration-100 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+													class={`absolute top-full right-0 z-30 mt-px w-[min(16rem,calc(100vw-2rem))] border border-border bg-surface shadow-lg transition-opacity duration-100 ${
+														openActivateId === algorithmId
+															? 'visible opacity-100'
+															: 'invisible opacity-0'
+													}`}
 												>
 													<div
 														class="border-b border-border px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-muted"

--- a/software/sorter/frontend/src/lib/components/settings/StepperSidebar.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/StepperSidebar.svelte
@@ -5,10 +5,11 @@
 	import { stepperLabels } from '$lib/settings/stations';
 	import type { EndstopConfig } from '$lib/settings/stations';
 	import {
-		STEPPER_GEAR_RATIOS,
 		loadStoredStepperPulseSetting,
-		persistStoredStepperPulseSetting
+		persistStoredStepperPulseSetting,
+		stepperGearRatioForSetup
 	} from '$lib/settings/stepper-control';
+	import type { MachineSetupKey } from '$lib/settings/stations';
 	import { Cog } from 'lucide-svelte';
 	import { Alert, Button } from '$lib/components/primitives';
 	import { onMount } from 'svelte';
@@ -98,7 +99,28 @@
 		persistStoredStepperPulseSetting(stepperKey, 'pulseDegrees', pulseDegrees);
 	});
 
-	const gearRatio = $derived(gearRatioOverride ?? STEPPER_GEAR_RATIOS[stepperKey]);
+	// Machine setup decides gearing for shared motor ports (carousel→C4,
+	// C1 rotor→belt); loaded per machine alongside the other settings.
+	let machineSetup = $state<MachineSetupKey | undefined>(undefined);
+	const gearRatio = $derived(
+		gearRatioOverride ?? stepperGearRatioForSetup(stepperKey, machineSetup)
+	);
+
+	async function loadMachineSetup() {
+		try {
+			const res = await fetch(`${currentBackendBaseUrl()}/api/machine-setup`);
+			if (!res.ok) return;
+			const payload = await res.json();
+			machineSetup =
+				payload?.setup === 'classification_channel' ||
+				payload?.setup === 'manual_carousel' ||
+				payload?.setup === 'belt_feeder'
+					? payload.setup
+					: undefined;
+		} catch {
+			// Fall back to the static per-key ratio.
+		}
+	}
 
 	// --- Endstop settings ---
 	let endstopActiveHigh = $state(false);
@@ -678,6 +700,7 @@
 		if (machineKey !== loadedMachineKey) {
 			loadedMachineKey = machineKey;
 			void loadSettings();
+			void loadMachineSetup();
 			tmcLoaded = false;
 			if (driverSettingsOpen) void loadTmcSettings();
 		}
@@ -685,6 +708,7 @@
 
 	onMount(() => {
 		void loadSettings();
+		void loadMachineSetup();
 		void loadStallState();
 		const interval = setInterval(() => {
 			if (endstop) void loadLiveStatus();

--- a/software/sorter/frontend/src/lib/components/setup/steps/CalibrationStep.svelte
+++ b/software/sorter/frontend/src/lib/components/setup/steps/CalibrationStep.svelte
@@ -3,7 +3,11 @@
 	import { getMachinesContext } from '$lib/machines/context';
 	import { onMount } from 'svelte';
 
-	type MachineSetupKey = 'standard_carousel' | 'classification_channel' | 'manual_carousel';
+	type MachineSetupKey =
+		| 'standard_carousel'
+		| 'classification_channel'
+		| 'manual_carousel'
+		| 'belt_feeder';
 
 	type CarouselLiveStatus = {
 		live_available: boolean;
@@ -45,7 +49,9 @@
 	let machineSetup = $state<MachineSetupKey>('standard_carousel');
 	const systemState = $derived(manager.selectedMachine?.systemStatus?.hardware_state ?? 'standby');
 	const homingStep = $derived(manager.selectedMachine?.systemStatus?.homing_step ?? null);
-	const usesCarouselEndstop = $derived(machineSetup !== 'classification_channel');
+	const usesCarouselEndstop = $derived(
+		machineSetup !== 'classification_channel' && machineSetup !== 'belt_feeder'
+	);
 
 	let carouselLoading = $state(false);
 	let carouselSaving = $state(false);
@@ -193,7 +199,9 @@
 			if (!res.ok) return;
 			const payload = await res.json();
 			machineSetup =
-				payload?.setup === 'classification_channel' || payload?.setup === 'manual_carousel'
+				payload?.setup === 'classification_channel' ||
+				payload?.setup === 'manual_carousel' ||
+				payload?.setup === 'belt_feeder'
 					? payload.setup
 					: 'standard_carousel';
 		} catch {

--- a/software/sorter/frontend/src/lib/settings/stations.ts
+++ b/software/sorter/frontend/src/lib/settings/stations.ts
@@ -16,11 +16,12 @@ import {
 	Zap
 } from 'lucide-svelte';
 import {
+	BELT_STEPPER_GEAR_RATIO,
 	CLASSIFICATION_CHANNEL_STEPPER_GEAR_RATIO,
 	CLASSIFICATION_CHANNEL_STEPPER_LABEL
 } from '$lib/settings/stepper-control';
 
-export type MachineSetupKey = 'classification_channel' | 'manual_carousel';
+export type MachineSetupKey = 'classification_channel' | 'manual_carousel' | 'belt_feeder';
 
 export type CameraRole =
 	| 'c_channel_2'
@@ -55,6 +56,7 @@ export type EndstopConfig = {
 };
 
 export type StationSlug =
+	| 'belt-feeder'
 	| 'c-channel-1'
 	| 'c-channel-2'
 	| 'c-channel-3'
@@ -174,6 +176,11 @@ export const tuningNavItems: SettingsNavItem[] = [
 		icon: SlidersHorizontal
 	},
 	{
+		href: '/settings/tuning/feeder-belt',
+		label: 'B1 Belt Feeder',
+		icon: SlidersHorizontal
+	},
+	{
 		href: '/settings/tuning/feeder-constant-movement',
 		label: 'Feeder Constant Movement',
 		icon: SlidersHorizontal
@@ -197,11 +204,32 @@ export const tuningNavItems: SettingsNavItem[] = [
 
 export const stationPageConfigs: StationPageConfig[] = [
 	{
+		// B1 belt topology only: same physical motor port as C-Channel 1, but
+		// labeled and geared for the belt (4:1 gearbox instead of the rotor's
+		// 130:12). settingsNavItemsForSetup shows exactly one of the two.
+		slug: 'belt-feeder',
+		href: '/settings/belt-feeder',
+		label: 'B1 Belt Feeder',
+		icon: Wrench,
+		description:
+			'Cleated conveyor replacing C1+C2. Manual stepper control for the belt motor on the C1 rotor port; the speed controller is tuned under Tuning → B1 Belt Feeder.',
+		cameraRoles: [],
+		zoneChannels: [],
+		stepperKeys: ['c_channel_1'],
+		stepperDisplay: {
+			c_channel_1: {
+				label: 'Belt Motor (B1)',
+				gearRatio: BELT_STEPPER_GEAR_RATIO
+			}
+		}
+	},
+	{
 		slug: 'c-channel-1',
 		href: '/settings/c-channel-1',
 		label: 'C-Channel 1',
 		icon: Wrench,
-		description: 'Bulk feed channel. This station only exposes manual stepper control.',
+		description:
+			'Bulk feed channel. This station only exposes manual stepper control. In the B1 belt topology the belt motor lives on this rotor port.',
 		cameraRoles: [],
 		zoneChannels: [],
 		stepperKeys: ['c_channel_1']
@@ -305,9 +333,18 @@ const baseSettingsNavItems: SettingsNavEntry[] = [
 
 export function settingsNavItemsForSetup(setup: MachineSetupKey): SettingsNavEntry[] {
 	const hiddenSlugs =
-		setup === 'classification_channel'
-			? new Set<StationSlug>(['carousel', 'classification-chamber'])
-			: new Set<StationSlug>(['classification-channel']);
+		setup === 'belt_feeder'
+			? // B1 belt topology: the belt-feeder station replaces C1, and there
+				// is no C2 channel and no carousel/chamber.
+				new Set<StationSlug>([
+					'c-channel-1',
+					'c-channel-2',
+					'carousel',
+					'classification-chamber'
+				])
+			: setup === 'classification_channel'
+				? new Set<StationSlug>(['belt-feeder', 'carousel', 'classification-chamber'])
+				: new Set<StationSlug>(['belt-feeder', 'classification-channel']);
 
 	return baseSettingsNavItems.filter((entry) => {
 		if (!('href' in entry)) return true;

--- a/software/sorter/frontend/src/lib/settings/stepper-control.ts
+++ b/software/sorter/frontend/src/lib/settings/stepper-control.ts
@@ -28,15 +28,29 @@ export const STEPPER_GEAR_RATIOS: Record<StepperKey, number> = {
 export const CLASSIFICATION_CHANNEL_STEPPER_LABEL = 'Classification C-Channel (C4)';
 export const CLASSIFICATION_CHANNEL_STEPPER_GEAR_RATIO = STEPPER_GEAR_RATIOS.c_channel_4;
 
+// B1 belt topology: the belt motor sits on the C1 rotor port but drives the
+// belt through a 4:1 reduction gearbox instead of the 130:12 rotor gearing.
+export const BELT_STEPPER_GEAR_RATIO = 4;
+
+// The classification C-channel (C4) rides on the carousel stepper port in every
+// setup that has one: the plain classification_channel topology and the B1
+// belt topology (belt + C3 + C4).
+export function usesClassificationChannel(setup: string | null | undefined): boolean {
+	return setup === 'classification_channel' || setup === 'belt_feeder';
+}
+
 export function stepperGearRatioForSetup(
 	stepperKey: StepperKey,
 	machineSetup?: MachineSetupKey
 ): number {
 	if (
 		stepperKey === 'c_channel_4' ||
-		(stepperKey === 'carousel' && machineSetup === 'classification_channel')
+		(stepperKey === 'carousel' && usesClassificationChannel(machineSetup))
 	) {
 		return CLASSIFICATION_CHANNEL_STEPPER_GEAR_RATIO;
+	}
+	if (stepperKey === 'c_channel_1' && machineSetup === 'belt_feeder') {
+		return BELT_STEPPER_GEAR_RATIO;
 	}
 	return STEPPER_GEAR_RATIOS[stepperKey] ?? 1;
 }
@@ -111,8 +125,7 @@ export async function triggerStoredStepperPulse(
 
 	if (settings.pulseMode === 'degrees') {
 		const gearRatio = options?.gearRatio ?? STEPPER_GEAR_RATIOS[stepperKey] ?? 1;
-		const motorDegrees =
-			settings.pulseDegrees * gearRatio * (direction === 'ccw' ? -1 : 1);
+		const motorDegrees = settings.pulseDegrees * gearRatio * (direction === 'ccw' ? -1 : 1);
 		const params = new URLSearchParams({
 			stepper: stepperKey,
 			degrees: String(motorDegrees),

--- a/software/sorter/frontend/src/lib/setup/wizard-types.ts
+++ b/software/sorter/frontend/src/lib/setup/wizard-types.ts
@@ -70,7 +70,7 @@ export type WizardSummary = {
 			mode: 'auto_channels' | 'manual_carousel';
 		};
 		machine_setup: {
-			key: 'classification_channel' | 'manual_carousel';
+			key: 'standard_carousel' | 'classification_channel' | 'manual_carousel' | 'belt_feeder';
 			label: string;
 			description: string;
 			feeding_mode: 'auto_channels' | 'manual_carousel';
@@ -78,6 +78,7 @@ export type WizardSummary = {
 			uses_carousel_transport: boolean;
 			uses_classification_chamber: boolean;
 			uses_classification_channel: boolean;
+			uses_belt_feeder: boolean;
 			runs_reverse_pulse_calibration: boolean;
 			homes_carousel: boolean;
 			homes_chute: boolean;

--- a/software/sorter/frontend/src/routes/+page.svelte
+++ b/software/sorter/frontend/src/routes/+page.svelte
@@ -40,9 +40,9 @@
 	let startSystemPending = $state(false);
 	let classification_view = $state<'top' | 'bottom'>('top');
 	let classification_layer = $state<'raw' | 'annotated'>('annotated');
-	let machineSetup = $state<'standard_carousel' | 'classification_channel' | 'manual_carousel'>(
-		'standard_carousel'
-	);
+	let machineSetup = $state<
+		'standard_carousel' | 'classification_channel' | 'manual_carousel' | 'belt_feeder'
+	>('standard_carousel');
 	let exitIncidentActionPending = $state(false);
 	let exitIncidentActionError = $state<string | null>(null);
 	let stallIncidentActionPending = $state(false);
@@ -67,7 +67,9 @@
 		machine.machine?.camerasConfig?.cameras ?? {}
 	);
 	const c4CameraRole = $derived(
-		machineSetup === 'classification_channel' || isConfigured('classification_channel')
+		machineSetup === 'classification_channel' ||
+			machineSetup === 'belt_feeder' ||
+			isConfigured('classification_channel')
 			? 'classification_channel'
 			: 'carousel'
 	);
@@ -127,7 +129,10 @@
 	}
 
 	function cropFor(role: string): DashboardFeedCrop | null {
-		if (role === 'carousel' && machineSetup === 'classification_channel') {
+		if (
+			role === 'carousel' &&
+			(machineSetup === 'classification_channel' || machineSetup === 'belt_feeder')
+		) {
 			return dashboardCrops.classification_channel ?? dashboardCrops.carousel ?? null;
 		}
 		return dashboardCrops[role] ?? null;
@@ -186,7 +191,10 @@
 		if (stallIncidentActionPending) return;
 		stallIncidentActionPending = true;
 		stallIncidentActionError = null;
-		stallIncidentActionError = await postStallAction('/stall-incident/clear', 'Could not clear stall');
+		stallIncidentActionError = await postStallAction(
+			'/stall-incident/clear',
+			'Could not clear stall'
+		);
 		stallIncidentActionPending = false;
 	}
 
@@ -218,6 +226,7 @@
 			incident.kind === 'channel_dropzone_stuck' ||
 			incident.kind === 'c2_separation_needed' ||
 			incident.kind === 'bulk_feeder_stalled' ||
+			incident.kind === 'belt_feeder_stalled' ||
 			incident.kind === 'feeder_detection_unavailable' ||
 			incident.kind === 'feeder_jam' ||
 			incident.kind === 'distribution_chute_jam' ||
@@ -348,6 +357,9 @@
 		if (incident.kind === 'bulk_feeder_stalled') {
 			return `${currentBackendBaseUrl()}/api/feeder/bulk-feed-incident`;
 		}
+		if (incident.kind === 'belt_feeder_stalled') {
+			return `${currentBackendBaseUrl()}/api/feeder/belt-feed-incident`;
+		}
 		if (incident.kind === 'feeder_detection_unavailable') {
 			return `${currentBackendBaseUrl()}/api/feeder/detection-incident`;
 		}
@@ -380,6 +392,7 @@
 			incident.kind === 'channel_dropzone_stuck' ||
 			incident.kind === 'c2_separation_needed' ||
 			incident.kind === 'bulk_feeder_stalled' ||
+			incident.kind === 'belt_feeder_stalled' ||
 			incident.kind === 'feeder_detection_unavailable' ||
 			incident.kind === 'feeder_jam' ||
 			incident.kind === 'distribution_chute_jam' ||
@@ -409,6 +422,9 @@
 		}
 		if (incident?.kind === 'bulk_feeder_stalled') {
 			return 'Bulk Feed Stalled';
+		}
+		if (incident?.kind === 'belt_feeder_stalled') {
+			return 'Belt Feed Stalled';
 		}
 		if (incident?.kind === 'feeder_detection_unavailable') {
 			return 'Detection Unavailable';
@@ -446,6 +462,7 @@
 		if (role === 'c_channel_2' || channel === 'c2') return 'C2';
 		if (role === 'c_channel_3' || channel === 'c3') return 'C3';
 		if (role === 'bulk_feeder' || channel === 'c1') return 'C1';
+		if (role === 'belt_feeder' || channel === 'b1') return 'B1';
 		if (role === 'feeder_detection' || channel === 'feeder') return 'Feeder';
 		if (channel === 'distribution' || role.startsWith('distribution_')) return 'Distribution';
 		if (isClassificationExitStuckIncident(incident) || role === 'carousel' || channel === 'c4')
@@ -465,6 +482,9 @@
 		}
 		if (incident?.kind === 'bulk_feeder_stalled') {
 			return 'No pieces are reaching the next channel.';
+		}
+		if (incident?.kind === 'belt_feeder_stalled') {
+			return 'The belt ran for the whole jam window without a new piece reaching C3. Check the boat and the belt, then clear.';
 		}
 		if (incident?.kind === 'feeder_detection_unavailable') {
 			return 'Feeder camera detection is not reliable.';
@@ -514,6 +534,7 @@
 			return 'Status';
 		if (incident?.kind === 'c2_separation_needed') return 'Tracks';
 		if (incident?.kind === 'bulk_feeder_stalled') return 'Stall';
+		if (incident?.kind === 'belt_feeder_stalled') return 'Stall';
 		if (incident?.kind === 'feeder_detection_unavailable') return 'Unavailable';
 		if (incident?.kind === 'feeder_jam') return 'Stalled';
 		if (incident?.kind === 'distribution_chute_jam') return 'Elapsed';
@@ -540,6 +561,10 @@
 		if (incident?.kind === 'bulk_feeder_stalled') {
 			const stalled = incidentNumber(incident, 'stalled_ms');
 			return stalled === null ? '-' : `${stalled.toFixed(0)} ms`;
+		}
+		if (incident?.kind === 'belt_feeder_stalled') {
+			const stalled = incidentNumber(incident, 'stalled_ms');
+			return stalled === null ? '-' : `${(stalled / 1000).toFixed(1)} s`;
 		}
 		if (incident?.kind === 'feeder_detection_unavailable') {
 			const unavailable = incidentNumber(incident, 'unavailable_ms');
@@ -592,6 +617,7 @@
 		)
 			return 'Reason';
 		if (incident?.kind === 'bulk_feeder_stalled') return 'Pulses';
+		if (incident?.kind === 'belt_feeder_stalled') return 'Timeout';
 		if (incident?.kind === 'feeder_detection_unavailable') return 'Detail';
 		if (
 			incident?.kind === 'distribution_chute_jam' ||
@@ -605,6 +631,10 @@
 	function exitIncidentSecondaryMetricValue(incident: Record<string, unknown> | null): string {
 		if (incident?.kind === 'c2_separation_needed') {
 			return incident.automated_motion_enabled === true ? 'Enabled' : 'Disabled';
+		}
+		if (incident?.kind === 'belt_feeder_stalled') {
+			const timeout = incidentNumber(incident, 'jam_timeout_s');
+			return timeout === null ? '-' : `${timeout.toFixed(0)} s`;
 		}
 		if (incident?.kind === 'bulk_feeder_stalled') {
 			const pulses = incidentNumber(incident, 'pulses_since_activity');
@@ -745,6 +775,7 @@
 			(isChannelExitStuckIncident(incident) ||
 				incident.kind === 'c2_separation_needed' ||
 				incident.kind === 'bulk_feeder_stalled' ||
+				incident.kind === 'belt_feeder_stalled' ||
 				incident.kind === 'feeder_detection_unavailable' ||
 				incident.kind === 'distribution_chute_jam' ||
 				incident.kind === 'distribution_servo_bus_offline') &&
@@ -827,7 +858,8 @@
 			if (
 				payload?.setup === 'classification_channel' ||
 				payload?.setup === 'manual_carousel' ||
-				payload?.setup === 'standard_carousel'
+				payload?.setup === 'standard_carousel' ||
+				payload?.setup === 'belt_feeder'
 			) {
 				machineSetup = payload.setup;
 			}
@@ -861,7 +893,10 @@
 	};
 
 	function cameraLabel(role: string): string {
-		if (role === 'carousel' && machineSetup === 'classification_channel') {
+		if (
+			role === 'carousel' &&
+			(machineSetup === 'classification_channel' || machineSetup === 'belt_feeder')
+		) {
 			return 'Classification Channel';
 		}
 		return CAMERA_LABELS[role] ?? role;
@@ -891,27 +926,33 @@
 		{#if machine.machine}
 			<div class="flex h-[calc(100vh-7rem)] min-h-0 gap-3">
 				{#if camera_layout === 'split_feeder'}
-					{@const uses_chamber = machineSetup !== 'classification_channel'}
+					{@const uses_chamber =
+						machineSetup !== 'classification_channel' && machineSetup !== 'belt_feeder'}
 					{@const has_cls_top = uses_chamber && isConfigured('classification_top')}
 					{@const has_cls_bottom = uses_chamber && isConfigured('classification_bottom')}
 					{@const classification_camera = preferredClassificationCamera(
 						has_cls_top,
 						has_cls_bottom
 					)}
+					{@const has_c2 = machineSetup !== 'belt_feeder'}
+					<!-- The B1 belt topology has no C2 channel, so the existing two-row
+					     dashboard naturally becomes C3 stacked over C4. -->
 					<div class="flex min-h-0 min-w-0 flex-1 flex-col gap-3">
 						<div class="flex min-h-0 flex-1 gap-3">
-							<div class="min-w-0 flex-1">
-								<CameraFeed
-									camera="c_channel_2"
-									label={cameraLabel('c_channel_2')}
-									crop={cropFor('c_channel_2')}
-									controls={['annotations', 'zones', 'crop', 'fullscreen']}
-								>
-									{#snippet headerActions()}
-										<CameraChannelControls stepperKey="c_channel_2" />
-									{/snippet}
-								</CameraFeed>
-							</div>
+							{#if has_c2}
+								<div class="min-w-0 flex-1">
+									<CameraFeed
+										camera="c_channel_2"
+										label={cameraLabel('c_channel_2')}
+										crop={cropFor('c_channel_2')}
+										controls={['annotations', 'zones', 'crop', 'fullscreen']}
+									>
+										{#snippet headerActions()}
+											<CameraChannelControls stepperKey="c_channel_2" />
+										{/snippet}
+									</CameraFeed>
+								</div>
+							{/if}
 							<div class="min-w-0 flex-1">
 								<CameraFeed
 									camera="c_channel_3"
@@ -1387,12 +1428,12 @@
 										</div>
 										<div class="mt-1 text-xs text-text-muted">
 											{#if stallIncident.requires_rehome}
-												A stepper stalled and the machine paused. The chute lost its home
-												position, so it must be re-homed before sorting can resume. Clear
-												the jam, then re-home — or clear the stall now and re-home later.
+												A stepper stalled and the machine paused. The chute lost its home position,
+												so it must be re-homed before sorting can resume. Clear the jam, then
+												re-home — or clear the stall now and re-home later.
 											{:else}
-												A stepper stalled and the machine paused. Clear the jam, then clear
-												the stall; resume from the header once it's cleared.
+												A stepper stalled and the machine paused. Clear the jam, then clear the
+												stall; resume from the header once it's cleared.
 											{/if}
 										</div>
 										{#if incidentString(stallIncident, 'operator_message')}
@@ -1500,7 +1541,11 @@
 							{/if}
 						</div>
 					{/if}
-					<CollapsibleSection title="Recent Pieces" storageKey="recent" grow>
+					<CollapsibleSection
+						title="Recent Pieces"
+						storageKey="recent"
+						grow
+					>
 						<RecentObjects />
 					</CollapsibleSection>
 					<CollapsibleSection title="Runtime" storageKey="runtimeTabs">

--- a/software/sorter/frontend/src/routes/settings/+layout.svelte
+++ b/software/sorter/frontend/src/routes/settings/+layout.svelte
@@ -12,7 +12,8 @@
 	import {
 		CLASSIFICATION_CHANNEL_STEPPER_LABEL,
 		stepperGearRatioForSetup,
-		triggerStoredStepperPulse
+		triggerStoredStepperPulse,
+		usesClassificationChannel
 	} from '$lib/settings/stepper-control';
 	import { onMount } from 'svelte';
 
@@ -68,7 +69,7 @@
 	}
 
 	function stepperHotkeyLabel(stepperKey: StepperKey): string {
-		if (stepperKey === 'carousel' && machineSetup === 'classification_channel') {
+		if (stepperKey === 'carousel' && usesClassificationChannel(machineSetup)) {
 			return CLASSIFICATION_CHANNEL_STEPPER_LABEL;
 		}
 		return stepperLabels[stepperKey];
@@ -106,10 +107,12 @@
 			const res = await fetch(`${currentBackendBaseUrl()}/api/machine-setup`);
 			if (!res.ok) return;
 			const payload = await res.json();
-			if (payload?.setup === 'manual_carousel') {
-				machineSetup = 'manual_carousel';
-			} else if (payload?.setup === 'classification_channel') {
-				machineSetup = 'classification_channel';
+			if (
+				payload?.setup === 'manual_carousel' ||
+				payload?.setup === 'classification_channel' ||
+				payload?.setup === 'belt_feeder'
+			) {
+				machineSetup = payload.setup;
 			}
 		} catch {
 			// Ignore transient backend fetch issues in the nav shell.

--- a/software/sorter/frontend/src/routes/settings/tuning/feeder-belt/+page.svelte
+++ b/software/sorter/frontend/src/routes/settings/tuning/feeder-belt/+page.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+	import { getBackendHttpBase } from '$lib/backend';
+	import { Alert } from '$lib/components/primitives';
+	import SectionCard from '$lib/components/settings/SectionCard.svelte';
+	import SettingsSaveBar from '$lib/components/settings/SettingsSaveBar.svelte';
+	import TuningParamRow from '$lib/components/settings/TuningParamRow.svelte';
+	import UnsavedChangesDialog from '$lib/components/settings/UnsavedChangesDialog.svelte';
+	import { createUnsavedGuard } from '$lib/settings/unsavedChanges.svelte';
+	import {
+		groupTuningSections,
+		type TuningFieldMeta,
+		type TuningValues
+	} from '$lib/settings/tuning';
+
+	type BeltStatus = {
+		ts: number;
+		reason: string;
+		commanded_speed_usteps_per_s?: number;
+		target_speed_usteps_per_s?: number;
+		base_speed_usteps_per_s?: number | null;
+		c3_pieces?: number | null;
+		c3_full_speed_pieces?: number | null;
+		c3_stop_pieces?: number | null;
+		running_for_s?: number | null;
+		since_last_arrival_s?: number | null;
+		jam_timeout_s?: number | null;
+		jam_countdown_s?: number | null;
+	};
+
+	let fields = $state<TuningFieldMeta[]>([]);
+	let values = $state<TuningValues>({});
+	let loading = $state(true);
+	let saving = $state(false);
+	let error = $state<string | null>(null);
+	let saved = $state(false);
+	let beltStatus = $state<BeltStatus | null>(null);
+	let beltStatusAvailable = $state(false);
+	// False while the status poll fails. Without it the derived below never
+	// re-runs (nothing changes) and the last snapshot would stay "fresh" forever.
+	let pollOk = $state(true);
+
+	let sections = $derived(groupTuningSections(fields));
+
+	// Guards navigation while the form differs from what is stored on the machine.
+	// Armed only once load() has taken a snapshot, so it never fires on a page
+	// that is still fetching.
+	const guard = createUnsavedGuard({
+		current: () => values,
+		save,
+		ready: () => !loading && !saving
+	});
+
+	// Status older than ~3 s means the belt flow is not ticking (feeder idle,
+	// different feeder mode, or backend restart) — show it greyed out.
+	let statusFresh = $derived(
+		pollOk && beltStatus !== null && Date.now() / 1000 - beltStatus.ts < 3
+	);
+
+	const REASON_LABELS: Record<string, string> = {
+		running: 'Running at full speed',
+		throttled: 'Throttled — C3 filling up',
+		stopped_c3_full: 'Stopped — C3 full',
+		disabled: 'Stopped — belt disabled in config',
+		no_perception: 'Stopped — no C3 perception state yet',
+		no_belt_stepper: 'Stopped — no belt stepper bound',
+		held: 'Held — incident or manual feed',
+		chute_move: 'Paused — chute is moving',
+		idle: 'Idle — feeder not in FEEDING state'
+	};
+
+	function speedPct(s: BeltStatus): string {
+		const base = s.base_speed_usteps_per_s ?? 0;
+		if (!base) return '—';
+		return `${Math.round((Math.abs(s.commanded_speed_usteps_per_s ?? 0) / base) * 100)}%`;
+	}
+
+	async function pollStatus() {
+		try {
+			const res = await fetch(`${getBackendHttpBase()}/api/tuning/feeder-belt/status`);
+			if (!res.ok) {
+				pollOk = false;
+				return;
+			}
+			const data = await res.json();
+			beltStatusAvailable = Boolean(data.available);
+			beltStatus = data.status ?? null;
+			pollOk = true;
+		} catch {
+			// Keep the last snapshot on screen, greyed out as stale.
+			pollOk = false;
+		}
+	}
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			const res = await fetch(`${getBackendHttpBase()}/api/tuning/feeder-belt`);
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
+			const data = await res.json();
+			fields = data.fields;
+			values = { ...data.config };
+			guard.markSaved();
+		} catch (e: any) {
+			error = e.message ?? 'Failed to load config';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function save() {
+		saving = true;
+		saved = false;
+		error = null;
+		try {
+			const res = await fetch(`${getBackendHttpBase()}/api/tuning/feeder-belt`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(values)
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({}));
+				throw new Error(body.detail ?? `HTTP ${res.status}`);
+			}
+			const data = await res.json();
+			values = { ...data.config };
+			guard.markSaved();
+			saved = true;
+			setTimeout(() => (saved = false), 3000);
+		} catch (e: any) {
+			error = e.message ?? 'Failed to save config';
+		} finally {
+			saving = false;
+		}
+	}
+
+	$effect(() => {
+		load();
+		void pollStatus();
+		const interval = setInterval(() => void pollStatus(), 1000);
+		return () => clearInterval(interval);
+	});
+</script>
+
+<svelte:head><title>Sorter - B1 Belt Feeder Tuning</title></svelte:head>
+
+<div class="flex flex-col gap-6 p-6">
+	<div>
+		<div class="text-lg font-semibold text-text">B1 Belt Feeder Tuning</div>
+		<div class="mt-1 text-sm text-text-muted">
+			The B1 cleated conveyor runs continuously and is throttled by C3's fill level: full speed
+			while C3 has at most the full-speed piece count, ramping linearly down to a stop at the stop
+			count. C3's own exit metering into the classification channel is tuned on the Feeder Simple
+			Pulse page. Changes take effect within ~1 second (no restart needed).
+		</div>
+	</div>
+
+	{#if !loading}
+		<SettingsSaveBar {save} reset={load} {saving} dirty={guard.isDirty} />
+	{/if}
+
+	{#if error}
+		<Alert variant="danger">{error}</Alert>
+	{/if}
+
+	{#if saved}
+		<Alert variant="success">Saved. Changes apply within ~1 second.</Alert>
+	{/if}
+
+	<SectionCard
+		title="Live status"
+		description="What the belt controller is doing right now — why the belt moves (or doesn't), the C3 fill level driving the ramp, and the jam countdown."
+	>
+		{#if !beltStatusAvailable || beltStatus === null}
+			<div class="text-sm text-text-muted">
+				No belt controller active yet. The status appears once the machine runs the belt_feeder
+				setup and feeding has started.
+			</div>
+		{:else}
+			<div class="flex flex-col gap-3 {statusFresh ? '' : 'opacity-50'}">
+				{#if !statusFresh}
+					<div class="text-sm text-text-muted">
+						Stale snapshot — the belt flow is not ticking right now (feeder idle or paused).
+					</div>
+				{/if}
+				<div
+					class="text-sm font-medium {beltStatus.reason === 'running' ||
+					beltStatus.reason === 'throttled'
+						? 'text-success'
+						: 'text-text'}"
+				>
+					{REASON_LABELS[beltStatus.reason] ?? beltStatus.reason}
+				</div>
+				<div class="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-3">
+					<div>
+						<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">Speed</div>
+						<div class="text-sm text-text tabular-nums">
+							{Math.abs(beltStatus.commanded_speed_usteps_per_s ?? 0)} µsteps/s ({speedPct(
+								beltStatus
+							)})
+						</div>
+					</div>
+					<div>
+						<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+							C3 pieces
+						</div>
+						<div class="text-sm text-text tabular-nums">
+							{beltStatus.c3_pieces ?? '—'} (full ≤{beltStatus.c3_full_speed_pieces ?? '—'}, stop ≥{beltStatus.c3_stop_pieces ??
+								'—'})
+						</div>
+					</div>
+					<div>
+						<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+							Running for
+						</div>
+						<div class="text-sm text-text tabular-nums">
+							{beltStatus.running_for_s != null ? `${beltStatus.running_for_s}s` : '—'}
+						</div>
+					</div>
+					<div>
+						<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+							Last piece into C3
+						</div>
+						<div class="text-sm text-text tabular-nums">
+							{beltStatus.since_last_arrival_s != null
+								? `${beltStatus.since_last_arrival_s}s ago`
+								: 'none yet'}
+						</div>
+					</div>
+					<div>
+						<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+							Jam countdown
+						</div>
+						<div class="text-sm text-text tabular-nums">
+							{beltStatus.jam_countdown_s != null
+								? `${beltStatus.jam_countdown_s}s of ${beltStatus.jam_timeout_s}s`
+								: '—'}
+						</div>
+					</div>
+				</div>
+			</div>
+		{/if}
+	</SectionCard>
+
+	<SectionCard
+		title="Parameters"
+		description="Belt speed, the C3 fill-level ramp, and jam detection for the B1 belt topology."
+	>
+		{#if loading}
+			<div class="text-sm text-text-muted">Loading…</div>
+		{:else}
+			<div class="flex flex-col gap-8">
+				{#each sections as section}
+					<div class="flex flex-col gap-4">
+						<div class="text-xs font-semibold tracking-wider text-text-muted uppercase">
+							{section.name}
+						</div>
+						{#each section.fields as field}
+							<TuningParamRow {field} bind:values />
+						{/each}
+					</div>
+				{/each}
+			</div>
+
+			<div class="mt-6">
+				<SettingsSaveBar {save} reset={load} {saving} dirty={guard.isDirty} />
+			</div>
+		{/if}
+	</SectionCard>
+
+	<UnsavedChangesDialog {guard} />
+</div>

--- a/software/sorter/frontend/src/routes/setup/+page.svelte
+++ b/software/sorter/frontend/src/routes/setup/+page.svelte
@@ -337,8 +337,13 @@
 
 	function cameraRolesForLayout(): string[] {
 		const setup = wizard?.config.machine_setup;
-		const auxiliaryRole = setup?.uses_classification_channel ? 'classification_channel' : 'carousel';
-		const roles = ['c_channel_2', 'c_channel_3', auxiliaryRole];
+		const auxiliaryRole = setup?.uses_classification_channel
+			? 'classification_channel'
+			: 'carousel';
+		// The B1 belt topology has no C2 channel, so there is no C2 camera to assign.
+		const roles = setup?.uses_belt_feeder
+			? ['c_channel_3', auxiliaryRole]
+			: ['c_channel_2', 'c_channel_3', auxiliaryRole];
 		if (setup?.uses_classification_chamber ?? true) {
 			roles.push('classification_top', 'classification_bottom');
 		}


### PR DESCRIPTION
## What this is

The first of a series that brings the mature parts of `b1-belt-feeder` to main, lane by lane. This lane is the machine topology itself: a new setup `belt_feeder` pairs a cleated conveyor on the C1 rotor port with the existing C3 pulse-perception exit metering and the C4 classification channel. C2 has no motor and no camera in this topology.

## Contents

- `FeederMode.BELT_REV01` (`subsystems/feeder/belt/`): the belt runs at a continuous speed throttled by C3's perception fill level, stops on hold and while the chute moves, and raises its own `belt_feeder_stalled` incident when the jam window passes without a new piece reaching C3. C3's stuck watchdog treats the belt as its upstream.
- Setup registry entry, required steppers (`c_channel_1` as the belt, `c_channel_3`), `belt_stepper` alias, capability-based C4 rotor profile (`uses_classification_channel` instead of a key check, which had left `belt_feeder` at the slow profile), `[feeder_belt]` tuning section with `GET/POST /api/tuning/feeder-belt` and a belt status endpoint, `machine.example.toml` section.
- Frontend: "B1 Belt Feeder" hardware station, feeder-belt tuning page, dashboard without the C2 tile (C3 over C4), belt-stall incident card, setup camera roles without C2.
- Fixes carried by the same lane: OBSBOT auto-exposure detection for non-standard V4L2 menus, `[perception.conf_thresholds]` per-channel detector confidence, C4 rev01 forward-only converge with a no-detection grace on the walled platter (`precise_blind_grace_ms`), tap-to-open model activation menu for the touch tablet.

## What changes for machines without a belt

Nothing selects `belt_feeder` unless the setup does. The only defaults that change for every setup are the rev01 single-piece converge (forward-only, 1200 ms blind grace instead of hunting) and the model activation menu (tap instead of hover).

## Included after review

The second commit (after the Codex review, see the comment below) adds the stale-perception stop, the stall-latch stop with the watch-only StallGuard load monitor, the bounded stuck-watchdog nudge, the belt_feeder / belt_rev01 pairing and turns the rev01 blind grace off by default.

## Not included

Every later lane (Waveshare door safeguard, C4 two-piece hardening, C3 exit pacing, set extraction). Those follow as separate PRs on top of this one.

## How it was ported

Squash of `b243aa49 … 6de68166` from `b1-belt-feeder`, in production on the B1 machine since July. Commit cherry-picks no longer apply (main moved underneath since July), so 28 files were taken from the branch directly and 9 shared files (`irl/config.py`, `main.py`, `toml_config.py`, `vision_manager.py`, `rev01_config.py`, dashboard, setup page, header, models section) were hand-ported to main's current structure.

## Tests

- `tests/test_belt_feeder.py` (14) and the dashboard config test pass.
- Full backend suite: the same 20 failures as on current main, nothing new (those 20 are what #523 fixes).
- `pnpm check`: no errors in the touched files.