### PR TITLE
catalog: the cable clamp's long screw is 5 mm too short (M3 x 35 -> M3 x 40)

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -630,6 +630,11 @@ Screw the remaining Cable cage brackets to the other 5 corners of the Cable cage
 
 Place an {% include fastener.html size="M3" variant="nut" %} into the bottom of the Cable clamp (outer) (the video skips this), then push it into the recess in the Top interface chute mount. Fasten it with two {% include fastener.html size="M3" variant="socket-button" length="10" %} screws.
 
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>The nut is not captive. It drops into a hex pocket 5.7 mm across flats and 8 mm deep, and nothing holds it in until the clamp is pushed into the recess and the chute mount closes the pocket off. Check it is lying flat on the floor of the pocket, and keep that face upwards while you mount the clamp. If it falls out, or ends up skewed part-way up the pocket, the long screw later in this step has nothing to start on, and you cannot get at it once the clamp is bolted down. <cite>Reported by Daddy-O's Bricks - Bill.</cite></p>
+</div>
+
 Rotate the chute until it hits the limit switch.
 
 Fold your IDC ribbon cable around the Cable clamp (inner), following the guides on the clamp. Slide the cable and clamp together into the Cable clamp (outer), leaving a significant tail to connect to the chute.

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -632,7 +632,7 @@ Place an {% include fastener.html size="M3" variant="nut" %} into the bottom of 
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p>The nut is not captive. It drops into a hex pocket 5.7 mm across flats and 8 mm deep, and nothing holds it in until the clamp is pushed into the recess and the chute mount closes the pocket off. Check it is lying flat on the floor of the pocket, and keep that face upwards while you mount the clamp. If it falls out, or ends up skewed part-way up the pocket, the long screw later in this step has nothing to start on, and you cannot get at it once the clamp is bolted down. <cite>Reported by Daddy-O's Bricks - Bill.</cite></p>
+  <p>The nut is not captive: nothing holds it in the pocket until the clamp is pushed into the recess. Check it is lying flat on the bottom of the pocket and keep that face upwards while you mount the clamp. If it falls out or sits skewed, the long screw later in this step has nothing to start on, and you cannot get at it once the clamp is bolted down.</p>
 </div>
 
 Rotate the chute until it hits the limit switch.

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -94,7 +94,7 @@ parts_needed:
     qty: 2
   - part: scr-m3-20-cs
     qty: 1
-  - part: scr-m3-35-bhcs
+  - part: scr-m3-40-fhcs
     qty: 1
   - part: scr-m4-12-cs
     qty: 8
@@ -638,7 +638,7 @@ Guide the rest of the ribbon cable around the side of the Top interface chute mo
 
 Screw the Ribbon cable clamp lightly to the Cable cage bracket (cable mount) with one {% include fastener.html size="M3" variant="socket-button" length="10" %} screw, clamping the ribbon cable between the two.
 
-Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long {% include fastener.html size="M3" variant="flat" length="35" %} screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end.
+Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long {% include fastener.html size="M3" variant="flat" length="40" %} screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end.
 
 {% include step.html n="12" title="Attach the cable cage bottom" %}
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6297,6 +6297,33 @@
       ],
       "versions": [
         {
+          "version": "1",
+          "uid": "e0p9",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "part": "cable-clamp-inner",
+              "qty": 1,
+              "uid": "3fue"
+            },
+            {
+              "part": "cable-clamp-outer",
+              "qty": 1,
+              "uid": "50dv"
+            },
+            {
+              "part": "scr-m3-35-bhcs",
+              "qty": 1,
+              "uid": "38vn"
+            },
+            {
+              "part": "nut-m3",
+              "qty": 1,
+              "uid": "sc1c"
+            }
+          ]
+        },
+        {
           "version": "2",
           "date": "2026-09-09",
           "message": "M3 × 35 mm flat head replaced by M3 × 40 mm flat head. The stack under the screw head is 32.00 mm to the floor of the nut pocket in the outer clamp and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin and builders could not pick the nut up. 40 mm spans the 8.00 mm pocket.",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3487,9 +3487,9 @@
       "name": "M3 × 35 mm flat head",
       "category": "Screws",
       "alternative": "Flat or pan head",
-      "description": "The long M3 that clamps the two cable-clamp halves together at the top interface, threading into an M3 nut in the bottom of the Cable clamp (outer).",
+      "description": "Retired 2026-09-09, no longer used by any assembly: at 35 mm this screw cleared the far face of the nut by only 0.60 mm and did not reach in practice. The cable clamp takes the M3 × 40 mm flat head (scr-m3-40-fhcs) now. Kept as an unused entry rather than deleted, because chute-stepper-gearing v1 pins this uid in its line snapshot and a minted uid has to stay resolvable (VERSIONING.md).",
       "created_at": "2026-07-18",
-      "updated_at": "2026-08-30",
+      "updated_at": "2026-09-09",
       "attributes": [
         {
           "label": "Thread",
@@ -3503,7 +3503,40 @@
           "label": "Head",
           "value": "Flat (pancake) head, hex socket. Pan head works too."
         }
-      ]
+      ],
+      "note": "Do not add a new joint to this entry. Reported 2026-09-09: with the ribbon cable in the clamp the 35 mm screw would not pick up the nut. The stack under the head is 32.00 mm to the nut pocket floor and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin. See scr-m3-40-fhcs for the measurements."
+    },
+    {
+      "id": "scr-m3-40-fhcs",
+      "uid": "ucgw",
+      "kind": "cots",
+      "cots": {
+        "type": "screw",
+        "size": "M3",
+        "variant": "flat",
+        "length_mm": 40
+      },
+      "name": "M3 × 40 mm flat head",
+      "category": "Screws",
+      "alternative": "Flat or pan head",
+      "description": "The long M3 that clamps the two cable-clamp halves together at the top interface, threading into an M3 nut in the pocket in the Cable clamp (outer).",
+      "created_at": "2026-09-09",
+      "updated_at": "2026-09-09",
+      "attributes": [
+        {
+          "label": "Thread",
+          "value": "M3"
+        },
+        {
+          "label": "Length",
+          "value": "40 mm"
+        },
+        {
+          "label": "Head",
+          "value": "Flat (pancake) head, hex socket. Pan head works too."
+        }
+      ],
+      "note": "Was M3 × 35 mm (scr-m3-35-bhcs) until 2026-09-09. Measured off the two clamp masters in their shared export frame: the screw bears on the flat underside of the Cable clamp (inner) at Z 204.62 and the floor of the nut pocket in the Cable clamp (outer) is at Z 236.62, so the stack under the head is 32.00 mm, and 34.40 mm is needed to come through a 2.4 mm nut sitting on that floor. 35 mm left 0.60 mm of margin, inside the combined tolerance of the screw, the nut and the print. The pocket is a hex 5.70 mm across flats and 8.00 mm deep, so at 40 mm the screw spans the whole pocket and picks the nut up wherever it is sitting; the chute mount leaves a Ø6.4 mm relief 8.5 mm deep above it, so the tip cannot foul."
     },
     {
       "id": "scr-m4-6-cs",
@@ -6239,8 +6272,8 @@
     },
     {
       "id": "cable-clamp",
-      "uid": "e0p9",
-      "version": "1",
+      "uid": "rwaw",
+      "version": "2",
       "name": "Cable clamp",
       "description": "Inner + outer ribbon cable clamp; the two halves clamp together around the cable and the pair bolts to the top interface chute mount.",
       "docs": "/hardware/assembly/distribution/top-interface/",
@@ -6254,12 +6287,21 @@
           "qty": 1
         },
         {
-          "part": "scr-m3-35-bhcs",
+          "part": "scr-m3-40-fhcs",
           "qty": 1
         },
         {
           "part": "nut-m3",
           "qty": 1
+        }
+      ],
+      "versions": [
+        {
+          "version": "2",
+          "date": "2026-09-09",
+          "message": "M3 × 35 mm flat head replaced by M3 × 40 mm flat head. The stack under the screw head is 32.00 mm to the floor of the nut pocket in the outer clamp and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin and builders could not pick the nut up. 40 mm spans the 8.00 mm pocket.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -346,6 +346,18 @@
       }
     },
     {
+      "id": "delete-unused-m3-35-flat-head-screw",
+      "name": "Delete the unused M3 x 35 mm flat head screw",
+      "priority": "P4",
+      "condition": "retired",
+      "description": "This screw reaches no bill of materials. Its only live use was the long screw clamping the two cable-clamp halves together at the top interface, and 35 mm was too short for that joint: the stack under the screw head is 32.00 mm to the floor of the nut pocket in the Cable clamp (outer) and 34.40 mm to come through the nut, so it carried 0.60 mm of margin and the nut could not be picked up. Cable clamp v2 carries the M3 x 40 mm flat head (scr-m3-40-fhcs) instead. Chute stepper gearing v1 also listed it, but v2 replaced it with the M3 x 20 mm countersunk (scr-m3-20-cs), so every remaining reference is a historical snapshot of a superseded assembly. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #618.",
+      "targets": {
+        "hardware": [
+          "scr-m3-35-bhcs"
+        ]
+      }
+    },
+    {
       "id": "delete-unused-m3-15-washer",
       "name": "Delete the unused M3 x 15 mm washer",
       "priority": "P4",
@@ -3504,7 +3516,7 @@
           "value": "Flat (pancake) head, hex socket. Pan head works too."
         }
       ],
