### PR TITLE
Honor the Chute Jam Off policy for the banner and the pause

### DIFF
--- a/software/sorter/backend/subsystems/distribution/positioning.py
+++ b/software/sorter/backend/subsystems/distribution/positioning.py
@@ -78,6 +78,7 @@ class Positioning(BaseState):
         self._blocked_layers: set[int] = set()
         self._servo_offline_layers: set[int] = set()
         self._jam_pause_enqueued: bool = False
+        self._jam_ignored_logged: bool = False
         self._servo_bus_pause_enqueued: bool = False
         self._chute_move_estimated_ms: int = 0
 
@@ -633,8 +634,22 @@ class Positioning(BaseState):
     def _raiseChuteJamAlert(self, detail: str) -> None:
         """Hard alert: chute / servo can't physically move. Raises the red
         banner *and* enqueues a pause so the operator has to intervene.
+
+        Honors the Chute Jam incident policy: when it is Off, the condition
+        is logged once per move and otherwise ignored - no incident, no
+        banner, no pause - and positioning keeps waiting for the motion to
+        finish. The policy used to gate only the incident card, so a machine
+        set to Off still paused on a red banner.
         """
         elapsed_ms = int(max(0.0, time.monotonic() - self._moving_started_at) * 1000.0)
+        if _incidentHandlingOff(DISTRIBUTION_CHUTE_JAM_INCIDENT_KIND):
+            if not self._jam_ignored_logged:
+                self._jam_ignored_logged = True
+                self.logger.warning(
+                    f"{CHUTE_JAM_ALERT_PREFIX} check tripped ({detail}) but Chute Jam "
+                    "handling is Off - ignoring and waiting for the motion to finish"
+                )
+            return
         self._publishDistributionIncident(
             DISTRIBUTION_CHUTE_JAM_INCIDENT_KIND,
             detail=detail,
@@ -681,6 +696,7 @@ class Positioning(BaseState):
         except Exception:
             pass
         self._jam_pause_enqueued = False
+        self._jam_ignored_logged = False
         self._clearDistributionIncident(DISTRIBUTION_CHUTE_JAM_INCIDENT_KIND)
 
     def _clearBinsFullAlertIfOwned(self) -> None:

--- a/software/sorter/backend/tests/test_servo_bus_fatal.py
+++ b/software/sorter/backend/tests/test_servo_bus_fatal.py
@@ -19,7 +19,7 @@ import queue
 import time
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from defs.events import PauseCommandEvent
 from defs.known_object import KnownObject
@@ -315,15 +315,23 @@ class ServoBusFatalTests(unittest.TestCase):
         self.assertIsNone(self.runtime_stats.servo_bus_offline_since_ts)
         self.assertIsNone(self.runtime_stats.snapshot().get("active_incident"))
 
-    def test_chute_timeout_publishes_distribution_incident(self) -> None:
+    def _mk_timed_out_chute_move(self) -> Positioning:
         positioning = self._mk_positioning(servos=[_mk_healthy_servo()])
         positioning._phase = "moving"
         positioning._target_address = BinAddress(0, 0, 0)
         positioning._moving_started_at = time.monotonic() - 10.0
         positioning._chute_move_estimated_ms = 100
         positioning.chute.stepper.stopped = False
+        return positioning
 
-        positioning.step()
+    def test_chute_timeout_publishes_distribution_incident(self) -> None:
+        # The Chute Jam incident defaults to Off; this is the Manual path.
+        positioning = self._mk_timed_out_chute_move()
+
+        with patch(
+            "subsystems.distribution.positioning._incidentHandlingOff", return_value=False
+        ):
+            positioning.step()
 
         self.assertIsNotNone(shared_state.hardware_error)
         assert shared_state.hardware_error is not None
@@ -332,6 +340,26 @@ class ServoBusFatalTests(unittest.TestCase):
         self.assertIsNotNone(snap.get("active_incident"))
         self.assertEqual("distribution_chute_jam", snap["active_incident"]["kind"])
         self.assertGreaterEqual(snap["active_incident"]["elapsed_ms"], 10000)
+
+    def test_chute_timeout_is_ignored_when_incident_handling_is_off(self) -> None:
+        # Off means ignore the condition: no incident, no red banner, no pause.
+        # Positioning keeps waiting for the motion, logging the trip once.
+        positioning = self._mk_timed_out_chute_move()
+
+        with patch(
+            "subsystems.distribution.positioning._incidentHandlingOff", return_value=True
+        ):
+            self.assertIsNone(positioning.step())
+            self.assertIsNone(positioning.step())
+
+        self.assertIsNone(shared_state.hardware_error)
+        self.assertTrue(self.cmd_queue.empty())
+        self.assertIsNone(self.runtime_stats.snapshot().get("active_incident"))
+        warnings = [
+            m for level, m in positioning.logger.messages
+            if level == "warning" and "Chute Jam handling is Off" in m
+        ]
+        self.assertEqual(1, len(warnings))
 
 
 class MainBootServoHealthCheckTests(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #596. The Off policy only gated the incident card: the chute-jam timeout still set the red hardware-error banner and enqueued a pause, so a machine set to Off still stopped on it (#594), and the new Off default did nothing on its own.

When the policy is Off, the tripped check is logged once per move and positioning keeps waiting for the motion to finish: no incident, no banner, no pause. Manual and Auto are unchanged.

- `positioning.py`: early return in `_raiseChuteJamAlert` when handling is Off, with a once-per-move warning (flag reset alongside the existing jam-pause flag)
- `tests/test_servo_bus_fatal.py`: existing timeout test now pins the policy to Manual; new test covers Off (no banner, empty command queue, no incident, one warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)