### PR TITLE
The camera lamp's LED strip: a catalog line, and a page for wiring it

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/camera-lamp.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-lamp.md
@@ -8,7 +8,7 @@ kicker: Feeder — Camera lamp
 lede: The arm, the shaded lamp and the camera that hang over a C-channel.
 permalink: /hardware/assembly/feeder/camera-lamp/
 author: reveryx
-contributors: [spencer, danny]
+contributors: [spencer, danny, brickcyclealice]
 og_image: https://assets.basically.website/sorter-docs/camera-lamp-on-channel-w1600-8d957377d671.jpg
 warning: >-
   **Steps 6, 7 and 8 are not verified against a build.** Steps 1 to 5 are photographed on
@@ -16,8 +16,9 @@ warning: >-
   3 were confirmed by ReveryX against the parts. Still open: which of the ring's two sockets
   the clasp is meant to use (step 6); the arm mount's dovetail onto the NEMA bracket
   (step 7), which a builder has described but nobody has dimensioned or photographed; and
-  the cover going on, which has no build photograph yet (step 8). Wiring the strip back to the board is not on this page at
-  all. Everything else is measured off the published STLs. Fill the gaps in as you build.
+  the cover going on, which has no build photograph yet (step 8). Wiring the strip back to the board is its own page, [Make your own LED
+  drop]({{ '/hardware/electronics/led-drop/' | relative_url }}). Everything else is measured
+  off the published STLs. Fill the gaps in as you build.
 parts_needed:
   - part: c-channel-arm-mount
     qty: 1
@@ -45,6 +46,12 @@ parts_needed:
     qty: 12
   - part: scr-m3-8-cs
     qty: 2
+  - part: led-strip-24v
+    qty: 1
+  - part: led-strip-connector-8mm
+    qty: 1
+  - part: dupont-lead-2p-1m
+    qty: 1
 ---
 
 <div class="prep-item">
@@ -175,9 +182,11 @@ The camera board sits in the recess in the **Camera clasp top**. Put the **Camer
 
 Six **Inner reflector LED hooks** friction-fit into the rim of the **Lamp inner reflector**, evenly spaced 60° apart, one per 2.7 mm socket around its outside. Each hook retains the LED strip against the reflector. No screws.
 
-**How much strip, measured off the reflector.** The strip sits against the inner face of the reflector's outer skirt, which is 147 mm across and about 18 mm tall, so one turn around it is **462 mm**. The photograph below shows two turns side by side in that skirt, which puts a lamp at roughly **0.92 m** and a three-lamp machine at about **2.8 m**. The strip in the parts calculator is a 24 V daylight-white 6000 K COB strip sold as a 5 m roll, one roll per machine, which covers all three.
+**How much strip, and where 950 mm comes from.** The strip sits against the inner face of the reflector's outer skirt, which is 147 mm across and about 18 mm tall, so one turn around it is **462 mm** and the two turns that fit side by side are **924 mm**. Cut at the first mark past that, which on the catalog's strip is 25 of its 1.5 in segments, about **950 mm**. That is what is on the build photographed here. One 5 m roll gives five of these lengths, so a roll covers a machine's three lamps.
 
-**Fitting it.** Two turns, and **950 mm** on the build photographed here.
+**Cut only on the printed marks, never between them.** The pads are at the marks, so a cut anywhere else leaves nothing to connect to.
+
+**Fitting it.** Two turns, LEDs facing inwards.
 
 1. Peel the blue film off the first stretch of the strip and start it under one of the hooks, adhesive against the inside of the skirt.
 2. Work it round the skirt until you are back where you started. That is one turn.
@@ -200,7 +209,7 @@ The bare wires at the starting end are trimmed later, when the drop to the board
   </figure>
 </div>
 
-**Still open:** how the strip is joined and wired back from here. The strip is not a line in the lamp's parts list, and the drop to the board is its own job. Spencer said on 2026-09-06 that the strips run at 24 V off the LED headers on the basically board.
+**Wiring it back to the board** is [Make your own LED drop]({{ '/hardware/electronics/led-drop/' | relative_url }}): the clamp-on connector onto those bare wires, and the run to an LED header. Nothing is joined end to end here, the far end of the strip stays dead. The strip runs at 24 V off the basically board, which Spencer confirmed on 2026-09-06.
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/camera-lamp-lit-from-below-w1600-bb9d54f4f43e.jpg" alt="The lamp lit, photographed from underneath: a ring of LED strip glowing around the outside of the white reflector, the reflector's central funnel in the middle, and the arm behind it">
@@ -245,4 +254,4 @@ The **Lamp outer cover** friction-fits down over the reflector, and that is the 
 
 <div class="img-placeholder">Photo of the cover going on, or on: pending from the build.</div>
 
-Wiring, for both the LED strip and the camera, is on the [electronics]({{ '/hardware/electronics/' | relative_url }}) page. Build the other three lamps the same way, and see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for how the channels themselves sit together.
+Wiring is [Make your own LED drop]({{ '/hardware/electronics/led-drop/' | relative_url }}) for the strip, and the [electronics]({{ '/hardware/electronics/' | relative_url }}) page for the camera. Build the other two lamps the same way, and see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for how the channels themselves sit together.

--- a/docs/src/content/hardware/electronics/index.md
+++ b/docs/src/content/hardware/electronics/index.md
@@ -174,23 +174,25 @@ Three outputs, three loads, no spare. The cooling fans are deliberately not on t
 
 ### 4.3 &nbsp; LEDs (from basically board v1.3)
 
