### PR TITLE
Take the output guide off C1 and C4, fix the camera clasp screw count, and clear eight stale changes entries

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -88,7 +88,7 @@ The numbers this page most needs, and none of them are written down anywhere tod
 
 {% include step.html n="4" title="Fit the output guides" %}
 
-One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) at each handover, C1 to C2 and C2 to C3.
+One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) on C2 and one on C3. Each belongs to the channel it is mounted on, not to the gap between two; C1 and the classification channel take none.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -51,7 +51,7 @@ The parts list above is **all four channels' worth** — the count is fixed for 
 {% include fastener-legend.html %}
 
 - **Build 4 per machine**, three in the feeder and one for the classification channel. It is the same build four times over, and the rotor is the only thing that changes.
-- **One rotor per unit, and only one of the two.** The three feeder channels take the Rotor (faceted); the classification channel takes the Rotor (finned), the one with the fins in the photographs below. The list above already splits them the way a real machine needs them: three faceted, one finned. Colour does not change with the rotor: both print ash grey, as do the stator and the output guide, on all four channels.
+- **One rotor per unit, and only one of the two.** The three feeder channels take the Rotor (faceted); the classification channel takes the Rotor (finned), the one with the fins in the photographs below. The list above already splits them the way a real machine needs them: three faceted, one finned. Colour does not change with the rotor: both print ash grey on all four channels, as do the stator and the output guide.
 - Every channel also carries a [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), whose parts and screws belong to that page rather than to the list above.
 - **The charcoal parts are the gear train and one bracket.** The output, idler and input gears follow the feeder colour, which is charcoal by default and yours to change on the [parts calculator](https://parts-calculator.basically.website/assembly?focus=c-channel). Of the four NEMA brackets, C1's is charcoal and C2 to C4's are ash grey.
 

--- a/docs/src/content/hardware/assembly/feeder/index.md
+++ b/docs/src/content/hardware/assembly/feeder/index.md
@@ -16,7 +16,7 @@ The feeder takes unsorted parts from the bulk input and, through four C-channel 
 2. **[Camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }})**, the arm, light and camera over a channel. One per channel.
 3. **[Classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }})**, where parts are imaged for classification.
 4. **[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }})**, the bucket and cap that feed C1.
-5. **[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }})**, the handovers between channels.
+5. **[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }})**, the walls on C2 and C3 that push parts off the channel.
 6. **[Arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }})**, the stand, the heights, and how the four sit together.
 
 Everything after the C-channel page is an AI-generated first draft: the parts are recorded, the steps and the photographs are not. Each page says at the top what is missing from it.

--- a/docs/src/content/hardware/assembly/feeder/output-guides.md
+++ b/docs/src/content/hardware/assembly/feeder/output-guides.md
@@ -5,15 +5,15 @@ type: how-to
 section: hardware
 slug: assembly-output-guides
 kicker: Feeder — Output guides
-lede: The printed guides that carry parts from one C-channel to the next.
+lede: The printed guide on a channel's exit that stops parts riding round instead of dropping off.
 permalink: /hardware/assembly/feeder/output-guides/
 author: barthel
 warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly), not from an actual build.
-  The Output guide is in the parts catalog with a quantity and a colour and nothing else: it is
-  in no assembly there, and where it mounts is not recorded anywhere. This page exists to be
-  filled in, not to be followed.
+  The tree records which channels take a guide and that it is held by friction, but not where on
+  the channel it sits, at what angle, or how far it projects. This page exists to be filled in,
+  not to be followed.
 parts_needed:
   - part: output-guide
     qty: 2
@@ -21,7 +21,7 @@ parts_needed:
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Build and <a href="{{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}">arrange the C-channels</a> before you start.</strong> It's a required stage before this page, not optional or covered here — the guide only goes in once the channels either side of it are standing at their final heights.</p>
+    <p><strong>Build and <a href="{{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}">arrange the C-channels</a> before you start.</strong> It's a required stage before this page, not optional or covered here — a guide only goes in once its channel and the one below it are standing at their final heights.</p>
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
@@ -29,9 +29,9 @@ parts_needed:
   </figure>
 </div>
 
-An output guide bridges the gap where one C-channel hands parts to the next, so a part leaving a rotor lands on the following channel instead of on the floor.
+An output guide sits on one channel's exit and stops a part riding round past it. Without one a piece that does not drop off at the exit carries on round the rotor instead, so the guide is a wall that forces it off.
 
-Two per machine. Which channels they sit between is not recorded: three feeder channels give two handovers, C1 to C2 and C2 to C3 (see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for what these names mean), so two guides is consistent with one per handover, but that is inference from the count rather than a documented fact.
+**Two per machine, on C-channels 2 and 3** (see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for what these names mean). A guide belongs to the channel it is mounted on rather than to the gap between two, so the count is not one per handover: C1 takes none because its bulk cap has a guide built into it, and the classification channel takes none because the finned rotor's fins sweep through where one would sit.
 
 {% include fastener-legend.html %}
 
@@ -46,11 +46,11 @@ Two per machine. Which channels they sit between is not recorded: three feeder c
   </figure>
 </div>
 
-{% include step.html n="2" title="Fit a guide at each handover" %}
+{% include step.html n="2" title="Fit a guide on C2 and C3" %}
 
-The guide goes in once the two channels either side of it are at their final heights.
+The guide pushes onto the C-channel drive and is held by the fit alone: no screws, no inserts, nothing to tighten. Fit it once its channel is at its final height.
 
