### PR TITLE
sorter: robustness fixes from the B1 runs

### DIFF
--- a/software/sorter/backend/hardware/bus.py
+++ b/software/sorter/backend/hardware/bus.py
@@ -89,13 +89,15 @@ class MCUBusError(Exception):
 class MCUBus:
     """Class for communicating with the MCU over a serial bus using a custom protocol."""
 
-    def __init__(self, port: str, baudrate: int = 576000, timeout: float = 0.1):
+    def __init__(self, port: str, baudrate: int = 576000, timeout: float = 0.25):
         """Initialize the MCUBus with the given serial port parameters.
 
         Args:
             port: The serial port to use (e.g. "/dev/ttyUSB0")
             baudrate: The baud rate for the serial communication (default 576000)
-            timeout: The read timeout in seconds (default 0.01s = 10ms)
+            timeout: The read timeout in seconds (default 0.25 s — a reply
+                that has started may stall while the board steps a pulse;
+                100 ms cut GET_STALL_STATUS replies mid-frame ~100x/hour).
         """
 
         self._serial = serial.Serial(port, baudrate=baudrate, timeout=timeout)

--- a/software/sorter/backend/incident_records.py
+++ b/software/sorter/backend/incident_records.py
@@ -86,6 +86,17 @@ def _ensureInitialized() -> None:
             )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_incidents_kind ON incidents(kind)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_incidents_status ON incidents(status)")
+            # This runs once per backend process, i.e. at (re)start. Any row
+            # still 'active' belongs to a previous process whose in-memory
+            # incident slot is gone, so nothing could ever resolve it; close it
+            # here instead of letting phantom actives pile up in the log.
+            now = time.time()
+            conn.execute(
+                "UPDATE incidents SET status = 'resolved', resolved_at = ?, "
+                "resolved_by = 'backend_restart', updated_at = ?, "
+                "duration_s = MAX(0, ? - triggered_at) WHERE status = 'active'",
+                (now, now, now),
+            )
             conn.commit()
             _initialized = True
         finally:

--- a/software/sorter/backend/incident_records.py
+++ b/software/sorter/backend/incident_records.py
@@ -34,6 +34,12 @@ def _connect() -> sqlite3.Connection:
     return conn
 
 
+def closeStaleActiveRows() -> None:
+    """Close incident rows a previous backend process left active. Called at
+    startup so an orphan does not wait for the first incident query."""
+    _ensureInitialized()
+
+
 @contextmanager
 def _connection() -> Iterator[sqlite3.Connection]:
     _ensureInitialized()

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -949,7 +949,7 @@ def parseCameraDeviceSettings(raw: object) -> dict[str, int | float | bool]:
             # Driver sentinel: cap.get() returns -1 for properties the device
             # does not actually expose. Persisting/applying these poisons the
             # camera — drop them.
-            if float(value) == -1.0 and key in {"focus", "gain", "exposure", "white_balance_temperature"}:
+            if float(value) == -1.0 and key in {"focus", "gain", "exposure", "white_balance_temperature", "zoom"}:
                 continue
             result[key] = float(value)
 

--- a/software/sorter/backend/irl/config.py
+++ b/software/sorter/backend/irl/config.py
@@ -933,6 +933,7 @@ def parseCameraDeviceSettings(raw: object) -> dict[str, int | float | bool]:
         "exposure",
         "white_balance_temperature",
         "focus",
+        "zoom",
         "power_line_frequency",
         "backlight_compensation",
     }