-Each LED drop is two segments: a 2x1 dupont feed from the board to a female DC jack (the unplug point), then a 6 in male-DC pigtail into the module. The strip end uses a solderless clamp-on connector rather than soldering to pads.
+Each LED drop is drawn as two segments: a 2x1 dupont feed from the board to a female DC jack (the unplug point), then a 6 in male-DC pigtail into the module. On a v1.3 board the barrel pair is optional and the drop can be one continuous 22 AWG pair, dupont at the board and a solderless clamp-on connector at the strip; the drawing has not been redrawn for that yet. Building one is [Make your own LED drop]({{ '/hardware/electronics/led-drop/' | relative_url }}).
+
+All three drops now feed an LED strip in a [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), on C-channels 2 and 3 and the classification channel. The 50 mm COB plates that L1 and L2 used to feed went with the light post they were mounted on. The WireViz drawing still shows them as COB boards and has not been redrawn yet.
 
 <table>
   <thead><tr><th>ID</th><th>Segment</th><th>From</th><th>To</th><th>Cond.</th><th>Length</th></tr></thead>
   <tbody>
-    <tr><td class="wire-id">L1</td><td>COB board feed</td><td>2x1 dupont (board)</td><td>Female DC jack</td><td>2</td><td>36 in</td></tr>
-    <tr><td class="wire-id">L1p</td><td>COB board pigtail</td><td>Male DC jack</td><td>COB board</td><td>2</td><td>6 in</td></tr>
-    <tr><td class="wire-id">L2</td><td>COB board feed</td><td>2x1 dupont (board)</td><td>Female DC jack</td><td>2</td><td>36 in</td></tr>
-    <tr><td class="wire-id">L2p</td><td>COB board pigtail</td><td>Male DC jack</td><td>COB board</td><td>2</td><td>6 in</td></tr>
-    <tr><td class="wire-id">L3</td><td>LED strip feed</td><td>2x1 dupont (board)</td><td>Female DC jack</td><td>2</td><td>36 in</td></tr>
-    <tr><td class="wire-id">L3p</td><td>LED strip pigtail</td><td>Male DC jack</td><td>LED strip (6000K)</td><td>2</td><td>6 in</td></tr>
+    <tr><td class="wire-id">L1</td><td>Lamp feed, C2</td><td>2x1 dupont (board)</td><td>Female DC jack</td><td>2</td><td>36 in</td></tr>
+    <tr><td class="wire-id">L1p</td><td>Lamp pigtail, C2</td><td>Male DC jack</td><td>LED strip (6000K)</td><td>2</td><td>6 in</td></tr>
+    <tr><td class="wire-id">L2</td><td>Lamp feed, C3</td><td>2x1 dupont (board)</td><td>Female DC jack</td><td>2</td><td>36 in</td></tr>
+    <tr><td class="wire-id">L2p</td><td>Lamp pigtail, C3</td><td>Male DC jack</td><td>LED strip (6000K)</td><td>2</td><td>6 in</td></tr>
+    <tr><td class="wire-id">L3</td><td>Lamp feed, classification</td><td>2x1 dupont (board)</td><td>Female DC jack</td><td>2</td><td>36 in</td></tr>
+    <tr><td class="wire-id">L3p</td><td>Lamp pigtail, classification</td><td>Male DC jack</td><td>LED strip (6000K)</td><td>2</td><td>6 in</td></tr>
   </tbody>
 </table>
 
 <div class="callout">
   <span class="callout-icon" aria-hidden="true">›</span>
-  <p>LED strip for the classification channel is <b>6000K</b>. Length: 2× revolutions around the classification channel inner tube = 108.400 mm × 2, so roughly 220 mm.</p>
+  <p>The strip is <b>6000K</b> daylight white, 8 mm COB, and each lamp takes <b>950 mm</b> of it: two turns around the inside of the reflector's skirt. Three lamps is 2.85 m, so one 5 m roll does a machine. The 220 mm figure that used to be here was two turns around the old classification dome's inner tube, which is retired.</p>
 </div>
 
 <div class="callout callout-warning">

