### PR TITLE
docs: arranging C-channels stands on the new support structure, not legs

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -140,7 +140,7 @@ The same again, with the **68 mm printed** legs.
   <figcaption>The same stand from lower down, with all three adapters in view. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
-{% include step.html n="5" title="★ Lay the three stands out" %}
+{% include step.html n="5" title="Lay the three stands out" %}
 
 Put all three on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s top plate. **The drop between channels comes out of this on its own** — you don't measure it, you get it by using the right leg on each channel and standing all three guides on the same flat surface.
 
@@ -171,11 +171,6 @@ Put all three on the [top interface]({{ '/hardware/assembly/distribution/top-int
 <div class="callout">
   <p>Don't add more drop than this to fix bouncing. A part is supposed to arrive at the next rotor with most of its energy gone; a bigger drop makes pieces bounce further and re-clump, which is the problem the cascade exists to solve. If parts are riding round a channel instead of leaving it, that's the <a href="{{ '/hardware/assembly/feeder/output-guides/' | relative_url }}">output guide</a>'s job, not the height's.</p>
 </div>
-
-**Still not recorded**, and these are the numbers this page most needs from a real build:
-
-- how far two channels overlap horizontally, which is what fixes where the guides sit relative to one another,
-- how far around the circle each handover happens.
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -176,9 +176,7 @@ Put all three on the [top interface]({{ '/hardware/assembly/distribution/top-int
 
 {% include step.html n="6" title="Install the classification channel" %}
 
-C4 goes in first, before the three above it, and it takes **no support structure of its own** — no layout guide, no legs, no adapters. It sits flat on the top plate and slides onto the layout guide that C3 stands in. The plate carries its weight; C3's guide locates it and sets which way round it goes. <cite>Tip: BrickCycleAlice.</cite>
-
-That is also what closes the height. C3's guide stands on the plate, so the plate is the zero the other three are measured from, and the 80 mm step below C3's 80 mm seat lands exactly there. Measured on the STLs, the fit is between the stator's base flange — the bottom 19 mm of the drive, r 103–120 mm — and the guide's ring, r 98–118 mm and 28 mm tall. Stand the drive on the plate and the flange is inside the ring.
+C4 goes in first, before the three above it, and it takes **no support structure of its own** — no layout guide, no legs, no adapters. It sits flat on the top plate and slides onto the layout guide that C3 stands in.
 
 The top plate itself has no mount holes for a C-channel, so nothing bolts down here.
 

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -10,14 +10,7 @@ permalink: /hardware/assembly/feeder/arranging-c-channels/
 author: barthel
 contributors: [brickcyclealice]
 og_image: https://assets.basically.website/sorter-parts/c-channel-stands-all-three-full-9b385f0819e2.jpg
-warning: >-
-  **AI-generated first draft.** Written from the machine assembly tree in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and measured
-  off the published STLs, not from an actual build. The parts, the leg lengths and the 80 mm
-  step between channels are real and current. **The order of the steps, the photographs, and
-  Steps 5, 6 and 8 come from BrickCycleAlice's build**; the rest has not been walked through
-  by a builder. One thing is still missing: how far two channels overlap horizontally and
-  where round the circle each handover happens. Fill it in as you build.
+last_verified: 2026-09-10
 parts_needed:
   - part: layout-guide
     qty: 3
@@ -135,7 +128,7 @@ The same three moves, with the **148 mm printed** legs.
 
 {% include step.html n="4" title="Build C3's stand" %}
 
-The same again, with the **68 mm printed** legs. This is the shortest stand, and it is also the one the classification channel drops into in step 6, so it is worth getting square before you go on.
+The same again, with the **68 mm printed** legs.
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stand-c3-full-8a3466156d18.jpg" alt="C3's stand: the layout guide with three short printed support legs and their dovetail adapters">

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -14,11 +14,10 @@ warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and measured
   off the published STLs, not from an actual build. The parts, the leg lengths and the 80 mm
-  step between channels are real and current, and BrickCycleAlice's photographs of all three
-  stands are on Steps 2 and 3 — but no step below has been walked through by a builder. Two
-  things are still missing: how far two channels overlap horizontally and where round the
-  circle each handover happens, and how the classification channel is fixed down. Fill them
-  in as you build.
+  step between channels are real and current. Steps 2, 4 and 6 and the photographs come from
+  BrickCycleAlice's build; the rest has not been walked through by a builder. One thing is
+  still missing: how far two channels overlap horizontally and where round the circle each
+  handover happens. Fill it in as you build.
 parts_needed:
   - part: layout-guide
     qty: 3
@@ -44,7 +43,7 @@ parts_needed:
 
 Four [C-channels]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}) are built the same way and then stood at different heights, so a part cascades from one to the next under gravity and arrives at the [interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) singulated.
 
-C1, C2 and C3 each stand on the same three-piece support structure: a **Layout guide** it stands on, three **support legs** standing in that, and a **Support dovetail adapter** on top of each leg that slides up into the C-channel drive from below. The legs are the only thing that differs between the three channels, and their lengths are what set the drop between one channel and the next. The classification channel has no support structure of its own.
+C1, C2 and C3 each stand on the same three-piece support structure: a **Layout guide** it stands on, three **support legs** standing in that, and a **Support dovetail adapter** on top of each leg that slides up into the C-channel drive from below. The legs are the only thing that differs between the three channels, and their lengths are what set the drop between one channel and the next. The classification channel has no support structure of its own: it stands on the top plate and is located by C3's layout guide (step 6).
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -135,7 +134,9 @@ Build the same stack three times, once per channel, with that channel's legs:
   <figcaption>The same C3 stand from lower down, with all three adapters in view. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
-**Not recorded:** how the three legs are clocked around the channel — which of the three sits under the stepper, under the exit, or under the camera lamp arm. The layout guide is exported on its own, so the STLs don't say.
+<div class="callout">
+  <p><strong>Clock all three the same way, with the steppers toward the centre of the guides.</strong> Nothing in the STLs says which of a channel's three legs sits under the motor — the layout guide is exported on its own — so this is how it is actually built. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
 
 {% include step.html n="3" title="★ Set the heights and the spacing" %}
 
@@ -147,7 +148,7 @@ Build the same stack three times, once per channel, with that channel's legs:
 | C2 | C-channel 2 support leg, printed | 148 mm |
 | C3 | C-channel 3 support leg, printed | 68 mm |
 
-228, 148, 68 — an even 80 mm step. Every leg sockets the same 18 mm into its guide and carries the same adapter, so the step passes straight through to the drives: measured from the underside of the layout guides, the three seats land at **240 mm, 160 mm and 80 mm**. Another 80 mm below C3 is zero, which is the surface the guides themselves stand on. That's the argument in step 6 for where the classification channel goes.
+228, 148, 68 — an even 80 mm step. Every leg sockets the same 18 mm into its guide and carries the same adapter, so the step passes straight through to the drives: measured from the underside of the layout guides, the three seats land at **240 mm, 160 mm and 80 mm**. Another 80 mm below C3 is zero, which is the surface the guides themselves stand on — the top plate, and where the classification channel goes (step 6).
 
 <div class="img-row">
   <figure>
@@ -172,9 +173,11 @@ Build the same stack three times, once per channel, with that channel's legs:
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="4" title="Fit the output guides" %}
+{% include step.html n="4" title="Fit the rotors and the output guides" %}
 
-One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) on C2 and one on C3. Each belongs to the channel it is mounted on, not to the gap between two; C1 and the classification channel take none.
+With the channels standing, drop the rotor units in and fit the output guides at the same time.
+
+One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) on C2 and one on C3. Each belongs to the channel it is mounted on, not to the gap between two; C1 and the classification channel take none. <cite>Order: BrickCycleAlice.</cite>
 
 <div class="img-placeholder">Image coming</div>
 
@@ -184,15 +187,13 @@ One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url 
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="6" title="★ Stand the classification channel" %}
+{% include step.html n="6" title="Stand the classification channel" %}
 