-**Not recorded:** what the guide fastens to, with what, and at what angle. <span class="fastener-todo">fastener not recorded</span>
+**Not recorded:** where on the drive it seats, at what angle, and how far it projects over the exit.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -216,17 +216,6 @@
       }
     },
     {
-      "id": "secure-classification-chamber-rotation",
-      "name": "Keep the classification chamber aligned",
-      "priority": "P4",
-      "description": "The classification chamber can rotate out of place too easily. Even passing pieces can push it out of alignment, which shifts the camera detection zones. A more secure rotational lock would be a useful improvement.",
-      "targets": {
-        "parts": [
-          "classification-dome"
-        ]
-      }
-    },
-    {
       "id": "retain-interface-spacer",
       "name": "Keep the interface spacer in its slot",
       "priority": "P4",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6320,10 +6320,36 @@
         },
         {
           "version": "3",
+          "uid": "5tvh",
           "date": "2026-09-02",
           "message": "Renamed from Classification chamber and consolidated with the other channels: the dome and the Camera & LED insert give way to the Camera lamp with the IMX415 4K camera, and it gains the output guide. Same drive, same finned rotor.",
           "breaking": false,
-          "commit": "e22fce30"
+          "commit": "e22fce30",
+          "lines": [
+            {
+              "assembly": "c-channel",
+              "qty": 1,
+              "uid": "4tvc"
+            },
+            {
+              "assembly": "rotor-unit-finned",
+              "qty": 1,
+              "uid": "7ol7"
+            },
+            {
+              "part": "output-guide",
+              "qty": 1,
+              "uid": "z9yd"
+            },
+            {
+              "assembly": "camera-lamp",
+              "qty": 1,
+              "args": {
+                "camera": "cam-imx415"
+              },
+              "uid": "u4si"
+            }
+          ]
         },
         {
           "version": "4",
@@ -7420,10 +7446,43 @@
         },
         {
           "version": "3",
+          "uid": "jnwt",
           "date": "2026-09-02",
           "message": "The prototype supports give way to the new support structure: the shared layout guide and dovetail adapters with this channel's own legs. An old assembled channel stands on the old feet and does not fit the new layout.",
           "breaking": true,
-          "commit": "3bbea57f"
+          "commit": "3bbea57f",
+          "lines": [
+            {
+              "assembly": "channel-one-support-structure",
+              "qty": 1,
+              "uid": "z6fs"
+            },
+            {
+              "assembly": "c-channel",
+              "qty": 1,
+              "uid": "4tvc"
+            },
+            {
+              "assembly": "rotor-unit-faceted",
+              "qty": 1,
+              "uid": "ylvv"
+            },
+            {
+              "part": "output-guide",
+              "qty": 1,
+              "uid": "z9yd"
+            },
+            {
+              "assembly": "camera-lamp",
+              "qty": 1,
+              "uid": "u4si"
+            },
+            {
+              "part": "bulk-cap",
+              "qty": 1,
+              "uid": "737f"
+            }
+          ]
         },
         {
           "version": "4",
@@ -10092,6 +10151,32 @@
         }
       },
       "versions": [
+        {
+          "version": "1",
+          "uid": "pdmk",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "part": "camera-clasp-bottom",
+              "qty": 1,
+              "uid": "zub8"
+            },
+            {
+              "param": "camera",
+              "qty": 1
+            },
+            {
+              "part": "camera-clasp-top",
+              "qty": 1,
+              "uid": "u816"
+            },
+            {
+              "part": "scr-m3-8-cs",
+              "qty": 4,
+              "uid": "l6br"
+            }
+          ]
+        },
         {
           "version": "2",
           "date": "2026-09-08",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -399,21 +399,6 @@
       }
     },
     {
-      "id": "camera-clasp-screw-count",
-      "name": "Adapted camera module: the clasp takes 2 screws, not 4",
-      "priority": "P3",
-      "description": "The Adapted camera module lists 4x M3 x 8 countersunk and marks the count as not confirmed at the bench. The published STLs have only two screw positions: the Camera clasp bottom has two 3.50 mm clearance holes with a countersink on its underside, the Camera clasp top has the two matching 2.80 mm self-tapping pilots 5.00 mm deep, and the pair sits on the diagonal 43.2 mm apart. There is no third or fourth hole in either half. Changing the line is an assembly revision and has to be stamped as a new version, so the count is left as authored until somebody does that with a build in front of them. Note also that an M3 x 8 countersunk only reaches about 2 mm into the top half through the 6 mm bottom half, so the length is worth checking at the same time. Measured 2026-09-05 while writing the camera lamp assembly docs page.",
-      "targets": {
-        "assemblies": [
-          "adapted-camera-module"
-        ],
-        "parts": [
-          "camera-clasp-top",
-          "camera-clasp-bottom"
-        ]
-      }
-    },
-    {
       "id": "merge-bearing-holders",
       "name": "Merge the two chute bearing holders into one part",
       "priority": "P1",
@@ -10096,8 +10081,8 @@
     },
     {
       "id": "adapted-camera-module",
-      "uid": "pdmk",
-      "version": "1",
+      "uid": "vfct",
+      "version": "2",
       "name": "Adapted camera module",
       "description": "A camera board clasped between the printed top and bottom halves, ready to snap into the Camera lamp arm.",
       "params": {
@@ -10106,6 +10091,15 @@
           "note": "Which camera board the clasp holds: the OV9732 on C-channels 1-3, the IMX415 4K on C-channel 4."
         }
       },
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-09-08",
+          "message": "Two M3 x 8 countersunk, not four. The published clasp STLs have only two screw positions: two 3.50 mm clearance holes in the bottom half and the two matching 2.80 mm pilots 5.00 mm deep in the top, on the diagonal 43.2 mm apart. There is no third or fourth hole in either half. The length is still worth a look at the bench: an M3 x 8 reaches about 2 mm into the top half through the 6 mm bottom half.",
+          "breaking": false,
+          "commit": null
+        }
+      ],
       "lines": [
         {
           "part": "camera-clasp-bottom",
@@ -10121,7 +10115,7 @@
         },
         {
           "part": "scr-m3-8-cs",
-          "qty": 4
+          "qty": 2
         }
       ],
       "connections": [
@@ -10129,10 +10123,10 @@
           "from": "camera-clasp-top",
           "to": "camera-clasp-bottom",
           "via": "scr-m3-8-cs",
-          "qty": 4,
+          "qty": 2,
           "method": "self-tap",
           "draft": true,
-          "note": "Clasp the camera board between the halves; the screw count is not yet confirmed at the bench."
+          "note": "Clasp the camera board between the halves. Two positions, on the diagonal 43.2 mm apart: 3.50 mm clearance holes countersunk on the bottom half's underside, 2.80 mm self-tapping pilots 5.00 mm deep in the top half. Measured off the published STLs, not yet confirmed at the bench."
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -55,7 +55,9 @@
       "name": "The output guide and the C4 finned rotor cannot both be fitted",
       "priority": "P0",
       "condition": "broken",
-      "description": "C-channel 4 carries both the finned rotor unit and the Short and Angled Output Guide, and the two occupy the same space. The guide's inner face sits at r 67.82 mm; the finned rotor's body at that height is r 64.6, so the body clears it by about 3 mm, but the rotor's five fins reach out to r 85.4 and sweep through the guide. Rotated against the guide at 5 degree steps through a full turn, the finned rotor interferes at 24 of 72 positions, up to 0.504 cm3, in the region r 69.3 to 96.6 mm, azimuth -56.6 to -51.2 deg, z 2.5 to 27.4 mm; the fin sweep is up to 21.2 mm past the guide's inner face over the band z 8 to 29. The faceted rotor used on C1 to C3 interferes at none of the 72 positions and clears the guide by 1.5 to 1.8 mm along its whole height, which is the clearance the guide is dimensioned to. This is not the clocking error in output-guide-clocking: a rotor covers every azimuth, so no rotation of the guide changes it. C4 had no guide in the tree until e22fce30 (#534, 2026-09-02) consolidated all four channels onto one shape. Which way it is fixed, a C4-specific guide, shorter fins, or no guide on C4, is a CAD decision. Reported by Extremetaz. Tracked as sorter-v2 issue #543.",
+      "status": "complete",
+      "completed_at": "2026-09-08",
+      "description": "C-channel 4 carried both the finned rotor unit and the Short and Angled Output Guide, and the two occupy the same space. The guide's inner face sits at r 67.82 mm; the finned rotor's five fins reach out to r 85.4 and sweep up to 21.2 mm past that face over the band z 8 to 29, striking the guide at 24 of 72 rotations. The faceted rotor used on C1 to C3 clears the same guide by 1.5 to 1.8 mm along its whole height, which is the clearance the guide is dimensioned to. Resolved by taking the guide off C-channel 4: it had none until e22fce30 (#534, 2026-09-02) consolidated all four channels onto one shape. Reported from a build by Extremetaz.",
       "images": [
         {
           "url": "https://assets.basically.website/sorter-parts/c4-guide-finned-rotor-full-5c7e8f36a2e3.png",
@@ -69,39 +71,6 @@
           "rotor-finned"
         ],
         "assemblies": [
-          "classification-chamber"
-        ]
-      }
-    },
-    {
-      "id": "output-guide-clocking",
-      "name": "The output guide is clocked wrong and overlaps the stator on every channel",
-      "priority": "P0",
-      "condition": "broken",
-      "description": "The Short and Angled Output Guide, as pinned, overlaps the stator it mounts to by 3.014 cm3 (r 102.99 to 119.99 mm, azimuth -45.05 to -40.00 deg, over the full height z -19 to 50). That is on all four channels, because one guide STL serves all of them. The stator's exit opening is 45.0 deg at the wall (az -90.1 to -45.1) and 42.0 deg at the base flange; the guide is 23.3 deg wide and sits at -63.3 to -40.0, hard against one end of the opening and lapping past it. Rotating the guide -5.1 to -18.3 deg clears the stator, but that does not settle it: the stator's base flange indexes on a 25.714 deg notch grid (14 positions, notch width 4.8 to 5.0 mm of arc), the guide's base lobe pair sits at -43.5 deg which is not on that grid, and the nearest grid position inside the opening (-64.2) needs -20.7 deg, 2.4 deg outside the clear window. So the exported clocking is not the assembled clocking and where the guide is meant to index has to come from the CAD. Reported by ReveryX. Tracked as sorter-v2 issue #541. On C1 the guide additionally overlaps the Bulk cap by 0.315 cm3 at r 113.45 to 116.78, z 40 to 50, which is how this was spotted, and that half is not a clocking error: the cap has the original straight output guide built into it. 39.7 cm3 of that older guide's 54.13 cm3 lies inside the cap's solid, and sampling the cap at fixed radii through a full turn finds material only in a band at azimuth -96 to -74 deg, reaching inward from r 103 at the base to r 51 at z 25 and r 15 at z 45. A bucket floor would be present at every azimuth; this is a wall at one azimuth that leans in as it rises, standing in the stator's exit opening. So C1 does not want a separate guide at all, and no rotation of one would help. Spencer filed that as sorter-v2 issue #580, remove the output guide from the bulk bucket; the C1 assembly line is not changed here.",
-      "images": [
-        {
-          "url": "https://assets.basically.website/sorter-parts/c1-output-guide-clear-window-full-b764d42da838.png",
-          "alt": "Two top-down sections. At z = 45 mm the stator wall, the bulk cap's two concentric walls, the guide as exported overlapping both, and the guide rotated -11.7 degrees clear of them. At z = -12 mm the stator's base flange with its ring of index notches, and the guide's base lobes buried in solid flange.",
-          "caption": "Sections at z = 45 and z = -12. The guide as exported (yellow) against the clear position (green)."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/c1-bulk-cap-output-guide-clash-full-4bda026498a4.png",
-          "alt": "Top-down section at z = 45 mm showing the bulk cap's two concentric walls, the stator ring between them, the output guide lying in the cap's relief cut, and the interference at the guide's outer end marked in red",
-          "caption": "The bulk cap overlap on C1 alone, section at z = 45 mm."
-        }
-      ],
-      "targets": {
-        "parts": [
-          "output-guide",
-          "stator",
-          "bulk-cap"
-        ],
-        "assemblies": [
-          "bulk-bucket",
-          "c-channel",
-          "channel-two",
-          "channel-three",
           "classification-chamber"
         ]
       }
@@ -132,33 +101,6 @@
       "targets": {
         "parts": [
           "output-guide"
-        ]
-      }
-    },
-    {
-      "id": "improve-camera-extension",
-      "name": "Make the camera extension official",
-      "priority": "P2",
-      "description": "The camera extension was a prototype and needs to be made official. The finished design should also force the camera into the correct orientation.",
-      "targets": {
-        "parts": [
-          "camera-led-insert",
-          "camera-extension",
-          "camera-extension-mount"
-        ],
-        "assemblies": [
-          "camera-extension-assembly"
-        ]
-      }
-    },
-    {
-      "id": "retain-camera-led-strips",
-      "name": "Mechanically retain the camera LED strips",
-      "priority": "P2",
-      "description": "Update the Camera & LED insert so the LED strips are mechanically retained instead of depending on their adhesive. Integrated clips would be a good approach.",
-      "targets": {
-        "parts": [
-          "camera-led-insert"
         ]
       }
     },