--- a/docs/src/content/hardware/electronics/led-drop.md
+++ b/docs/src/content/hardware/electronics/led-drop.md
@@ -1,0 +1,76 @@
+---
+layout: default
+title: Make your own LED drop
+type: reference
+section: hardware
+slug: electronics-led-drop
+kicker: Electronics — LED drop
+lede: Wire a camera lamp's LED strip back to a 24V LED header on basically board v1.3, with or without a soldering iron.
+permalink: /hardware/electronics/led-drop/
+author: brickcyclealice
+contributors: [effreek, barthel]
+warning: >-
+  **Not validated against a built machine.** The lamp end here is from a real build; the run
+  back to the board is the LED drop off the harness notes, and the values marked **GUESS** in
+  the [WireViz drawing]({{ '/hardware/electronics/wireviz/' | relative_url }}), including the
+  wire gauge and which board pin is +24V, are guesses. Meter the header before you plug a lamp
+  into it.
+parts_needed:
+  - part: led-strip-24v
+    qty: 1
+  - part: led-strip-connector-8mm
+    qty: 1
+  - part: dupont-lead-2p-1m
+    qty: 1
+tools_needed: [Side cutters, Multimeter, "Only if you solder: iron, solder and heatshrink", "Only if you make your own lead: crimp tool"]
+---
+
+Each [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}) needs one LED drop: a two-conductor run at 24V from an LED header on basically board v1.3 to the ring of strip inside the lamp. A machine has three lamps, so three drops, on C-channels 2 and 3 and the classification channel. Each one carries about 0.5A.
+
+**The quantities above are for one drop, so a machine needs three of each**, except the strip: one 5 m roll cuts into all three rings, and the Dupont leads come five to a pack. So a machine is one roll, three connectors and one pack.
+
+<dl class="spec-list">
+  <dt>Board end</dt><dd>A 2-pin 2.54 mm Dupont plug onto one of the board's four LED headers, <code>J8</code> to <code>J11</code>.</dd>
+  <dt>In between</dt><dd><b>On a v1.3 board it is Dupont straight to the strip</b>: one continuous pair of 22 AWG, about a metre, board to lamp, no connector in the middle. That is how the lamp Spencer photographed is built, and it is what Jon (who drew the harness) says to do.</dd>
+  <dt>Optional unplug point</dt><dd>A 5.5 × 2.1 mm barrel pair partway along, so the lamp comes off the machine without unwiring, which splits the run into about 36 in of feed and about 6 in of pigtail. The harness notes still draw it that way. Fit it if you want it; nothing needs it.</dd>
+  <dt>Lamp end</dt><dd>A solderless clamp-on connector, or solder, onto the two pads at the cut end of the strip.</dd>
+</dl>
+
+<div class="callout">
+  <p><b>You do not need a soldering iron.</b> A clamp-on connector at the strip and a ready-made 2-pin Dupont pigtail at the board is a whole drop out of two bought parts, joined once in the middle. You do not need a crimp tool either unless you make the Dupont end yourself.</p>
+</div>
+
+## Choosing the parts
+
+<dl class="spec-list">
+  <dt>Which connector</dt><dd>Three variants of the same body, all SuperBrightLEDs, all <b>8 mm COB only</b>, 22 AWG, 3A. <code>SBL-RA2P-8</code> ($1.59) is the one in the list above: it bites the strip at one end and <b>your own wire</b> at the other, no wire supplied. <code>SBL-RA2P-8-1</code> ($1.69) is the same thing with 4 in of tinned lead already on it, so you splice rather than clamp. <code>SBL-RA2P-8-DC</code> ($2.79) ends in a 5.5 × 2.1 mm barrel socket, which is only useful if you fit the optional unplug point. <b>Match the width</b>: a 10 mm connector, or one for SMD strip, will not grip.</dd>
+  <dt>If you would rather solder</dt><dd>Soldering wire straight to the strip's pads is the only other way to make this joint, and it needs no connector. It is at the end of this page. You do not have to: the clamp-on connector is the route this page is built around, and it needs no iron.</dd>
+  <dt>If you own a crimp tool</dt><dd>You can make the lead yourself instead of buying it: about a metre of 22 AWG stranded per drop, one red and one black, plus a 2-pin 2.54 mm Dupont female housing and two crimps. Gauge is a <b>GUESS</b> in the harness notes.</dd>
+  <dt>Barrel pair, if you want the unplug point</dt><dd>5.5 × 2.1 mm, one male and one female, <b>tip positive</b>. Buy only the mating half if your strip connector already brings one. The same size as the PSU outputs, so check you are not about to plug a lamp into a PSU jack. Not in the catalog, because a v1.3 board does not need it.</dd>
+  <dt>Insulation</dt><dd>Heatshrink, or lever connectors (Wago 221) or solder-seal butt splices, only if you end up splicing something.</dd>
+</dl>
+
+<div class="callout">
+  <span class="callout-icon" aria-hidden="true">›</span>
+  <p><b>No current-limiting resistor on this drop.</b> The strip has its own, and board v1.3 already carries one in series with the +24V feed to each LED header. That is only true of the strip: a 50 mm COB plate needs its own resistor, see the <a href="{{ '/hardware/electronics/' | relative_url }}">wire harness</a> page.</p>
+</div>
+
+## Build it
+
+1. **Cut the strip on a mark.** 950 mm for a lamp, cut where the strip is printed as cuttable, which leaves half of each copper pad on your piece. The full measurement is on the [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}) page, step 5.
+2. **Clamp the connector onto the pads.** Lift the lid, slide the cut end in until the two pads sit under the sprung contacts, press it shut. The pad printed <code>+24V</code> takes the red side. Nothing to strip, nothing to solder. Soldering to the pads instead is below.
+3. **Clamp the wire into the other end**, red to the <code>+24V</code> side, if you are using the strip-to-wire connector. It bites through the insulation, so the wire does not need stripping either.
+4. **Run the pair out of the reflector and down the arm**, and cable-tie it along the arm so it is not hanging in the channel.
+5. **At the board end, push the 2-pin Dupont housing onto an LED header.** Red to +24V, and check which pin that is with a meter first. If you are using the pre-crimped lead, cut its male plug off and the female end is already the plug you need; otherwise crimp a housing on yourself.
+6. **Only if you want an unplug point**, cut the run where the arm meets the channel and put the barrel pair in, red to the tip. The lamp then comes off the machine there without unwiring anything.
+7. **Set the output in software.** Settings, then the channel, then the LED button: pick which of the board's LED outputs this lamp is on, and set the brightness with the slider. Nothing lights until an output is assigned.
+
+Repeat for all three lamps.
+
+### Soldering to the pads instead
+
+Perfectly good, and it is what the strip is designed for. Clear any coating off the two pads, melt a little solder onto each until it wets the copper, tin 3 mm of bared wire the same way, then hold the wire on the pad and touch the iron to both for a second or two. Red to <code>+24V</code>, black to <code>-</code>. Insulate each joint so the two cannot touch. Keep the iron on the pad briefly: the strip's backing and the LED next to the pad do not like being cooked.
+
+## Reference
+
+The drop's two segments are <code>L1</code>/<code>L1p</code> to <code>L3</code>/<code>L3p</code> in the wire schedule on the [wire harness]({{ '/hardware/electronics/' | relative_url }}) page, and the drawings are on [WireViz drawings]({{ '/hardware/electronics/wireviz/' | relative_url }}). Both still split every drop at a barrel jack, because <code>leds.yml</code> has not been redrawn since the straight run became the recommendation.

