### PR TITLE
Default the Chute Jam incident to Off

### DIFF
--- a/software/sorter/backend/tests/test_dashboard_config.py
+++ b/software/sorter/backend/tests/test_dashboard_config.py
@@ -31,7 +31,7 @@ class DashboardConfigTests(unittest.TestCase):
         self.assertFalse(config["show_sample_capture"])
         self.assertEqual("automatic", config["incident_handling"]["exit_stuck"])
         self.assertEqual("automatic", config["incident_handling"]["feeder_jam"])
-        self.assertEqual("manual", config["incident_handling"]["distribution_chute_jam"])
+        self.assertEqual("off", config["incident_handling"]["distribution_chute_jam"])
         self.assertEqual("manual", config["incident_handling"]["distribution_servo_bus_offline"])
         self.assertEqual("manual", config["incident_handling"]["distribution_no_bin_available"])
         definition_kinds = [item["kind"] for item in config["incident_definitions"]]

--- a/software/sorter/backend/toml_config.py
+++ b/software/sorter/backend/toml_config.py
@@ -468,7 +468,10 @@ _INCIDENT_FEEDER_JAM = "feeder_jam"
 _INCIDENT_HANDLING_DEFAULTS: dict[str, str] = {
     _INCIDENT_EXIT_STUCK: _INCIDENT_MODE_AUTOMATIC,
     _INCIDENT_FEEDER_JAM: _INCIDENT_MODE_AUTOMATIC,
-    "distribution_chute_jam": _INCIDENT_MODE_MANUAL,
+    # Off by default: the chute-jam check is a move-budget timeout, and on
+    # deployed machines it has fired on stalls unrelated to the chute
+    # (#594). StallGuard still covers a real mechanical jam.
+    "distribution_chute_jam": _INCIDENT_MODE_OFF,
     "distribution_servo_bus_offline": _INCIDENT_MODE_MANUAL,
     "distribution_no_bin_available": _INCIDENT_MODE_MANUAL,
 }


### PR DESCRIPTION
The Chute Jam incident is the positioning state machine's move-budget timeout, not StallGuard. On a deployed machine it fired on a disk stall that happened before the chute moved (#594) and paused the sort on a jam that did not exist. A real mechanical jam is still caught by StallGuard, and operators can switch the incident to Manual in Incident Handling if they want the timeout.

- `toml_config.py`: `distribution_chute_jam` default `manual` → `off`
- `tests/test_dashboard_config.py`: updated the default assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)