@@ -242,17 +184,6 @@
       }
     },
     {
-      "id": "lock-overhead-camera-mount",
-      "name": "Lock the overhead camera mount",
-      "priority": "P3",
-      "description": "It would be ideal to lock the overhead camera mount in place completely.",
-      "targets": {
-        "assemblies": [
-          "camera-mount"
-        ]
-      }
-    },
-    {
       "id": "upgrade-interface-lazy-susan-fasteners",
       "name": "Update interface lazy-Susan fasteners to M5",
       "priority": "P3",
@@ -311,7 +242,9 @@
       "name": "Output gear to rotor screw does not reach the rotor",
       "priority": "P0",
       "condition": "broken",
-      "description": "The six screws holding the Output gear (130T) to the rotor were specified as M3 x 8 mm countersunk. The gear is 8.00 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 x 8 seated flush in the countersink ends level with the gear's top face and takes no thread in the rotor at all. Fit M3 x 12 mm countersunk for now: 4.0 mm of thread in the rotor's 5.0 mm flange, 1 mm short of breaking through the far side. Whether the joint settles as a 12 mm screw or the gear boss changes is still to be decided, so treat the length as provisional. Reported from a build by aleph1111/christoph and scres; measured off the pinned output-gear and rotor STLs.",
+      "status": "complete",
+      "completed_at": "2026-09-01",
+      "description": "The six screws holding the Output gear (130T) to the rotor were specified as M3 x 8 mm countersunk. The gear is 8.00 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 x 8 seated flush in the countersink ends level with the gear's top face and takes no thread in the rotor at all. Fit M3 x 12 mm countersunk for now: 4.0 mm of thread in the rotor's 5.0 mm flange, 1 mm short of breaking through the far side. Whether the joint settles as a 12 mm screw or the gear boss changes is still to be decided, so treat the length as provisional. Reported from a build by aleph1111/christoph and scres; measured off the pinned output-gear and rotor STLs. Fixed: both rotor units call for M3 x 12 mm countersunk, with the reason recorded on the joint (441d9114, #515, 2026-09-01), and the docs page was corrected in #378.",
       "targets": {
         "parts": [
           "output-gear",
@@ -1971,14 +1904,13 @@
       "id": "output-guide",
       "uid": "z9yd",
       "name": "Short and Angled Output Guide",
-      "description": "Output guide. 4 needed, one per C-channel. Ash grey.",
-      "internal_notes": "Plain 'Output Guide.stl'. 4 total, one per C-channel. Fixed ash grey since the C-channel overhaul (2026-09-02); it was 2 on the feeder colour role (black) before that.",
+      "description": "Output guide. 2 needed, one each on C-channels 2 and 3. Ash grey.",
+      "internal_notes": "Plain 'Output Guide.stl'. 2 total, one each on C2 and C3. Fixed ash grey since the C-channel overhaul (2026-09-02); it was 2 on the feeder colour role (black) before that. e22fce30 (#534) briefly put one on all four channels; C1 and C4 gave theirs back on 2026-09-08 (the Bulk cap has a guide moulded in, and the finned rotor sweeps through one).",
       "version": "2",
       "created_at": "2026-06-27",
       "updated_at": "2026-06-27",
       "quantities": {
-        "feeder": 3,
-        "classification-channel": 1
+        "feeder": 2
       },
       "assembly": null,
       "stl_hash": "d53a04f1715d87ac5d8eb7e583099898c4177bc90887ec032885db1bf0f7ed8f",
@@ -6359,10 +6291,10 @@
     },
     {
       "id": "classification-chamber",
-      "uid": "5tvh",
-      "version": "3",
+      "uid": "qzw4",
+      "version": "4",
       "name": "C-channel 4 - Classification",
-      "description": "The lowest channel, where classification happens: a C-channel drive with the finned rotor, the Short and Angled Output Guide, and a Camera lamp carrying the IMX415 4K camera.",
+      "description": "The lowest channel, where classification happens: a C-channel drive with the finned rotor and a Camera lamp carrying the IMX415 4K camera. No output guide: the rotor's fins sweep through where one would sit.",
       "docs": "/hardware/assembly/feeder/classification-chamber/",
       "versions": [
         {
@@ -6407,6 +6339,13 @@
           "message": "Renamed from Classification chamber and consolidated with the other channels: the dome and the Camera & LED insert give way to the Camera lamp with the IMX415 4K camera, and it gains the output guide. Same drive, same finned rotor.",
           "breaking": false,
           "commit": "e22fce30"
+        },
+        {
+          "version": "4",
+          "date": "2026-09-08",
+          "message": "The Short and Angled Output Guide comes off C4. The finned rotor's five fins reach r 85.4 mm and sweep up to 21.2 mm past the guide's inner face at r 67.82, so the two cannot both be fitted; the faceted rotor on C1 to C3 clears the same guide by 1.5 to 1.8 mm. This restores the state before e22fce30 (#534), which gave C4 a guide when all four channels were consolidated onto one shape. Reported from a build by Extremetaz. sorter-v2 issue #543.",
+          "breaking": false,
+          "commit": null
         }
       ],
       "lines": [
@@ -6419,10 +6358,6 @@
           "qty": 1
         },
         {
-          "part": "output-guide",
-          "qty": 1
-        },
-        {
           "assembly": "camera-lamp",
           "qty": 1,
           "args": {
@@ -6430,15 +6365,7 @@
           }
         }
       ],
-      "connections": [
-        {
-          "from": "output-guide",
-          "to": "c-channel",
-          "qty": 1,
-          "method": "friction",
-          "note": "The guide pushes onto the C-channel drive and is held by the fit alone."
-        }
-      ]
+      "connections": []
     },
     {
       "id": "chute-bearing",
@@ -7403,10 +7330,10 @@
     },
     {
       "id": "bulk-bucket",
-      "uid": "jnwt",
-      "version": "3",
+      "uid": "imbu",
+      "version": "4",
       "name": "C-channel 1 - Bulk bucket",
-      "description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor, the Short and Angled Output Guide, a Camera lamp, and the Bulk cap, standing on the tallest supports.",
+      "description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor, a Camera lamp, and the Bulk cap, standing on the tallest supports. No output guide: the Bulk cap has one built into it.",
       "lines": [
         {
           "assembly": "channel-one-support-structure",
@@ -7421,10 +7348,6 @@
           "qty": 1
         },
         {
-          "part": "output-guide",
-          "qty": 1
-        },
-        {
           "assembly": "camera-lamp",
           "qty": 1
         },
@@ -7434,13 +7357,6 @@
         }
       ],
       "connections": [
-        {
-          "from": "output-guide",
-          "to": "c-channel",
-          "qty": 1,
-          "method": "friction",
-          "note": "The guide pushes onto the C-channel drive and is held by the fit alone."
-        },
         {
           "from": "channel-one-support-structure",
           "to": "c-channel",
@@ -7523,6 +7439,13 @@
           "message": "The prototype supports give way to the new support structure: the shared layout guide and dovetail adapters with this channel's own legs. An old assembled channel stands on the old feet and does not fit the new layout.",
           "breaking": true,
           "commit": "3bbea57f"
+        },
+        {
+          "version": "4",
+          "date": "2026-09-08",
+          "message": "The Short and Angled Output Guide comes off C1. The Bulk cap has the original straight output guide built into it, so a separate guide has nowhere to sit and fouls the cap; 39.7 cm3 of the old guide's 54.13 cm3 lies inside the cap's solid. This restores the state before e22fce30 (#534), which gave C1 a guide when all four channels were consolidated onto one shape. sorter-v2 issue #580.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -231,17 +231,6 @@
 			}
 		},
 		{
-			"id": "secure-classification-chamber-rotation",
-			"name": "Keep the classification chamber aligned",
-			"priority": "P4",
-			"description": "The classification chamber can rotate out of place too easily. Even passing pieces can push it out of alignment, which shifts the camera detection zones. A more secure rotational lock would be a useful improvement.",
-			"targets": {
-				"parts": [
-					"classification-dome"
-				]
-			}
-		},
-		{
 			"id": "retain-interface-spacer",
 			"name": "Keep the interface spacer in its slot",
 			"priority": "P4",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -70,7 +70,9 @@
 			"name": "The output guide and the C4 finned rotor cannot both be fitted",
 			"priority": "P0",
 			"condition": "broken",
-			"description": "C-channel 4 carries both the finned rotor unit and the Short and Angled Output Guide, and the two occupy the same space. The guide's inner face sits at r 67.82 mm; the finned rotor's body at that height is r 64.6, so the body clears it by about 3 mm, but the rotor's five fins reach out to r 85.4 and sweep through the guide. Rotated against the guide at 5 degree steps through a full turn, the finned rotor interferes at 24 of 72 positions, up to 0.504 cm3, in the region r 69.3 to 96.6 mm, azimuth -56.6 to -51.2 deg, z 2.5 to 27.4 mm; the fin sweep is up to 21.2 mm past the guide's inner face over the band z 8 to 29. The faceted rotor used on C1 to C3 interferes at none of the 72 positions and clears the guide by 1.5 to 1.8 mm along its whole height, which is the clearance the guide is dimensioned to. This is not the clocking error in output-guide-clocking: a rotor covers every azimuth, so no rotation of the guide changes it. C4 had no guide in the tree until e22fce30 (#534, 2026-09-02) consolidated all four channels onto one shape. Which way it is fixed, a C4-specific guide, shorter fins, or no guide on C4, is a CAD decision. Reported by Extremetaz. Tracked as sorter-v2 issue #543.",
+			"status": "complete",
+			"completed_at": "2026-09-08",
+			"description": "C-channel 4 carried both the finned rotor unit and the Short and Angled Output Guide, and the two occupy the same space. The guide's inner face sits at r 67.82 mm; the finned rotor's five fins reach out to r 85.4 and sweep up to 21.2 mm past that face over the band z 8 to 29, striking the guide at 24 of 72 rotations. The faceted rotor used on C1 to C3 clears the same guide by 1.5 to 1.8 mm along its whole height, which is the clearance the guide is dimensioned to. Resolved by taking the guide off C-channel 4: it had none until e22fce30 (#534, 2026-09-02) consolidated all four channels onto one shape. Reported from a build by Extremetaz.",
 			"images": [
 				{
 					"url": "https://assets.basically.website/sorter-parts/c4-guide-finned-rotor-full-5c7e8f36a2e3.png",
@@ -84,39 +86,6 @@
 					"rotor-finned"
 				],
 				"assemblies": [
-					"classification-chamber"
-				]
-			}
-		},
-		{
-			"id": "output-guide-clocking",
-			"name": "The output guide is clocked wrong and overlaps the stator on every channel",
-			"priority": "P0",
-			"condition": "broken",
-			"description": "The Short and Angled Output Guide, as pinned, overlaps the stator it mounts to by 3.014 cm3 (r 102.99 to 119.99 mm, azimuth -45.05 to -40.00 deg, over the full height z -19 to 50). That is on all four channels, because one guide STL serves all of them. The stator's exit opening is 45.0 deg at the wall (az -90.1 to -45.1) and 42.0 deg at the base flange; the guide is 23.3 deg wide and sits at -63.3 to -40.0, hard against one end of the opening and lapping past it. Rotating the guide -5.1 to -18.3 deg clears the stator, but that does not settle it: the stator's base flange indexes on a 25.714 deg notch grid (14 positions, notch width 4.8 to 5.0 mm of arc), the guide's base lobe pair sits at -43.5 deg which is not on that grid, and the nearest grid position inside the opening (-64.2) needs -20.7 deg, 2.4 deg outside the clear window. So the exported clocking is not the assembled clocking and where the guide is meant to index has to come from the CAD. Reported by ReveryX. Tracked as sorter-v2 issue #541. On C1 the guide additionally overlaps the Bulk cap by 0.315 cm3 at r 113.45 to 116.78, z 40 to 50, which is how this was spotted, and that half is not a clocking error: the cap has the original straight output guide built into it. 39.7 cm3 of that older guide's 54.13 cm3 lies inside the cap's solid, and sampling the cap at fixed radii through a full turn finds material only in a band at azimuth -96 to -74 deg, reaching inward from r 103 at the base to r 51 at z 25 and r 15 at z 45. A bucket floor would be present at every azimuth; this is a wall at one azimuth that leans in as it rises, standing in the stator's exit opening. So C1 does not want a separate guide at all, and no rotation of one would help. Spencer filed that as sorter-v2 issue #580, remove the output guide from the bulk bucket; the C1 assembly line is not changed here.",
-			"images": [
-				{
-					"url": "https://assets.basically.website/sorter-parts/c1-output-guide-clear-window-full-b764d42da838.png",
-					"alt": "Two top-down sections. At z = 45 mm the stator wall, the bulk cap's two concentric walls, the guide as exported overlapping both, and the guide rotated -11.7 degrees clear of them. At z = -12 mm the stator's base flange with its ring of index notches, and the guide's base lobes buried in solid flange.",
-					"caption": "Sections at z = 45 and z = -12. The guide as exported (yellow) against the clear position (green)."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/c1-bulk-cap-output-guide-clash-full-4bda026498a4.png",
-					"alt": "Top-down section at z = 45 mm showing the bulk cap's two concentric walls, the stator ring between them, the output guide lying in the cap's relief cut, and the interference at the guide's outer end marked in red",
-					"caption": "The bulk cap overlap on C1 alone, section at z = 45 mm."
-				}
-			],
-			"targets": {
-				"parts": [
-					"output-guide",
-					"stator",
-					"bulk-cap"
-				],
-				"assemblies": [
-					"bulk-bucket",
-					"c-channel",
-					"channel-two",
-					"channel-three",
 					"classification-chamber"
 				]
 			}
@@ -147,33 +116,6 @@
 			"targets": {
 				"parts": [
 					"output-guide"
-				]
-			}
-		},
-		{
-			"id": "improve-camera-extension",
-			"name": "Make the camera extension official",
-			"priority": "P2",
-			"description": "The camera extension was a prototype and needs to be made official. The finished design should also force the camera into the correct orientation.",
-			"targets": {
-				"parts": [
-					"camera-led-insert",
-					"camera-extension",
-					"camera-extension-mount"
-				],
-				"assemblies": [
-					"camera-extension-assembly"
-				]
-			}
-		},
-		{
-			"id": "retain-camera-led-strips",
-			"name": "Mechanically retain the camera LED strips",
-			"priority": "P2",
-			"description": "Update the Camera & LED insert so the LED strips are mechanically retained instead of depending on their adhesive. Integrated clips would be a good approach.",
-			"targets": {
-				"parts": [
-					"camera-led-insert"
 				]
 			}
 		},
@@ -257,17 +199,6 @@
 			}
 		},
 		{
-			"id": "lock-overhead-camera-mount",
-			"name": "Lock the overhead camera mount",
-			"priority": "P3",
-			"description": "It would be ideal to lock the overhead camera mount in place completely.",
-			"targets": {
-				"assemblies": [
-					"camera-mount"
-				]
-			}
-		},
-		{
 			"id": "upgrade-interface-lazy-susan-fasteners",
 			"name": "Update interface lazy-Susan fasteners to M5",
 			"priority": "P3",
@@ -326,7 +257,9 @@
 			"name": "Output gear to rotor screw does not reach the rotor",
 			"priority": "P0",
 			"condition": "broken",
-			"description": "The six screws holding the Output gear (130T) to the rotor were specified as M3 x 8 mm countersunk. The gear is 8.00 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 x 8 seated flush in the countersink ends level with the gear's top face and takes no thread in the rotor at all. Fit M3 x 12 mm countersunk for now: 4.0 mm of thread in the rotor's 5.0 mm flange, 1 mm short of breaking through the far side. Whether the joint settles as a 12 mm screw or the gear boss changes is still to be decided, so treat the length as provisional. Reported from a build by aleph1111/christoph and scres; measured off the pinned output-gear and rotor STLs.",
+			"status": "complete",
+			"completed_at": "2026-09-01",
+			"description": "The six screws holding the Output gear (130T) to the rotor were specified as M3 x 8 mm countersunk. The gear is 8.00 mm thick at the bolt circle and a countersunk screw's length is measured over its head, so an M3 x 8 seated flush in the countersink ends level with the gear's top face and takes no thread in the rotor at all. Fit M3 x 12 mm countersunk for now: 4.0 mm of thread in the rotor's 5.0 mm flange, 1 mm short of breaking through the far side. Whether the joint settles as a 12 mm screw or the gear boss changes is still to be decided, so treat the length as provisional. Reported from a build by aleph1111/christoph and scres; measured off the pinned output-gear and rotor STLs. Fixed: both rotor units call for M3 x 12 mm countersunk, with the reason recorded on the joint (441d9114, #515, 2026-09-01), and the docs page was corrected in #378.",
 			"targets": {
 				"parts": [
 					"output-gear",
@@ -477,21 +410,6 @@
 				],
 				"assemblies": [
 					"servo-adapter"
-				]
-			}
-		},
-		{
-			"id": "camera-clasp-screw-count",
-			"name": "Adapted camera module: the clasp takes 2 screws, not 4",
-			"priority": "P3",
-			"description": "The Adapted camera module lists 4x M3 x 8 countersunk and marks the count as not confirmed at the bench. The published STLs have only two screw positions: the Camera clasp bottom has two 3.50 mm clearance holes with a countersink on its underside, the Camera clasp top has the two matching 2.80 mm self-tapping pilots 5.00 mm deep, and the pair sits on the diagonal 43.2 mm apart. There is no third or fourth hole in either half. Changing the line is an assembly revision and has to be stamped as a new version, so the count is left as authored until somebody does that with a build in front of them. Note also that an M3 x 8 countersunk only reaches about 2 mm into the top half through the 6 mm bottom half, so the length is worth checking at the same time. Measured 2026-09-05 while writing the camera lamp assembly docs page.",
-			"targets": {
-				"assemblies": [
-					"adapted-camera-module"
-				],
-				"parts": [
-					"camera-clasp-top",
-					"camera-clasp-bottom"
 				]
 			}
 		},