-**The classification channel has no support structure in the parts list** — no layout guide, no legs, no adapters. Where its weight goes is the one part of the feeder nobody has written down, and it's been asked in the server twice without an answer.
+**The classification channel takes no support structure of its own** — no layout guide, no legs, no adapters. It sits flat on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s top plate, and it slides onto the layout guide that C3 stands in. The plate carries its weight; C3's guide locates it and sets which way round it goes. <cite>Tip: BrickCycleAlice.</cite>
 
-What the geometry says, which is an inference and not a build: the 80 mm step continues, so C4's seat falls exactly at the level the three layout guides stand on. Resting the drive straight on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s plate puts it at the right height — the stator and the NEMA bracket bottom out together and the stepper mounts on the bracket's upper face, so nothing hangs below the seating plane to foul the plate. What that doesn't give you is anything holding it down or setting which way it's clocked. The top plate has no mount holes for a C-channel.
+That also closes the height. C3's guide stands on the plate, so the plate is the zero the other three are measured from, and the 80 mm step below C3's 80 mm seat lands exactly there. Measured on the STLs, the fit is between the stator's base flange (r 103–120 mm, and the 19 mm of it that hangs below the drive's seating face) and the guide's ring (r 98–118 mm, 28 mm tall) — the flange drops inside the ring.
 
-**If you work this out on your own machine, it's the single most useful thing you could send back.** <span class="fastener-todo">not recorded</span>
-
-<div class="img-placeholder">Image coming</div>
+The top plate itself has no mount holes for a C-channel, so nothing bolts down here.
 
 {% include step.html n="7" title="Turn it all by hand" %}
 

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -189,7 +189,18 @@ The top plate itself has no mount holes for a C-channel, so nothing bolts down h
 
 Now the other three drives go on their stands. Lower each one onto its three dovetail adapters so the tangs engage it from below. It's a friction fit; the channel's own weight holds it.
 
-<div class="img-placeholder">Image coming</div>
+The rotors are out of both photographs below, which is the only way to see the joints — with a rotor in, the middle of a channel is covered. They also show the clocking from step 5: every stepper ends up in the middle of the group.
+
+<div class="img-row">
+  <figure>
+    <img src="https://assets.basically.website/sorter-parts/c-channel-drives-three-on-full-0fb34fea7ae4.jpg" alt="Three C-channel drives sitting on their stands with no rotors fitted, the fourth stand still empty beside them, all the steppers pointing into the middle of the group">
+    <figcaption>Three drives on, one stand still empty. Rotors left out so the joints show. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img src="https://assets.basically.website/sorter-parts/c-channel-drives-all-four-full-44246243494e.jpg" alt="All four C-channel drives in place without rotors, their stepper motors gathered together at the centre of the group">
+    <figcaption>All four drives in place, steppers together in the middle. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 {% include step.html n="8" title="Fit the rotors and the output guides" %}
 

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -10,16 +10,22 @@ permalink: /hardware/assembly/feeder/arranging-c-channels/
 author: barthel
 warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
-  calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and the
-  extrusion list on the bill of materials, not from an actual build. No height, angle or fastener here
-  has been checked against a machine, and the two starred steps are the ones that make the
-  feeder work. Fill it in as you build.
+  calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and measured
+  off the published STLs, not from an actual build. The parts, the leg lengths and the 80 mm
+  step between channels are real and current; nobody has photographed the stand. Two things
+  are still missing: how far two channels overlap horizontally and where round the circle
+  each handover happens, and how the classification channel is fixed down. Fill them in as
+  you build.
 parts_needed:
-  - part: leg
-    qty: 9
-  - part: foot
-    qty: 9
-  - part: leg-extension
+  - part: layout-guide
+    qty: 3
+  - part: ext-2020-c1
+    qty: 3
+  - part: channel-two-support-leg
+    qty: 3
+  - part: channel-three-support-leg
+    qty: 3
+  - part: support-dovetail-adapter
     qty: 9
 ---
 
@@ -35,54 +41,99 @@ parts_needed:
 
 Four [C-channels]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}) are built the same way and then stood at different heights, so a part cascades from one to the next under gravity and arrives at the [interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) singulated.
 
-The fasteners and quantities in the parts list come from the parts registry and are called out inline at each step.
+C1, C2 and C3 each stand on the same three-piece support structure: a **Layout guide** it stands on, three **support legs** standing in that, and a **Support dovetail adapter** on top of each leg that slides up into the C-channel drive from below. The legs are the only thing that differs between the three channels, and their lengths are what set the drop between one channel and the next. The classification channel has no support structure of its own.
 
-{% include fastener-legend.html %}
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>The Leg, Foot and Leg extension are retired.</strong> Three printed parts stacked with dovetails used to hold each channel up, 9 of each across the feeder. They were replaced on 2026-09-02 by the layout guide, the support legs and the dovetail adapters, and the heights on this page only come out right with the new parts. Don't re-add them from an older photo, an older print list, or a machine built before that date.</p>
+</div>
 
 Steps below refer to the channels by the names the software uses, in the order a part travels:
 
 - **C1**, the bulk channel, under the [bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}). Highest.
-- **C2**, with a [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and an [overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}).
+- **C2**, with a [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}).
 - **C3**, the same again, and the last metering stage.
-- **The classification channel**, inside the [classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}), which images the part before it drops into the chute.
+- **The classification channel**, inside the [classification chamber]({{ '/hardware/assembly/feeder/classification-chamber/' | relative_url }}), which images the part before it drops into the chute. Lowest.
 
 {% include step.html n="1" title="Preparation" %}
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Legs, feet and leg extensions:</strong> 3 of each per channel, 9 of each across the three feeder channels. The Leg is the 135 mm print, the extension raises it further, and the foot is what meets the bench. No heat inserts recorded.</p>
+    <p><strong>Three layout guides, one per channel.</strong> It's a ring about 250 mm across and 28 mm thick, spoked to a hub, with three square sockets standing on it. The same part goes under C1, C2 and C3 — it is <em>not</em> one big base that positions all three channels at once, so print three.</p>
   </div>
   <figure class="prep-item-figure">