--- a/software/sorter/backend/machine_platform/stepper_safety.py
+++ b/software/sorter/backend/machine_platform/stepper_safety.py
@@ -1,0 +1,59 @@
+"""Bring every stepper the IRL knows to a stop.
+
+Used at the two moments where a stepper may still be executing a command
+nobody remembers: right after the hardware is (re)discovered — a crashed
+backend never got to stop the motors, and the fresh process assumes they are
+idle — and first thing at shutdown, before cameras and vision are torn down.
+Seen 2026-09-05: a belt started 1 s before a crash ran through restart and
+homing and flooded C3 with 40 pieces.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+STEPPER_ATTRIBUTES: tuple[str, ...] = (
+    "c_channel_1_rotor_stepper",
+    "c_channel_2_rotor_stepper",
+    "c_channel_3_rotor_stepper",
+    "c_channel_4_rotor_stepper",
+    "carousel_stepper",
+    "chute_stepper",
+)
+
+
+def irlSteppers(irl: Any) -> list[tuple[str, Any]]:
+    seen: set[int] = set()
+    out: list[tuple[str, Any]] = []
+    for name in STEPPER_ATTRIBUTES:
+        stepper = getattr(irl, name, None)
+        if stepper is None or id(stepper) in seen:
+            continue
+        seen.add(id(stepper))
+        out.append((name, stepper))
+    return out
+
+
+def stopStepper(stepper: Any) -> None:
+    """Zero the speed first (a running move_at_speed is the dangerous case),
+    then halt if the stepper offers it."""
+    move_at_speed = getattr(stepper, "move_at_speed", None)
+    if callable(move_at_speed):
+        move_at_speed(0)
+    halt = getattr(stepper, "halt", None)
+    if callable(halt):
+        halt(disable_driver=False)
+
+
+def stopAllSteppers(irl: Any, logger: Any, *, reason: str) -> list[str]:
+    """Stop every stepper; failures are logged, never raised — this runs on
+    paths (crash shutdown, recovery start) that must not abort."""
+    stopped: list[str] = []
+    for name, stepper in irlSteppers(irl):
+        try:
+            stopStepper(stepper)
+            stopped.append(name)
+        except Exception as exc:
+            logger.warning(f"Stepper '{name}': stop failed during {reason}: {exc}")
+    if stopped:
+        logger.info(f"Stopped steppers ({reason}): {', '.join(stopped)}")
+    return stopped

--- a/software/sorter/backend/machine_platform/stepper_safety.py
+++ b/software/sorter/backend/machine_platform/stepper_safety.py
@@ -33,15 +33,26 @@ def irlSteppers(irl: Any) -> list[tuple[str, Any]]:
     return out
 
 
-def stopStepper(stepper: Any) -> None:
-    """Zero the speed first (a running move_at_speed is the dangerous case),
-    then halt if the stepper offers it."""
+def stopStepper(stepper: Any) -> bool:
+    """Zero the speed (a running move_at_speed is the dangerous case), forced
+    past a software disable — this is exactly the moment nobody trusts the
+    motor's state. If the firmware does not acknowledge the stop (a jitter in
+    flight rejects overlapping commands), cut the driver instead. Returns
+    whether the motor is known to be stopped."""
     move_at_speed = getattr(stepper, "move_at_speed", None)
-    if callable(move_at_speed):
-        move_at_speed(0)
-    halt = getattr(stepper, "halt", None)
-    if callable(halt):
-        halt(disable_driver=False)
+    if not callable(move_at_speed):
+        return False
+    try:
+        acked = move_at_speed(0, force=True)
+    except TypeError:
+        acked = move_at_speed(0)  # a driver without the force flag
+    if acked is not False:
+        return True
+    enable_force = getattr(stepper, "enable_force", None)
+    if callable(enable_force):
+        enable_force(False)
+        return True
+    return False
 
 
 def stopAllSteppers(irl: Any, logger: Any, *, reason: str) -> list[str]:
@@ -50,8 +61,10 @@ def stopAllSteppers(irl: Any, logger: Any, *, reason: str) -> list[str]:
     stopped: list[str] = []
     for name, stepper in irlSteppers(irl):
         try:
-            stopStepper(stepper)
-            stopped.append(name)
+            if stopStepper(stepper):
+                stopped.append(name)
+            else:
+                logger.warning(f"Stepper '{name}': stop not confirmed during {reason}")
         except Exception as exc:
             logger.warning(f"Stepper '{name}': stop failed during {reason}: {exc}")
     if stopped:

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -406,6 +406,9 @@ def runBroadcaster(gc: GlobalConfig) -> None:
 
 
 def main() -> None:
+    import incident_records
+
+    incident_records.closeStaleActiveRows()
     import server.shared_state as shared_state
 
     shutdown_requested = threading.Event()

--- a/software/sorter/backend/main.py
+++ b/software/sorter/backend/main.py
@@ -54,6 +54,9 @@ from hardware.waveshare_bus_service import close_all_waveshare_bus_services
 from server.waveshare_inventory import get_waveshare_inventory_manager
 import uvicorn
 import threading
+import traceback
+
+from machine_platform.stepper_safety import stopAllSteppers
 import queue
 import time
 import asyncio
@@ -656,6 +659,9 @@ def main() -> None:
         real_irl = mkIRLInterface(irl_config, gc)
         _replace_irl(real_irl)
         setHardwareRuntimeIRL(irl)
+        # A previous process may have died mid-move (a crash never reaches the
+        # motor stop below); nothing here may assume the motors are idle.
+        stopAllSteppers(irl, gc.logger, reason="recovery start")
         machine_setup = getattr(irl_config, "machine_setup", None)
         manual_feed_mode = bool(
             getattr(machine_setup, "manual_feed_mode", False)
@@ -898,6 +904,14 @@ def main() -> None:
 
     def _shutdown_runtime(reason: str) -> None:
         gc.logger.info(f"Shutting down ({reason})...")
+        # Motors first: everything below can take seconds, and a crash path
+        # may not get to the full hardware cleanup at all.
+        try:
+            live_irl = shared_state.getActiveIRL() or irl
+            if live_irl is not None:
+                stopAllSteppers(live_irl, gc.logger, reason="shutdown")
+        except Exception as exc:
+            gc.logger.warning(f"Failed to stop steppers at shutdown start: {exc}")
 
         try:
             gc.lifetime_stats.flush()
@@ -1080,6 +1094,12 @@ def main() -> None:
             time.sleep(gc.timeouts.main_loop_sleep_ms / 1000.0)
     except KeyboardInterrupt:
         shutdown_reason["value"] = "KeyboardInterrupt"
+    except Exception:
+        # Log it here: the shutdown reaper exits the process before the
+        # interpreter would print this traceback.
+        shutdown_reason["value"] = "main loop exception"
+        gc.logger.error(f"Main loop crashed:\n{traceback.format_exc()}")
+        raise
     finally:
         _shutdown_runtime(shutdown_reason["value"])
 

--- a/software/sorter/backend/perception/arcs.py
+++ b/software/sorter/backend/perception/arcs.py
@@ -620,13 +620,17 @@ def attributeBboxes(
             continue
         n_on_channel += 1
         sections = bboxSections(bbox, channel)
-        if not any_drop and sections & channel.drop_sections:
+        nd, ne, np_, nm = _bboxRegionCounts(bbox, channel)
+        # The drop gate and the handler's per-piece zone code must agree on
+        # what "in the drop arc" means, or the gate closes for a piece the
+        # handler never sees (the 2026-09-04 deadlock): both use the interior
+        # grid overlap.
+        if not any_drop and nd > 0:
             any_drop = True
         if not any_exit and sections & channel.exit_sections:
             any_exit = True
         if not any_precise and sections & channel.precise_sections:
             any_precise = True
-        nd, ne, np_, nm = _bboxRegionCounts(bbox, channel)
         per_bbox_counts.append((nd, ne, np_, nm, bbox))
         if not any_exit_majority and ne > np_ and ne > 0:
             any_exit_majority = True

--- a/software/sorter/backend/perception/arcs.py
+++ b/software/sorter/backend/perception/arcs.py
@@ -430,11 +430,20 @@ _AREA_GRID_N = 12  # 12x12 = 144 sample points per bbox; ample for area majority
 # Per-channel cached region lookup: section_id → 0=none 1=drop 2=exit_only 3=precise.
 # Keyed by channel_id; built once on first call and reused. The section sets are
 # immutable after ChannelDef construction so this never goes stale.
-_region_lookup_cache: dict[int, np.ndarray] = {}
+# Keyed by the zone section sets, not the channel id: a live zone edit
+# rebuilds the ChannelDef with new sections under the same id, and a table
+# cached per id kept classifying pieces by the previous layout.
+_RegionKey = tuple[frozenset[int], frozenset[int], frozenset[int]]
+_region_lookup_cache: dict[_RegionKey, np.ndarray] = {}
 
 
 def _region_lookup(channel: ChannelDef) -> np.ndarray:
-    cached = _region_lookup_cache.get(channel.channel_id)
+    key: _RegionKey = (
+        frozenset(channel.drop_sections),
+        frozenset(channel.exit_sections),
+        frozenset(channel.precise_sections),
+    )
+    cached = _region_lookup_cache.get(key)
     if cached is not None:
         return cached
     exit_only = channel.exit_sections - channel.precise_sections
@@ -445,7 +454,7 @@ def _region_lookup(channel: ChannelDef) -> np.ndarray:
         lut[int(s) % SECTION_COUNT] = 2
     for s in channel.precise_sections:
         lut[int(s) % SECTION_COUNT] = 3
-    _region_lookup_cache[channel.channel_id] = lut
+    _region_lookup_cache[key] = lut
     return lut
 
 
@@ -532,7 +541,14 @@ def orderedPieceObservations(
             gap = (entry_angle - relative) % 360.0
         if sec in exit_only and gap > 180.0:
             gap -= 360.0
-        out.append((gap, sec, int(lut[sec]), (int(bbox[0]), int(bbox[1]), int(bbox[2]), int(bbox[3]))))
+        # Zone by AREA, in line with the ``in_drop`` gate (any overlap with the
+        # drop arc): a piece resting across the drop arc's rear edge has its
+        # centre one section outside, and coding it by the centre alone left
+        # the flow deadlocked — gate closed (drop occupied), handler waiting
+        # for a drop piece that, to it, never existed.
+        n_drop, _n_exit_only, _n_precise, _n_on = _bboxRegionCounts(bbox, channel)
+        code = 1 if n_drop > 0 else int(lut[sec])
+        out.append((gap, sec, code, (int(bbox[0]), int(bbox[1]), int(bbox[2]), int(bbox[3]))))
     out.sort(key=lambda t: t[0])
     return out
 

--- a/software/sorter/backend/server/routers/detection.py
+++ b/software/sorter/backend/server/routers/detection.py
@@ -41,6 +41,7 @@ from server import shared_state
 from server.classification_training import getClassificationTrainingManager
 from server.machine_naming import display_name_from_hostname, random_display_name
 from server.routers.tailscale import current_hostname
+from subsystems.classification_channel.running import exitReleaseTestParams
 from subsystems.feeder.incidents import BELT_FEEDER_STALLED_INCIDENT_KIND
 from vision.detection_registry import (
     detection_algorithm_definition,
@@ -2107,24 +2108,15 @@ def _channel_exit_stepper(channel: str) -> tuple[str, Any]:
 def _validate_channel_exit_release_payload(
     payload: ChannelExitIncidentTestReleasePayload,
 ) -> dict[str, Any]:
-    amplitude_output = float(payload.amplitude_output_deg)
-    if amplitude_output < 0.1 or amplitude_output > 12.0:
-        raise HTTPException(status_code=400, detail="amplitude_output_deg must be between 0.1 and 12.0.")
-    speed = int(payload.microsteps_per_second)
-    if speed < 100 or speed > 16000:
-        raise HTTPException(status_code=400, detail="microsteps_per_second must be between 100 and 16000.")
-    cycles = int(payload.cycles)
-    if cycles < 1 or cycles > 20:
-        raise HTTPException(status_code=400, detail="cycles must be between 1 and 20.")
-    if payload.acceleration_microsteps_per_second_sq is None:
-        acceleration = max(1000, min(48000, int(round(speed * 3.0))))
-    else:
-        acceleration = int(payload.acceleration_microsteps_per_second_sq)
-        if acceleration < 1000 or acceleration > 48000:
-            raise HTTPException(
-                status_code=400,
-                detail="acceleration_microsteps_per_second_sq must be between 1000 and 48000.",
-            )
+    try:
+        amplitude_output, speed, cycles, acceleration = exitReleaseTestParams(
+            payload.amplitude_output_deg,
+            payload.microsteps_per_second,
+            payload.cycles,
+            payload.acceleration_microsteps_per_second_sq,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {
         "amplitude_output_deg": amplitude_output,
         "microsteps_per_second": speed,

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -3413,6 +3413,7 @@ def move_to_bin(payload: MoveToBinPayload) -> Dict[str, Any]:
     # Production door semantics: the TARGET layer's door is CLOSED (it
     # deflects the piece into that row), every other door is parked OPEN so
     # the piece passes through to the target.
+    door_failures: list[str] = []
     for i, servo in enumerate(servos):
         try:
             if i == payload.layer_index:
@@ -3420,8 +3421,13 @@ def move_to_bin(payload: MoveToBinPayload) -> Dict[str, Any]:
                     servo.close()
             elif hasattr(servo, "open"):
                 servo.open()
-        except Exception:
-            pass
+        except Exception as exc:
+            door_failures.append(f"layer {i}: {exc}")
+    if door_failures:
+        raise HTTPException(
+            status_code=409,
+            detail="Door(s) did not accept the command, chute not moved: " + "; ".join(door_failures),
+        )
 
     try:
         estimated_ms = chute.moveToBin(address)

--- a/software/sorter/backend/server/routers/hardware.py
+++ b/software/sorter/backend/server/routers/hardware.py
@@ -3410,11 +3410,16 @@ def move_to_bin(payload: MoveToBinPayload) -> Dict[str, Any]:
     if target_angle is None:
         raise HTTPException(status_code=400, detail="Bin is unreachable (angle out of range).")
 
-    # Close all servos first, then open the target layer
+    # Production door semantics: the TARGET layer's door is CLOSED (it
+    # deflects the piece into that row), every other door is parked OPEN so
+    # the piece passes through to the target.
     for i, servo in enumerate(servos):
         try:
-            if hasattr(servo, "isOpen") and servo.isOpen():
-                servo.close()
+            if i == payload.layer_index:
+                if hasattr(servo, "close"):
+                    servo.close()
+            elif hasattr(servo, "open"):
+                servo.open()
         except Exception:
             pass
 
@@ -3422,14 +3427,6 @@ def move_to_bin(payload: MoveToBinPayload) -> Dict[str, Any]:
         estimated_ms = chute.moveToBin(address)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Chute move failed: {e}")
-
-    # Open the target layer servo
-    target_servo = servos[payload.layer_index]
-    try:
-        if hasattr(target_servo, "open"):
-            target_servo.open()
-    except Exception:
-        pass
 
     return {
         "ok": True,

--- a/software/sorter/backend/subsystems/classification_channel/running.py
+++ b/software/sorter/backend/subsystems/classification_channel/running.py
@@ -89,6 +89,35 @@ class _ExitReleaseReview:
     approved: bool = False
 
 
+def exitReleaseTestParams(
+    amplitude_output_deg: float,
+    microsteps_per_second: int,
+    cycles: int = 1,
+    acceleration_microsteps_per_second_sq: int | None = None,
+) -> tuple[float, int, int, int]:
+    """Range-check the operator's exit-release test parameters (shared by the
+    exit-release review and the stall-watchdog Test Wiggle). Returns
+    (amplitude_output_deg, microsteps_per_second, cycles, acceleration)."""
+    amplitude_output = float(amplitude_output_deg)
+    if amplitude_output < 0.1 or amplitude_output > 12.0:
+        raise ValueError("amplitude_output_deg must be between 0.1 and 12.0.")
+    speed = int(microsteps_per_second)
+    if speed < 100 or speed > 24000:
+        raise ValueError("microsteps_per_second must be between 100 and 24000.")
+    cycle_count = int(cycles)
+    if cycle_count < 1 or cycle_count > 20:
+        raise ValueError("cycles must be between 1 and 20.")
+    if acceleration_microsteps_per_second_sq is None:
+        acceleration = max(1000, min(200000, int(round(speed * 3.0))))
+    else:
+        acceleration = int(acceleration_microsteps_per_second_sq)
+        if acceleration < 1000 or acceleration > 200000:
+            raise ValueError(
+                "acceleration_microsteps_per_second_sq must be between 1000 and 200000."
+            )
+    return amplitude_output, speed, cycle_count, acceleration
+
+
 DEFAULT_EXIT_RELEASE_STAGES: tuple[_ExitReleaseStage, ...] = (
     _ExitReleaseStage("contact-break-micro", 0.25, 2, 700, 1800, 300),
     _ExitReleaseStage("low-rock", 0.50, 2, 950, 2600, 300),
@@ -1660,23 +1689,9 @@ class Running(BaseState):
         if not self.irl.carousel_stepper.stopped:
             raise RuntimeError("The classification-channel stepper is still moving.")
 
-        amplitude_output = float(amplitude_output_deg)
-        if amplitude_output < 0.1 or amplitude_output > 12.0:
-            raise ValueError("amplitude_output_deg must be between 0.1 and 12.0.")
-        speed = int(microsteps_per_second)
-        if speed < 100 or speed > 16000:
-            raise ValueError("microsteps_per_second must be between 100 and 16000.")
-        cycle_count = int(cycles)
-        if cycle_count < 1 or cycle_count > 20:
-            raise ValueError("cycles must be between 1 and 20.")
-        if acceleration_microsteps_per_second_sq is None:
-            acceleration = max(1000, min(48000, int(round(speed * 3.0))))
-        else:
-            acceleration = int(acceleration_microsteps_per_second_sq)
-            if acceleration < 1000 or acceleration > 48000:
-                raise ValueError(
-                    "acceleration_microsteps_per_second_sq must be between 1000 and 48000."
-                )
+        amplitude_output, speed, cycle_count, acceleration = exitReleaseTestParams(
+            amplitude_output_deg, microsteps_per_second, cycles, acceleration_microsteps_per_second_sq
+        )
 
         stepper_per_output = getattr(
             self._config,

--- a/software/sorter/backend/tests/test_bins_move_to_doors.py
+++ b/software/sorter/backend/tests/test_bins_move_to_doors.py
@@ -1,0 +1,29 @@
+"""/api/bins/move-to uses the production door semantics: target closed, rest open."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from server.routers import hardware
+
+
+class _Servo:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def open(self) -> None:
+        self.calls.append("open")
+
+    def close(self) -> None:
+        self.calls.append("close")
+
+
+def test_move_to_closes_target_layer_and_opens_the_others() -> None:
+    upper, lower = _Servo(), _Servo()
+    chute = SimpleNamespace(getAngleForBin=lambda a: 42.0, moveToBin=lambda a: 500)
+    irl = SimpleNamespace(chute=chute, servos=[upper, lower])
+    controller = SimpleNamespace(irl=irl)
+    payload = hardware.MoveToBinPayload(layer_index=1, section_index=2, bin_index=0)
+    with patch("server.routers.hardware.shared_state.controller_ref", controller):
+        out = hardware.move_to_bin(payload)
+    assert out["ok"] and out["target_angle"] == 42.0
+    assert lower.calls == ["close"]
+    assert upper.calls == ["open"]

