### PR TITLE
parts-calculator: fix the /changes page crash and close out #403

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -293,7 +293,9 @@
       "name": "Ribbon cable clamp does not seat flat on the cage bracket",
       "priority": "P1",
       "condition": "broken",
-      "description": "The clamp cannot close on the ribbon cable. The lip at its lower end is a hook meant to go over the bottom edge of the cage post, which is what stops the clamp rotating on its single M3, but in the published files the lip's ledge sits 1.43 mm above the post's underside, so it lands on the post's bottom edge instead of clearing it. The clamp is then held 3.80 mm off the post at that end and pivots on the screw, sitting crooked with the cable loose. The screw hole is 3.5 mm on an M3, 0.25 mm of adjustment, so it cannot be pushed down over the edge. The fix is to drop the lip about 1.5 mm, extend the post's outer skirt about 1.5 mm, or notch the post to take the lip; the two parts change together and it is not decided which way it goes. Until then, cut the notch in the post, or trim the lip flush and accept that the clamp can rotate. Reported from builds by barthel, zed0 and Jon, design intent from ChrisKiepfer; measured off the pinned ribbon-cable-clamp and cage bracket STLs. Tracked as sorter-v2 issue #403.",
+      "status": "complete",
+      "completed_at": "2026-09-07",
+      "description": "The clamp could not close on the ribbon cable: the lip at its lower end is a hook meant to go over the bottom edge of the cage post, but the post's underside sat 1.43 mm above where the lip could reach, so it landed on the post's bottom edge instead of clearing it and pivoted loose on its single M3. Fixed by raising both cage brackets' underside ~2 mm (interface-cage-bracket and interface-cage-bracket-cable, both v2), which was also the fix for a separate problem found along the way: every bracket's v1 was exported from a 25mm-tall Onshape branch ('temp catcher wall') that had diverged from the 23mm-tall 'main' branch the rest of the cage now uses. The lip now clears the post's underside by 0.57 mm. ribbon-cable-clamp itself is unchanged. Reported from builds by barthel, zed0 and Jon, design intent from ChrisKiepfer, root-caused and fixed with Spencer. Tracked as sorter-v2 issue #403, fixed in PR #589.",
       "images": [
         {
           "url": "https://assets.basically.website/sorter-parts/clamp-lip-section-full-bb73576e2065.png",
@@ -382,7 +384,7 @@
       "name": "Delete the unused M5 socket/button head length-TBD placeholder",
       "priority": "P4",
       "condition": "retired",
-      "description": "This placeholder is not used anywhere in the machine. It stood in for an unmeasured M5 joint: first the three electronics mounts that bolt to the frame, which resolved to real parts in PR #428, and after that the two screws fastening the Chute stepper support block. That block was removed from the machine on 2026-08-31 (sorter-v2#489, closing sorter-v2#483) once the NEMA 23 chute stepper mount was confirmed to work without it, so its two screws went with it, and the length was never measured so there is nothing to resolve it to. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #563, alongside #453, #454, #478 and #536 for the other four.",
+      "description": "This placeholder is not used anywhere in the machine. It stood in for an unmeasured M5 joint: first the three electronics mounts that bolt to the frame, which resolved to real parts (scr-m5-12-shcs and scr-m5-16-shcs) in PR #428, and after that the two screws fastening the Chute stepper support block. That block was removed from the machine on 2026-08-31 (sorter-v2#489, closing sorter-v2#483) once the NEMA 23 chute stepper mount was confirmed to work without it, so its two screws went with it, and the length was never measured so there is nothing to resolve it to. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #563, alongside #453, #454, #478 and #536 for the other four -- #565 duplicates #563 (both filed independently for this same screw); a human should close one.",
       "targets": {
         "hardware": [
           "scr-m5-shcs-tbd"
@@ -454,18 +456,6 @@
           "layer",
           "bottom-layer",
           "chute"
-        ]
-      }
-    },
-    {
-      "id": "delete-unused-m5-shcs-tbd-placeholder",
-      "name": "Delete the unused M5 socket/button head length-TBD placeholder",
-      "priority": "P4",
-      "condition": "retired",
-      "description": "This placeholder screw is not used anywhere in the machine. It stood in for an unmeasured M5 joint -- first the three electronics mounts that bolt to the frame (resolved to scr-m5-12-shcs and scr-m5-16-shcs in PR #428), then the two screws fastening the Chute stepper support block, which was removed from the machine on 2026-08-31 (sorter-v2#489, sorter-v2#483) once the NEMA 23 chute stepper mount was confirmed to work without it. Its length was never measured. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #565, and it belongs with #453 and #454.",
-      "targets": {
-        "hardware": [
-          "scr-m5-shcs-tbd"
         ]
       }
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -308,7 +308,9 @@
 			"name": "Ribbon cable clamp does not seat flat on the cage bracket",
 			"priority": "P1",
 			"condition": "broken",
-			"description": "The clamp cannot close on the ribbon cable. The lip at its lower end is a hook meant to go over the bottom edge of the cage post, which is what stops the clamp rotating on its single M3, but in the published files the lip's ledge sits 1.43 mm above the post's underside, so it lands on the post's bottom edge instead of clearing it. The clamp is then held 3.80 mm off the post at that end and pivots on the screw, sitting crooked with the cable loose. The screw hole is 3.5 mm on an M3, 0.25 mm of adjustment, so it cannot be pushed down over the edge. The fix is to drop the lip about 1.5 mm, extend the post's outer skirt about 1.5 mm, or notch the post to take the lip; the two parts change together and it is not decided which way it goes. Until then, cut the notch in the post, or trim the lip flush and accept that the clamp can rotate. Reported from builds by barthel, zed0 and Jon, design intent from ChrisKiepfer; measured off the pinned ribbon-cable-clamp and cage bracket STLs. Tracked as sorter-v2 issue #403.",
+			"status": "complete",
+			"completed_at": "2026-09-07",
+			"description": "The clamp could not close on the ribbon cable: the lip at its lower end is a hook meant to go over the bottom edge of the cage post, but the post's underside sat 1.43 mm above where the lip could reach, so it landed on the post's bottom edge instead of clearing it and pivoted loose on its single M3. Fixed by raising both cage brackets' underside ~2 mm (interface-cage-bracket and interface-cage-bracket-cable, both v2), which was also the fix for a separate problem found along the way: every bracket's v1 was exported from a 25mm-tall Onshape branch ('temp catcher wall') that had diverged from the 23mm-tall 'main' branch the rest of the cage now uses. The lip now clears the post's underside by 0.57 mm. ribbon-cable-clamp itself is unchanged. Reported from builds by barthel, zed0 and Jon, design intent from ChrisKiepfer, root-caused and fixed with Spencer. Tracked as sorter-v2 issue #403, fixed in PR #589.",
 			"images": [
 				{
 					"url": "https://assets.basically.website/sorter-parts/clamp-lip-section-full-bb73576e2065.png",
@@ -397,7 +399,7 @@
 			"name": "Delete the unused M5 socket/button head length-TBD placeholder",
 			"priority": "P4",
 			"condition": "retired",
-			"description": "This placeholder is not used anywhere in the machine. It stood in for an unmeasured M5 joint: first the three electronics mounts that bolt to the frame, which resolved to real parts in PR #428, and after that the two screws fastening the Chute stepper support block. That block was removed from the machine on 2026-08-31 (sorter-v2#489, closing sorter-v2#483) once the NEMA 23 chute stepper mount was confirmed to work without it, so its two screws went with it, and the length was never measured so there is nothing to resolve it to. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #563, alongside #453, #454, #478 and #536 for the other four.",
+			"description": "This placeholder is not used anywhere in the machine. It stood in for an unmeasured M5 joint: first the three electronics mounts that bolt to the frame, which resolved to real parts (scr-m5-12-shcs and scr-m5-16-shcs) in PR #428, and after that the two screws fastening the Chute stepper support block. That block was removed from the machine on 2026-08-31 (sorter-v2#489, closing sorter-v2#483) once the NEMA 23 chute stepper mount was confirmed to work without it, so its two screws went with it, and the length was never measured so there is nothing to resolve it to. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #563, alongside #453, #454, #478 and #536 for the other four -- #565 duplicates #563 (both filed independently for this same screw); a human should close one.",
 			"targets": {
 				"hardware": [
 					"scr-m5-shcs-tbd"
@@ -469,18 +471,6 @@
 					"layer",
 					"bottom-layer",
 					"chute"
-				]
-			}
-		},
-		{
-			"id": "delete-unused-m5-shcs-tbd-placeholder",
-			"name": "Delete the unused M5 socket/button head length-TBD placeholder",
-			"priority": "P4",
-			"condition": "retired",
-			"description": "This placeholder screw is not used anywhere in the machine. It stood in for an unmeasured M5 joint -- first the three electronics mounts that bolt to the frame (resolved to scr-m5-12-shcs and scr-m5-16-shcs in PR #428), then the two screws fastening the Chute stepper support block, which was removed from the machine on 2026-08-31 (sorter-v2#489, sorter-v2#483) once the NEMA 23 chute stepper mount was confirmed to work without it. Its length was never measured. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #565, and it belongs with #453 and #454.",
-			"targets": {
-				"hardware": [
-					"scr-m5-shcs-tbd"
 				]
 			}
 		},


### PR DESCRIPTION
Two fixes, found while getting #589 merged.

**The /changes page was blank on both main and #589's preview**, unrelated to the cable-cage work. The `changes` array carries two entries with the identical id `delete-unused-m5-shcs-tbd-placeholder` (independently filed as duplicate issues #563 and #565), and Svelte's keyed `{#each changes as change (change.id)}` throws on a duplicate key — client-side only, so a direct load renders blank and a client-side navigation to the page leaves the previous page on screen with the URL already updated, which is what it looked like in the thread. Confirmed reproducible on production (`parts-calculator.basically.website/changes`) before this fix, and confirmed gone in a local build after it. Merged the two entries into one, keeping the fuller description and cross-referencing both issues (a human should close the duplicate one).

**Marks `fix-ribbon-cable-clamp-standoffs` (#403) complete**, now that both cage brackets are v2 (#589).

Regenerated; `generate.py`'s own checks (`check_generated_pins`, `check_versioning`, `check_connections`) pass.

request: https://discord.com/channels/1430279849171222682/1541295543681294448/1546624624991936563