-    <div class="img-placeholder">Image coming</div>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-layout-guide-full-8cf1b8fec1ec.png" alt="Render of the layout guide: a spoked ring with three open square sockets standing on it and a round hub in the middle">
+    <figcaption>The Layout guide, one per channel. <cite>Render from the published STL.</cite></figcaption>
   </figure>
 </div>
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>Feeder extrusion, from the bill of materials:</strong> 3 pieces of 2020 at 270 mm (bulk bucket supports), 3 at 190 mm (mid C-channel supports), 3 at 110 mm (lower C-channel supports), and the camera support, either 1 at 300 mm fixed or 1 at 350 mm plus 1 at 200 mm adjustable. No step records what any of them bolts to.</p>
+    <p><strong>Three legs per channel, and each channel's are different.</strong> C1's are 2020 aluminium extrusion cut to 228 mm — piece <strong>J</strong> on the <a href="https://parts-calculator.basically.website/framing">cut list</a>, and the only 2020 in the machine that isn't part of the frame. C2's and C3's are printed, and there's a separate STL for each. Both printed legs are the same shape: a 26 mm square spigot at each end and a fatter body between them, so the only difference is how long the body is.</p>
   </div>
   <figure class="prep-item-figure">
-    <div class="img-placeholder">Image coming</div>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-support-leg-full-87fa6d93be59.png" alt="Render of the printed C-channel 3 support leg: a square body with a narrower square spigot at each end, each spigot drilled through">
+    <figcaption>The C-channel 3 support leg. C2's is the same part with a longer body. <cite>Render from the published STL.</cite></figcaption>
   </figure>
+</div>
+
+<div class="prep-item">
+  <div class="prep-item-body">
+    <p><strong>Nine dovetail adapters</strong>, three per channel and the same part on all three. Each is 42 mm tall and in two halves: a 41 mm square block, 20 mm of it, with a socket in its underside that swallows the top 18 mm of a leg, and a 22 mm tapered tang above that goes up into the C-channel drive. <strong>The block's top face is what the channel sits on</strong>, 2 mm above the leg — not the tip of the tang.</p>
+  </div>
+  <figure class="prep-item-figure">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-support-dovetail-adapter-full-0a3f5f941324.png" alt="Render of the support dovetail adapter: a square block with a tapered tang standing on it and a hole through one side of the block">
+    <figcaption>The Support dovetail adapter. <cite>Render from the published STL.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="callout">
+  <p><strong>There are no fasteners in the stand at all.</strong> Every joint in it is gravity or friction: a leg stands in the layout guide, an adapter sits on a leg, and the three adapters push up into the drive. Nothing here is screwed and nothing takes a heat insert. The printed legs and the adapters do have holes through them — 2 × Ø4.20 in each leg, 2 × Ø5.50 in each adapter — and none of them is fastened. Don't go looking for the screws.</p>
 </div>
 
 {% include step.html n="2" title="Stand each channel" %}
 
-Fit 3 legs, 3 extensions and 3 feet to each of the three feeder channels.
+Build the same stack three times, once per channel, with that channel's legs:
 
-**Not recorded:** how the leg, extension and foot stack, what fastens them to each other, and how a leg attaches to the channel's stator or NEMA bracket. <span class="fastener-todo">fastener not recorded</span>
+1. Put the layout guide down flat, sockets up.
+2. Stand the three legs in it. The sockets are 18 mm deep and the legs are held by their own weight — C1's extrusion, C2's and C3's printed legs.
+3. Drop a dovetail adapter over the top of each leg. The socket in its underside takes the top 18 mm of the leg, so the block's top face lands 2 mm above the leg on every channel — that face is the seat.
+4. Lower the built C-channel onto the three tangs so they engage the drive from below. It's a friction fit; the channel's weight holds it.
 
-**Not recorded:** whether the classification channel stands on legs of its own or is carried by the chamber and the interface below it. The catalog gives 9 of each for the feeder and none for the classification channel, which suggests the latter.
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>C1's legs don't fit their sockets closely.</strong> Both sockets — the one in the layout guide and the one under the adapter — are 26 mm square and 18 mm deep, which is what the printed legs' spigots are made to. C1's leg is 2020 extrusion, 20 mm square, so it has about 3 mm of slack a side at both ends. Nothing in the parts registry says what takes that up. The heights below still work as long as the extrusion bottoms out in the socket, but if you're building C1, check this against your own parts.</p>
+</div>
+
+**Not recorded:** how the three legs are clocked around the channel — which of the three sits under the stepper, under the exit, or under the camera lamp arm. The layout guide is exported on its own, so the STLs don't say. <span class="fastener-todo">not recorded</span>
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="3" title="★ Set the heights and the spacing (the numbers that make parts actually cascade)" %}
+{% include step.html n="3" title="★ Set the heights and the spacing" %}
 
-The numbers this page most needs, and none of them are written down anywhere today. For each handover, record:
+**The drop is 80 mm per handover, and it's built into the legs.** You don't measure it; you get it by using the right leg on each channel and standing all three layout guides on the same flat surface.
 
-- the drop from one rotor to the next,
-- the horizontal overlap between the two channels,
-- how far around the circle the handover happens.
+| Channel | Leg | Length |
+|---|---|---|
+| C1 | `ext-2020-c1`, 2020 extrusion, piece J | 228 mm |
+| C2 | C-channel 2 support leg, printed | 148 mm |
+| C3 | C-channel 3 support leg, printed | 68 mm |
+
+228, 148, 68 — an even 80 mm step. Every leg sockets the same 18 mm into its guide and carries the same adapter, so the step passes straight through to the drives: measured from the underside of the layout guides, the three seats land at **240 mm, 160 mm and 80 mm**. Another 80 mm below C3 is zero, which is the surface the guides themselves stand on. That's the argument in step 6 for where the classification channel goes.
+
+<figure>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-support-heights-full-a32b5d7f02ad.png" alt="Elevation of the three support stacks side by side, C1 tallest to C3 shortest, with dashed lines marking seat heights at 240, 160 and 80 mm above the surface the layout guides stand on, and 80 mm marked between each pair">
+  <figcaption>The three stacks to scale, from the published STLs, with one of each channel's three legs shown. C1's leg is drawn as a plain 20 × 20 × 228 mm extrusion. The dashed lines are the faces the C-channel drives sit on. <cite>Render from the published STLs.</cite></figcaption>
+</figure>
+
+<div class="callout">
+  <p>Don't add more drop than this to fix bouncing. A part is supposed to arrive at the next rotor with most of its energy gone; a bigger drop makes pieces bounce further and re-clump, which is the problem the cascade exists to solve. If parts are riding round a channel instead of leaving it, that's the <a href="{{ '/hardware/assembly/feeder/output-guides/' | relative_url }}">output guide</a>'s job, not the height's.</p>
+</div>
+
+**Still not recorded**, and these are the numbers this page most needs from a real build:
+
+- how far two channels overlap horizontally, which is what fixes where the guides sit relative to one another,
+- how far around the circle each handover happens.
 
 <div class="img-placeholder">Image coming</div>
 
@@ -92,15 +143,19 @@ One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url 
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="5" title="Add the bulk input, the light posts and the camera arms" %}
+{% include step.html n="5" title="Add the bulk input and the camera lamps" %}
 
-[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}) on C1. A [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and an [overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}) on C2 and on C3.
+[Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}) on C1. A [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}) on C2 and on C3 — C1 has neither a lamp nor an output guide, because it's fed in bulk and nothing reads vision off it.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="6" title="★ Hand over to the classification channel (the other unresolved joint)" %}
+{% include step.html n="6" title="★ Stand the classification channel" %}
 