-      "note": "Do not add a new joint to this entry. Reported 2026-09-09: with the ribbon cable in the clamp the 35 mm screw would not pick up the nut. The stack under the head is 32.00 mm to the nut pocket floor and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin. See scr-m3-40-fhcs for the measurements."
+      "note": "Do not add a new joint to this entry. Reported 2026-09-09: with the ribbon cable in the clamp the 35 mm screw would not pick up the nut. The stack under the head is 32.00 mm to the nut pocket floor and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin. See scr-m3-40-fhcs for the measurements. Deletion tracked as sorter-v2 issue #618."
     },
     {
       "id": "scr-m3-40-fhcs",

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -3547,8 +3547,7 @@
           "label": "Head",
           "value": "Flat (pancake) head, hex socket. Pan head works too."
         }
-      ],
-      "note": "Was M3 × 35 mm (scr-m3-35-bhcs) until 2026-09-09. Measured off the two clamp masters in their shared export frame: the screw bears on the flat underside of the Cable clamp (inner) at Z 204.62 and the floor of the nut pocket in the Cable clamp (outer) is at Z 236.62, so the stack under the head is 32.00 mm, and 34.40 mm is needed to come through a 2.4 mm nut sitting on that floor. 35 mm left 0.60 mm of margin, inside the combined tolerance of the screw, the nut and the print. The pocket is a hex 5.70 mm across flats and 8.00 mm deep, so at 40 mm the screw spans the whole pocket and picks the nut up wherever it is sitting; the chute mount leaves a Ø6.4 mm relief 8.5 mm deep above it, so the tip cannot foul."
+      ]
     },
     {
       "id": "scr-m4-6-cs",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -799,8 +799,8 @@
 		},
 		{
 			"id": "cable-clamp",
-			"uid": "e0p9",
-			"version": "1",
+			"uid": "rwaw",
+			"version": "2",
 			"name": "Cable clamp",
 			"description": "Inner + outer ribbon cable clamp; the two halves clamp together around the cable and the pair bolts to the top interface chute mount.",
 			"docs": "/hardware/assembly/distribution/top-interface/",
@@ -814,12 +814,49 @@
 					"qty": 1
 				},
 				{
-					"part": "scr-m3-35-bhcs",
+					"part": "scr-m3-40-fhcs",
 					"qty": 1
 				},
 				{
 					"part": "nut-m3",
 					"qty": 1
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "e0p9",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"part": "cable-clamp-inner",
+							"qty": 1,
+							"uid": "3fue"
+						},
+						{
+							"part": "cable-clamp-outer",
+							"qty": 1,
+							"uid": "50dv"
+						},
+						{
+							"part": "scr-m3-35-bhcs",
+							"qty": 1,
+							"uid": "38vn"
+						},
+						{
+							"part": "nut-m3",
+							"qty": 1,
+							"uid": "sc1c"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "rwaw",
+					"date": "2026-09-09",
+					"message": "M3 \u00d7 35 mm flat head replaced by M3 \u00d7 40 mm flat head. The stack under the screw head is 32.00 mm to the floor of the nut pocket in the outer clamp and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin and builders could not pick the nut up. 40 mm spans the 8.00 mm pocket.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -20371,10 +20408,10 @@
 			},
 			"name": "M3 \u00d7 35 mm flat head",
 			"category": "Screws",