--- a/software/sorter/backend/tests/test_bins_move_to_doors.py
+++ b/software/sorter/backend/tests/test_bins_move_to_doors.py
@@ -27,3 +27,22 @@ def test_move_to_closes_target_layer_and_opens_the_others() -> None:
     assert out["ok"] and out["target_angle"] == 42.0
     assert lower.calls == ["close"]
     assert upper.calls == ["open"]
+
+
+def test_a_door_that_fails_blocks_the_chute_move() -> None:
+    import pytest
+    from fastapi import HTTPException
+
+    class _Broken(_Servo):
+        def close(self) -> None:
+            raise RuntimeError("bus timeout")
+
+    moves: list = []
+    chute = SimpleNamespace(getAngleForBin=lambda a: 42.0, moveToBin=lambda a: moves.append(a) or 500)
+    irl = SimpleNamespace(chute=chute, servos=[_Servo(), _Broken()])
+    payload = hardware.MoveToBinPayload(layer_index=1, section_index=2, bin_index=0)
+    with patch("server.routers.hardware.shared_state.controller_ref", SimpleNamespace(irl=irl)):
+        with pytest.raises(HTTPException) as info:
+            hardware.move_to_bin(payload)
+    assert info.value.status_code == 409
+    assert moves == [], "the chute must not move onto an unverified door"