-The other open question: how the classification channel sits relative to C3 and to the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) below it, and what carries its weight.
+**The classification channel has no support structure in the parts list** — no layout guide, no legs, no adapters. Where its weight goes is the one part of the feeder nobody has written down, and it's been asked in the server twice without an answer.
+
+What the geometry says, which is an inference and not a build: the 80 mm step continues, so C4's seat falls exactly at the level the three layout guides stand on. Resting the drive straight on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s plate puts it at the right height — the stator and the NEMA bracket bottom out together and the stepper mounts on the bracket's upper face, so nothing hangs below the seating plane to foul the plate. What that doesn't give you is anything holding it down or setting which way it's clocked. The top plate has no mount holes for a C-channel.
+
+**If you work this out on your own machine, it's the single most useful thing you could send back.** <span class="fastener-todo">not recorded</span>
 
 <div class="img-placeholder">Image coming</div>
 

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -8,14 +8,17 @@ kicker: Feeder — Arranging C-channels
 lede: How the four C-channels stand, at what heights, and what passes parts between them.
 permalink: /hardware/assembly/feeder/arranging-c-channels/
 author: barthel
+contributors: [brickcyclealice]
+og_image: https://assets.basically.website/sorter-parts/c-channel-stands-all-three-full-9b385f0819e2.jpg
 warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and measured
   off the published STLs, not from an actual build. The parts, the leg lengths and the 80 mm
-  step between channels are real and current; nobody has photographed the stand. Two things
-  are still missing: how far two channels overlap horizontally and where round the circle
-  each handover happens, and how the classification channel is fixed down. Fill them in as
-  you build.
+  step between channels are real and current, and BrickCycleAlice's photographs of all three
+  stands are on Steps 2 and 3 — but no step below has been walked through by a builder. Two
+  things are still missing: how far two channels overlap horizontally and where round the
+  circle each handover happens, and how the classification channel is fixed down. Fill them
+  in as you build.
 parts_needed:
   - part: layout-guide
     qty: 3
@@ -104,12 +107,35 @@ Build the same stack three times, once per channel, with that channel's legs:
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>C1's legs don't fit their sockets closely.</strong> Both sockets — the one in the layout guide and the one under the adapter — are 26 mm square and 18 mm deep, which is what the printed legs' spigots are made to. C1's leg is 2020 extrusion, 20 mm square, so it has about 3 mm of slack a side at both ends. Nothing in the parts registry says what takes that up. The heights below still work as long as the extrusion bottoms out in the socket, but if you're building C1, check this against your own parts.</p>
+  <p><strong>C1's legs don't fit their sockets closely.</strong> Both sockets — the one in the layout guide and the one under the adapter — are 26 mm square and 18 mm deep, which is what the printed legs' spigots are made to. C1's leg is 2020 extrusion, 20 mm square, so on the STLs it has about 3 mm of slack a side at both ends, and nothing in the parts registry says what takes that up. It goes together — the first photo below is C1 built — but the heights only come out right if the extrusion bottoms out in the socket rather than sitting proud. Worth checking on your own parts.</p>
 </div>
 
-**Not recorded:** how the three legs are clocked around the channel — which of the three sits under the stepper, under the exit, or under the camera lamp arm. The layout guide is exported on its own, so the STLs don't say. <span class="fastener-todo">not recorded</span>
+<div class="img-row">
+  <figure>
+    <img src="https://assets.basically.website/sorter-parts/c-channel-stand-c1-full-408a46f64257.jpg" alt="C1's stand: the layout guide flat on a bench with three 2020 aluminium extrusion legs standing in its sockets, each capped by a printed dovetail adapter">
+    <figcaption>C1, on the 228 mm 2020 legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img src="https://assets.basically.website/sorter-parts/c-channel-stand-c2-full-6c846cbbedd2.jpg" alt="C2's stand: the layout guide with three printed support legs standing in its sockets, each capped by a dovetail adapter">
+    <figcaption>C2, on the 148 mm printed legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img src="https://assets.basically.website/sorter-parts/c-channel-stand-c3-full-8a3466156d18.jpg" alt="C3's stand: the layout guide with three short printed support legs and their dovetail adapters">
+    <figcaption>C3, on the 68 mm printed legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
-<div class="img-placeholder">Image coming</div>
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stand-adapter-dovetail-full-5476503ba39a.jpg" alt="Close-up of one leg: it stands in the layout guide's square socket at the bottom, and the dovetail adapter caps its top, with a ribbed dovetail rail across the adapter's upper face">
+  <figcaption>One leg, both joints. The square socket in the layout guide at the bottom, the adapter over the top of the leg, and the dovetail rail on the adapter's upper face — that rail is what the C-channel drive slides onto. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stand-c3-side-full-0887a0989be9.jpg" alt="The C3 stand from a lower angle, showing all three dovetail adapters and the way their rails are oriented">
+  <figcaption>The same C3 stand from lower down, with all three adapters in view. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+**Not recorded:** how the three legs are clocked around the channel — which of the three sits under the stepper, under the exit, or under the camera lamp arm. The layout guide is exported on its own, so the STLs don't say.
 
 {% include step.html n="3" title="★ Set the heights and the spacing" %}
 
@@ -129,6 +155,11 @@ Build the same stack three times, once per channel, with that channel's legs:
     <figcaption>The three stacks to scale, from the published STLs, with one of each channel's three legs shown. C1's leg is drawn as a plain 20 × 20 × 228 mm extrusion. The dashed lines are the faces the C-channel drives sit on. <cite>Render from the published STLs.</cite></figcaption>
   </figure>
 </div>
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stands-all-three-full-9b385f0819e2.jpg" alt="All three stands laid out together, longest legs to shortest, showing the three leg lengths side by side">
+  <figcaption>The three stands built, longest to shortest. This is the whole of the height setting: same guide, same adapter, three leg lengths. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
 
 <div class="callout">
   <p>Don't add more drop than this to fix bouncing. A part is supposed to arrive at the next rotor with most of its energy gone; a bigger drop makes pieces bounce further and re-clump, which is the problem the cascade exists to solve. If parts are riding round a channel instead of leaving it, that's the <a href="{{ '/hardware/assembly/feeder/output-guides/' | relative_url }}">output guide</a>'s job, not the height's.</p>

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -191,7 +191,7 @@ One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url 
 
 **The classification channel takes no support structure of its own** — no layout guide, no legs, no adapters. It sits flat on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s top plate, and it slides onto the layout guide that C3 stands in. The plate carries its weight; C3's guide locates it and sets which way round it goes. <cite>Tip: BrickCycleAlice.</cite>
 
