### PR TITLE
hive: surface OpenRouter account errors to the user instead of a 502

### DIFF
--- a/software/hive/backend/app/routers/profiles.py
+++ b/software/hive/backend/app/routers/profiles.py
@@ -818,7 +818,7 @@ def create_profile_ai_message_stream(
                     sort_keys=True,
                 ),
             )
-            yield f"data: {json.dumps({'type': 'error', 'error': exc.error_message})}\n\n"
+            yield f"data: {json.dumps({'type': 'error', 'error': exc.error_message, 'code': exc.error_code})}\n\n"
         except Exception as exc:
             logger.exception(
                 "profile_ai.http_failed %s",
@@ -834,7 +834,7 @@ def create_profile_ai_message_stream(
                     sort_keys=True,
                 ),
             )
-            yield f"data: {json.dumps({'type': 'error', 'error': str(exc)})}\n\n"
+            yield f"data: {json.dumps({'type': 'error', 'error': str(exc), 'code': 'AI_ERROR'})}\n\n"
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 

--- a/software/hive/backend/app/services/openrouter.py
+++ b/software/hive/backend/app/services/openrouter.py
@@ -27,6 +27,42 @@ class OpenRouterResponse:
     generation_id: str | None = None
 
 
+# OpenRouter answers 401/402/403/429 about the caller's own account: the key
+# the user pasted into Settings is wrong, or its account has no credits, or it
+# is being throttled. Those used to come back as a 502 "OpenRouter request
+# failed: <upstream text>", which reads as a Hive outage and gets reported as
+# one (2026-09-07: a user retried a no-credits key fifteen times and filed it as
+# "I got a 502"). They are the user's to fix, so they get a 4xx, a stable code
+# the frontend can point at Settings for, and a message that says what to do.
+# Everything else really is upstream failing and stays a 502.
+def _apiErrorForOpenRouterStatus(status: int, upstream_message: str | None) -> APIError:
+    detail = f" (OpenRouter said: {upstream_message})" if upstream_message else ""
+    if status == 402:
+        return APIError(
+            402,
+            "Your OpenRouter account has no credits. Add credits at openrouter.ai, or switch to a key from a funded account in Settings."
+            + detail,
+            "OPENROUTER_NO_CREDITS",
+        )
+    if status in (401, 403):
+        return APIError(
+            400,
+            "OpenRouter rejected your API key. Check the key in Settings." + detail,
+            "OPENROUTER_KEY_REJECTED",
+        )
+    if status == 429:
+        return APIError(
+            429,
+            "OpenRouter is rate limiting your key. Wait a moment and try again." + detail,
+            "OPENROUTER_RATE_LIMITED",
+        )
+    return APIError(
+        502,
+        f"OpenRouter request failed: {upstream_message or f'HTTP {status}'}",
+        "OPENROUTER_HTTP_ERROR",
+    )
+
+
 def run_openrouter_chat(
     *,
     api_key: str,
@@ -84,11 +120,7 @@ def run_openrouter_chat(
                 message = error_obj.get("message")
             if not message:
                 message = error_payload.get("message")
-        raise APIError(
-            502,
-            f"OpenRouter request failed: {message or f'HTTP {exc.code}'}",
-            "OPENROUTER_HTTP_ERROR",
-        ) from exc
+        raise _apiErrorForOpenRouterStatus(exc.code, message) from exc
     except URLError as exc:
         raise APIError(502, "OpenRouter could not be reached", "OPENROUTER_NETWORK_ERROR") from exc
 

--- a/software/hive/backend/tests/test_openrouter_errors.py
+++ b/software/hive/backend/tests/test_openrouter_errors.py
@@ -1,0 +1,44 @@
+import io
+import json
+from urllib.error import HTTPError
+
+import pytest
+
+from app.errors import APIError
+from app.services import openrouter
+
+
+def _httpError(status: int, message: str | None) -> HTTPError:
+    body = json.dumps({"error": {"message": message}}).encode() if message else b"not json"
+    return HTTPError("https://openrouter.ai/api/v1/chat/completions", status, "err", {}, io.BytesIO(body))
+
+
+@pytest.mark.parametrize(
+    "upstream_status, expected_status, expected_code",
+    [
+        (402, 402, "OPENROUTER_NO_CREDITS"),
+        (401, 400, "OPENROUTER_KEY_REJECTED"),
+        (403, 400, "OPENROUTER_KEY_REJECTED"),
+        (429, 429, "OPENROUTER_RATE_LIMITED"),
+        (500, 502, "OPENROUTER_HTTP_ERROR"),
+        (503, 502, "OPENROUTER_HTTP_ERROR"),
+    ],
+)
+def test_account_problems_are_the_users_not_a_gateway_failure(monkeypatch, upstream_status, expected_status, expected_code):
+    def fake_urlopen(request, timeout):
+        raise _httpError(upstream_status, "Insufficient credits. This account never purchased credits.")
+
+    monkeypatch.setattr(openrouter, "urlopen", fake_urlopen)
+    with pytest.raises(APIError) as excinfo:
+        openrouter.run_openrouter_chat(api_key="k", model="m", messages=[{"role": "user", "content": "hi"}])
+    assert excinfo.value.status_code == expected_status
+    assert excinfo.value.error_code == expected_code
+    assert "Insufficient credits" in excinfo.value.error_message
+
+
+def test_no_credits_message_tells_the_user_what_to_do(monkeypatch):
+    monkeypatch.setattr(openrouter, "urlopen", lambda request, timeout: (_ for _ in ()).throw(_httpError(402, None)))
+    with pytest.raises(APIError) as excinfo:
+        openrouter.run_openrouter_chat(api_key="k", model="m", messages=[])
+    assert excinfo.value.error_message.startswith("Your OpenRouter account has no credits.")
+    assert "Settings" in excinfo.value.error_message

--- a/software/hive/frontend/src/lib/api.ts
+++ b/software/hive/frontend/src/lib/api.ts
@@ -2165,7 +2165,7 @@ export const api = {
 		if (!res.ok) {
 			let errorData;
 			try { errorData = await res.json(); } catch { errorData = { error: `HTTP ${res.status}` }; }
-			throw errorData;
+			throw { ...errorData, status: res.status };
 		}
 		const reader = res.body!.getReader();
 		const decoder = new TextDecoder();
@@ -2189,7 +2189,7 @@ export const api = {
 					if (event.type === 'complete' && event.message) {
 						finalMessage = event.message as SortingProfileAiMessage;
 					} else if (event.type === 'error') {
-						throw { error: event.error || 'AI request failed', code: 'AI_ERROR' };
+						throw { error: event.error || 'AI request failed', code: event.code || 'AI_ERROR' };
 					} else {
 						onEvent(event);
 					}

--- a/software/hive/frontend/src/lib/components/profile/edit/ProfileChatPanel.svelte
+++ b/software/hive/frontend/src/lib/components/profile/edit/ProfileChatPanel.svelte
@@ -40,6 +40,8 @@
 		aiMessage: string;
 		onAiMessageChange: (value: string) => void;
 		aiBusy: boolean;
+		aiError: string | null;
+		aiErrorCode: string | null;
 		isNewProfile: boolean;
 		workingRulesLength: number;
 		visibleAiProgressCards: AiProgressCard[];
@@ -74,6 +76,8 @@
 		aiMessage,
 		onAiMessageChange,
 		aiBusy,
+		aiError,
+		aiErrorCode,
 		isNewProfile,
 		workingRulesLength,
 		visibleAiProgressCards,
@@ -315,6 +319,14 @@
 							{/if}
 						</div>
 					{/each}
+					{#if aiError}
+						<div class="mr-8 border border-danger/40 bg-danger/[0.06] px-3 py-2.5 text-xs" role="alert">
+							<div class="font-medium text-danger">{aiError}</div>
+							{#if aiErrorCode?.startsWith('OPENROUTER_')}
+								<a href="/settings" class="mt-1 inline-block font-medium text-primary hover:text-primary-hover">Fix your OpenRouter key in Settings</a>
+							{/if}
+						</div>
+					{/if}
 					{#if aiBusy}
 						<div class="mr-8">
 							<div class="mb-2 space-y-2" aria-live="polite">

--- a/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
+++ b/software/hive/frontend/src/routes/profiles/[id]/edit/+page.svelte
@@ -849,11 +849,13 @@
 
 	// --- Save ---
 	let suggestingNote = $state(false);
+	let suggestNoteError = $state<string | null>(null);
 
 	async function openSavePopover() {
 		changeNote = '';
 		showSavePopover = true;
 		suggestingNote = false;
+		suggestNoteError = null;
 
 		if (!profile) return;
 		if (!hasOpenRouter) return;
@@ -868,8 +870,8 @@
 			if (showSavePopover && !changeNote) {
 				changeNote = result.change_note;
 			}
-		} catch (e) {
-			console.warn('[Hive] Failed to suggest change note:', e);
+		} catch (e: any) {
+			suggestNoteError = e?.error || 'Could not suggest a change note';
 		} finally {
 			suggestingNote = false;
 		}
@@ -966,6 +968,9 @@
 	}
 
 	// --- AI ---
+	let aiError = $state<string | null>(null);
+	let aiErrorCode = $state<string | null>(null);
+
 	async function sendAiMessage() {
 		if (!profile || !aiMessage.trim()) return;
 		const userMsg = aiMessage.trim();
@@ -990,7 +995,8 @@
 
 		aiBusy = true;
 		aiProgress = [{ type: 'thinking' }];
-		error = null;
+		aiError = null;
+		aiErrorCode = null;
 		try {
 			let response: SortingProfileAiMessage;
 			try {
@@ -1006,8 +1012,11 @@
 						aiProgress = [...aiProgress, event as typeof aiProgress[number]];
 					}
 				);
-			} catch {
-				// Fallback to non-streaming endpoint
+			} catch (e: any) {
+				// The fallback exists for a backend without the streaming route. Any
+				// other failure already cost a model call; making it again from the
+				// non-streaming route just doubles the bill and the wait.
+				if (e?.status !== 404) throw e;
 				aiProgress = [{ type: 'thinking' }];
 				response = await api.createSortingProfileAiMessage(profile.id, {
 					message: userMsg,
@@ -1032,7 +1041,8 @@
 				await loadProfile();
 			}
 		} catch (e: any) {
-			error = e.error || e.message || 'Request failed';
+			aiError = e.error || e.message || 'Request failed';
+			aiErrorCode = typeof e?.code === 'string' ? e.code : null;
 		} finally {
 			aiBusy = false;
 			aiProgress = [];
@@ -1158,6 +1168,9 @@
 							</div>
 						{/if}
 					</div>
+					{#if suggestNoteError}
+						<p class="mb-3 text-xs text-danger">{suggestNoteError}</p>
+					{/if}
 					<div class="flex justify-end gap-2">
 						<Button variant="secondary" size="sm" onclick={closeSavePopover}>Cancel</Button>
 						<Button size="sm" onclick={() => void saveVersion()} disabled={savingVersion} loading={savingVersion}>
@@ -1315,6 +1328,8 @@
 			{aiMessage}
 			onAiMessageChange={(value) => { aiMessage = value; }}
 			{aiBusy}
+			{aiError}
+			{aiErrorCode}
 			{isNewProfile}
 			workingRulesLength={workingRules.length}
 			{visibleAiProgressCards}


### PR DESCRIPTION
On prod today a user's profile AI chat failed fifteen times with a 502. The cause was their own OpenRouter key: the account has no credits. The backend wrapped OpenRouter's 402 in a 502 "OpenRouter request failed: …", so it looked like a Hive outage and was reported as one.

- OpenRouter 401/402/403/429 now map to a 4xx with a stable code (`OPENROUTER_NO_CREDITS`, `OPENROUTER_KEY_REJECTED`, `OPENROUTER_RATE_LIMITED`) and a message that tells the user what to do. Other upstream failures stay 502.
- The streaming error event carries the code.
- The profile editor shows AI failures inside the chat panel, with a "Fix your OpenRouter key in Settings" link for `OPENROUTER_*` codes.
- A stream that reached the model and failed is no longer retried through the non-streaming route. Only a 404 on the stream route falls back.
- A failed change-note suggestion shows in the save popover instead of being swallowed.

Tests: new `test_openrouter_errors.py` plus existing profile tests pass; `pnpm check` clean.

Not deploying with this merge. No `hive/v*` tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