@@ -918,10 +836,10 @@
 		},
 		{
 			"id": "classification-chamber",
-			"uid": "5tvh",
-			"version": "3",
+			"uid": "qzw4",
+			"version": "4",
 			"name": "C-channel 4 - Classification",
-			"description": "The lowest channel, where classification happens: a C-channel drive with the finned rotor, the Short and Angled Output Guide, and a Camera lamp carrying the IMX415 4K camera.",
+			"description": "The lowest channel, where classification happens: a C-channel drive with the finned rotor and a Camera lamp carrying the IMX415 4K camera. No output guide: the rotor's fins sweep through where one would sit.",
 			"docs": "/hardware/assembly/feeder/classification-chamber/",
 			"versions": [
 				{
@@ -966,7 +884,40 @@
 					"date": "2026-09-02",
 					"message": "Renamed from Classification chamber and consolidated with the other channels: the dome and the Camera & LED insert give way to the Camera lamp with the IMX415 4K camera, and it gains the output guide. Same drive, same finned rotor.",
 					"breaking": false,
-					"commit": "e22fce30"
+					"commit": "e22fce30",
+					"lines": [
+						{
+							"assembly": "c-channel",
+							"qty": 1,
+							"uid": "4tvc"
+						},
+						{
+							"assembly": "rotor-unit-finned",
+							"qty": 1,
+							"uid": "7ol7"
+						},
+						{
+							"part": "output-guide",
+							"qty": 1,
+							"uid": "z9yd"
+						},
+						{
+							"assembly": "camera-lamp",
+							"qty": 1,
+							"args": {
+								"camera": "cam-imx415"
+							},
+							"uid": "u4si"
+						}
+					]
+				},
+				{
+					"version": "4",
+					"uid": "qzw4",
+					"date": "2026-09-08",
+					"message": "The Short and Angled Output Guide comes off C4. The finned rotor's five fins reach r 85.4 mm and sweep up to 21.2 mm past the guide's inner face at r 67.82, so the two cannot both be fitted; the faceted rotor on C1 to C3 clears the same guide by 1.5 to 1.8 mm. This restores the state before e22fce30 (#534), which gave C4 a guide when all four channels were consolidated onto one shape. Reported from a build by Extremetaz. sorter-v2 issue #543.",
+					"breaking": false,
+					"commit": null
 				}
 			],
 			"lines": [
@@ -979,10 +930,6 @@
 					"qty": 1
 				},
 				{
-					"part": "output-guide",
-					"qty": 1
-				},
-				{
 					"assembly": "camera-lamp",
 					"qty": 1,
 					"args": {
@@ -990,15 +937,7 @@
 					}
 				}
 			],
