### PR TITLE
docs: show the door's travel limits in door module step 4

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -184,6 +184,13 @@ The shaft is captured at both ends once this is together, so there is only one o
   <figcaption>The holders, with their bearings in blue, going onto the ends of the shaft and down onto the race. The covers are not shown. <cite>Rendered from the parts' own geometry in assembly position, not from a build. Render: Balloon.</cite></figcaption>
 </figure>
 
+Hung this way the door has **80.5° of swing**, from 10.7° off horizontal at its flattest to 88.9° at its steepest. Both ends of that are the door meeting the race across its full width, not the holders.
+
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-travel-limits-full-323c3b543a10.png" alt="Render of the assembled door module seen from the servo end at an angle, with the chute door drawn twice: once in grey lying almost flat, and once in orange hanging almost vertically, both pivoting on the same shaft below the bearing race">
+  <figcaption>The two ends of the door's swing, 80.5° apart. Grey is the flattest the door goes, with the plate 10.7° off horizontal; orange is the steepest, at 88.9°. The covers are not shown. <cite>Measured and rendered from the parts' own geometry, not from a build. Render: Balloon.</cite></figcaption>
+</figure>
+
 {% include step.html n="5" title="Bolt the flap assembly to the chute core" %}
 
 Six of the core's 18 inserts belong to this module. Four are used here, two in step 6:


### PR DESCRIPTION
Adds a second figure to **step 4** of the door module page, showing the chute door at both ends of its swing, and states the travel figure in the prose above it.

**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1547057481174483016/1547068271772049488): "Make a pr to put the fourth rendering into this step, so people can see how to install the door. I'll get proper photos but they wont get loaded today."**

It follows on from two earlier messages in the same thread, which are what produced the render: [the request for views of the bearing assembly](https://discord.com/channels/1430279849171222682/1536088194557419660/1547057481174483016) ("can you give me this rendering from a few views, so I can see the door orientation") and [the question about travel](https://discord.com/channels/1430279849171222682/1547057481174483016/1547065722226614394) ("Wow much rotation is possible on the chute door/flap? I'm getting about 70degs (by eye)").

## Where the numbers come from

The 80.5° is measured, not quoted. `chute-door` was swept about the hinge axis against `bearing-race` and both `bearing-holder-*` by voxel interference at 0.25 mm, using the published STLs:

- collision-free from **-14.37° to +66.10°**, one contiguous run, no interference at the modelled position
- in plate terms that is **10.7° off horizontal** at the flattest and **88.9°** at the steepest
- **both limits are the door against the race**, over its full 110 mm width, and neither involves the holders. Forward, the plate root's underside meets the race's lower lip at 11 to 15 mm out from the axis. Back, the door's rounded top edge binds in the channel in the race's underside

The forward limit is good to about a degree; the back one is a shallow graze and is worth a few degrees either way. That is consistent with Alice's "about 70degs (by eye)".

This sits alongside step 6's existing note that the MG995 only rotates 180° and has to be clocked so both extremes fall inside its range.

## Caveats kept out of the page

The figure does not show the covers, and it cannot show the door module on the chute core: `chute-core` is exported in a different coordinate frame from the door module's parts, so the two cannot be placed together without guessing. The page already carries a callout saying step 4 is worked out from the parts rather than reported by a builder, and this figure is the same kind of evidence.

Alice has said photographs of a real build are coming but not today, so treat this as the interim illustration.

## Asset

Rendered here and published to the parts bucket as `door-travel-limits-full-323c3b543a10.png`. Nothing binary is committed.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1547057481174483016
request: https://discord.com/channels/1430279849171222682/1547057481174483016/1547065722226614394
request: https://discord.com/channels/1430279849171222682/1547057481174483016/1547068271772049488
preview: /hardware/assembly/distribution/chute/door-module/
-->
