### PR TITLE
docs: the C-channel input gear's clamp screw is axial, not radial

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -96,10 +96,16 @@ The Input gear (12T, screw) takes its {% include fastener.html size="M3" variant
 
 The bore is plain and round, so there is nothing to key it: turn the gear until that hole lines up with the flat on the shaft, push the gear all the way on, then tighten the screw down onto the flat. The head drops into a counterbore in the toothed end face. Tighten until the head is seated and the gear does not turn on the shaft, and no further, it is threading into plastic.
 
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-screw-hole-full-b4e56bf5b643.png" alt="Two views of the 12-tooth input gear from its toothed end: at a slight angle, and then square on. Both show the round central bore with a smaller screw hole running beside it and opening into it, and a wider counterbore recessed into the end face around them. The outside of the gear is unbroken, with no hole in the side of the boss">
-  <figcaption>Left, the toothed end at a slight angle; right, the same end square on. The screw hole runs beside the bore and opens into it, and the head seats in the counterbore around it. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
-</figure>
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-screw-end-angled-full-dd4887827574.png" alt="Render of the 12-tooth input gear seen from its toothed end at a slight angle, showing the round central bore, a smaller screw hole running beside it, and a shallow wider recess around both, cut into the end face. The outside of the gear is unbroken">
+    <figcaption>The toothed end, at a slight angle. The small hole beside the bore is the screw hole, and the shallow recess around the pair of them is the counterbore the head seats in. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-screw-end-square-full-8a5956d68731.png" alt="Render of the same gear end square on, showing the screw hole overlapping the edge of the bore so the two openings run together into one figure-of-eight shape">
+    <figcaption>The same end square on. The screw hole breaks into the bore, which is what lets the screw reach the flat on the shaft. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
+  </figure>
+</div>
 
 {% include step.html n="4" title="Fit the idler gear and the stepper to the NEMA bracket" %}
 

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -92,13 +92,13 @@ Bolt the Output gear onto the underside of the rotor with 6 {% include fastener.
 
 {% include step.html n="3" title="Fit the input gear to the motor shaft" %}
 
-The Input gear (12T, screw) has a hole through its boss, parallel to the shaft, for the {% include fastener.html size="M3" variant="countersunk" length="8" %} screw that clamps it on. The bore is plain and round, so there is nothing to key it: turn the gear until that screw lines up with the flat on the NEMA 17's shaft, push the gear all the way on, then tighten the screw down onto the flat.
+The Input gear (12T, screw) takes its {% include fastener.html size="M3" variant="countersunk" length="8" %} clamping screw **parallel to the shaft, alongside the bore**, not radially into the side of the boss. The hole runs the full length of the gear, 3.6 mm off the axis, and breaks into the Ø4.9 mm bore along the way, so the screw ends up bearing on the flat of the NEMA 17's shaft.
 
-The head drops into a counterbore in the boss. Tighten until the head is seated and the gear does not turn on the shaft, and no further, it is threading into plastic.
+The bore is plain and round, so there is nothing to key it: turn the gear until that hole lines up with the flat on the shaft, push the gear all the way on, then tighten the screw down onto the flat. The head drops into a counterbore in the toothed end face. Tighten until the head is seated and the gear does not turn on the shaft, and no further, it is threading into plastic.
 
 <figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-on-motor-shaft-w1600-be00a0374988.jpg" alt="A black NEMA 17 stepper motor lying on its side with the small grey 12-tooth input gear pushed fully onto its shaft, the clamping screw visible in the side of the gear boss">
-  <figcaption>Pushed fully onto the shaft, clamp screw bearing on the flat. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-screw-hole-full-b4e56bf5b643.png" alt="Two views of the 12-tooth input gear from its toothed end: at a slight angle, and then square on. Both show the round central bore with a smaller screw hole running beside it and opening into it, and a wider counterbore recessed into the end face around them. The outside of the gear is unbroken, with no hole in the side of the boss">
+  <figcaption>Left, the toothed end at a slight angle; right, the same end square on. The screw hole runs beside the bore and opens into it, and the head seats in the counterbore around it. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
 </figure>
 
 {% include step.html n="4" title="Fit the idler gear and the stepper to the NEMA bracket" %}

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -8,10 +8,10 @@ kicker: Feeder — C-channel
 lede: The C-channel stage itself.
 permalink: /hardware/assembly/feeder/c-channel/
 author: spencer
-contributors: [barthel, brickcyclealice, christoph]
+contributors: [barthel, brickcyclealice, christoph, danny]
 warning: >-
   **Steps 1 to 5 come from a build**, the order of operations and the photographs are
-  BrickCycleAlice's. Step 6, the camera lamp, is still an AI-generated first draft written
+  BrickCycleAlice's, apart from step 3's, which are Danny's. Step 6, the camera lamp, is still an AI-generated first draft written
   from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=c-channel) and has
   not been checked against a machine. Correct it as you build.
@@ -98,12 +98,12 @@ The bore is plain and round, so there is nothing to key it: turn the gear until 
 
 <div class="img-row">
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-screw-end-angled-full-dd4887827574.png" alt="Render of the 12-tooth input gear seen from its toothed end at a slight angle, showing the round central bore, a smaller screw hole running beside it, and a shallow wider recess around both, cut into the end face. The outside of the gear is unbroken">
-    <figcaption>The toothed end, at a slight angle. The small hole beside the bore is the screw hole, and the shallow recess around the pair of them is the counterbore the head seats in. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-clamp-screw-driving-w1600-dfa74d5a362c.jpg" alt="The charcoal 12-tooth input gear pushed onto the shaft of a NEMA 17, seen from above. A driver bit is turning the clamping screw, which stands in a hole in the end face beside the bore with its thread still showing. The flat on the motor shaft is visible through the bore next to it">
+    <figcaption>The screw goes in beside the bore, parallel to the shaft, not into the side of the gear. The bright shape next to it is the flat on the shaft. <cite>Photo: Danny.</cite></figcaption>
   </figure>
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-screw-end-square-full-8a5956d68731.png" alt="Render of the same gear end square on, showing the screw hole overlapping the edge of the bore so the two openings run together into one figure-of-eight shape">
-    <figcaption>The same end square on. The screw hole breaks into the bore, which is what lets the screw reach the flat on the shaft. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-input-gear-clamp-screw-seated-w1600-39abf5a9ff47.jpg" alt="The same gear and motor with the clamping screw driven fully home, its head sitting down in the round counterbore in the toothed end face, and the gear seated against the front face of the motor">
+    <figcaption>Tightened. The head sits down in the counterbore and the gear is pushed all the way onto the shaft. <cite>Photo: Danny.</cite></figcaption>
   </figure>
 </div>
 


### PR DESCRIPTION
Step 3 of the C-channel page told two different stories. The prose said the clamping screw runs parallel to the shaft; the photograph under it showed a gear with the screw going into the side of the boss.

**Requested by Danny (@lifeisworthliving) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1547021572324335698):** "C-channel step 3 is outdated. It shows an older revision of the input gear with the side screw hole. The updated design has a vertical screw hole".