-That also closes the height. C3's guide stands on the plate, so the plate is the zero the other three are measured from, and the 80 mm step below C3's 80 mm seat lands exactly there. Measured on the STLs, the fit is between the stator's base flange (r 103–120 mm, and the 19 mm of it that hangs below the drive's seating face) and the guide's ring (r 98–118 mm, 28 mm tall) — the flange drops inside the ring.
+That also closes the height. C3's guide stands on the plate, so the plate is the zero the other three are measured from, and the 80 mm step below C3's 80 mm seat lands exactly there. Measured on the STLs, the fit is between the stator's base flange — the bottom 19 mm of the drive, r 103–120 mm — and the guide's ring, r 98–118 mm and 28 mm tall. Stand the drive on the plate and the flange is inside the ring.
 
 The top plate itself has no mount holes for a C-channel, so nothing bolts down here.
 

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -90,7 +90,7 @@ Steps below refer to the channels by the names the software uses, in the order a
 </div>
 
 <div class="callout">
-  <p><strong>There are no fasteners in the stand at all.</strong> Every joint in it is gravity or friction: a leg stands in the layout guide, an adapter sits on a leg, and the three adapters push up into the drive. Nothing here is screwed and nothing takes a heat insert. The printed legs and the adapters do have holes through them — 2 × Ø4.20 in each leg, 2 × Ø5.50 in each adapter — and none of them is fastened. Don't go looking for the screws.</p>
+  <p><strong>There are no fasteners in the stand at all.</strong> Every joint in it is gravity or friction: a leg stands in the layout guide, an adapter sits on a leg, and the three adapters push up into the drive. Nothing here is screwed and nothing takes a heat insert. The printed legs and the adapters do have holes through them — 2 × Ø4.20 in each leg, 2 × Ø5.50 in each adapter — and none of them is fastened. Don't go looking for the screws. There is a case for adding one on C1, which carries the bulk bin; see step 2.</p>
 </div>
 
 {% include step.html n="2" title="Build C1's stand" %}
@@ -105,9 +105,13 @@ The tallest one. Three moves, and they are the same three on every channel:
 
 The channel itself goes on later, in step 7, once all three stands are laid out and the classification channel is in.
 
+<div class="callout">
+  <p><strong>How the 2020 sits at each end.</strong> Into the layout guide it slides with a firm fit. At the adapter it is only braced on three sides. Nothing is fastened at either end, here or anywhere else in the stand. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>C1's legs don't fit their sockets closely.</strong> Both sockets — the one in the layout guide and the one under the adapter — are 26 mm square and 18 mm deep, which is what the printed legs' spigots are made to. C1's leg is 2020 extrusion, 20 mm square, so on the STLs it has about 3 mm of slack a side at both ends, and nothing in the parts registry says what takes that up. It goes together, as the photo shows — but the heights only come out right if the extrusion bottoms out in the socket rather than sitting proud. Worth checking on your own parts.</p>
+  <p><strong>C1 carries the bulk bin, and a full bin is heavy.</strong> The stand is a friction fit end to end and nothing stops the drive lifting off its adapters, so a machine that gets leaned on — or refilled by someone using the feeder to steady themselves — is worth bolting. Which T-nut and bolt suit the 2020 legs hasn't been settled, so there is no combination to quote here yet.</p>
 </div>
 
 <figure class="single-figure">

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -172,8 +172,6 @@ Put all three on the [top interface]({{ '/hardware/assembly/distribution/top-int
   <p>Don't add more drop than this to fix bouncing. A part is supposed to arrive at the next rotor with most of its energy gone; a bigger drop makes pieces bounce further and re-clump, which is the problem the cascade exists to solve. If parts are riding round a channel instead of leaving it, that's the <a href="{{ '/hardware/assembly/feeder/output-guides/' | relative_url }}">output guide</a>'s job, not the height's.</p>
 </div>
 
-<div class="img-placeholder">Image coming</div>
-
 {% include step.html n="6" title="Install the classification channel" %}
 
 C4 goes in first, before the three above it, and it takes **no support structure of its own** — no layout guide, no legs, no adapters. It sits flat on the top plate and slides onto the layout guide that C3 stands in.

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -14,10 +14,10 @@ warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=feeder) and measured
   off the published STLs, not from an actual build. The parts, the leg lengths and the 80 mm
-  step between channels are real and current. Steps 2, 4 and 6 and the photographs come from
-  BrickCycleAlice's build; the rest has not been walked through by a builder. One thing is
-  still missing: how far two channels overlap horizontally and where round the circle each
-  handover happens. Fill it in as you build.
+  step between channels are real and current. **The order of the steps, the photographs, and
+  Steps 5, 6 and 8 come from BrickCycleAlice's build**; the rest has not been walked through
+  by a builder. One thing is still missing: how far two channels overlap horizontally and
+  where round the circle each handover happens. Fill it in as you build.
 parts_needed:
   - part: layout-guide
     qty: 3
@@ -43,7 +43,7 @@ parts_needed:
 
 Four [C-channels]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}) are built the same way and then stood at different heights, so a part cascades from one to the next under gravity and arrives at the [interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }}) singulated.
 
-C1, C2 and C3 each stand on the same three-piece support structure: a **Layout guide** it stands on, three **support legs** standing in that, and a **Support dovetail adapter** on top of each leg that slides up into the C-channel drive from below. The legs are the only thing that differs between the three channels, and their lengths are what set the drop between one channel and the next. The classification channel has no support structure of its own: it stands on the top plate and is located by C3's layout guide (step 6).
+C1, C2 and C3 each stand on the same three-piece support structure: a **Layout guide** it stands on, three **support legs** standing in that, and a **Support dovetail adapter** on top of each leg that slides up into the C-channel drive from below. The legs are the only thing that differs between the three channels, and their lengths are what set the drop between one channel and the next. The classification channel has no support structure of its own: it stands on the top plate and is located by C3's layout guide (step 6), and it goes in before the other three.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -93,54 +93,59 @@ Steps below refer to the channels by the names the software uses, in the order a
   <p><strong>There are no fasteners in the stand at all.</strong> Every joint in it is gravity or friction: a leg stands in the layout guide, an adapter sits on a leg, and the three adapters push up into the drive. Nothing here is screwed and nothing takes a heat insert. The printed legs and the adapters do have holes through them — 2 × Ø4.20 in each leg, 2 × Ø5.50 in each adapter — and none of them is fastened. Don't go looking for the screws.</p>
 </div>
 
-{% include step.html n="2" title="Stand each channel" %}
+{% include step.html n="2" title="Build C1's stand" %}
 
-Build the same stack three times, once per channel, with that channel's legs:
+The tallest one. Three moves, and they are the same three on every channel:
 
 <ol class="numbered-steps">
-  <li>Put the layout guide down flat, sockets up.</li>
-  <li>Stand the three legs in it. The sockets are 18 mm deep and the legs are held by their own weight — C1's extrusion, C2's and C3's printed legs.</li>
-  <li>Drop a dovetail adapter over the top of each leg. The socket in its underside takes the top 18 mm of the leg, so the block's top face lands 2 mm above the leg on every channel — that face is the seat.</li>
-  <li>Lower the built C-channel onto the three tangs so they engage the drive from below. It's a friction fit; the channel's weight holds it.</li>
+  <li>Put a layout guide down flat, sockets up.</li>
+  <li>Stand the three legs in it — for C1, the 228 mm lengths of 2020. The sockets are 18 mm deep and the legs are held by their own weight.</li>
+  <li>Drop a dovetail adapter over the top of each leg. The socket in its underside takes the top 18 mm of the leg, so the block's top face lands 2 mm above it. That face is what the channel will sit on.</li>
 </ol>