--- a/software/sorter/backend/tests/test_camera_zoom_control.py
+++ b/software/sorter/backend/tests/test_camera_zoom_control.py
@@ -1,0 +1,16 @@
+import unittest
+
+from vision import camera
+
+
+class ZoomControlTests(unittest.TestCase):
+    def test_zoom_is_a_known_usb_control(self):
+        keys = {spec["key"] for spec in camera._usb_camera_control_specs()}
+        self.assertIn("zoom", keys)
+        ctrl, fmt = camera._LINUX_V4L2CTL_CONTROL_MAP["zoom"]
+        self.assertEqual("zoom_absolute", ctrl)
+        self.assertEqual("26", fmt(26.4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/software/sorter/backend/tests/test_incident_records.py
+++ b/software/sorter/backend/tests/test_incident_records.py
@@ -1,0 +1,33 @@
+import incident_records
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_STATE_DB_PATH", str(tmp_path / "state.sqlite"))
+    monkeypatch.setattr(incident_records, "_initialized", False)
+
+
+def test_backend_restart_closes_incidents_left_active(tmp_path, monkeypatch) -> None:
+    _fresh_db(tmp_path, monkeypatch)
+    row_id = incident_records.openIncident({"kind": "exit_stuck", "channel": "c4", "triggered_at": 1000.0})
+    assert incident_records.listIncidents(status="active")["items"][0]["id"] == row_id
+
+    # A new process initialises the store again: the orphaned row is closed.
+    monkeypatch.setattr(incident_records, "_initialized", False)
+    incident_records._ensureInitialized()
+
+    assert incident_records.listIncidents(status="active")["items"] == []
+    resolved = incident_records.listIncidents(status="resolved")["items"][0]
+    assert resolved["id"] == row_id
+    assert resolved["resolved_by"] == "backend_restart"
+    assert resolved["duration_s"] >= 0.0
+
+
+def test_live_resolution_is_not_overwritten(tmp_path, monkeypatch) -> None:
+    _fresh_db(tmp_path, monkeypatch)
+    row_id = incident_records.openIncident({"kind": "exit_stuck", "channel": "c4"})
+    incident_records.resolveIncident(row_id, resolved_by="operator")
+
+    monkeypatch.setattr(incident_records, "_initialized", False)
+    incident_records._ensureInitialized()
+
+    assert incident_records.listIncidents(status="resolved")["items"][0]["resolved_by"] == "operator"

--- a/software/sorter/backend/tests/test_region_lookup_cache.py
+++ b/software/sorter/backend/tests/test_region_lookup_cache.py
@@ -1,0 +1,33 @@
+"""The zone → region table must follow a live zone edit.
+
+Regression: the table was cached per channel id and never dropped, so after
+the operator redrew the C4 zones (camera remount) a piece resting in the new
+DROP arc was still coded by the old layout, was never captured, and went to
+misc as a "stray head".
+"""
+from types import SimpleNamespace
+
+from perception.arcs import _region_lookup
+
+
+def _channel(drop, exit_, precise):
+    return SimpleNamespace(
+        channel_id=4,
+        drop_sections=frozenset(drop),
+        exit_sections=frozenset(exit_) | frozenset(precise),
+        precise_sections=frozenset(precise),
+    )
+
+
+def test_same_channel_id_with_new_zones_gets_a_new_table() -> None:
+    before = _region_lookup(_channel(drop=range(0, 10), exit_=range(20, 30), precise=range(25, 30)))
+    after = _region_lookup(_channel(drop=range(40, 50), exit_=range(60, 70), precise=range(65, 70)))
+    assert before[5] == 1 and after[5] == 0
+    assert after[45] == 1
+    assert after[62] == 2 and after[67] == 3
+
+
+def test_identical_zones_reuse_the_cached_table() -> None:
+    a = _region_lookup(_channel(drop=range(0, 5), exit_=range(10, 20), precise=range(15, 20)))
+    b = _region_lookup(_channel(drop=range(0, 5), exit_=range(10, 20), precise=range(15, 20)))
+    assert a is b

--- a/software/sorter/backend/tests/test_stepper_safety.py
+++ b/software/sorter/backend/tests/test_stepper_safety.py
@@ -7,24 +7,31 @@ from machine_platform.stepper_safety import stopAllSteppers, stopStepper
 
 
 class _Stepper:
-    def __init__(self, fail: bool = False) -> None:
+    def __init__(self, fail: bool = False, ack: bool = True) -> None:
         self.calls: list = []
         self.fail = fail
+        self.ack = ack
 
-    def move_at_speed(self, speed: int) -> None:
+    def move_at_speed(self, speed: int, force: bool = False) -> bool:
         if self.fail:
             raise RuntimeError("bus down")
-        self.calls.append(("speed", speed))
+        self.calls.append(("speed", speed, force))
+        return self.ack
 
-    def halt(self, *, disable_driver: bool) -> bool:
-        self.calls.append(("halt", disable_driver))
-        return True
+    def enable_force(self, value: bool) -> None:
+        self.calls.append(("enable_force", value))
 
 
-def test_stop_zeroes_speed_then_halts_without_disabling() -> None:
+def test_stop_zeroes_speed_forced_past_a_software_disable() -> None:
     s = _Stepper()
-    stopStepper(s)
-    assert s.calls == [("speed", 0), ("halt", False)]
+    assert stopStepper(s)
+    assert s.calls == [("speed", 0, True)]
+
+
+def test_unacknowledged_stop_cuts_the_driver() -> None:
+    s = _Stepper(ack=False)
+    assert stopStepper(s)
+    assert s.calls == [("speed", 0, True), ("enable_force", False)]
 
 
 def test_stop_all_covers_every_stepper_once_and_survives_a_failure() -> None:
@@ -37,4 +44,4 @@ def test_stop_all_covers_every_stepper_once_and_survives_a_failure() -> None:
     )
     stopped = stopAllSteppers(irl, logging.getLogger("t"), reason="test")
     assert stopped == ["c_channel_1_rotor_stepper", "chute_stepper"]
-    assert belt.calls[0] == ("speed", 0) and chute.calls[0] == ("speed", 0)
+    assert belt.calls[0] == ("speed", 0, True) and chute.calls[0] == ("speed", 0, True)

--- a/software/sorter/backend/tests/test_stepper_safety.py
+++ b/software/sorter/backend/tests/test_stepper_safety.py
@@ -1,0 +1,40 @@
+import logging
+from types import SimpleNamespace
+
+import irl  # noqa: F401  (breaks the irl <-> machine_platform import cycle)
+
+from machine_platform.stepper_safety import stopAllSteppers, stopStepper
+
+
+class _Stepper:
+    def __init__(self, fail: bool = False) -> None:
+        self.calls: list = []
+        self.fail = fail
+
+    def move_at_speed(self, speed: int) -> None:
+        if self.fail:
+            raise RuntimeError("bus down")
+        self.calls.append(("speed", speed))
+
+    def halt(self, *, disable_driver: bool) -> bool:
+        self.calls.append(("halt", disable_driver))
+        return True
+
+
+def test_stop_zeroes_speed_then_halts_without_disabling() -> None:
+    s = _Stepper()
+    stopStepper(s)
+    assert s.calls == [("speed", 0), ("halt", False)]
+
+
+def test_stop_all_covers_every_stepper_once_and_survives_a_failure() -> None:
+    belt, chute, broken = _Stepper(), _Stepper(), _Stepper(fail=True)
+    irl = SimpleNamespace(
+        c_channel_1_rotor_stepper=belt,
+        chute_stepper=chute,
+        carousel_stepper=broken,
+        c_channel_4_rotor_stepper=broken,  # same object under two names
+    )
+    stopped = stopAllSteppers(irl, logging.getLogger("t"), reason="test")
+    assert stopped == ["c_channel_1_rotor_stepper", "chute_stepper"]
+    assert belt.calls[0] == ("speed", 0) and chute.calls[0] == ("speed", 0)

--- a/software/sorter/backend/tests/test_zone_code_area_overlap.py
+++ b/software/sorter/backend/tests/test_zone_code_area_overlap.py
@@ -1,0 +1,55 @@
+"""A piece straddling the drop arc's rear edge is a DROP piece.
+
+Regression (C4, 2026-09-04): the two-piece handler codes zones from
+``orderedPieceObservations``; a piece resting across the drop arc's rear edge
+had its bbox centre one section outside, so the handler saw a forward
+"stray" while the area-based ``in_drop`` gate stayed closed — a deadlock that
+ended in the stall watchdog and a good piece sent to misc.
+"""
+import numpy as np
+
+from perception.arcs import SECTION_COUNT, SECTION_DEG, orderedPieceObservations
+from perception.channel import ChannelDef
+
+
+def _channel() -> ChannelDef:
+    mask = np.zeros((400, 400), dtype=np.uint8)
+    mask[:, :] = 255
+    drop = frozenset(range(20, 40))
+    precise = frozenset(range(2, 6))
+    exit_ = frozenset(range(6, 12)) | precise
+    return ChannelDef(
+        channel_id=4,
+        camera_source_id="carousel",
+        center=(200.0, 200.0),
+        radius1_angle_image=0.0,
+        mask=mask,
+        drop_sections=drop,
+        exit_sections=exit_,
+        precise_sections=precise,
+    )
+
+
+def _bbox_centred_at_angle(deg: float, radius: float, half: int) -> tuple[int, int, int, int]:
+    cx = 200.0 + radius * np.cos(np.radians(deg))
+    cy = 200.0 + radius * np.sin(np.radians(deg))
+    return (int(cx - half), int(cy - half), int(cx + half), int(cy + half))
+
+
+def test_piece_across_drop_rear_edge_is_coded_drop() -> None:
+    ch = _channel()
+    rear_edge = 40 * SECTION_DEG  # first section OUTSIDE the drop arc
+    bbox = _bbox_centred_at_angle(rear_edge + 0.5 * SECTION_DEG, 120.0, 30)
+    obs = orderedPieceObservations([bbox], ch)
+    assert len(obs) == 1
+    _gap, sec, code, _ = obs[0]
+    assert sec not in ch.drop_sections  # centre lies outside the drop arc
+    assert code == 1
+
+
+def test_piece_well_outside_drop_keeps_its_centre_zone() -> None:
+    ch = _channel()
+    bbox = _bbox_centred_at_angle(8 * SECTION_DEG, 120.0, 4)  # small piece in exit-only
+    obs = orderedPieceObservations([bbox], ch)
+    assert obs[0][2] == 2
+    assert SECTION_COUNT > 40

--- a/software/sorter/backend/tests/test_zone_code_area_overlap.py
+++ b/software/sorter/backend/tests/test_zone_code_area_overlap.py
@@ -8,7 +8,7 @@ ended in the stall watchdog and a good piece sent to misc.
 """
 import numpy as np
 
-from perception.arcs import SECTION_COUNT, SECTION_DEG, orderedPieceObservations
+from perception.arcs import SECTION_COUNT, SECTION_DEG, attributeBboxes, orderedPieceObservations
 from perception.channel import ChannelDef
 
 
@@ -53,3 +53,16 @@ def test_piece_well_outside_drop_keeps_its_centre_zone() -> None:
     obs = orderedPieceObservations([bbox], ch)
     assert obs[0][2] == 2
     assert SECTION_COUNT > 40
+
+
+def test_gate_and_handler_agree_on_the_drop_arc() -> None:
+    """Whatever the handler codes DROP must close the gate, and vice versa —
+    a piece caught by nine boundary samples but not by the interior grid (or
+    the other way round) was the deadlock's other half."""
+    ch = _channel()
+    rear_edge = 40 * SECTION_DEG
+    for angle, half in ((rear_edge + 0.5 * SECTION_DEG, 30), (rear_edge + 2.5 * SECTION_DEG, 4), (30 * SECTION_DEG, 4)):
+        bbox = _bbox_centred_at_angle(angle, 120.0, half)
+        any_drop = attributeBboxes([bbox], ch)[0]
+        code = orderedPieceObservations([bbox], ch)[0][2]
+        assert any_drop == (code == 1), (angle, half, any_drop, code)

--- a/software/sorter/backend/vision/camera.py
+++ b/software/sorter/backend/vision/camera.py
@@ -235,6 +235,16 @@ def _usb_camera_control_specs() -> list[dict[str, Any]]:
             "step": 1.0,
             "help": "Manual focus distance, when supported by the driver.",
         },
