### PR TITLE
docs(top-interface): BrickCycleAlice's build photos on steps 3, 4, 5 and 8, and step 1's real credits

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -180,7 +180,7 @@ Before assembling anything, press all the heat inserts listed below into their p
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-upper-fixed-section-inserts-full-ful-4f73af3a5587.png" alt="The Interface upper fixed section ring, underside with the NEMA 23 bracket attached, showing four brass M4 heat inserts around its face">
-    <figcaption>Underside, with the NEMA 23 bracket attached. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+    <figcaption>Underside, with the NEMA 23 bracket attached. <cite>Photo: zed0, a still from the assembly video.</cite></figcaption>
   </figure>
 </div>
 
@@ -191,7 +191,7 @@ Before assembling anything, press all the heat inserts listed below into their p
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-nema23-inserts-full-5fda8f6ef8c0.png" alt="The Interface NEMA 23 bracket held up, showing four brass M5 inserts on the top edges and one M3 insert on the long tail">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-nema23-inserts-underside-full-97cf1ce3e1b0.png" alt="The underside of the Interface NEMA 23 bracket, showing the two remaining brass M5 heat inserts">
-    <figcaption>Top: four M5 on the edges and one M3 on the tail. Underside: the two remaining M5. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+    <figcaption>Top: four M5 on the edges and one M3 on the tail. Underside: the two remaining M5. <cite>Photo: zed0, a still from the assembly video.</cite></figcaption>
   </figure>
 </div>
 
@@ -202,7 +202,7 @@ Before assembling anything, press all the heat inserts listed below into their p
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-chute-mount-inserts-underside-full-ec67c0262221.png" alt="The underside of the white Top interface chute mount, showing brass M4 and M3 heat inserts around the ring">
-      <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+      <figcaption>Underside: the 4 M4 and 5 of the M3. The other 2 M3 sit by the cable-clamp recess on the top face. <cite>Photo: zed0, a still from the assembly video.</cite></figcaption>
     </figure>
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-chute-mount-inserts-underside-grey-w-52b54ffa44db.jpg" alt="A closer grey view of the Top interface chute mount underside, showing two of the M3 inserts on the ring beside the recess for the Limit switch hammer screw">
@@ -237,7 +237,7 @@ Before assembling anything, press all the heat inserts listed below into their p
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-limit-switch-hammer-inserts-full-ff286afdd969.png" alt="The Limit switch hammer held up, showing a single brass M3 heat insert in its round disc">
-    <figcaption>One M3 insert in the round disc. <cite>Photo: zed0.</cite></figcaption>
+    <figcaption>One M3 insert in the round disc. <cite>Photo: zed0, a still from the assembly video.</cite></figcaption>
   </figure>
 </div>
 
@@ -247,7 +247,7 @@ Before assembling anything, press all the heat inserts listed below into their p
   </div>
   <figure class="prep-item-figure">
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-prep-cable-cage-bracket-cable-inserts-ful-9188d3883103.png" alt="The Cable cage bracket (cable mount) held up, showing a single brass M3 heat insert">
-    <figcaption>The one M3 insert in the Cable cage bracket (cable mount). <cite>Photo: zed0.</cite></figcaption>
+    <figcaption>The one M3 insert in the Cable cage bracket (cable mount). <cite>Photo: zed0, a still from the assembly video.</cite></figcaption>
   </figure>
 </div>
 