**Photographs added by Danny (@lifeisworthliving) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1547395528231354418):** "Update the pictures in C-channel step 3 to the attached", with two photos of the current gear on a motor shaft.

## What the current part is

Measured off the STL the catalog pins for [`input-gear`](https://assets.basically.website/sorter-parts/input-gear-3587940de2e8.stl) (`stl_hash` `3587940d…`, unchanged since the part was created on 2026-06-27):

- Ø2.80 mm hole through the boss, **parallel to the shaft**, 3.61 mm off the axis, running the full 20.85 mm length.
- It breaks into the Ø4.87 mm bore (2.44 + 1.40 > 3.61), so the screw bears directly on the shaft flat.
- Ø6.40 mm × 2.7 mm counterbore for the head, in the **toothed end face**.
- No radial hole anywhere in the outer surface.

The part's own description in `parts-calculator/catalog/parts.json` says the same thing: "C-channel input/drive gear (12T) with vertical screw hole". So the geometry and the step text were already right, and only the picture was stale.

## The change

- Replaces the build photo of the older gear with **two of Danny's photos of the current one**, both on the motor shaft: the screw part way in with a driver on it, and the same screw tightened with its head down in the counterbore. Everything the renders were there to show is visible in them, on a real print, so the renders come back out.
- Says in the step that the screw goes in parallel to the shaft rather than radially, with the measured offset and which end the head seats in, so a builder holding the current part can tell it matches.
- Front matter: `danny` added to `contributors`, and the page warning now says step 3's photographs are his rather than BrickCycleAlice's.

Nothing else on the page changes. The other three photographs on it are unaffected: the gear is hidden under the motor in step 4, and steps 2 and 5 do not show it.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1547021572324335698
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1547395528231354418
preview: /hardware/assembly/feeder/c-channel/
-->