+        {
+            "key": "zoom",
+            "label": "Zoom",
+            "kind": "number",
+            "prop": _cv_prop("CAP_PROP_ZOOM"),
+            "min": 0.0,
+            "max": 100.0,
+            "step": 1.0,
+            "help": "Digital zoom / field of view (0 = widest), when supported by the camera.",
+        },
     ]
     return [spec for spec in specs if spec["prop"] is not None]
 
@@ -281,6 +291,7 @@ _LINUX_V4L2CTL_CONTROL_MAP: dict[str, tuple[str, Any]] = {
     "exposure": ("exposure_time_absolute", lambda v: str(int(round(float(v))))),
     "white_balance_temperature": ("white_balance_temperature", lambda v: str(int(round(float(v))))),
     "focus": ("focus_absolute", lambda v: str(int(round(float(v))))),
+    "zoom": ("zoom_absolute", lambda v: str(int(round(float(v))))),
     "power_line_frequency": ("power_line_frequency", lambda v: str(int(round(float(v))))),
     "backlight_compensation": ("backlight_compensation", lambda v: str(int(round(float(v))))),
 }

--- a/software/sorter/frontend/src/lib/components/settings/PictureSettingsSidebar.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/PictureSettingsSidebar.svelte
@@ -187,6 +187,13 @@
 		return `${role}::${typeof source === 'string' ? source : source === null ? 'none' : source}`;
 	}
 