@@ -308,19 +308,19 @@ Attach the whole assembly to the bottom of the Top plate with {% include fastene
 
 <div class="img-row">
   <figure>
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4305-full-931aaff1af40.jpg" alt="Close-up of a hand-cut plywood Top plate showing a countersunk screw hole near the S3 hole position">
-    <figcaption>A hand-cut Top plate with the S2/S3 holes countersunk. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-  </figure>
-</div>
-
-<div class="img-row">
-  <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step2-ribs-upper-fixed-section-w1600-4ebd47453115.jpg" alt="Six grey Interface ribs attached around the circular Interface upper fixed section">
     <figcaption>The 6 Interface ribs attached to the Interface upper fixed section. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step2-nema23-bracket-underside-w1600-cb1666b20cca.jpg" alt="Underside of the Interface upper fixed section with the Interface NEMA 23 bracket seated in its notch">
     <figcaption>Underside, with the Interface NEMA 23 bracket seated in its notch. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4305-full-931aaff1af40.jpg" alt="Close-up of a hand-cut plywood Top plate showing a countersunk screw hole near the S3 hole position">
+    <figcaption>A hand-cut Top plate with the S2/S3 holes countersunk. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -357,6 +357,14 @@ Slide the extrusion into the Interface bracket, careful not to dislodge the T-nu
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4293-full-d11cce819ba3.jpg" alt="Four M5 screws threaded a few turns into T-nuts hanging in the Interface bracket's channel before the extrusion is slid in">
     <figcaption>Screws threaded into the T-nuts first, ready for the extrusion. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step3-extrusion-slid-in-w1600-914b4213437a.jpg" alt="The extrusion slid into the Interface bracket's channel, with the four M5 screws driven into the T-nuts along the bracket's face and a brass M5 insert at each end of it">
+    <figcaption>The extrusion slid home and all four screws driven into the T-nuts. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step3-bracket-extrusion-joined-w1600-60b9e370b515.jpg" alt="The joined Interface bracket and extrusion from the outer side, the extrusion projecting past the bracket's lower end and the square socket for the vertical leg at the top">
+    <figcaption>The finished joint from the outer side, with the socket for the vertical leg at the top. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -9,6 +9,7 @@ lede: The interface between the feeder and the bin tower.
 permalink: /hardware/assembly/distribution/top-interface/
 author: zed0
 contributors: [barthel, brickcyclealice]
+og_image: https://assets.basically.website/sorter-docs/assembly-top-interface-framing-4-full-b9ae16940954.jpg
 parts_needed:
   - part: interface-upper-fixed-section
     qty: 1
@@ -122,6 +123,11 @@ tools_needed: [Hex key, Soldering iron or heat-set insert press]
 ---
 
 The top interface holds a chute that rotates on a lazy-susan bearing to aim incoming parts at whichever bin layer is currently selected. A NEMA 23 stepper drives the rotation through a small gear train (steps 6 and 9), and a limit switch and hammer (steps 4, 6, 8) give it a fixed reference point to home against, since the stepper alone has no way to know which way it is pointed. Everything on this page bolts onto the Top plate, which then sits on the hex frame built on the bin-frame page.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-4-full-b9ae16940954.jpg" alt="The finished top interface seen from above: the hexagonal aluminum frame around the plywood Top plate, six interface ribs radiating from the centre, and the white chute mount in the middle">
+  <figcaption>What this page builds, finished: the interface under its hex frame, ready for the top layer. <cite>Photo: zed0.</cite></figcaption>
+</figure>
 
 <div class="prep-item">
   <div class="prep-item-body">

--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -392,6 +392,17 @@ Push the Printed dowel pin into the Limit switch housing.
 
 Attach the Roller lever limit switch (the "endstop-mechanical" part in your kit) with two {% include fastener.html size="M3" variant="socket-button" length="16" %} screws (into the housing's 2 M3 inserts) so the roller sits next to the dowel pin.
 
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step4-switch-on-housing-w1600-dc1356ce0023.jpg" alt="The roller lever limit switch screwed to the grey Limit switch housing, its roller sitting alongside the printed dowel pin">
+    <figcaption>The switch on the housing, roller alongside the dowel pin. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step4-switch-on-housing-back-w1600-b973ca34358f.jpg" alt="The same limit switch housing from behind, showing both M3 screws through the switch body and the dowel pin standing proud of the housing">
+    <figcaption>From behind, with both M3 screws in and the dowel pin seated. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
 Align the switch housing with the extrusion of one of the prepared Interface brackets so the limit switch is on the same face as the sloped side of the bracket. Slide 2 T-nuts into the extrusion and fasten the Limit switch housing to the extrusion with two {% include fastener.html size="M5" variant="socket-button" length="16" %} screws. Slide it as far toward the Interface bracket as possible for now; it gets aligned properly later.
 
 <div class="callout">
@@ -403,6 +414,17 @@ Align the switch housing with the extrusion of one of the prepared Interface bra
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4301-full-9ca956feeb74.jpg" alt="Two T-nuts threaded onto their screws on the Limit switch housing's mounting face, ready for the extrusion">
     <figcaption>T-nuts threaded on before the extrusion goes in. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step4-housing-on-extrusion-w1600-3c2d478fa1c6.jpg" alt="The limit switch housing bolted to the extrusion of a prepared Interface bracket, seen along the whole length of the bracket">
+    <figcaption>The housing on the bracket's extrusion, slid up toward the bracket. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step4-housing-on-extrusion-close-w1600-5a430eea98ae.jpg" alt="Close view of the limit switch housing on the extrusion, with its two M5 screws and the switch facing the same way as the sloped side of the bracket">
+    <figcaption>Closer: the two M5 screws, switch on the same face as the bracket's slope. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -429,6 +451,17 @@ Slide a T-nut just into the end of the extrusion of the limit switch interface b
 
 <div class="img-row">
   <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step5-extrusion-into-rib-w1600-171a74d5ef45.jpg" alt="A bracket's extrusion slid into an Interface rib on the underside of the Top plate, held by a single screw">
+    <figcaption>The extrusion slid into its rib, still loose on one screw. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step5-extrusion-into-rib-close-w1600-6f7cb227905b.jpg" alt="Closer view of the same joint with the rib, the bracket and the Top plate's hole lined up">
+    <figcaption>Closer, with the bracket's holes lined up on the Top plate's. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="img-row">
+  <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/img-4311-full-f9e44da3df95.jpg" alt="Looking down through one of the Top plate's screw holes, with light visible through it into the extrusion channel below">
     <figcaption>What a clear sightline through the hole looks like. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
@@ -442,6 +475,17 @@ Slide a T-nut just into the end of the extrusion of the limit switch interface b
 Repeat with the 5 other prepared Interface brackets into the 5 other Interface ribs.
 
 Flip the whole assembly and screw all 6 Interface brackets into place with {% include fastener.html size="M5" variant="countersunk" length="22" %} screws through holes I1 to I6 and O1 to O6.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step5-all-six-brackets-w1600-075fb97be950.jpg" alt="All six Interface brackets and their extrusions installed around the Interface upper fixed section, seen from above, with the limit switch bracket among them">
+    <figcaption>All six brackets in, the limit switch one among them. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step5-flipped-for-io-screws-w1600-7e736e282210.jpg" alt="The assembly flipped onto its Top plate, the plate's face up with the marked I and O holes around the centre opening">
+    <figcaption>Flipped over, ready for the I and O screws. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -535,6 +579,17 @@ Once done, check that the chute rotates freely relative to the Interface upper f
 </figure>
 
 Loosen the screws attaching the Limit switch housing to the extrusion. Slide the housing so the Limit switch hammer passes between the Roller lever limit switch and the Printed dowel pin in both directions of rotation, without touching the dowel pin. Rotate the chute slowly to each limit by hand: you should feel and hear the switch click just before the hammer would otherwise hit the dowel pin. If the hammer rubs against the dowel pin, slide the housing slightly further away and re-test. Tighten the screws to keep the housing in this position.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step8-chute-installed-w1600-391797bae8a1.jpg" alt="The chute and its ring gear installed on the interface assembly, seen from above with all six brackets around it">
+    <figcaption>The chute in place, which is the state this adjustment starts from. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-step8-hammer-at-switch-w1600-c5ea45cae0c0.jpg" alt="Close view of the Limit switch hammer swung in between the roller lever limit switch and the printed dowel pin, beside the chute's ring gear teeth">
+    <figcaption>The hammer passing between the roller and the dowel pin, clear of both. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 {% include step.html n="9" title="Install the chute stepper motor" %}
 


### PR DESCRIPTION
BrickCycleAlice went through the Top interface page against her own build and said where each of her numbered photos belongs. This places them, and fixes the credits on step 1.

**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1547526128942583838/1547527748074086510):** "Top interface Step 1, my photos have Grey parts, the black and white part photos have the wrong source listed, go back a few revisions. Step 2 this photo should be the last one,"

Then, in the same thread: ["step 3 add photos 6 and 8"](https://discord.com/channels/1430279849171222682/1547526128942583838/1547527943083786250), ["Step 4, photos 9 and 10, Then photos 14 and 15"](https://discord.com/channels/1430279849171222682/1547526128942583838/1547529114775195699), ["Step 5, photos 18 and 19, then 22 and 23"](https://discord.com/channels/1430279849171222682/1547526128942583838/1547529722140041286), ["step 8, photos 24 and 25"](https://discord.com/channels/1430279849171222682/1547526128942583838/1547530192996671508), and finally ["Ok that's all I've got for the top interface. I'm thinking we do a pr per page, to allow for ease of review and tracking."](https://discord.com/channels/1430279849171222682/1547526128942583838/1547531053433102336) The photo numbers are the ones agreed with her on 6 Sep, from her 30 Aug build thread.

## Step 1: four stills were credited to the wrong person

The black parts and the white chute mount in the Preparation step are not photographs at all. They are frames from the assembly videos, grabbed in August from timestamps barthel read out one at a time: [the NEMA 23 bracket and upper fixed section](https://discord.com/channels/1430279849171222682/1537170859633156116/1537786184858861688) from `O_ApnzrWRsE`, [the Interface bracket](https://discord.com/channels/1430279849171222682/1537170859633156116/1537792559735377920) from `-mtU3WXP73M`, [the Limit switch housing](https://discord.com/channels/1430279849171222682/1537170859633156116/1537797838115831899) from `YzYzytRl3p4`, and [the white chute mount underside](https://discord.com/channels/1430279849171222682/1537170859633156116/1537802005794521168) from `7oYiOXYF8rA`. zed0, in the same thread: ["I wasn't taking photos at that point I'm afraid. I'd just be taking video stills too"](https://discord.com/channels/1430279849171222682/1537170859633156116/1537822932649119865).

Nothing on the page carried a credit until #449 added them in bulk, and that is where four stills picked up `Photo: BrickCycleAlice` for parts she has never printed in that colour. All six stills in step 1 now read `Photo: zed0, a still from the assembly video.` — zed0 because YouTube's oEmbed names zed0 as the uploader of all four videos, including the white one ("Basically sorter - top interface assembly - lazy susan"), which answers her [guess that the white one might be Spencer's](https://discord.com/channels/1430279849171222682/1547526128942583838/1547529340907163678). The wording keeps `Photo:` at the front so `docs/scripts/validate_credits.py` still recognises it.

Her grey-part photos on the same step keep her credit.

## Step 2: photo 16 moves to the end

The hand-cut Top plate close-up was sitting between the alternative-fastener note and the two assembly photos. It is now the last figure in the step, as she asked.

## Steps 3, 4, 5 and 8: twelve of her photos placed

All uploaded to the `sorter-docs` namespace on the asset service.

- **Step 3**, photos 6 and 8: the extrusion slid home with all four screws in, and the finished joint from the outer side, next to the existing photo 5.
- **Step 4**, photos 9 and 10 beside mounting the roller lever switch on the housing; photos 14 and 15 at the end of the step, where the housing goes onto the bracket's extrusion.
- **Step 5**, photos 18 and 19 with the extrusion-into-the-rib text; photos 22 and 23 on the flip-and-bolt-through-I1-I6/O1-O6 paragraph.
- **Step 8**, photos 24 and 25 under the adjustment text, the second showing the hammer passing clear of the dowel pin.

## Checks

`npm run check` 0 errors, `docs/scripts/validate_images.py` clean at 240 assets, `docs/scripts/validate_credits.py` at the same 8 failures it reports on `main` (three of them on this page: the Top plate and the two cable cage plates have never had a credit, unrelated to this change).

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547527748074086510
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547527943083786250
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547528533012643840
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547529114775195699
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547529136640237670
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547529722140041286
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547530192996671508
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547531053433102336
preview: /hardware/assembly/distribution/top-interface/
-->