-			"connections": [
-				{
-					"from": "output-guide",
-					"to": "c-channel",
-					"qty": 1,
-					"method": "friction",
-					"note": "The guide pushes onto the C-channel drive and is held by the fit alone."
-				}
-			]
+			"connections": []
 		},
 		{
 			"id": "chute-bearing",
@@ -1969,10 +1908,10 @@
 		},
 		{
 			"id": "bulk-bucket",
-			"uid": "jnwt",
-			"version": "3",
+			"uid": "imbu",
+			"version": "4",
 			"name": "C-channel 1 - Bulk bucket",
-			"description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor, the Short and Angled Output Guide, a Camera lamp, and the Bulk cap, standing on the tallest supports.",
+			"description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor, a Camera lamp, and the Bulk cap, standing on the tallest supports. No output guide: the Bulk cap has one built into it.",
 			"lines": [
 				{
 					"assembly": "channel-one-support-structure",
@@ -1987,10 +1926,6 @@
 					"qty": 1
 				},
 				{
-					"part": "output-guide",
-					"qty": 1
-				},
-				{
 					"assembly": "camera-lamp",
 					"qty": 1
 				},
@@ -2000,13 +1935,6 @@
 				}
 			],
 			"connections": [
-				{
-					"from": "output-guide",
-					"to": "c-channel",
-					"qty": 1,
-					"method": "friction",
-					"note": "The guide pushes onto the C-channel drive and is held by the fit alone."
-				},
 				{
 					"from": "channel-one-support-structure",
 					"to": "c-channel",
@@ -2089,7 +2017,47 @@
 					"date": "2026-09-02",
 					"message": "The prototype supports give way to the new support structure: the shared layout guide and dovetail adapters with this channel's own legs. An old assembled channel stands on the old feet and does not fit the new layout.",
 					"breaking": true,
-					"commit": "3bbea57f"
+					"commit": "3bbea57f",
+					"lines": [
+						{
+							"assembly": "channel-one-support-structure",
+							"qty": 1,
+							"uid": "z6fs"
+						},
+						{
+							"assembly": "c-channel",
+							"qty": 1,
+							"uid": "4tvc"
+						},
+						{
+							"assembly": "rotor-unit-faceted",
+							"qty": 1,
+							"uid": "ylvv"
+						},
+						{
+							"part": "output-guide",
+							"qty": 1,
+							"uid": "z9yd"
+						},
+						{
+							"assembly": "camera-lamp",
+							"qty": 1,
+							"uid": "u4si"
+						},
+						{
+							"part": "bulk-cap",
+							"qty": 1,
+							"uid": "737f"
+						}
+					]
+				},
+				{
+					"version": "4",
+					"uid": "imbu",
+					"date": "2026-09-08",
+					"message": "The Short and Angled Output Guide comes off C1. The Bulk cap has the original straight output guide built into it, so a separate guide has nowhere to sit and fouls the cap; 39.7 cm3 of the old guide's 54.13 cm3 lies inside the cap's solid. This restores the state before e22fce30 (#534), which gave C1 a guide when all four channels were consolidated onto one shape. sorter-v2 issue #580.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -4757,8 +4725,8 @@
 		},
 		{
 			"id": "adapted-camera-module",
-			"uid": "pdmk",
-			"version": "1",
+			"uid": "vfct",
+			"version": "2",
 			"name": "Adapted camera module",
 			"description": "A camera board clasped between the printed top and bottom halves, ready to snap into the Camera lamp arm.",
 			"params": {
@@ -4767,6 +4735,42 @@
 					"note": "Which camera board the clasp holds: the OV9732 on C-channels 1-3, the IMX415 4K on C-channel 4."
 				}
 			},
+			"versions": [
+				{
+					"version": "1",
+					"uid": "pdmk",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"part": "camera-clasp-bottom",
+							"qty": 1,
+							"uid": "zub8"
+						},
+						{
+							"param": "camera",
+							"qty": 1
+						},
+						{
+							"part": "camera-clasp-top",
+							"qty": 1,
+							"uid": "u816"
+						},
+						{
+							"part": "scr-m3-8-cs",
+							"qty": 4,
+							"uid": "l6br"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "vfct",
+					"date": "2026-09-08",
+					"message": "Two M3 x 8 countersunk, not four. The published clasp STLs have only two screw positions: two 3.50 mm clearance holes in the bottom half and the two matching 2.80 mm pilots 5.00 mm deep in the top, on the diagonal 43.2 mm apart. There is no third or fourth hole in either half. The length is still worth a look at the bench: an M3 x 8 reaches about 2 mm into the top half through the 6 mm bottom half.",
+					"breaking": false,
+					"commit": null
+				}
+			],
 			"lines": [
 				{
 					"part": "camera-clasp-bottom",
@@ -4782,7 +4786,7 @@
 				},
 				{
 					"part": "scr-m3-8-cs",
-					"qty": 4
+					"qty": 2
 				}
 			],
 			"connections": [
@@ -4790,10 +4794,10 @@
 					"from": "camera-clasp-top",
 					"to": "camera-clasp-bottom",
 					"via": "scr-m3-8-cs",
-					"qty": 4,
+					"qty": 2,
 					"method": "self-tap",
 					"draft": true,
-					"note": "Clasp the camera board between the halves; the screw count is not yet confirmed at the bench."
+					"note": "Clasp the camera board between the halves. Two positions, on the diagonal 43.2 mm apart: 3.50 mm clearance holes countersunk on the bottom half's underside, 2.80 mm self-tapping pilots 5.00 mm deep in the top half. Measured off the published STLs, not yet confirmed at the bench."
 				}
 			]
 		},
