### PR TITLE
docs: verify an edit with the cheapest check, and keep vite's cache out of node_modules

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .svelte-kit
+.vite
 build
 vite.config.ts.timestamp-*
 _site/

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -11,6 +11,27 @@ adding and editing articles. Read it before touching anything here.
 data files, and includes all hot-reload; restart after changing
 `src/lib/server/content.ts`.
 
+## Verifying an edit
+
+The cheapest check that covers the change, and only that:
+
+- **A page edit** (markdown, frontmatter, an image or video embed): `npm run
+  check` from `docs/` for the Svelte and TypeScript side, `python3
+  scripts/validate_images.py` for every asset URL on the page, then load the
+  page on `npm run dev` and look at it.
+- **A change to layout, `src/lib/server/content.ts`, `svelte.config.js`,
+  `vite.config.ts`, or a data file every page reads**: `npm run build`, once.
+  It prerenders every page, needs about 500 MB of memory and a few minutes on
+  one CPU, and is not the way to check a paragraph.
+- **A dependency change**: the pull request's preview build is the check. An
+  environment may provide `node_modules` read-only, installed from the
+  lockfile on `main` (an agent's does); `npm ci` refuses there, so say what
+  you added in the PR and let the preview install it.
+
+Vite's dependency cache is `.vite/` in this directory rather than the default
+inside `node_modules`, so the dev server works when `node_modules` is not
+writable. It is ignored by git.
+
 ## Favicon — the docs site color is yellow
 
 Every web UI in the ecosystem shows the same basically brick on a full-bleed

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	// Outside node_modules, so the dev server works where node_modules is
+	// provided read-only (an agent's environment installs it from the lockfile
+	// and mounts it that way). Ignored by git.
+	cacheDir: '.vite',
 	server: {
 		fs: {
 			// content markdown + liquid includes live outside routes/lib

--- a/parts-calculator/.gitignore
+++ b/parts-calculator/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.vite
 
 # Output
 .output

--- a/parts-calculator/vite.config.ts
+++ b/parts-calculator/vite.config.ts
@@ -4,6 +4,10 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+	// Outside node_modules, so the dev server works where node_modules is
+	// provided read-only (an agent's environment installs it from the lockfile
+	// and mounts it that way). Ignored by git.
+	cacheDir: '.vite',
 	// Vite doesn't read PORT on its own. Honour it when set so a supervising
 	// tool can assign a free port; fall back to Vite's default otherwise.
 	server: process.env.PORT


### PR DESCRIPTION
docs: verify an edit with the cheapest check, and keep vite's cache out of node_modules

A page edit was being checked with a full `npm run build`: every page
prerendered, about 500 MB of memory and minutes of CPU, to look at one
paragraph. `docs/AGENTS.md` now says which check covers which change: `npm
run check` plus `validate_images.py` plus the dev server for a page, the
full build only for layout, config or the content engine, and the PR's
preview build for a dependency change.

Vite's dependency cache moves from `node_modules/.vite` to `.vite/` in the
project directory (docs and parts-calculator, both gitignored), so the dev
server works in an environment that provides `node_modules` read-only,
installed from the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
