### PR TITLE
gitignore + AGENTS.md: machine-local agent context lives in agents.local/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,12 @@
 # Machine-local agent notes (private: machine names, tailnet, access details).
 # The committed AGENTS.md files are public.
 AGENTS.local.md
+agents.local/
 .tmp-*
+
+# Machine-generated on the Pi (dev.sh --dump logs, sorting-profile storage). Never source.
+/software/logs/
+/software/mine/
 
 machine.toml
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 useful documentation for any agent or contributor working in this repository:
 how things build, where things live, what the conventions are. Nothing
 specific to one person's machines, accounts, or setup goes in this file; that
-belongs in the gitignored `AGENTS.local.md`.
+belongs in the gitignored `agents.local/` directory.
 
 Deliberately thin right now; sections get filled in as the systems they
 describe land.
@@ -13,6 +13,6 @@ describe land.
   pipeline (sources in git, renders in the assets bucket, CI publishes).
 - `docs/AGENTS.md`: working on the docs site.
 
-If a gitignored `AGENTS.local.md` exists next to this file, read it too: it
-carries machine-local private context (machine names, access details) that
-never gets committed.
+If a gitignored `agents.local/` directory exists next to this file, read
+its `README.md` and the files it lists: they carry machine-local private
+context (machine names, access details) that never gets committed.


### PR DESCRIPTION
## Summary
- Replace the single gitignored `AGENTS.local.md` with a gitignored `agents.local/` directory; `AGENTS.md` now points agents at its `README.md`.
- Ignore `software/logs/` and `software/mine/`, which the software generates on the machine and which kept showing up as untracked clutter.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)