### PR TITLE
C1 takes no camera lamp: three per machine, not four

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -52,7 +52,7 @@ The parts list above is **all four channels' worth** — the count is fixed for 
 
 - **Build 4 per machine**, three in the feeder and one for the classification channel. It is the same build four times over, and the rotor is the only thing that changes.
 - **One rotor per unit, and only one of the two.** The three feeder channels take the Rotor (faceted); the classification channel takes the Rotor (finned), the one with the fins in the photographs below. The list above already splits them the way a real machine needs them: three faceted, one finned. Colour does not change with the rotor: both print ash grey on all four channels, as do the stator and the output guide.
-- Every channel also carries a [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), whose parts and screws belong to that page rather than to the list above.
+- C2, C3 and the classification channel also carry a [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), whose parts and screws belong to that page rather than to the list above. C1, the bulk bucket, does not.
 - **The charcoal parts are the gear train and one bracket.** The output, idler and input gears follow the feeder colour, which is charcoal by default and yours to change on the [parts calculator](https://parts-calculator.basically.website/assembly?focus=c-channel). Of the four NEMA brackets, C1's is charcoal and C2 to C4's are ash grey.
 
 {% include step.html n="1" title="Preparation" %}
@@ -127,7 +127,7 @@ Turn the stage by hand before wiring it. The train should run without a tight sp
 
 {% include step.html n="6" title="Hang the camera lamp over the channel" %}
 
-Every channel carries a camera lamp: an arm mounted to the channel, a shaded lamp on the end of it and a camera looking down through the middle. It has its own page, [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), and none of its screws are in the list above.
+C2, C3 and the classification channel each carry a camera lamp: an arm mounted to the channel, a shaded lamp on the end of it and a camera looking down through the middle. It has its own page, [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), and none of its screws are in the list above. Skip this step on C1, the bulk bucket, which takes no lamp.
 
 The light post and the overhead camera mount that used to do this job were retired on 2026-09-02. Their pages are still up for machines already built that way.
 

--- a/docs/src/content/hardware/assembly/feeder/camera-lamp.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-lamp.md
@@ -66,11 +66,10 @@ It replaces the [light post]({{ '/hardware/assembly/feeder/light-post/' | relati
   <figcaption>The finished thing, over a channel, lit. <cite>Photo: Spencer.</cite></figcaption>
 </figure>
 
-**The parts list above is one lamp's worth.** The catalog gives one to each of the four channels, so a machine takes four of everything on it: C1, C2 and C3 with the OV9732, and the classification channel with the [IMX415]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}) 4K module instead. Everything else is identical between the four.
+**The parts list above is one lamp's worth.** A machine takes three lamps, so three of everything on it: C2 and C3 with the OV9732, and the classification channel with the [IMX415]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}) 4K module instead. Everything else is identical between the three. **C1, the bulk bucket, takes no lamp**: it is fed in bulk and nothing reads vision off it.
 
-<div class="callout callout-warning">
-  <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><b>Whether C1 really takes a camera is an open question.</b> The parts list gives C1 a full lamp including an OV9732, but the software has no C1 camera role at all: the crop zones are the second channel, the third channel and the classification channel, and nothing reads vision off the bulk channel. The lamp itself is not in doubt on any channel. If you are buying rather than printing, the third OV9732 is the one to hold off on (raised by BrickCycleAlice, 2026-09-05, unanswered).</p>
+<div class="callout">
+  <p><b>If you printed four, one set is spare.</b> The parts list gave C1 a lamp of its own until 2026-09-08, when Jon confirmed the machine takes three. The software agrees: the crop zones are the second channel, the third channel and the classification channel, and nothing reads vision off the bulk channel, so C1 needs neither the lamp nor an OV9732. Question raised by BrickCycleAlice, 2026-09-05.</p>
 </div>
 
 {% include fastener-legend.html %}
@@ -91,7 +90,7 @@ It replaces the [light post]({{ '/hardware/assembly/feeder/light-post/' | relati
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Print counts, if you are printing for the whole machine:</strong> 4 each of the mount, arm, bracket A, bracket B, ring, both clasp halves, reflector and cover, and <strong>24</strong> LED hooks, six per lamp. The hooks are the ones people come up short on.</p>
+    <p><strong>Print counts, if you are printing for the whole machine:</strong> 3 each of the mount, arm, bracket A, bracket B, ring, both clasp halves, reflector and cover, and <strong>18</strong> LED hooks, six per lamp. The hooks are the ones people come up short on.</p>
   </div>
   <figure class="prep-item-figure">
     <div class="img-placeholder">Image coming</div>
@@ -141,7 +140,9 @@ The clasp is what carries the camera into the lamp: its two halves form a 4 mm s
 
 Six **Inner reflector LED hooks** friction-fit into the rim of the **Lamp inner reflector**, evenly spaced 60° apart, one per 2.7 mm socket around its outside. Each hook retains the LED strip against the reflector. No screws.
 
-**Not recorded:** which LED strip, how much of it, how it is joined and how it is wired back to the board. None of that is in the catalog yet, and the strip is not a part in the machine's list. What the photograph shows is strip run in a ring around the inside of the reflector, retained by the hooks, with the leads coming out and down the arm.
+**How much strip, measured off the reflector.** The strip sits against the inner face of the reflector's outer skirt, which is 147 mm across and about 18 mm tall, so one turn around it is **462 mm**. The photograph below shows two turns side by side in that skirt, which puts a lamp at roughly **0.92 m** and a three-lamp machine at about **2.8 m**. The strip in the parts calculator is a 24 V daylight-white 6000 K COB strip sold as a 5 m roll, one roll per machine, which covers all three.
+
+**Not recorded:** which strip is actually on the lamps in these photographs, how it is joined and how it is wired back to the board. None of that is in the catalog, and the strip is not a line in the lamp's parts list. What the photograph shows is strip run in a ring around the inside of the reflector, retained by the hooks, with the leads coming out and down the arm. Spencer said on 2026-09-06 that the strips run at 24 V off the LED headers on the basically board.
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-lit-from-below-w1600-bb9d54f4f43e.jpg" alt="The lamp lit, photographed from underneath: a ring of LED strip glowing around the outside of the white reflector, the reflector's central funnel in the middle, and the arm behind it">

--- a/docs/src/content/hardware/assembly/feeder/index.md
+++ b/docs/src/content/hardware/assembly/feeder/index.md
@@ -13,7 +13,7 @@ author: spencer
 The feeder takes unsorted parts from the bulk input and, through four C-channel stages, spaces them out one at a time and carries each through the classification chamber before it drops to the distribution system below. Each channel meters parts by rotation; only after a part is imaged in the classification chamber does the software know where it should go next. Build the pages below roughly in order: the C-channel itself (built four times), then what mounts on it, then how the four are arranged and heighted relative to one another.
 
 1. **[C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }})**, the C-channel stage itself. Build four.
-2. **[Camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }})**, the arm, light and camera over a channel. One per channel.
+2. **[Camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }})**, the arm, light and camera over a channel. Three per machine, one each on C2, C3 and the classification channel; the bulk bucket has none.
 3. **[Classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }})**, where parts are imaged for classification.
 4. **[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }})**, the bucket and cap that feed C1.
 5. **[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }})**, the walls on C2 and C3 that push parts off the channel.

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7330,10 +7330,10 @@
     },
     {
       "id": "bulk-bucket",
-      "uid": "imbu",
-      "version": "4",
+      "uid": "tpd3",
+      "version": "5",
       "name": "C-channel 1 - Bulk bucket",
-      "description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor, a Camera lamp, and the Bulk cap, standing on the tallest supports. No output guide: the Bulk cap has one built into it.",
+      "description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor and the Bulk cap, standing on the tallest supports. No output guide: the Bulk cap has one built into it. No camera lamp either: C1 is fed in bulk and nothing reads vision off it.",
       "lines": [
         {
           "assembly": "channel-one-support-structure",
@@ -7345,10 +7345,6 @@
         },
         {
           "assembly": "rotor-unit-faceted",
-          "qty": 1
-        },
-        {
-          "assembly": "camera-lamp",
           "qty": 1
         },
         {
@@ -7477,6 +7473,13 @@
           "version": "4",
           "date": "2026-09-08",
           "message": "The Short and Angled Output Guide comes off C1. The Bulk cap has the original straight output guide built into it, so a separate guide has nowhere to sit and fouls the cap; 39.7 cm3 of the old guide's 54.13 cm3 lies inside the cap's solid. This restores the state before e22fce30 (#534), which gave C1 a guide when all four channels were consolidated onto one shape. sorter-v2 issue #580.",
+          "breaking": false,
+          "commit": null
+        },
+        {
+          "version": "5",
+          "date": "2026-09-08",
+          "message": "The Camera lamp comes off C1. Jon (@effreek) confirmed 2026-09-08 that the machine takes three lamps, on C2, C3 and the classification channel, and that the bulk bucket gets none; e22fce30 (#534) gave C1 one when all four channels were consolidated onto one shape. The software has no C1 camera role either, so the lamp, its arm and its OV9732 were parts nobody needed. Resolves the open question BrickCycleAlice raised 2026-09-05.",
           "breaking": false,
           "commit": null
         }
@@ -10336,7 +10339,7 @@
       "uid": "u4si",
       "version": "1",
       "name": "Camera lamp",
-      "description": "The per-channel camera and light: the arm with its ring, the adapted camera module snapped in, and the shaded lamp over the top. One per C-channel; which camera it carries is a parameter.",
+      "description": "The per-channel camera and light: the arm with its ring, the adapted camera module snapped in, and the shaded lamp over the top. Three per machine, on C-channels 2 and 3 and the classification channel; the bulk bucket has none. Which camera it carries is a parameter.",
       "params": {
         "camera": {
           "default": "cam-ov9732",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -7471,10 +7471,38 @@
         },
         {
           "version": "4",
+          "uid": "imbu",
           "date": "2026-09-08",
           "message": "The Short and Angled Output Guide comes off C1. The Bulk cap has the original straight output guide built into it, so a separate guide has nowhere to sit and fouls the cap; 39.7 cm3 of the old guide's 54.13 cm3 lies inside the cap's solid. This restores the state before e22fce30 (#534), which gave C1 a guide when all four channels were consolidated onto one shape. sorter-v2 issue #580.",
           "breaking": false,
-          "commit": null
+          "commit": null,
+          "lines": [
+            {
+              "assembly": "channel-one-support-structure",
+              "qty": 1,
+              "uid": "z6fs"
+            },
+            {
+              "assembly": "c-channel",
+              "qty": 1,
+              "uid": "4tvc"
+            },
+            {
+              "assembly": "rotor-unit-faceted",
+              "qty": 1,
+              "uid": "ylvv"
+            },
+            {
+              "assembly": "camera-lamp",
+              "qty": 1,
+              "uid": "u4si"
+            },
+            {
+              "part": "bulk-cap",
+              "qty": 1,
+              "uid": "737f"
+            }
+          ]
         },
         {
           "version": "5",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -1897,10 +1897,10 @@
 		},
 		{
 			"id": "bulk-bucket",
-			"uid": "imbu",
-			"version": "4",
+			"uid": "tpd3",
+			"version": "5",
 			"name": "C-channel 1 - Bulk bucket",
-			"description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor, a Camera lamp, and the Bulk cap, standing on the tallest supports. No output guide: the Bulk cap has one built into it.",
+			"description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor and the Bulk cap, standing on the tallest supports. No output guide: the Bulk cap has one built into it. No camera lamp either: C1 is fed in bulk and nothing reads vision off it.",
 			"lines": [
 				{
 					"assembly": "channel-one-support-structure",
@@ -1912,10 +1912,6 @@
 				},
 				{
 					"assembly": "rotor-unit-faceted",
-					"qty": 1
-				},
-				{
-					"assembly": "camera-lamp",
 					"qty": 1
 				},
 				{
@@ -2045,6 +2041,41 @@
 					"uid": "imbu",
 					"date": "2026-09-08",
 					"message": "The Short and Angled Output Guide comes off C1. The Bulk cap has the original straight output guide built into it, so a separate guide has nowhere to sit and fouls the cap; 39.7 cm3 of the old guide's 54.13 cm3 lies inside the cap's solid. This restores the state before e22fce30 (#534), which gave C1 a guide when all four channels were consolidated onto one shape. sorter-v2 issue #580.",
+					"breaking": false,
+					"commit": null,
+					"lines": [
+						{
+							"assembly": "channel-one-support-structure",
+							"qty": 1,
+							"uid": "z6fs"
+						},
+						{
+							"assembly": "c-channel",
+							"qty": 1,
+							"uid": "4tvc"
+						},
+						{
+							"assembly": "rotor-unit-faceted",
+							"qty": 1,
+							"uid": "ylvv"
+						},
+						{
+							"assembly": "camera-lamp",
+							"qty": 1,
+							"uid": "u4si"
+						},
+						{
+							"part": "bulk-cap",
+							"qty": 1,
+							"uid": "737f"
+						}
+					]
+				},
+				{
+					"version": "5",
+					"uid": "tpd3",
+					"date": "2026-09-08",
+					"message": "The Camera lamp comes off C1. Jon (@effreek) confirmed 2026-09-08 that the machine takes three lamps, on C2, C3 and the classification channel, and that the bulk bucket gets none; e22fce30 (#534) gave C1 one when all four channels were consolidated onto one shape. The software has no C1 camera role either, so the lamp, its arm and its OV9732 were parts nobody needed. Resolves the open question BrickCycleAlice raised 2026-09-05.",
 					"breaking": false,
 					"commit": null
 				}
@@ -4922,7 +4953,7 @@
 			"uid": "u4si",
 			"version": "1",
 			"name": "Camera lamp",
-			"description": "The per-channel camera and light: the arm with its ring, the adapted camera module snapped in, and the shaded lamp over the top. One per C-channel; which camera it carries is a parameter.",
+			"description": "The per-channel camera and light: the arm with its ring, the adapted camera module snapped in, and the shaded lamp over the top. Three per machine, on C-channels 2 and 3 and the classification channel; the bulk bucket has none. Which camera it carries is a parameter.",
 			"params": {
 				"camera": {
 					"default": "cam-ov9732",


### PR DESCRIPTION
**Asked by Jon (@effreek)** in [#balloon-electronics](https://discord.com/channels/1430279849171222682/1546665692022050847/1546956188976156675), on a thread where I had just told [iubiubiub](https://discord.com/channels/1430279849171222682/1535802933768364052/1546665692022050847) the machine takes four camera lamps because that is what the catalog says:

> this is incorrect. it should only be 3 lamps. the bulk bucket doesn't get a lamp.

## What changed

**The catalog.** `bulk-bucket` (C-channel 1) loses its `camera-lamp` line, v4 to v5. `e22fce30` (#534) gave C1 one when all four channels were consolidated onto one shape; nothing since has used it. The lamp itself is untouched, as are C2, C3 and the classification channel.

The software agrees with Jon: there is no C1 camera role anywhere in `software/sorter/backend`, the crop zones are the second channel, the third channel and the classification channel, and the bulk station ignores vision. BrickCycleAlice raised exactly this on 2026-09-05 and it had gone unanswered until now.

Knock-on counts for anybody printing or buying: **3** lamps, so 3 each of the mount, arm, brackets A and B, ring, both clasp halves, reflector and cover, **18** LED hooks rather than 24, and **2** OV9732 rather than 3.

**The docs.** `camera-lamp.md`, `c-channel.md` and the feeder index all said every channel carries one. The open-question warning on `camera-lamp.md` is now a plain note for people who already printed four.

**Also on `camera-lamp.md`, the LED strip.** The page said the length was not recorded, which is what started the thread. It is measurable off the published reflector STL: the strip sits against the inner face of the reflector's outer skirt, a cylinder 147.0 mm across (r 73.5, outer face r 75.0) and about 18 mm tall (z 158.41 to 176.52), so **one turn is 462 mm**. [Spencer's photograph of a lit lamp](https://assets.basically.website/sorter-docs/camera-lamp-lit-from-below-w1600-bb9d54f4f43e.jpg) shows two turns side by side in that skirt, each with its own LED row and its own printing, so **about 0.92 m per lamp and 2.8 m for a machine**. The catalog's `led-strip-24v` is a 24 V daylight-white 6000 K COB strip on a 5 m roll, one roll per machine, which covers all three. Which strip is actually on the lamps in those photographs, and how it is wired, is still not recorded, and the page still says so.

## Checks

`check_versioning.py --base origin/main`, `check_generated_pins.py`, `check_connections.py` and `check_asset_urls.py` all pass. `generate.py --metadata-only` regenerated `catalog.generated.json` in the same commit. `bulk-bucket` v5 is left with `"commit": null` because the board squashes.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1546665692022050847/1546956188976156675
request: https://discord.com/channels/1430279849171222682/1535802933768364052/1546665692022050847
preview: /hardware/assembly/feeder/camera-lamp/
-->