+
+The channel itself goes on later, in step 7, once all three stands are laid out and the classification channel is in.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>C1's legs don't fit their sockets closely.</strong> Both sockets — the one in the layout guide and the one under the adapter — are 26 mm square and 18 mm deep, which is what the printed legs' spigots are made to. C1's leg is 2020 extrusion, 20 mm square, so on the STLs it has about 3 mm of slack a side at both ends, and nothing in the parts registry says what takes that up. It goes together — the first photo below is C1 built — but the heights only come out right if the extrusion bottoms out in the socket rather than sitting proud. Worth checking on your own parts.</p>
-</div>
-
-<div class="img-row">
-  <figure>
-    <img src="https://assets.basically.website/sorter-parts/c-channel-stand-c1-full-408a46f64257.jpg" alt="C1's stand: the layout guide flat on a bench with three 2020 aluminium extrusion legs standing in its sockets, each capped by a printed dovetail adapter">
-    <figcaption>C1, on the 228 mm 2020 legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-parts/c-channel-stand-c2-full-6c846cbbedd2.jpg" alt="C2's stand: the layout guide with three printed support legs standing in its sockets, each capped by a dovetail adapter">
-    <figcaption>C2, on the 148 mm printed legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-  </figure>
-  <figure>
-    <img src="https://assets.basically.website/sorter-parts/c-channel-stand-c3-full-8a3466156d18.jpg" alt="C3's stand: the layout guide with three short printed support legs and their dovetail adapters">
-    <figcaption>C3, on the 68 mm printed legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-  </figure>
+  <p><strong>C1's legs don't fit their sockets closely.</strong> Both sockets — the one in the layout guide and the one under the adapter — are 26 mm square and 18 mm deep, which is what the printed legs' spigots are made to. C1's leg is 2020 extrusion, 20 mm square, so on the STLs it has about 3 mm of slack a side at both ends, and nothing in the parts registry says what takes that up. It goes together, as the photo shows — but the heights only come out right if the extrusion bottoms out in the socket rather than sitting proud. Worth checking on your own parts.</p>
 </div>
 
 <figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stand-c1-full-408a46f64257.jpg" alt="C1's stand: the layout guide flat on a bench with three 2020 aluminium extrusion legs standing in its sockets, each capped by a printed dovetail adapter">
+  <figcaption>C1's stand, on the 228 mm 2020 legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+{% include step.html n="3" title="Build C2's stand" %}
+
+The same three moves, with the **148 mm printed** legs.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stand-c2-full-6c846cbbedd2.jpg" alt="C2's stand: the layout guide with three printed support legs standing in its sockets, each capped by a dovetail adapter">
+  <figcaption>C2's stand, on the 148 mm printed legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+<figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stand-adapter-dovetail-full-5476503ba39a.jpg" alt="Close-up of one leg: it stands in the layout guide's square socket at the bottom, and the dovetail adapter caps its top, with a ribbed dovetail rail across the adapter's upper face">
-  <figcaption>One leg, both joints. The square socket in the layout guide at the bottom, the adapter over the top of the leg, and the dovetail rail on the adapter's upper face — that rail is what the C-channel drive slides onto. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  <figcaption>One leg of that stand, both joints. The square socket in the layout guide at the bottom, the adapter over the top of the leg, and the dovetail rail on the adapter's upper face — that rail is what the C-channel drive slides onto. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+{% include step.html n="4" title="Build C3's stand" %}
+
+The same again, with the **68 mm printed** legs. This is the shortest stand, and it is also the one the classification channel drops into in step 6, so it is worth getting square before you go on.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stand-c3-full-8a3466156d18.jpg" alt="C3's stand: the layout guide with three short printed support legs and their dovetail adapters">
+  <figcaption>C3's stand, on the 68 mm printed legs. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-stand-c3-side-full-0887a0989be9.jpg" alt="The C3 stand from a lower angle, showing all three dovetail adapters and the way their rails are oriented">
-  <figcaption>The same C3 stand from lower down, with all three adapters in view. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  <figcaption>The same stand from lower down, with all three adapters in view. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
-<div class="callout">
-  <p><strong>Clock all three the same way, with the steppers toward the centre of the guides.</strong> Nothing in the STLs says which of a channel's three legs sits under the motor — the layout guide is exported on its own — so this is how it is actually built. <cite>Tip: BrickCycleAlice.</cite></p>
-</div>
+{% include step.html n="5" title="★ Lay the three stands out" %}
 
-{% include step.html n="3" title="★ Set the heights and the spacing" %}
-
-**The drop is 80 mm per handover, and it's built into the legs.** You don't measure it; you get it by using the right leg on each channel and standing all three layout guides on the same flat surface.
+Put all three on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s top plate. **The drop between channels comes out of this on its own** — you don't measure it, you get it by using the right leg on each channel and standing all three guides on the same flat surface.
 
 | Channel | Leg | Length |
 |---|---|---|
@@ -148,7 +153,7 @@ Build the same stack three times, once per channel, with that channel's legs:
 | C2 | C-channel 2 support leg, printed | 148 mm |
 | C3 | C-channel 3 support leg, printed | 68 mm |
 
-228, 148, 68 — an even 80 mm step. Every leg sockets the same 18 mm into its guide and carries the same adapter, so the step passes straight through to the drives: measured from the underside of the layout guides, the three seats land at **240 mm, 160 mm and 80 mm**. Another 80 mm below C3 is zero, which is the surface the guides themselves stand on — the top plate, and where the classification channel goes (step 6).
+228, 148, 68 — an even **80 mm step**. Every leg sockets the same 18 mm into its guide and carries the same adapter, so the step passes straight through to the drives: measured from the underside of the layout guides, the three seats land at **240 mm, 160 mm and 80 mm**. Another 80 mm below C3 is zero, which is the plate itself, and that is where the classification channel goes.
 
 <div class="img-row">
   <figure>
@@ -163,6 +168,10 @@ Build the same stack three times, once per channel, with that channel's legs:
 </figure>
 
 <div class="callout">
+  <p><strong>Clock all three the same way, with the steppers toward the centre of the guides.</strong> Nothing in the STLs says which of a channel's three legs sits under the motor — the layout guide is exported on its own — so this is how it is actually built. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
+<div class="callout">
   <p>Don't add more drop than this to fix bouncing. A part is supposed to arrive at the next rotor with most of its energy gone; a bigger drop makes pieces bounce further and re-clump, which is the problem the cascade exists to solve. If parts are riding round a channel instead of leaving it, that's the <a href="{{ '/hardware/assembly/feeder/output-guides/' | relative_url }}">output guide</a>'s job, not the height's.</p>
 </div>
 
@@ -173,29 +182,37 @@ Build the same stack three times, once per channel, with that channel's legs:
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="4" title="Fit the rotors and the output guides" %}
+{% include step.html n="6" title="Install the classification channel" %}
 
-With the channels standing, drop the rotor units in and fit the output guides at the same time.
+C4 goes in first, before the three above it, and it takes **no support structure of its own** — no layout guide, no legs, no adapters. It sits flat on the top plate and slides onto the layout guide that C3 stands in. The plate carries its weight; C3's guide locates it and sets which way round it goes. <cite>Tip: BrickCycleAlice.</cite>
 