+	// While the operator's draft differs from what is saved, the live camera
+	// deliberately carries preview values; the drift check must not nag then.
+	const deviceDraftDirty = $derived(
+		JSON.stringify(draftUsbSettings) !== JSON.stringify(savedUsbSettings) ||
+			JSON.stringify(draftAndroidSettings) !== JSON.stringify(savedAndroidSettings)
+	);
+
 	let devicePreviewAbortController: AbortController | null = null;
 	let devicePreviewTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -1036,6 +1043,7 @@
 					<CaptureModePanel {role} />
 					<DriftDetection
 						{role}
+						paused={deviceDraftDirty}
 						onAction={() => {
 							void loadDeviceSettings();
 						}}

--- a/software/sorter/frontend/src/lib/components/settings/picture/DriftDetection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/picture/DriftDetection.svelte
@@ -25,10 +25,14 @@
 	let {
 		role,
 		pollMs = 10000,
+		paused = false,
 		onAction
 	}: {
 		role: CameraRole;
 		pollMs?: number;
+		// True while the operator is previewing unsaved values: the live camera is
+		// supposed to differ from the saved settings, so no check and no dialog.
+		paused?: boolean;
 		onAction?: (action: 'adopt' | 'restore') => void;
 	} = $props();
 
@@ -57,7 +61,7 @@
 	}
 
 	async function check(): Promise<void> {
-		if (applying || open) return;
+		if (applying || open || paused) return;
 		loading = true;
 		try {
 			const res = await fetch(

--- a/software/sorter/frontend/src/lib/components/settings/picture/DriftDetection.svelte
+++ b/software/sorter/frontend/src/lib/components/settings/picture/DriftDetection.svelte
@@ -71,6 +71,9 @@
 			if (!res.ok) return;
 			const data = (await res.json()) as DiffResponse;
 			if (!data.supported) return;
+			// The operator may have started previewing while the request was
+			// in flight: a dialog now would fight their unsaved values.
+			if (paused || applying) return;
 			diffs = data.diffs ?? [];
 			savedSnapshot = data.saved ?? {};
 			liveSnapshot = data.live ?? {};

--- a/software/sorter/frontend/src/routes/+page.svelte
+++ b/software/sorter/frontend/src/routes/+page.svelte
@@ -704,14 +704,14 @@
 					parsed.speed ?? parsed.microsteps_per_second,
 					EXIT_RELEASE_DEFAULTS.speed,
 					100,
-					16000
+					24000
 				),
 				acceleration: Math.round(
 					clampNumber(
 						parsed.acceleration ?? parsed.acceleration_microsteps_per_second_sq,
 						EXIT_RELEASE_DEFAULTS.acceleration,
 						1000,
-						48000
+						200000
 					)
 				),
 				cycles: Math.round(clampNumber(parsed.cycles, EXIT_RELEASE_DEFAULTS.cycles, 1, 20))
@@ -743,13 +743,13 @@
 	}
 
 	function setExitReleaseSpeed(value: number) {
-		exitReleaseSpeed = Math.round(clampNumber(value, EXIT_RELEASE_DEFAULTS.speed, 100, 16000));
+		exitReleaseSpeed = Math.round(clampNumber(value, EXIT_RELEASE_DEFAULTS.speed, 100, 24000));
 		writeExitReleaseTuning();
 	}
 
 	function setExitReleaseAcceleration(value: number) {
 		exitReleaseAcceleration = Math.round(
-			clampNumber(value, EXIT_RELEASE_DEFAULTS.acceleration, 1000, 48000)
+			clampNumber(value, EXIT_RELEASE_DEFAULTS.acceleration, 1000, 200000)
 		);
 		writeExitReleaseTuning();
 	}
@@ -1302,7 +1302,7 @@
 										id="exit-release-speed"
 										type="range"
 										min="100"
-										max="16000"
+										max="24000"
 										step="100"
 										value={exitReleaseSpeed}
 										oninput={(event) =>
@@ -1321,8 +1321,8 @@
 										id="exit-release-acceleration"
 										type="range"
 										min="1000"
-										max="48000"
-										step="500"
+										max="200000"
+										step="2000"
 										value={exitReleaseAcceleration}
 										oninput={(event) =>
 											setExitReleaseAcceleration(


### PR DESCRIPTION
## What this is

Third lane from `b1-belt-feeder`, stacked on #591. Small, independent fixes found during the September runs; none of them is belt-specific.

## Contents

- **incidents**: rows left active by a previous backend process are closed at startup instead of blocking the new run.
- **main**: the traceback of a main-loop exception is logged before shutdown.
- **hardware**: every stepper is stopped first at recovery start and at shutdown.
- **bus**: 250 ms read timeout on the MCU bus, so a silent board cannot hang the coordinator.
- **bins**: `/api/bins/move-to` closes the target layer's door like production does.
- **cameras**: zoom is an adjustable USB camera control; auto-exposure detection handles non-standard V4L2 menus (OBSBOT).
- **perception**: the region lookup table is keyed by zone sections, not by channel id; a piece overlapping the drop arc is a DROP piece for the handler.
- **c4**: the exit-release test parameters are range-checked in one shared validator (`exitReleaseTestParams`, up to 24000 µsteps/s and 200000 µsteps/s², the values the stall-clear ladder in #529 needs), used by both the review endpoint and the router.
- **ui**: no camera-drift dialog while the operator previews unsaved values.
- **tests**: `irl` is imported before `machine_platform` in the stepper safety test (import cycle).

## Origin

`d124d773 … 9fc547b0` on `b1-belt-feeder` (2026-09-04/05).

## Tests

Full backend suite: the same 20 pre-existing failures as on main (what #523 fixes), nothing new. `pnpm check`: no new errors.