--- a/docs/src/liquid/_data/nav.yml
+++ b/docs/src/liquid/_data/nav.yml
@@ -100,6 +100,8 @@ sections:
             url: /hardware/electronics/wireviz/
           - title: Make your own PSU pigtail
             url: /hardware/electronics/psu-pigtail/
+          - title: Make your own LED drop
+            url: /hardware/electronics/led-drop/
       - title: Helpers
         url: /hardware/helpers/
         children:

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5380,9 +5380,9 @@
       },
       "name": "White/daylight LED strip - 24v",
       "category": "Wire harness",
-      "description": "Lighting for classification chamber",
+      "description": "The light in a Camera lamp: two turns inside the reflector's skirt, held by the six LED hooks. Bought as a 5 m roll and cut into 950 mm rings, so one roll covers a machine's three lamps. Also the classification chamber's lighting before the dome was retired.",
       "created_at": "2026-07-18",
-      "updated_at": "2026-07-18",
+      "updated_at": "2026-09-10",
       "image_url": "https://assets.basically.website/sorter-parts/led-strip-24v-full-961391ece43d.jpg",
       "sourcing": {
         "vendors": [
@@ -5396,8 +5396,143 @@
           }
         ]
       },
+      "attributes": [
+        {
+          "label": "Buy",
+          "value": "One 5 m (16.4 ft) roll"
+        },
+        {
+          "label": "Cut into",
+          "value": "3 x 950 mm, one per Camera lamp"
+        },
+        {
+          "label": "Colour temperature",
+          "value": "6000K daylight white, CRI 90+"
+        },
+        {
+          "label": "Width",
+          "value": "8 mm, COB (dotless)"
+        },
+        {
+          "label": "Cut pitch",
+          "value": "Cuttable every 1.5 in (38 mm) on the printed marks"
+        }
+      ],
+      "caption": "950 mm cut from a 5 m roll. One roll does all three lamps.",
+      "stock": {
+        "unit_length_mm": 5000,
+        "cut_length_mm": 950,
+        "pieces_per_unit": 5,
+        "unit_label": "5 m (16.4 ft) roll",
+        "piece_label": "950 mm lamp ring"
+      }
+    },
+    {
+      "id": "led-strip-connector-8mm",
+      "uid": "bdwo",
+      "kind": "cots",
+      "cots": {
+        "type": "connector"
+      },
+      "name": "Solderless clamp-on strip connector, 8 mm COB",
+      "category": "Wire harness",
+      "description": "Joins an LED strip to wire without soldering: the cut end of the strip clamps under sprung contacts at one end, the wire clamps into the other. One per Camera lamp, so three per machine.",
+      "note": "8 mm COB strip only: a 10 mm connector, or one for SMD strip, will not grip. Soldering the pads is the only other way to get wire onto the strip.",
+      "alternative": "Solder the wire to the strip pads instead, which needs no connector at all",
+      "created_at": "2026-09-10",
+      "updated_at": "2026-09-10",
+      "image_url": "https://assets.basically.website/sorter-parts/led-strip-connector-8mm-full-915e0ed03fdc.jpg",
+      "attributes": [
+        {
+          "label": "Fits",
+          "value": "8 mm (0.31 in) COB strip"
+        },
+        {
+          "label": "Wire",
+          "value": "22 AWG, not supplied"
+        },
+        {
+          "label": "Conductors",
+          "value": "2"
+        },
+        {
+          "label": "Max current",
+          "value": "3 A"
+        },
+        {
+          "label": "Variants",
+          "value": "SBL-RA2P-8-1 comes with 4 in leads fitted; SBL-RA2P-8-DC ends in a 5.5 x 2.1 mm barrel socket"
+        }
+      ],
       "sheet_qty": {
-        "per_machine": 1
+        "per_machine": 3
+      },
+      "caption": "One per lamp. Strip in one end, your wire in the other.",
+      "docs_page": "/hardware/electronics/led-drop/",
+      "sourcing": {
+        "vendors": [
+          {
+            "region": "US",
+            "vendor": "SuperBrightLEDs",
+            "url": "https://www.superbrightleds.com/solderless-clamp-on-led-strip-light-to-pigtail-adaptor-8mm-cob-strips-22-awg",
+            "price": 1.59,
+            "pack_qty": 1,
+            "as_of": "2026-09-10",
+            "note": "Part SBL-RA2P-8, sold singly."
+          }
+        ]
+      }
+    },
+    {
+      "id": "dupont-lead-2p-1m",
+      "uid": "1lzt",
+      "kind": "cots",
+      "cots": {
+        "type": "cable"
+      },
+      "name": "Pre-crimped 2-pin Dupont lead, 1 m",
+      "category": "Wire harness",
+      "description": "A metre of 22 AWG red and black with a 2-pin 2.54 mm Dupont housing crimped on. One of these is a whole LED drop: the Dupont end pushes onto an LED header (J8 to J11), the far end goes into the strip connector. The pack is male-to-female, so cut the male plug off and discard it.",
+      "note": "Sold male-to-female: cut the male plug off and discard it. Any 22 AWG pair plus a 2-pin Dupont housing does the same job if you own a crimp tool.",
+      "alternative": "Your own 22 AWG pair plus a 2-pin 2.54 mm Dupont housing and two crimps",
+      "created_at": "2026-09-10",
+      "updated_at": "2026-09-10",
+      "attributes": [
+        {
+          "label": "Pitch",
+          "value": "2.54 mm, 2-pin single row"
+        },
+        {
+          "label": "Wire",
+          "value": "22 AWG stranded, red and black"
+        },
+        {
+          "label": "Length",
+          "value": "100 cm"
+        },
+        {
+          "label": "Pack",
+          "value": "5 sets, so three lamps and two spares"
+        }
+      ],
+      "sheet_qty": {
+        "per_machine": 3
+      },
+      "caption": "Cut the male end off and it is one LED drop.",
+      "docs_page": "/hardware/electronics/led-drop/",
+      "sourcing": {
+        "vendors": [
+          {
+            "region": "US",
+            "vendor": "Amazon",
+            "url": "https://www.amazon.com/dp/B0CCTZJZZ3",
+            "affiliate_url": "https://www.amazon.com/dp/B0CCTZJZZ3?tag=sorterv2-20",
+            "price": 8.48,
+            "pack_qty": 5,
+            "as_of": "2026-09-10",
+            "note": "Kidisoii KI-0715-Dupont-MF-2P-100CM."
+          }
+        ]
       }
     },
     {
@@ -10452,10 +10587,10 @@
     },
     {
       "id": "reflector-with-led-hooks",
-      "uid": "awve",
-      "version": "1",
+      "uid": "auja",
+      "version": "2",
       "name": "Reflector with LED hooks",
-      "description": "The white inner reflector with its six LED hooks friction-fitted on.",
+      "description": "The white inner reflector with its six LED hooks friction-fitted on, holding the ring of LED strip.",
       "docs": "/hardware/assembly/feeder/camera-lamp/",
       "lines": [
         {
@@ -10465,6 +10600,10 @@
         {
           "part": "inner-reflector-led-hook",
           "qty": 6
+        },
+        {
+          "part": "led-strip-24v",
+          "qty": 1
         }
       ],
       "connections": [
@@ -10474,6 +10613,39 @@
           "qty": 6,
           "method": "friction",
           "note": "Each hook friction-fits onto the reflector and retains an LED strip."
+        },
+        {
+          "from": "led-strip-24v",
+          "to": "lamp-inner-reflector",
+          "qty": 1,
+          "method": "friction",
+          "note": "Two turns of strip against the inner face of the reflector's skirt, retained by the six hooks. 950 mm per lamp."
+        }
+      ],
+      "versions": [
+        {
+          "version": "1",
+          "uid": "awve",
+          "message": "As recorded before the first stamped change.",
+          "lines": [
+            {
+              "part": "lamp-inner-reflector",
+              "qty": 1,
+              "uid": "4vio"
+            },
+            {
+              "part": "inner-reflector-led-hook",
+              "qty": 6,
+              "uid": "l5qn"
+            }
+          ]
+        },
+        {
+          "version": "2",
+          "date": "2026-09-10",
+          "message": "Record the LED strip as a member. The strip was always in this assembly (the hooks exist to retain it) but was never a line, so it appeared in no parts list and builders had nothing to buy from. It is one 950 mm piece cut from the 5 m roll, two turns inside the skirt.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -5008,10 +5008,10 @@
 		},
 		{
 			"id": "reflector-with-led-hooks",
-			"uid": "awve",
-			"version": "1",
+			"uid": "auja",
+			"version": "2",
 			"name": "Reflector with LED hooks",
-			"description": "The white inner reflector with its six LED hooks friction-fitted on.",
+			"description": "The white inner reflector with its six LED hooks friction-fitted on, holding the ring of LED strip.",
 			"docs": "/hardware/assembly/feeder/camera-lamp/",
 			"lines": [
 				{
@@ -5021,6 +5021,10 @@
 				{
 					"part": "inner-reflector-led-hook",
 					"qty": 6
+				},
+				{
+					"part": "led-strip-24v",
+					"qty": 1
 				}
 			],
 			"connections": [
@@ -5030,6 +5034,40 @@
 					"qty": 6,
 					"method": "friction",
 					"note": "Each hook friction-fits onto the reflector and retains an LED strip."
+				},
+				{
+					"from": "led-strip-24v",
+					"to": "lamp-inner-reflector",
+					"qty": 1,
+					"method": "friction",
+					"note": "Two turns of strip against the inner face of the reflector's skirt, retained by the six hooks. 950 mm per lamp."
+				}
+			],
+			"versions": [
+				{
+					"version": "1",
+					"uid": "awve",
+					"message": "As recorded before the first stamped change.",
+					"lines": [
+						{
+							"part": "lamp-inner-reflector",
+							"qty": 1,
+							"uid": "4vio"
+						},
+						{
+							"part": "inner-reflector-led-hook",
+							"qty": 6,
+							"uid": "l5qn"
+						}
+					]
+				},
+				{
+					"version": "2",
+					"uid": "auja",
+					"date": "2026-09-10",
+					"message": "Record the LED strip as a member. The strip was always in this assembly (the hooks exist to retain it) but was never a line, so it appeared in no parts list and builders had nothing to buy from. It is one 950 mm piece cut from the 5 m roll, two turns inside the skirt.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -22708,16 +22746,41 @@
 			},
 			"name": "White/daylight LED strip - 24v",
 			"category": "Wire harness",
-			"description": "Lighting for classification chamber",
+			"description": "The light in a Camera lamp: two turns inside the reflector's skirt, held by the six LED hooks. Bought as a 5 m roll and cut into 950 mm rings, so one roll covers a machine's three lamps. Also the classification chamber's lighting before the dome was retired.",
 			"note": null,
 			"created_at": "2026-07-18",
-			"updated_at": "2026-07-18",
-			"attributes": [],
-			"sheet_qty": {
-				"per_machine": 1
-			},
+			"updated_at": "2026-09-10",
+			"attributes": [
+				{
+					"label": "Buy",
+					"value": "One 5 m (16.4 ft) roll"
+				},
+				{
+					"label": "Cut into",
+					"value": "3 x 950 mm, one per Camera lamp"
+				},
+				{
+					"label": "Colour temperature",
+					"value": "6000K daylight white, CRI 90+"
+				},
+				{
+					"label": "Width",
+					"value": "8 mm, COB (dotless)"
+				},
+				{
+					"label": "Cut pitch",
+					"value": "Cuttable every 1.5 in (38 mm) on the printed marks"
+				}
+			],
+			"sheet_qty": null,
 			"sheet_qty_text": null,
-			"stock": null,
+			"stock": {
+				"unit_length_mm": 5000,
+				"cut_length_mm": 950,
+				"pieces_per_unit": 5,
+				"unit_label": "5 m (16.4 ft) roll",
+				"piece_label": "950 mm lamp ring"
+			},
 			"sourcing": {
 				"vendors": [
 					{
@@ -22731,10 +22794,125 @@
 				]
 			},
 			"alternative": null,
-			"caption": null,
+			"caption": "950 mm cut from a 5 m roll. One roll does all three lamps.",
 			"docs_page": null,
 			"conflicts": null,
 			"image": "https://assets.basically.website/sorter-parts/led-strip-24v-full-961391ece43d.jpg"
+		},
+		{
+			"id": "led-strip-connector-8mm",
+			"uid": "bdwo",
+			"kind": "cots",
+			"cots": {
+				"type": "connector"
+			},
+			"name": "Solderless clamp-on strip connector, 8 mm COB",
+			"category": "Wire harness",
+			"description": "Joins an LED strip to wire without soldering: the cut end of the strip clamps under sprung contacts at one end, the wire clamps into the other. One per Camera lamp, so three per machine.",
+			"note": "8 mm COB strip only: a 10 mm connector, or one for SMD strip, will not grip. Soldering the pads is the only other way to get wire onto the strip.",
+			"created_at": "2026-09-10",
+			"updated_at": "2026-09-10",
+			"attributes": [
+				{
+					"label": "Fits",
+					"value": "8 mm (0.31 in) COB strip"
+				},
+				{
+					"label": "Wire",
+					"value": "22 AWG, not supplied"
+				},
+				{
+					"label": "Conductors",
+					"value": "2"
+				},
+				{
+					"label": "Max current",
+					"value": "3 A"
+				},
+				{
+					"label": "Variants",
+					"value": "SBL-RA2P-8-1 comes with 4 in leads fitted; SBL-RA2P-8-DC ends in a 5.5 x 2.1 mm barrel socket"
+				}
+			],
+			"sheet_qty": {
+				"per_machine": 3
+			},
+			"sheet_qty_text": null,
+			"stock": null,
+			"sourcing": {
+				"vendors": [
+					{
+						"region": "US",
+						"vendor": "SuperBrightLEDs",
+						"url": "https://www.superbrightleds.com/solderless-clamp-on-led-strip-light-to-pigtail-adaptor-8mm-cob-strips-22-awg",
+						"price": 1.59,
+						"pack_qty": 1,
+						"as_of": "2026-09-10",
+						"note": "Part SBL-RA2P-8, sold singly."
+					}
+				]
+			},
+			"alternative": "Solder the wire to the strip pads instead, which needs no connector at all",
+			"caption": "One per lamp. Strip in one end, your wire in the other.",
+			"docs_page": "/hardware/electronics/led-drop/",
+			"conflicts": null,
+			"image": "https://assets.basically.website/sorter-parts/led-strip-connector-8mm-full-915e0ed03fdc.jpg"
+		},
+		{
+			"id": "dupont-lead-2p-1m",
+			"uid": "1lzt",
+			"kind": "cots",
+			"cots": {
+				"type": "cable"
+			},
+			"name": "Pre-crimped 2-pin Dupont lead, 1 m",
+			"category": "Wire harness",
+			"description": "A metre of 22 AWG red and black with a 2-pin 2.54 mm Dupont housing crimped on. One of these is a whole LED drop: the Dupont end pushes onto an LED header (J8 to J11), the far end goes into the strip connector. The pack is male-to-female, so cut the male plug off and discard it.",
+			"note": "Sold male-to-female: cut the male plug off and discard it. Any 22 AWG pair plus a 2-pin Dupont housing does the same job if you own a crimp tool.",
+			"created_at": "2026-09-10",
+			"updated_at": "2026-09-10",
+			"attributes": [
+				{
+					"label": "Pitch",
+					"value": "2.54 mm, 2-pin single row"
+				},
+				{
+					"label": "Wire",
+					"value": "22 AWG stranded, red and black"
+				},
+				{
+					"label": "Length",
+					"value": "100 cm"
+				},
+				{
+					"label": "Pack",
+					"value": "5 sets, so three lamps and two spares"
+				}
+			],
+			"sheet_qty": {
+				"per_machine": 3
+			},
+			"sheet_qty_text": null,
+			"stock": null,
+			"sourcing": {
+				"vendors": [
+					{
+						"region": "US",
+						"vendor": "Amazon",
+						"url": "https://www.amazon.com/dp/B0CCTZJZZ3",
+						"affiliate_url": "https://www.amazon.com/dp/B0CCTZJZZ3?tag=sorterv2-20",
+						"price": 8.48,
+						"pack_qty": 5,
+						"as_of": "2026-09-10",
+						"note": "Kidisoii KI-0715-Dupont-MF-2P-100CM."
+					}
+				]
+			},
+			"alternative": "Your own 22 AWG pair plus a 2-pin 2.54 mm Dupont housing and two crimps",
+			"caption": "Cut the male end off and it is one LED drop.",
+			"docs_page": "/hardware/electronics/led-drop/",
+			"conflicts": null,
+			"image": null
 		},
 		{
 			"id": "endstop-mechanical",


### PR DESCRIPTION
The LED strip in a camera lamp was in no parts list and its wiring was written down nowhere, which is where this build stopped.

**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1547465864184463402/1547474283423473726): "Ok, can you double check this against any similar items already in hardware. Then make a pr for this, as at present it is stopping a build. I'll get Jon or someone else who knows connections to double check."** The thread started with ["help me out with the led strip for the lamp, it's not in the parts needed, how long should it be how do I join the ends? Do I use the sticky backed tape to help secure it?"](https://discord.com/channels/1430279849171222682/1536088194557419660/1547465864184463402)

## The catalog: the strip is a member now

`led-strip-24v` was a transitional `sheet_qty` hand count sitting outside the tree, so it appeared in no assembly and on no page's parts list. It is now a line of `reflector-with-led-hooks` (v1 to v2), which is the node whose six hooks exist to retain it.

The similar item already in the catalog is **`rod-steel-3-8`**, the steel rod the retired overhead camera arms were cut from: a `stock` part, bought as a 4 ft length, counted in pieces, with the app dividing pieces into lengths to buy. `parts.json`'s own schema comment says that is the pattern ("A cots part that is cut from a bought length carries `stock {...}`; its lines count PIECES and the app divides to get lengths to buy"), so the strip now carries `stock` too: a 5 m roll, cut into 950 mm rings, 5 per roll. Three lamps therefore ask for one roll, and the count comes from the tree rather than a hand number.

`breaking` is `false`: the strip was always physically in this assembly, it was just never recorded.

## Where 950 mm comes from

The reflector's outer skirt is 147 mm across, so one turn is 462 mm and the two turns that fit side by side are 924 mm. That measurement is off the published `lamp-inner-reflector` STL and has been on the camera lamp page since #548. The catalog's roll is [cuttable every 1.5 in](https://www.amazon.com/dp/B0DHV8ZF4R), so the first mark past 924 mm is 25 segments, about 950 mm. [BrickCycleAlice cut 950 mm and it fits](https://discord.com/channels/1430279849171222682/1547465864184463402/1547468694681034762), which is the first time that figure has been checked against hardware rather than geometry; her photo of it hooked in is the new figure on step 5.

## The new page

`/hardware/electronics/led-drop/`, shaped like the [PSU pigtail page](https://github.com/basicallysource/sorter-v2/blob/main/docs/src/content/hardware/electronics/psu-pigtail.md): what one drop is, what to buy, a no-iron route, soldering to the pads as the alternative, and the run back to an LED header.

Sources it rests on:

- The solderless clamp-on connectors are the ones Jon posted in the 8 Aug electronics sync, [strip to wire](https://discord.com/channels/1430279849171222682/1430279852015091805/1535696087019421706) and [strip to a 5.5 mm barrel](https://discord.com/channels/1430279849171222682/1430279852015091805/1535695862028701746). `SBL-RA2P-8` is $1.59 and takes your own wire in its far end (none supplied), `SBL-RA2P-8-1` is $1.69 with 4 in of lead already on it, `SBL-RA2P-8-DC` is $2.79 and ends in a barrel socket. All 8 mm COB only, 3 A, 22 AWG. None is in the catalog and none is claimed to be adopted.
- The segment lengths, the 22 AWG and the barrel unplug point are `electronics/wire_harness/leds.yml`, which marks the gauge and the board pin order as GUESS. The page says so and tells the builder to meter the header.
- 24 V off the board is [Spencer, 6 Sep](https://discord.com/channels/1430279849171222682/1430279852015091805/1546237820346044566): "24v via the gpio on basically board".
- No current-limiting resistor on this drop: Jon, 2026-08-19, and the resistor section already on the wire harness page.
- The unplug point is written as optional because [BrickCycleAlice pointed out](https://discord.com/channels/1430279849171222682/1547465864184463402/1547474929987887225) that Spencer's photographed lamp has "a long red and black coming straight off the clamp", no barrel anywhere.

## Also in here

- The wire schedule's three LED drops (4.3) named COB boards on L1 and L2. Those plates went with the light post in #534, so all three drops now feed lamp strips, and the 220 mm length note (two turns around the retired dome's inner tube) is replaced by 950 mm.
- **The WireViz drawing still shows COB boards** on L1/L2, because `leds.yml` has not been redrawn. The page says so rather than pretending otherwise. That redraw is a separate job and wants Jon.
- The camera lamp page said "build the other three lamps"; a machine has three lamps in total, so it is the other two.

## Changed after review

Jon reviewed this on 10 Sep: **"If you have the 1.3 board it's just DuPont to the strip led"**, and asked for the crimp adapter he described in an engineering meeting.

- **The straight run is now the route, the barrel pair the option.** It was the other way round, because that is how `leds.yml` draws it. The lamp Spencer photographed has no barrel either, so the drawing is the odd one out. `leds.yml` is not touched here; the page and the wire harness section both say the drawing has not been redrawn.
- **`SBL-RA2P-8` was described as ending in bare wire. It does not.** It is a strip-to-wire clamp with bite points at both ends and no wire supplied, which is exactly the connector Jon described in the [8 Aug electronics sync](https://discord.com/channels/1430279849171222682/1430279852015091805/1535696087019421706) ("insulation displacement IDC crimp points on both sides, one for the strip LED and the other one for the wire") and the one `leds.yml`'s `STRIP` note already asks for. `SBL-RA2P-8-1` is the 4 in pigtail version he said he would probably define, in the 9 Aug general engineering meeting.

## The drop's parts are in the catalog now

barthel asked whether the shopping list was in the BOM. It was not: the strip was, the rest of the drop was not, and nor is any other harness consumable. Two new `cots` parts in **Wire harness**, both with sourcing:

- **`led-strip-connector-8mm`**, the solderless clamp-on strip-to-wire connector (SuperBrightLEDs `SBL-RA2P-8`, $1.59), with a published product photo.
- **`dupont-lead-2p-1m`**, a metre of 22 AWG with a 2-pin 2.54 mm Dupont housing already crimped on (Kidisoii `B0CCTZJZZ3`, $8.48 for five). Cut the male end off and one lead is a whole drop, which is the route that needs no crimp tool. **No product photo**: the vendor's images are not fetchable, so the card renders "no image" until somebody with one in hand photographs it.

**Both are counted, three per machine.** They went in uncounted at first; barthel and BrickCycleAlice corrected that, and they are right: "Mira doesn't know how to solder", so the clamp-on connector is the route the docs are built on, not one of two equal options a builder picks between. `sheet_qty: {per_machine: 3}` on each, which is how every other cable in the catalog is counted (`cable-micro-usb`, `cable-idc-2x8-*`), so the machine BOM now includes them. Each also carries `alternative`, which renders the **A** badge and names the substitute for a builder who does own an iron or a crimp tool: soldering the pads, or crimping a housing onto their own 22 AWG.

The LED drop page gets `parts_needed` and `tools_needed`, so the site renders its own **Parts needed** block from the catalog rather than the page describing parts in prose. The hand-written warning callout moved into `warning:` front matter, because the site puts that above the parts block and it was sitting below it. What is left of the prose section is the choosing advice the cards cannot carry: connector variants, the width warning, the build-your-own-lead route, and the barrel pair (still not a catalog part, because a v1.3 board does not need one).

**Where they are listed:** on the camera lamp page as well as the LED drop page, because the builder meets both parts at step 5 of building a lamp. `parts_needed` is display-only, so two pages listing one part counts nothing twice; the quantity lives on the part. The LED drop page's `tools_needed` names what the alternative routes need instead: an iron, solder and heatshrink if you solder, a crimp tool if you make your own lead. Those are consumables and tools rather than catalog parts, so they are not BOM entries.

## Rebased onto #627

#627 ("a real build through step 5") landed on main and rewrote this same page and this same step, with three of BrickCycleAlice's photos of the strip going into the skirt. **Its version is better than this branch's was, so this branch's step 5 is gone** and only what #627 does not have is carried across: the three parts in the page's list, where 950 mm comes from (924 mm of turns, first cut mark past it), cut-only-on-the-marks, the links to the new LED drop page in place of "still open: how the strip is joined", the other-two-lamps count, and BrickCycleAlice in `contributors`. The redundant photo this branch had added is dropped; #627's three cover it.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1547465864184463402/1547473147438170132
request: https://discord.com/channels/1430279849171222682/1547465864184463402/1547474283423473726
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1547465864184463402
request: https://discord.com/channels/1430279849171222682/1547465864184463402/1547468694681034762
request: https://discord.com/channels/1430279849171222682/1547465864184463402/1547474929987887225
request: https://discord.com/channels/1430279849171222682/1547477697255579690/1547555098131955834
request: https://discord.com/channels/1430279849171222682/1547477697255579690/1547578536594772039
request: https://discord.com/channels/1430279849171222682/1547477697255579690/1547583150123778130
request: https://discord.com/channels/1430279849171222682/1547477697255579690/1547586147042197504
request: https://discord.com/channels/1430279849171222682/1547477697255579690/1547598368182767616
preview: /hardware/electronics/led-drop/
-->