-			"description": "The long M3 that clamps the two cable-clamp halves together at the top interface, threading into an M3 nut in the bottom of the Cable clamp (outer).",
-			"note": null,
+			"description": "Retired 2026-09-09, no longer used by any assembly: at 35 mm this screw cleared the far face of the nut by only 0.60 mm and did not reach in practice. The cable clamp takes the M3 \u00d7 40 mm flat head (scr-m3-40-fhcs) now. Kept as an unused entry rather than deleted, because chute-stepper-gearing v1 pins this uid in its line snapshot and a minted uid has to stay resolvable (VERSIONING.md).",
+			"note": "Do not add a new joint to this entry. Reported 2026-09-09: with the ribbon cable in the clamp the 35 mm screw would not pick up the nut. The stack under the head is 32.00 mm to the nut pocket floor and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin. See scr-m3-40-fhcs for the measurements.",
 			"created_at": "2026-07-18",
-			"updated_at": "2026-08-30",
+			"updated_at": "2026-09-09",
 			"attributes": [
 				{
 					"label": "Thread",
@@ -20383,6 +20420,46 @@
 				{
 					"label": "Length",
 					"value": "35 mm"
+				},
+				{
+					"label": "Head",
+					"value": "Flat (pancake) head, hex socket. Pan head works too."
+				}
+			],
+			"sheet_qty": null,
+			"sheet_qty_text": null,
+			"stock": null,
+			"sourcing": null,
+			"alternative": "Flat or pan head",
+			"caption": null,
+			"docs_page": null,
+			"conflicts": null,
+			"image": null
+		},
+		{
+			"id": "scr-m3-40-fhcs",
+			"uid": "ucgw",
+			"kind": "cots",
+			"cots": {
+				"type": "screw",
+				"size": "M3",
+				"variant": "flat",
+				"length_mm": 40
+			},
+			"name": "M3 \u00d7 40 mm flat head",
+			"category": "Screws",
+			"description": "The long M3 that clamps the two cable-clamp halves together at the top interface, threading into an M3 nut in the pocket in the Cable clamp (outer).",
+			"note": "Was M3 \u00d7 35 mm (scr-m3-35-bhcs) until 2026-09-09. Measured off the two clamp masters in their shared export frame: the screw bears on the flat underside of the Cable clamp (inner) at Z 204.62 and the floor of the nut pocket in the Cable clamp (outer) is at Z 236.62, so the stack under the head is 32.00 mm, and 34.40 mm is needed to come through a 2.4 mm nut sitting on that floor. 35 mm left 0.60 mm of margin, inside the combined tolerance of the screw, the nut and the print. The pocket is a hex 5.70 mm across flats and 8.00 mm deep, so at 40 mm the screw spans the whole pocket and picks the nut up wherever it is sitting; the chute mount leaves a \u00d86.4 mm relief 8.5 mm deep above it, so the tip cannot foul.",
+			"created_at": "2026-09-09",
+			"updated_at": "2026-09-09",
+			"attributes": [
+				{
+					"label": "Thread",
+					"value": "M3"
+				},
+				{
+					"label": "Length",
+					"value": "40 mm"
 				},
 				{
 					"label": "Head",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -20461,7 +20461,7 @@
 			"name": "M3 \u00d7 40 mm flat head",
 			"category": "Screws",
 			"description": "The long M3 that clamps the two cable-clamp halves together at the top interface, threading into an M3 nut in the pocket in the Cable clamp (outer).",
-			"note": "Was M3 \u00d7 35 mm (scr-m3-35-bhcs) until 2026-09-09. Measured off the two clamp masters in their shared export frame: the screw bears on the flat underside of the Cable clamp (inner) at Z 204.62 and the floor of the nut pocket in the Cable clamp (outer) is at Z 236.62, so the stack under the head is 32.00 mm, and 34.40 mm is needed to come through a 2.4 mm nut sitting on that floor. 35 mm left 0.60 mm of margin, inside the combined tolerance of the screw, the nut and the print. The pocket is a hex 5.70 mm across flats and 8.00 mm deep, so at 40 mm the screw spans the whole pocket and picks the nut up wherever it is sitting; the chute mount leaves a \u00d86.4 mm relief 8.5 mm deep above it, so the tip cannot foul.",
+			"note": null,
 			"created_at": "2026-09-09",
 			"updated_at": "2026-09-09",
 			"attributes": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -361,6 +361,18 @@
 			}
 		},
 		{
+			"id": "delete-unused-m3-35-flat-head-screw",
+			"name": "Delete the unused M3 x 35 mm flat head screw",
+			"priority": "P4",
+			"condition": "retired",
+			"description": "This screw reaches no bill of materials. Its only live use was the long screw clamping the two cable-clamp halves together at the top interface, and 35 mm was too short for that joint: the stack under the screw head is 32.00 mm to the floor of the nut pocket in the Cable clamp (outer) and 34.40 mm to come through the nut, so it carried 0.60 mm of margin and the nut could not be picked up. Cable clamp v2 carries the M3 x 40 mm flat head (scr-m3-40-fhcs) instead. Chute stepper gearing v1 also listed it, but v2 replaced it with the M3 x 20 mm countersunk (scr-m3-20-cs), so every remaining reference is a historical snapshot of a superseded assembly. It should be deleted outright, but a minted part id has to stay resolvable once it exists, and the catalog's own consistency check refuses a change that removes one, so deleting it needs that check overridden by someone who can make that call, not an edit from here. Tracked as sorter-v2 issue #618.",
+			"targets": {
+				"hardware": [
+					"scr-m3-35-bhcs"
+				]
+			}
+		},
+		{
 			"id": "delete-unused-m3-15-washer",
 			"name": "Delete the unused M3 x 15 mm washer",
 			"priority": "P4",
@@ -20409,7 +20421,7 @@
 			"name": "M3 \u00d7 35 mm flat head",
 			"category": "Screws",
 			"description": "Retired 2026-09-09, no longer used by any assembly: at 35 mm this screw cleared the far face of the nut by only 0.60 mm and did not reach in practice. The cable clamp takes the M3 \u00d7 40 mm flat head (scr-m3-40-fhcs) now. Kept as an unused entry rather than deleted, because chute-stepper-gearing v1 pins this uid in its line snapshot and a minted uid has to stay resolvable (VERSIONING.md).",
-			"note": "Do not add a new joint to this entry. Reported 2026-09-09: with the ribbon cable in the clamp the 35 mm screw would not pick up the nut. The stack under the head is 32.00 mm to the nut pocket floor and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin. See scr-m3-40-fhcs for the measurements.",
+			"note": "Do not add a new joint to this entry. Reported 2026-09-09: with the ribbon cable in the clamp the 35 mm screw would not pick up the nut. The stack under the head is 32.00 mm to the nut pocket floor and 34.40 mm through the nut, so 35 mm carried 0.60 mm of margin. See scr-m3-40-fhcs for the measurements. Deletion tracked as sorter-v2 issue #618.",
 			"created_at": "2026-07-18",
 			"updated_at": "2026-09-09",
 			"attributes": [


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1487518366020276397/1547318343403438102
request: https://discord.com/channels/1430279849171222682/1547318343403438102/1547321717771341994
request: https://discord.com/channels/1430279849171222682/1547318343403438102/1547334678178959421
request: https://discord.com/channels/1430279849171222682/1547318343403438102/1547339749226713220
request: https://discord.com/channels/1430279849171222682/1547318343403438102/1547342150130213006
request: https://discord.com/channels/1430279849171222682/1547318343403438102/1547463923790385152
request: https://discord.com/channels/1430279849171222682/1547318343403438102/1547465184245977088
preview: /hardware/assembly/distribution/top-interface/
-->

**Requested by Daddy-O's Bricks - Bill (@daddyosbricksbill) [from Discord](https://discord.com/channels/1430279849171222682/1487518366020276397/1547318343403438102):** *"the docs say to put a m3 nut into the bottom of the outer cable clamp then install it onto the top interface chute mount. When I add the ribbon cable to the inner cable clamp and try to pick up the nut with the 35mm screw is doesn't reach the bottom to grab it. ... I am not sure if this should be flagged as a CAD issue, a hardware issue, or a process issue in the docs."*

**Also requested by barthel (@uwe_barthel)**, twice in the same thread. On the screw, [from Discord](https://discord.com/channels/1430279849171222682/1547318343403438102/1547321717771341994): *"The M3 x 35mm screw is only used here. To make assembly easier and more secure, we could replace this screw (which is used in only one place) with an M3 x 40mm screw or make a slight adjustment to the component. I'd prefer to replace the screws."* And on the nut, [from Discord](https://discord.com/channels/1430279849171222682/1547318343403438102/1547339749226713220): *"Add a warning about the loose m3 nut in top interface page step 11."*

The screw is too short. It is a hardware spec problem, not a defect in either clamp.

## Measured

Both clamp masters are exported in the same assembly frame, so the two halves stack directly. Pinned STLs, unchanged since the report:

- `cable-clamp-inner` (`3fue`): https://assets.basically.website/sorter-parts/cable-clamp-inner-16cfdfea28d0.stl
- `cable-clamp-outer` (`50dv`): https://assets.basically.website/sorter-parts/cable-clamp-outer-dd778421784b.stl
- `top-interface-split-spur-gear-3` (`Top interface chute mount`): https://assets.basically.website/sorter-parts/top-interface-split-spur-gear-3-11f50ca23d80.stl

Along the screw axis, at X −76.60 / Y +15.85:

| Z | feature |
| --- | --- |
| 204.62 | flat underside of the inner clamp, where the head bears. Plain Ø3.50 bore opening flush, no countersink, no counterbore. |
| 219.37 | inner/outer mating plane. Ø3.50 through the inner clamp for 14.75 mm. |
| 236.62 | floor of the nut pocket in the outer clamp. Ø3.50 through the outer clamp for 17.25 mm. |
| 236.62 → 244.62 | the nut pocket: a blind hex, **5.70 mm across flats, 8.00 mm deep**, opening on the face that meets the chute mount. |
| 244.62 → 253.18 | Ø6.4 relief in the chute mount directly above the pocket. |

So the stack under the head is **32.00 mm** to the near face of an M3 nut sitting on the pocket floor, and **34.40 mm** to come through it (ISO 4032 M3, 2.40 mm).

`scr-m3-35-bhcs` is a flat (pancake) head, whose length is measured under the head, so 35 mm cleared the far face of the nut by **0.60 mm**. That is inside the combined tolerance of the screw's length, a nut on the thin side, and a pocket floor that printed a fraction high, and it goes negative outright if the two halves are held even slightly apart by the ribbon. It also assumes the nut is sitting flat on the floor of an 8.00 mm pocket: a 35 mm screw only enters the pocket by 3.00 mm, so a nut anywhere else in it is unreachable. Bill's second photo is that, the tip arriving at the pocket floor and no further.

At 40 mm the screw spans the whole pocket, catches the nut wherever it is sitting, and stops flush with the face against the chute mount, which has 8.5 mm of relief above it. 40 mm also survives the head-type confusion: most suppliers sell "M3 x 35 flat head" as a countersunk screw, which in a hole with no countersink sits ~1.7 mm proud and loses that much reach.

## What changed

- **New hardware part `scr-m3-40-fhcs`** (`ucgw`), M3 × 40 mm flat head, flat or pan head. Its catalog row says what the screw is for and nothing else, [at barthel's request](https://discord.com/channels/1430279849171222682/1547318343403438102/1547465184245977088): *"Remove the long explanatory text for the M3x40mm screw in the parts calculator. Just state what it's used for."* The measurements live on the `cable-clamp` v2 changelog entry, the P4 entry on the retired 35 mm row, and #618.
- **`cable-clamp` stamped v2** (`rwaw`, superseding `e0p9`), swapping the screw line. `breaking: false`, because an already-built clamp pair is still a clamp pair, only the screw you should have used changed. `commit` left `null` because the board squashes.
- **`scr-m3-35-bhcs` retired in place**, not deleted: `chute-stepper-gearing` v1 pins its uid in a line snapshot, and per [`VERSIONING.md`](https://github.com/basicallysource/sorter-v2/blob/main/parts-calculator/VERSIONING.md) a minted uid has to stay resolvable. Nothing else uses it: `chute-stepper-gearing` v2 already replaced it with `scr-m3-20-cs`.
- **`top-interface.md`** step 11 and its `parts_needed` now name the 40 mm screw.
- **A warning callout in step 11** on the same page: the nut is not captive, nothing holds it in the pocket until the clamp is pushed into the recess, so it can fall out or sit skewed where the screw has nothing to start on. Kept to what a builder has to do, with no dimensions and no reporter credit, [at barthel's request](https://discord.com/channels/1430279849171222682/1547318343403438102/1547342150130213006): *"Remove unnecessary information from the documentation, such as '5.7 mm across flats and 8 mm deep,' and 'reported by.'"*
- **`scr-m3-35-bhcs` marked to be deleted**: a P4 `retired` `changes` entry, `delete-unused-m3-35-flat-head-screw`, so the calculator puts a visible marker on the row wherever it renders it. Deletion itself is tracked as #618, labelled `bom`. [Requested by barthel](https://discord.com/channels/1430279849171222682/1547318343403438102/1547463923790385152): *"Mark the M3x35mm flat head screw in the part calculator as 'to be deleted' and create a corresponding GitHub issue with the tag 'bom'."*
- Regenerated with `catalog/generate.py --metadata-only`.

No CAD change is proposed. The pocket is deep for a 2.4 mm nut, but with a screw that spans it that stops mattering.

[zed0 pointed out](https://discord.com/channels/1430279849171222682/1547318343403438102/1547326427559632966) that both clamps are completely replaced in later versions of the CAD. Nothing here assumes otherwise. These two parts are what the catalog ships today and the nut mechanism is intact, which is [barthel's reason](https://discord.com/channels/1430279849171222682/1547318343403438102/1547329449559592961) for describing it as it stands: *"If anything changes there, I'd suggest we update the documentation."*