-One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) on C2 and one on C3. Each belongs to the channel it is mounted on, not to the gap between two; C1 and the classification channel take none. <cite>Order: BrickCycleAlice.</cite>
+That is also what closes the height. C3's guide stands on the plate, so the plate is the zero the other three are measured from, and the 80 mm step below C3's 80 mm seat lands exactly there. Measured on the STLs, the fit is between the stator's base flange — the bottom 19 mm of the drive, r 103–120 mm — and the guide's ring, r 98–118 mm and 28 mm tall. Stand the drive on the plate and the flange is inside the ring.
+
+The top plate itself has no mount holes for a C-channel, so nothing bolts down here.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="5" title="Add the bulk input and the camera lamps" %}
+{% include step.html n="7" title="Install C1, C2 and C3" %}
+
+Now the other three drives go on their stands. Lower each one onto its three dovetail adapters so the tangs engage it from below. It's a friction fit; the channel's own weight holds it.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="8" title="Fit the rotors and the output guides" %}
+
+With the channels standing, drop the rotor units in and fit the output guides at the same time. <cite>Order: BrickCycleAlice.</cite>
+
+One [output guide]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }}) on C2 and one on C3. Each belongs to the channel it is mounted on, not to the gap between two; C1 and the classification channel take none.
+
+<div class="img-placeholder">Image coming</div>
+
+{% include step.html n="9" title="Add the bulk input and the camera lamps" %}
 
 [Bulk input]({{ '/hardware/assembly/feeder/bulk-input/' | relative_url }}) on C1. A [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}) on C2 and on C3 — C1 has neither a lamp nor an output guide, because it's fed in bulk and nothing reads vision off it.
 
 <div class="img-placeholder">Image coming</div>
 
-{% include step.html n="6" title="Stand the classification channel" %}
-
-**The classification channel takes no support structure of its own** — no layout guide, no legs, no adapters. It sits flat on the [top interface]({{ '/hardware/assembly/distribution/top-interface/' | relative_url }})'s top plate, and it slides onto the layout guide that C3 stands in. The plate carries its weight; C3's guide locates it and sets which way round it goes. <cite>Tip: BrickCycleAlice.</cite>
-
-That also closes the height. C3's guide stands on the plate, so the plate is the zero the other three are measured from, and the 80 mm step below C3's 80 mm seat lands exactly there. Measured on the STLs, the fit is between the stator's base flange — the bottom 19 mm of the drive, r 103–120 mm — and the guide's ring, r 98–118 mm and 28 mm tall. Stand the drive on the plate and the flange is inside the ring.
-
-The top plate itself has no mount holes for a C-channel, so nothing bolts down here.
-
-{% include step.html n="7" title="Turn it all by hand" %}
+{% include step.html n="10" title="Turn it all by hand" %}
 
 Run parts through the whole cascade by hand, one channel at a time, before wiring the steppers. Anything that needs a nudge here will jam under power. Wiring is on the [electronics]({{ '/hardware/electronics/' | relative_url }}) page.
 

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -95,10 +95,12 @@ Steps below refer to the channels by the names the software uses, in the order a
 
 Build the same stack three times, once per channel, with that channel's legs:
 
-1. Put the layout guide down flat, sockets up.
-2. Stand the three legs in it. The sockets are 18 mm deep and the legs are held by their own weight — C1's extrusion, C2's and C3's printed legs.
-3. Drop a dovetail adapter over the top of each leg. The socket in its underside takes the top 18 mm of the leg, so the block's top face lands 2 mm above the leg on every channel — that face is the seat.
-4. Lower the built C-channel onto the three tangs so they engage the drive from below. It's a friction fit; the channel's weight holds it.
+<ol class="numbered-steps">
+  <li>Put the layout guide down flat, sockets up.</li>
+  <li>Stand the three legs in it. The sockets are 18 mm deep and the legs are held by their own weight — C1's extrusion, C2's and C3's printed legs.</li>
+  <li>Drop a dovetail adapter over the top of each leg. The socket in its underside takes the top 18 mm of the leg, so the block's top face lands 2 mm above the leg on every channel — that face is the seat.</li>
+  <li>Lower the built C-channel onto the three tangs so they engage the drive from below. It's a friction fit; the channel's weight holds it.</li>
+</ol>
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -121,10 +123,12 @@ Build the same stack three times, once per channel, with that channel's legs:
 
 228, 148, 68 — an even 80 mm step. Every leg sockets the same 18 mm into its guide and carries the same adapter, so the step passes straight through to the drives: measured from the underside of the layout guides, the three seats land at **240 mm, 160 mm and 80 mm**. Another 80 mm below C3 is zero, which is the surface the guides themselves stand on. That's the argument in step 6 for where the classification channel goes.
 
-<figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-support-heights-full-a32b5d7f02ad.png" alt="Elevation of the three support stacks side by side, C1 tallest to C3 shortest, with dashed lines marking seat heights at 240, 160 and 80 mm above the surface the layout guides stand on, and 80 mm marked between each pair">
-  <figcaption>The three stacks to scale, from the published STLs, with one of each channel's three legs shown. C1's leg is drawn as a plain 20 × 20 × 228 mm extrusion. The dashed lines are the faces the C-channel drives sit on. <cite>Render from the published STLs.</cite></figcaption>
-</figure>
+<div class="img-row">
+  <figure>
+    <img src="https://assets.basically.website/sorter-parts/c-channel-support-heights-full-a32b5d7f02ad.png" alt="Elevation of the three support stacks side by side, C1 tallest to C3 shortest, with dashed lines marking seat heights at 240, 160 and 80 mm above the surface the layout guides stand on, and 80 mm marked between each pair">
+    <figcaption>The three stacks to scale, from the published STLs, with one of each channel's three legs shown. C1's leg is drawn as a plain 20 × 20 × 228 mm extrusion. The dashed lines are the faces the C-channel drives sit on. <cite>Render from the published STLs.</cite></figcaption>
+  </figure>
+</div>
 
 <div class="callout">
   <p>Don't add more drop than this to fix bouncing. A part is supposed to arrive at the next rotor with most of its energy gone; a bigger drop makes pieces bounce further and re-clump, which is the problem the cascade exists to solve. If parts are riding round a channel instead of leaving it, that's the <a href="{{ '/hardware/assembly/feeder/output-guides/' | relative_url }}">output guide</a>'s job, not the height's.</p>

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -180,7 +180,10 @@ C4 goes in first, before the three above it, and it takes **no support structure
 
 The top plate itself has no mount holes for a C-channel, so nothing bolts down here.
 
-<div class="img-placeholder">Image coming</div>
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/c-channel-c4-on-c3-guide-full-574058daee19.jpg" alt="The classification channel's drive, stator ring with its stepper motor on the bracket, slid onto the layout guide that C3 stands in, with the three stands lying around it">
+  <figcaption>The classification channel's drive slid onto C3's layout guide, with the three stands beside it. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
 
 {% include step.html n="7" title="Install C1, C2 and C3" %}
 