@@ -11334,14 +11338,13 @@
 			"uid": "z9yd",
 			"name": "Short and Angled Output Guide",
 			"quantities": {
-				"feeder": 3,
-				"classification-channel": 1
+				"feeder": 2
 			},
 			"assembly": null,
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
-			"description": "Output guide. 4 needed, one per C-channel. Ash grey.",
+			"description": "Output guide. 2 needed, one each on C-channels 2 and 3. Ash grey.",
 			"version": "2",
 			"created_at": "2026-06-27",
 			"updated_at": "2026-06-27",


### PR DESCRIPTION
**Requested by Spencer (@spencerhubert) [from Discord](https://discord.com/channels/1430279849171222682/1545477314471657474/1546694513433645137): "this hsould have jusat been a thing to remove the part from the assembly not make more issues"**, and, on which assemblies: [the output guide should not be used in the assembly for the classificaiton channel or the bulk bucket](https://discord.com/channels/1430279849171222682/1545477314471657474/1546694860277293116), ["that was just a mistake"](https://discord.com/channels/1430279849171222682/1545477314471657474/1546694887418892308).

## Everything asked for in the thread, in this one PR

1. Output guide off `bulk-bucket` (C1) and `classification-chamber` (C4), version-stamped.
2. Count back to 2, on C2 and C3: the part's `quantities` and description follow.
3. `output-guide-clocking` deleted, not completed. Nothing was fixed; it was never a defect.
4. `output-guide-finned-rotor-clash` closed, resolved by the C4 removal.
5. `fix-output-gear-rotor-fastener` closed: the catalog has said M3 x 12 since #515.
6. `improve-camera-extension` and `retain-camera-led-strips` deleted, parts unused.
7. `lock-overhead-camera-mount` and `secure-classification-chamber-rotation` deleted, same reason: the Overhead camera mount and the Classification dome both went when the Camera lamp landed.
8. `camera-clasp-screw-count` solved rather than recorded: `adapted-camera-module` v1 to v2, 4 screws to 2.
9. Docs pages corrected to two guides, with the handover framing removed.
10. Issues #541, #543 and #580 closed by this PR; #540 closed as superseded.

The standing instruction behind all of it ("solve the problem, do not file it") is recorded in my own notes, not here, since it is not a repo change.

The two P0 entries #542 landed yesterday described a part that should not have been there. This takes it out instead, and clears four other entries he pointed at in the same thread.

## The output guide comes off C1 and C4

`bulk-bucket` v3 to v4 and `classification-chamber` v3 to v4, each losing its `output-guide` line and the friction joint that went with it. Both were given a guide by `e22fce30` (#534, 2026-09-02) when the four channels were consolidated onto one shape, and neither had one before that, so this restores the earlier state.

- **C1** because the Bulk cap has the original straight output guide moulded into it. 39.71 cm3 of that older guide's 54.13 cm3 lies inside the cap's solid, and sampling the cap at fixed radii through a full turn finds material in one azimuth band only, -96 to -74 deg, leaning inward as it rises. That is [#580](https://github.com/basicallysource/sorter-v2/issues/580), and it is what [ReveryX reported from a fitting](https://discord.com/channels/1430279849171222682/1545190826551017492/1545473777989853225): "the bulk bucket covers the mounting point, it is not possible to mount the output guide at the same time".
- **C4** because the finned rotor's five fins reach r 85.4 and sweep up to 21.2 mm past the guide's inner face at r 67.82, striking it at 24 of 72 rotations. The faceted rotor on C1 to C3 clears the same guide by 1.5 to 1.8 mm. That is [#543](https://github.com/basicallysource/sorter-v2/issues/543), from [Extremetaz's fitting](https://discord.com/channels/1430279849171222682/1437920132893511740/1545557815064526918): "the output guide is not required on C1 when the bulk bucket is in use. The output guide is also not campatible with the finned rotor in C4. So the count should be 2 of the short and angled output guide, not 4."

So the count is **2, on C2 and C3**, which is the number Extremetaz asked for. The `output-guide` part's `quantities` and description follow.

## The camera clasp takes two screws, not four

`adapted-camera-module` v1 to v2: `scr-m3-8-cs` 4 to 2, and the joint records the two positions. The published STLs have two screw positions and no more: two 3.50 mm clearance holes in the bottom half, the two matching 2.80 mm self-tapping pilots 5.00 mm deep in the top, on the diagonal 43.2 mm apart. That was measured on 2026-09-05 and then left alone, with a P3 entry explaining that changing it needed a version stamp. Stamping it is the fix. Still worth a look at the bench: an M3 x 8 reaches about 2 mm into the top half through the 6 mm bottom half.

## Changes entries out

Removed, all on Spencer's call in the same thread:

- `output-guide-clocking`, ["close this it's fine"](https://discord.com/channels/1430279849171222682/1545477314471657474/1546695024945926306). Deleted rather than marked complete, because nothing was fixed: the exported pose is not the assembled pose, so the 3.014 cm3 stator overlap was never a defect to begin with.
- `improve-camera-extension` and `retain-camera-led-strips`, ["remove these we are no longer using these parts at all"](https://discord.com/channels/1430279849171222682/1545477314471657474/1546695389254778930). The Camera extension, its mount and the Camera & LED insert have been unused since the Camera lamp landed on 2026-09-02.
- `lock-overhead-camera-mount`, same reason and [confirmed](https://discord.com/channels/1430279849171222682/1545477314471657474/1546695904726093844): the Overhead camera mount is out of the machine tree too.
- `secure-classification-chamber-rotation`, ["close this one too"](https://discord.com/channels/1430279849171222682/1545477314471657474/1546700071607996509). It asks for a rotational lock on the Classification dome, retired by the same Camera lamp overhaul.
- `camera-clasp-screw-count`, resolved by the version stamp above.

Marked complete rather than deleted, because the work behind them actually happened:

- `output-guide-finned-rotor-clash`, resolved by taking the guide off C4 in this PR.
- `fix-output-gear-rotor-fastener`, ["hasnt this been resolved too"](https://discord.com/channels/1430279849171222682/1545477314471657474/1546695136401039510) - yes. Both rotor units have called for M3 x 12 countersunk since `441d9114` (#515, 2026-09-01), with the reason recorded on the joint, and the docs page was corrected in #378.

## Docs

The guide pages carried #540's error from the other side: they say a guide bridges a handover between two channels. It does not, it belongs to the channel it is mounted on and stops a piece riding round past the exit ([Marc](https://discord.com/channels/1430279849171222682/1460692585881534579/1478714527548833907): "purpose of the 'output guide' is to prevent stuff going in infinite circles"). #540 fixed that framing but concluded four, one per channel. The framing is here with the count corrected to two. **#540 is superseded and should be closed.**

`output-guides.md`, `arranging-c-channels.md` step 4, the feeder index line, and one clause on `c-channel.md`.

## Generated data and versions

Regenerated with `catalog/generate.py --metadata-only`; the pin, versioning and connection checks pass. The three new version entries stay at `"commit": null` so a squash-merge does not orphan them, per the `layer` v4 precedent.

Closes #541. Closes #543. Closes #580.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1545477314471657474/1546694513433645137
request: https://discord.com/channels/1430279849171222682/1545477314471657474/1546694860277293116
request: https://discord.com/channels/1430279849171222682/1545477314471657474/1546695024945926306
request: https://discord.com/channels/1430279849171222682/1545477314471657474/1546695136401039510
request: https://discord.com/channels/1430279849171222682/1545477314471657474/1546695389254778930
request: https://discord.com/channels/1430279849171222682/1545477314471657474/1546696004617896098
request: https://discord.com/channels/1430279849171222682/1545477314471657474/1546698980300169286
request: https://discord.com/channels/1430279849171222682/1545477314471657474/1546700071607996509
preview: /hardware/assembly/feeder/output-guides/
-->