--- a/docs/src/content/hardware/assembly/feeder/index.md
+++ b/docs/src/content/hardware/assembly/feeder/index.md
@@ -19,6 +19,6 @@ The feeder takes unsorted parts from the bulk input and, through four C-channel 
 5. **[Output guides]({{ '/hardware/assembly/feeder/output-guides/' | relative_url }})**, the walls on C2 and C3 that push parts off the channel.
 6. **[Arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }})**, the stand, the heights, and how the four sit together.
 
-Everything after the C-channel page is an AI-generated first draft: the parts are recorded, the steps and the photographs are not. Each page says at the top what is missing from it.
+The C-channel page and the Arranging C-channels page are written from real builds. The rest are AI-generated first drafts: the parts are recorded, the steps and the photographs are not. Each of those says at the top what is missing from it.
 
 Two pages are kept for machines already built to the older arrangement and are not part of the build above: the **[light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }})** and the **[overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }})**, both replaced by the camera lamp on 2026-09-02.


### PR DESCRIPTION
**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1547408655928922293): "rewrite the arranging the c channels, with the new channel support structures instead of legs".**

The page still stood the feeder on the `Leg` / `Foot` / `Leg extension` stack, which was retired on 2026-09-02 by [#534](https://github.com/basicallysource/sorter-v2/pull/534) and is marked "Unused since 2026-09-02 ... do not re-add from old docs or photos" in the catalog. Its `parts_needed` asked for 9 of each of them.

**What the page says now**

- C1, C2 and C3 each stand on a **Layout guide**, three **support legs** and three **Support dovetail adapters** — `channel-one-support-structure`, `channel-two-support-structure`, `channel-three-support-structure` in `parts-calculator/catalog/parts.json`. `parts_needed` is those parts, at the catalog's quantities.
- **The drop between channels is 80 mm and it is built into the legs**, which step 3 previously said was "not written down anywhere today". C1's leg is `ext-2020-c1` at 228 mm (piece J), C2's is 148 mm and C3's is 68 mm, so with all three layout guides on one surface the seats land at 240 / 160 / 80 mm. Leg lengths measured off the published STLs; C1's is from the cut list.
- **No fasteners anywhere in the stand.** Every joint is `method: gravity` or friction in the catalog, and the Ø4.20 holes in the legs and Ø5.50 in the adapters take nothing.
- **Step 6 (the classification channel)** stays starred. It has no support structure in the tree, the top plate has no mount holes for a C-channel, and it has been asked in the server twice with no answer. The page gives the geometric argument for resting it on the top plate and labels it an inference.
- Step 5 said "light post and overhead camera mount", both retired by the same #534 and replaced by the camera lamp. Fixed to match [#604](https://github.com/basicallysource/sorter-v2/pull/604) and the feeder index.

**One thing I got wrong and have corrected.** I measured the guide's leg socket as a plain 26 mm square and warned that C1's 20 mm extrusion had ~3 mm of slack a side. [BrickCycleAlice, holding the parts](https://discord.com/channels/1430279849171222682/1547408655928922293/1547441671992647681): *"on the 2020, it slides in with a firm fit to the layout guide. It is only braced around three sides on the dovetail adapter"*. Re-sampling the boss properly shows internal ribs closing the socket to about 19.6 mm — my number came from taking the bounding box of a mid-height vertex band, which sees only features that begin or end at that height and misses the walls. The page now describes each end as built, and carries her point that C1 is worth bolting because the bulk bin is heavy when full and the whole stand is friction and gravity. No T-nut or bolt combination is quoted, because that is not settled.

**Images** are four renders made from the published STLs (`layout-guide`, `channel-three-support-leg`, `support-dovetail-adapter`) and published to the parts bucket: the three parts, plus an elevation of the three stacks to scale with the seat heights on it. The three "Image coming" placeholders those replace were on the steps that most needed a picture; the remaining placeholders are for photographs of a real build, which do not exist yet — nobody has photographed the feeder stand.

**Since the first push, BrickCycleAlice built all three stands and sent photographs and three build facts**, all of which are now on the page:

- **Five photographs**, the first that exist of the feeder stand: the three stands (C1 on its 2020 legs, C2, C3), a close-up of one leg showing both joints and the dovetail rail, and all three stands together. On Steps 2 and 3, credited, and published to `sorter-parts`. Her build also confirms `ext-2020-c1`: C1's legs really are 2020 extrusion, visibly so.
- **Step 6 is answered and no longer starred.** ["C4 sits flat on the top plate, it slides onto the layout guide that is under c3"](https://discord.com/channels/1430279849171222682/1547408655928922293/1547437778382626916). The plate carries it, C3's guide locates and clocks it. That also confirms the height: the plate is the zero the 80 mm step lands on. Measured on the STLs in support, the stator's base flange (r 103–120 mm, 19 mm of it below the drive's seating face) drops inside the guide's ring (r 98–118 mm, 28 mm tall). This closes a gap that had been asked in the server three times with no answer.
- **How the channels are clocked**, which the STLs cannot say: steppers toward the centre of the guides, same on all three. On Step 2 as a tip.
- **The rotors go in with the output guides**, once the channels are standing. Step 4 retitled.

- **The step order is hers too**, [asked for after she built it](https://discord.com/channels/1430279849171222682/1547408655928922293/1547439295504064583): build C1's stand, then C2's, then C3's, lay the three out, install the classification channel, then the other three drives. Ten steps instead of seven, and each stand step now carries its own photograph instead of three sharing a row.

- **The AI-generated-first-draft banner is gone**, [at her request](https://discord.com/channels/1430279849171222682/1547408655928922293/1547444632328208455): *"remove ai generated first draft. I built off these instructions."* The page takes `last_verified: 2026-09-10` instead, and the feeder index no longer calls everything after the C-channel page a first draft. She also trimmed the page herself as she read it: the "still not recorded" note about horizontal overlap and handover azimuth is off Step 5 (so no step is starred any more), and Step 6 is cut back to how C4 goes in, without the height argument or the STL fit measurements. She then sent a sixth photograph for it: the classification channel's drive slid onto C3's layout guide, which is the first picture anywhere of a C-channel drive engaged with a stand. And two more for Step 7, the four drives on their stands with the rotors deliberately left out so the joints are visible — which also show the clocking from Step 5, every stepper ending up in the middle of the group.

**Two things raised in review and deliberately not changed here.** She reported that the classification channel does get an output guide; the page still says two, on C2 and C3, because that is Spencer's decision of 2026-09-08 (#601) backed by a measured clash — the standard finned rotor's fins sweep through the guide on 24 of 72 rotations — and she agreed to leave it. Separately, the C-channel header photo this page shares with seven other pages shows a non-standard rotor, white where the catalog fixes both rotors to `ash-gray`; she is shooting a replacement, and it should be swapped across all eight pages in one change rather than here.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1547408655928922293
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547437778382626916
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547438471566852148
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547439295504064583
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547441671992647681
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547444632328208455
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547445424061943818
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547445758041661501
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547446047507484742
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547446253812588636
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547446791820156938
request: https://discord.com/channels/1430279849171222682/1547408655928922293/1547449793675264100
preview: /hardware/assembly/feeder/arranging-c-channels/
-->









