### PR TITLE
docs(chute): chute core and door module rebuilt around a real build

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -20,11 +20,6 @@ parts_needed:
 
 The chute is what steers a part into the right bin. Build one per layer, N for an N-layer machine. The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) doesn't add any extra chutes of its own, it's a mounting stage the bottommost chute sits on, bridged to it by a [layer connector]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
 
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-built-w1600-6d9c4c0c0ac6.jpg" alt="A built chute core standing on the bench: the printed core with the door module and its bearing covers on one side, the MG995 servo in its bracket above, and the funnel brackets projecting from the left">
-  <figcaption>What this page builds towards: a core with its sub-assemblies on it. The door module, its servo bracket, the funnel brackets and the layer connectors are all fitted here. <cite>Photo: BrickCycleAlice.</cite></figcaption>
-</figure>
-
 The heat inserts are in the parts list above. The screws that hold the four sub-assemblies on are on their own pages, listed where they are driven.
 
 {% include fastener-legend.html %}
@@ -74,9 +69,11 @@ Fit them in this order, each on its own page, and each with its own screws in it
 
 Every insert you pressed in at step 1 takes a screw from one of those four pages. That is why the inserts are listed here and the screws are not.
 
+## The finished result
+
+The chute is complete when all four are on. Repeat for every layer.
+
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-built-w1600-6d9c4c0c0ac6.jpg" alt="A built chute core standing on the bench: the printed core with the door module and its bearing covers on one side, the MG995 servo in its bracket above, and the funnel brackets projecting from the left">
   <figcaption>A core with the door module, its servo bracket, the funnel brackets and the layer connectors on, the connectors being the small blocks along the top. The layer adapter board is the only one of the four not in this shot. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
-
-The chute is complete when all four are on. Repeat for every layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -22,7 +22,7 @@ The chute is what steers a part into the right bin. Build one per layer, N for a
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-built-w1600-6d9c4c0c0ac6.jpg" alt="A built chute core standing on the bench: the printed core with the door module and its bearing covers on one side, the MG995 servo in its bracket above, and the funnel brackets projecting from the left">
-  <figcaption>What this page builds towards: a core with its sub-assemblies on it. The door module, its servo bracket and the funnel brackets are fitted here. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  <figcaption>What this page builds towards: a core with its sub-assemblies on it. The door module, its servo bracket, the funnel brackets and the layer connectors are all fitted here. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 The heat inserts are in the parts list above. The screws that hold the four sub-assemblies on are on their own pages, listed where they are driven.
@@ -76,7 +76,7 @@ Every insert you pressed in at step 1 takes a screw from one of those four pages
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-built-w1600-6d9c4c0c0ac6.jpg" alt="A built chute core standing on the bench: the printed core with the door module and its bearing covers on one side, the MG995 servo in its bracket above, and the funnel brackets projecting from the left">
-  <figcaption>A core with the door module, its servo bracket and the funnel brackets on. The layer adapter board and the layer connectors are not in this shot. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  <figcaption>A core with the door module, its servo bracket, the funnel brackets and the layer connectors on, the connectors being the small blocks along the top. The layer adapter board is the only one of the four not in this shot. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 The chute is complete when all four are on. Repeat for every layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -39,20 +39,20 @@ Press the heat inserts into the chute core before you mount anything else onto i
 <div class="prep-item">
   <div class="prep-item-body">
     <p><strong>Chute core:</strong> 18 × M3, which is every insert on this page: 6 for the door module (4 for its two bearing covers, 2 for the servo bracket arms), 4 for the layer connectors, 4 for the layer adapter board, and 4 for the funnel brackets. This is separate from the bearing assembly's own 10 inserts, which live in the bearing race and holders themselves.</p>
-    <p>All 18 are the same pocket, Ø4.2 mm and blind, 5.7 mm deep, split <strong>8 + 6 + 4</strong> across three faces. The views are rendered from the chute core STL, turned slightly off each face so the pockets shade as holes, and circle only the pockets visible in that view.</p>
+    <p>All 18 are the same pocket, Ø4.2 mm and blind, 5.7 mm deep, split <strong>8 + 6 + 4</strong> across three faces. The photos below are of a printed core with the inserts already pressed in, one face at a time, so what you are counting is brass rather than empty pockets.</p>
   </div>
   <div class="prep-item-figure prep-item-figure-split">
     <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-8-full-9f0f3b659b63.png" alt="Render of one long side of the chute core at a slight angle, with eight heat-insert pockets circled in red">
-      <figcaption>One long side: 8. The round cut-out near the end is the giveaway, this side has two pockets together beside it and one on its own in the middle of the face. <cite>Render: Balloon.</cite></figcaption>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-inserts-side-8-w1600-9c2931ac6bab.jpg" alt="One long side of a printed chute core, brass heat inserts pressed into all eight pockets on that face">
+      <figcaption>One long side: 8. Two of them sit together beside the cut-out at the top, one more is on its own in the small square pocket in the middle of the face. <cite>Photo: BrickCycleAlice.</cite></figcaption>
     </figure>
     <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-side-6-full-c4074e29338f.png" alt="Render of the other long side of the chute core at a slight angle, with six heat-insert pockets circled in red">
-      <figcaption>The other long side: 6. The same face mirrored, without those two. <cite>Render: Balloon.</cite></figcaption>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-inserts-side-6-w1600-0d620740ad93.jpg" alt="The other long side of the same chute core, with brass heat inserts in its six pockets and the two round tube openings across the middle of the face">
+      <figcaption>The other long side: 6. The same face mirrored, without the square-pocket insert or the second one beside the cut-out. <cite>Photo: BrickCycleAlice.</cite></figcaption>
     </figure>
     <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-inserts-v3-rear-full-ad4c2cc7869c.png" alt="Close render of the rear end of the chute core at a slight angle, with the four heat-insert pockets on the rear panel circled in red">
-      <figcaption>Rear face: the last 4, all on the panel at the top end. Shown closer in than the other two. <cite>Render: Balloon.</cite></figcaption>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-inserts-rear-w1600-1e4ceeaf46ea.jpg" alt="The rear panel of the chute core seen from above, four brass heat inserts in a square, with the curved channel of the core beside it">
+      <figcaption>Rear face: the last 4, in a square on the panel at the top end. <cite>Photo: BrickCycleAlice.</cite></figcaption>
     </figure>
   </div>
 </div>

--- a/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/chute-core.md
@@ -9,6 +9,7 @@ lede: The chute assembly. Build one per layer.
 permalink: /hardware/assembly/distribution/chute/chute-core/
 author: spencer
 contributors: [barthel]
+og_image: https://assets.basically.website/sorter-docs/assembly-chute-core-built-w1600-6d9c4c0c0ac6.jpg
 last_verified: 2026-09-07
 parts_needed:
   - part: chute-core
@@ -18,6 +19,11 @@ parts_needed:
 ---
 
 The chute is what steers a part into the right bin. Build one per layer, N for an N-layer machine. The [bottom interface]({{ '/hardware/assembly/distribution/bin-frame/bottom-interface/' | relative_url }}) doesn't add any extra chutes of its own, it's a mounting stage the bottommost chute sits on, bridged to it by a [layer connector]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}).
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-built-w1600-6d9c4c0c0ac6.jpg" alt="A built chute core standing on the bench: the printed core with the door module and its bearing covers on one side, the MG995 servo in its bracket above, and the funnel brackets projecting from the left">
+  <figcaption>What this page builds towards: a core with its sub-assemblies on it. The door module, its servo bracket and the funnel brackets are fitted here. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
 
 The heat inserts are in the parts list above. The screws that hold the four sub-assemblies on are on their own pages, listed where they are driven.
 
@@ -68,6 +74,9 @@ Fit them in this order, each on its own page, and each with its own screws in it
 
 Every insert you pressed in at step 1 takes a screw from one of those four pages. That is why the inserts are listed here and the screws are not.
 
-<div class="img-placeholder">Photo of a finished chute core with all four sub-assemblies bolted on: door module, layer adapter board, funnel brackets and layer connectors.</div>
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-chute-core-built-w1600-6d9c4c0c0ac6.jpg" alt="A built chute core standing on the bench: the printed core with the door module and its bearing covers on one side, the MG995 servo in its bracket above, and the funnel brackets projecting from the left">
+  <figcaption>A core with the door module, its servo bracket and the funnel brackets on. The layer adapter board and the layer connectors are not in this shot. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
 
 The chute is complete when all four are on. Repeat for every layer.

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -71,7 +71,7 @@ Four things make it up:
 - **Bearing assembly, its own:** 10 {% include fastener.html size="M3" variant="heat-insert" %} (4 in the race, 3 in each holder) and 10 {% include fastener.html size="M3" variant="countersunk" length="8" %}. Six hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each; all ten are driven in step 4. The two 6704-2RS bearings go into the holders in step 1. The covers are thin at the rim, so snug their screws down evenly rather than fully tightening one before the others.
 - **Servo adapter, its own:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %}, no heat inserts. They hold the servo-side and flap-side halves together with the MG995 Servo Horn clasped between them.
 - **Servo bracket, its own:** 6 {% include fastener.html size="M3" variant="heat-insert" %} in the housing, two on each of three faces, and one screw per insert. 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} hold the lower arm on, 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} hold the side arm on, and 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} hold the cover on. None of them goes through the servo.
-- **Holding the finished module to the chute core:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, plus one screw through each bracket arm's mounting ear, step 6. The two arms are not the same thickness there, so they do not take the same screw: the lower arm's ear is 8.40 mm and takes a {% include fastener.html size="M3" variant="countersunk" length="12" %}, the side arm's is 5.00 mm and takes a {% include fastener.html size="M3" variant="countersunk" length="8" %}. All six go into the core's own heat inserts, so there is nothing to press in here for them.
+- **Holding the finished module to the chute core:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, plus one screw through each bracket arm's mounting ear, step 7. The two arms are not the same thickness there, so they do not take the same screw: the lower arm's ear is 8.40 mm and takes a {% include fastener.html size="M3" variant="countersunk" length="12" %}, the side arm's is 5.00 mm and takes a {% include fastener.html size="M3" variant="countersunk" length="8" %}. All six go into the core's own heat inserts, so there is nothing to press in here for them.
 
 {% include step.html n="1" title="Preparation" %}
 
@@ -121,23 +121,7 @@ The photos are of printed parts with the inserts already pressed in, one part at
   <figcaption>A holder propped in the housing, which is steady enough to press against. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
-Two sub-assemblies go together here as well, before the steps that use them. Neither takes inserts.
-
-<div class="prep-item">
-  <div class="prep-item-body">
-    <p><strong>Servo adapter:</strong> the servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Drop the horn into the servo-side half <strong>splined sleeve first</strong>: the sleeve sits in the hole in the middle of that half and the two arms lie in the slot around it. It does not fit any other way. Bring the flap-side half down over it and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. The screws cut their own thread in the printed plastic.</p>
-  </div>
-  <div class="prep-item-figure prep-item-figure-split">
-    <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-sleeve-right-full-7518b1e88254.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the servo, with its splined sleeve facing to the right">
-      <figcaption>The MG995 Servo Horn. The splined sleeve, facing right here, is what goes into the servo-side (tan) half in the next picture; on the machine it is also what slides onto the servo's output shaft. <cite>Reference photo of the stock part, not from a build. Photographer not recorded.</cite></figcaption>
-    </figure>
-    <figure>
-      <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-exploded-full-57d2c57e666b.png" alt="Exploded render of the two servo adapter halves facing each other: the flap-side half in blue on the left showing its hexagonal socket and four countersunk holes, the servo-side half in tan on the right showing the long slot the two-arm horn seats in and its four pilot holes">
-      <figcaption>Exploded, in build order. The horn goes into the servo-side half (tan), sleeve into the middle hole and arms in the slot, then the flap-side half (blue) goes over it and takes the 4 screws. The hex socket in the flap side is what the door's shaft ends up in. <cite>Rendered from the part geometry in assembly position, not from a build. Render: Balloon.</cite></figcaption>
-    </figure>
-  </div>
-</div>
+One more sub-assembly goes together here, before the step that uses it, and it takes no inserts.
 
 <div class="prep-item">
   <div class="prep-item-body">
@@ -167,7 +151,7 @@ The two arms land on two other faces of the housing, so they are independent of 
 - **Lower arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} into the housing's inserts. The arm is 4.25 mm thick at the screws, so an 8 mm one reaches 3.75 mm in.
 - **Side arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} into the housing's inserts. This arm is 8.40 mm thick at the screws, so an 8 mm one would not reach them at all.
 
-Each arm has one further hole, in the ear at its far end. Those two are not driven here; they are what bolts the finished bracket to the chute core in step 6, so leave them empty.
+Each arm has one further hole, in the ear at its far end. Those two are not driven here; they are what bolts the finished bracket to the chute core in step 7, so leave them empty.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-bracket-assembled-full-2c6c3cddb48f.png" alt="Render of the assembled servo bracket seen from the cover side: the cover with its two screw lugs and the window the servo sits behind, the side arm to the right and the lower arm below, each with the single mounting ear that bolts to the chute core">
@@ -176,14 +160,14 @@ Each arm has one further hole, in the ear at its far end. Those two are not driv
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-bracket-built-full-d4b253675de4.jpg" alt="Photograph of a finished MG995 servo bracket lying on a bench: the printed housing with its cover and both arms fitted, the black servo body visible through the gap between them, the servo lead running off to the right, and the round servo adapter already fitted on the servo's output">
-  <figcaption>The same thing on a real machine, from the other side: housing, cover and both arms, with the MG995 inside and its lead running off to the right. The servo adapter is already on the output here; on this page that does not happen until step 6. <cite>Frame at 0:01 of the video in step 6. Video: Spencer.</cite></figcaption>
+  <figcaption>The same thing on a real machine, from the other side: housing, cover and both arms, with the MG995 inside and its lead running off to the right. The servo adapter is already on the output here; on this page that does not happen until step 7. <cite>Frame at 0:01 of the video in step 7. Video: Spencer.</cite></figcaption>
 </figure>
 
 {% include step.html n="4" title="Hang the door on its bearings and the race" %}
 
 The shaft is captured at both ends once this is together, so there is only one order it goes in: the holders have to go onto the shaft before anything is bolted down.
 
-**Check which way round the door goes first.** The shaft runs the length of the door's top edge and is Ø19.8 mm, but one end finishes in a hexagonal spigot 12.0 mm across the flats. That hex end is the servo side — it is what the servo adapter's flap-side half slides onto in step 6. The other end is plain round.
+**Check which way round the door goes first.** The shaft runs the length of the door's top edge and is Ø19.8 mm, but one end finishes in a hexagonal spigot 12.0 mm across the flats. That hex end is the servo side — it is what the servo adapter's flap-side half slides onto in step 7. The other end is plain round.
 
 1. **Slide a holder onto each end of the shaft**, bearings already seated. The bearing's Ø20 bore takes the Ø19.8 shaft, and the holder's own Ø21.0 mm hole clears the shaft by 0.6 mm all round, so neither should need forcing.
 2. **Lay the race along the back of the shaft**, on the opposite side from the flap, and bolt each holder down onto its end of it: 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per holder, 4 in total, into the race's four inserts. The holder seats flat against the race's end. The race arches over the shaft with about 0.5 mm of clearance and never touches it; if it does touch, something is not seated.
@@ -203,10 +187,10 @@ Hung this way the door has **80.5° of swing**, from 10.7° off horizontal at it
 
 {% include step.html n="5" title="Bolt the flap assembly to the chute core" %}
 
-Six of the core's 18 inserts belong to this module. Four are used here, two in step 6:
+Six of the core's 18 inserts belong to this module. Four are used here, two in step 7:
 
 - **2 bearing covers**, 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} in total, 2 per cover, into 5.00 mm of wall. These are the two holes left empty in each cover in step 4.
-- **Servo bracket lower arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="12" %}, and **side arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="8" %} — step 6.
+- **Servo bracket lower arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="12" %}, and **side arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="8" %} — step 7.
 
 <div class="img-row">
   <figure>
@@ -227,23 +211,49 @@ Snug all four down before tightening any of them, then cycle the door by hand th
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-flap-fitted-full-3988a30ff4a4.jpg" alt="Photograph of a printed chute core lying face up with the flap assembly already bolted to it: the round bearing cover, its six screw heads and central hex boss, sits on the core's long side, and the brass heads of the core's other heat inserts are visible across the face">
-  <figcaption>What you should have at the end of this step: the flap assembly on the core, held by the bearing cover you can see on the right. The servo bracket has not gone on yet. <cite>Frame at 0:01 of the video in step 6. Video: Spencer.</cite></figcaption>
+  <figcaption>What you should have at the end of this step: the flap assembly on the core, held by the bearing cover you can see on the right. The servo bracket has not gone on yet. <cite>Frame at 0:01 of the video in step 7. Video: Spencer.</cite></figcaption>
 </figure>
 
-{% include step.html n="6" title="Bolt the servo bracket on and couple it to the door" %}
+{% include step.html n="6" title="Build the servo adapter" %}
+
+The servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Drop the horn into the servo-side half **splined sleeve first**: the sleeve sits in the hole in the middle of that half and the two arms lie in the slot around it. It does not fit any other way. Bring the flap-side half down over it and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. The screws cut their own thread in the printed plastic.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-sleeve-right-full-7518b1e88254.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the servo, with its splined sleeve facing to the right">
+    <figcaption>The MG995 Servo Horn. The splined sleeve, facing right here, is what goes into the servo-side (tan) half in the next picture; on the machine it is also what slides onto the servo's output shaft. <cite>Reference photo of the stock part, not from a build. Photographer not recorded.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-adapter-exploded-full-57d2c57e666b.png" alt="Exploded render of the two servo adapter halves facing each other: the flap-side half in blue on the left showing its hexagonal socket and four countersunk holes, the servo-side half in tan on the right showing the long slot the two-arm horn seats in and its four pilot holes">
+    <figcaption>Exploded, in build order. The horn goes into the servo-side half (tan), sleeve into the middle hole and arms in the slot, then the flap-side half (blue) goes over it and takes the 4 screws. The hex socket in the flap side is what the door's shaft ends up in. <cite>Rendered from the part geometry in assembly position, not from a build. Render: Balloon.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-servo-adapter-servo-side-w1600-eaf8aa259871.jpg" alt="The finished servo adapter seen from the servo side: the black two-arm horn lying flush in its slot in the grey printed disc, the splined sleeve's opening in the middle of it and four empty countersunk holes around the face">
+    <figcaption>Finished, servo side. The horn sits flush in its slot with the splined sleeve in the middle, and that opening is what goes onto the servo's output shaft. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-servo-adapter-flap-side-w1600-76e5eb69f26e.jpg" alt="The same adapter from the flap side: a raised hub with a hexagonal socket in the middle and the four countersunk screws driven from this face around it">
+    <figcaption>The other side, and the one to check: four screws home, and the hexagonal socket in the raised hub that takes the hex end of the door's shaft. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+{% include step.html n="7" title="Bolt the servo bracket on and couple it to the door" %}
 
 The bracket goes on the same long side as the servo-side bearing cover, into the other two inserts in the first render above. The two arms do not take the same screw, because their mounting ears are not the same thickness:
 
 - **Lower arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="12" %} through an ear 8.40 mm thick. An 8 mm screw would not reach the insert at all; the 12 reaches 3.60 mm into it.
 - **Side arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="8" %} through an ear 5.00 mm thick, the same as the bearing covers'. The 8 reaches 3.00 mm in; a 12 would bottom out in the pocket.
 
-Then couple the servo to the door through the two-piece adapter you built in step 1. Its servo side goes onto the servo's splined output, through the horn clasped inside it, and its flap side has a hexagonal socket 12.4 mm across the flats that takes **the hex end of the door's shaft** — the end step 4 told you to point at the servo. The spigot is 12.0 mm across the flats, so it is a slip fit with about 0.4 mm to spare.
+Then couple the servo to the door through the two-piece adapter you built in the step above. Its servo side goes onto the servo's splined output, through the horn clasped inside it, and its flap side has a hexagonal socket 12.4 mm across the flats that takes **the hex end of the door's shaft** — the end step 4 told you to point at the servo. The spigot is 12.0 mm across the flats, so it is a slip fit with about 0.4 mm to spare.
 
 Clock it before you commit: centre the servo (or let it settle at its power-on default), fit the adapter at roughly the middle of the door's swing, then fine-tune once you can check both open and closed by eye. The video below shows how it is set.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-servo-video-frame-full-1f27d2aaa634.jpg" alt="Photograph of a real door module part-way through assembly: a hand holds the assembled servo adapter, a white disc with a hexagonal boss in the middle and four countersunk screws around it, in front of the MG995 in its printed bracket">
-  <figcaption>The same job on a real machine. The disc in frame is the servo adapter from step 1, screwed together with its four countersunk screws, with the hexagonal socket that takes the door's shaft facing the camera; the MG995 sits in its bracket behind it. <cite>Frame from the video below. Video: Spencer.</cite></figcaption>
+  <figcaption>The same job on a real machine. The disc in frame is the servo adapter from step 6, screwed together with its four countersunk screws, with the hexagonal socket that takes the door's shaft facing the camera; the MG995 sits in its bracket behind it. <cite>Frame from the video below. Video: Spencer.</cite></figcaption>
 </figure>
 
 <div class="callout callout-warning">

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -252,6 +252,11 @@ Snug all four down before tightening any of them, then cycle the door by hand th
 
 The servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Drop the horn into the servo-side half **splined sleeve first**: the sleeve sits in the hole in the middle of that half and the two arms lie in the slot around it. It does not fit any other way. Bring the flap-side half down over it and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. The screws cut their own thread in the printed plastic.
 
+<div class="callout">
+  <span class="callout-icon" aria-hidden="true">💡</span>
+  <p>The four screw holes are not spaced evenly around the centre. They sit on a 15 mm radius but the gaps between them alternate 84° and 96°, so the flap side only drops on in two of the four quarter turns. Line all four holes up by eye before you press the halves together, rather than finding out on the third screw. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
 <div class="img-row">
   <figure>
     <img class="doc-figure" src="https://assets.basically.website/sorter-parts/mg995-servo-horn-sleeve-right-full-7518b1e88254.png" alt="The MG995 Servo Horn, a two-arm splined servo arm that ships with the servo, with its splined sleeve facing to the right">

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -84,8 +84,8 @@ Every pocket is the same one the rest of the chute uses: Ø4.2 mm, blind, 5.7 mm
     <p><strong>Servo bracket (housing):</strong> 6 × M3, two on each of three faces. 2 take the lower arm, 2 take the side arm and 2 take the cover. The servo does not screw to the housing at all, so none of these is for it.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-servo-bracket-housing-full-7545917fe3d9.png" alt="Render of the servo bracket housing at an angle, with its six heat-insert pockets circled in red, two on each of three faces">
-    <figcaption>All six, seen from the corner. That is the only angle that catches all three faces at once. <cite>Render: Balloon.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-inserts-servo-bracket-housing-w1600-ca8e04d2c1d7.jpg" alt="A printed servo bracket housing standing on end, brass heat inserts pressed into all six pockets: two on the top face, two on the front face beside the open pocket, two on the bottom edge">
+    <figcaption>All six, seen from the corner. That is the only angle that catches all three faces at once. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -94,8 +94,8 @@ Every pocket is the same one the rest of the chute uses: Ø4.2 mm, blind, 5.7 mm
     <p><strong>Bearing race:</strong> 4 × M3, two at each end. These are the ones the holders screw down onto.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-race-full-4a30d9cbcc4a.png" alt="Render of the bearing race seen almost straight on, with its four heat-insert pockets circled in red, two at each end">
-    <figcaption>Two at each end of the race. <cite>Render: Balloon.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-inserts-bearing-race-w1600-c3730d2c7c58.jpg" alt="A printed bearing race lying flat, brass heat inserts in the two pockets at each end and a raised chevron in the middle of the same face">
+    <figcaption>Two at each end of the race. They are on the same face as the raised chevron in the middle. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -104,12 +104,22 @@ Every pocket is the same one the rest of the chute uses: Ø4.2 mm, blind, 5.7 mm
     <p><strong>Bearing holder (left) and bearing holder (right):</strong> 3 × M3 each, 6 between them, on the outboard face around the bearing bore.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-inserts-bearing-holder-left-full-20b5c1bf8883.png" alt="Render of the left bearing holder at an angle, with its three heat-insert pockets circled in red around the bearing bore">
-    <figcaption>Three around the bore on the outboard face. The left holder is shown; the right one takes the same three. <cite>Render: Balloon.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-inserts-bearing-holder-w1600-9f39521a7c9b.jpg" alt="A printed bearing holder held at an angle, three brass heat inserts spaced around its empty bearing bore, one on the small ear and two on the body">
+    <figcaption>Three around the bore on the outboard face. One holder is shown; the other takes the same three. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
-The views are rendered from each part's STL, turned slightly off the face so the pockets shade as holes, and circle only the pockets visible from that angle. The counts match what the [parts calculator](https://parts-calculator.basically.website/assembly?focus=flap-module) asks for: 6 + 4 + 3 + 3.
+The photos are of printed parts with the inserts already pressed in, one part at a time, so the brass is what you count. The counts match what the [parts calculator](https://parts-calculator.basically.website/assembly?focus=flap-module) asks for: 6 + 4 + 3 + 3.
+
+<div class="callout">
+  <span class="callout-icon" aria-hidden="true">💡</span>
+  <p>No bench vice? Stand a bearing holder in the servo bracket housing while you press its inserts. The housing's pocket holds the holder upright and square, and leaves both your hands for the iron. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-holder-propped-in-housing-w1600-8617b387f402.jpg" alt="A bearing holder with its three brass inserts standing against the open servo bracket housing, which props it upright on the bench">
+  <figcaption>A holder propped in the housing, which is steady enough to press against. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
 
 Two sub-assemblies go together here as well, before the steps that use them. Neither takes inserts.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -273,6 +273,8 @@ Six of the core's 18 inserts belong to this module. Four are used here, two in s
 
 Snug all four down before tightening any of them, then cycle the door by hand through its full swing. It should turn freely on the bearings and not touch the core anywhere; if it binds, slacken off and let the assembly settle square before tightening again.
 
+<div class="img-placeholder">Photos of the flap assembly on the core: sliding it in, bolted down with the door closed and then fully open, the same pair from the other side, and one from the back with the door closed. A half-open door in a finished photo is what a wrong install looks like, so the two ends of the swing are the shots that show this is right.</div>
+
 {% include step.html n="7" title="Build the servo adapter" %}
 
 The servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Drop the horn into the servo-side half **splined sleeve first**: the sleeve sits in the hole in the middle of that half and the two arms lie in the slot around it. It does not fit any other way. Bring the flap-side half down over it and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. The screws cut their own thread in the printed plastic.

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -192,11 +192,6 @@ Each arm has one further hole, in the ear at its far end. Those two are not driv
   <figcaption>The bracket assembled, seen from the cover side. The two ears sticking out at bottom and right, one on each arm, are the pair that bolt to the chute core. <cite>Rendered from the part geometry in assembly position, not from a build. Render: Balloon.</cite></figcaption>
 </figure>
 
-<figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-bracket-built-full-d4b253675de4.jpg" alt="Photograph of a finished MG995 servo bracket lying on a bench: the printed housing with its cover and both arms fitted, the black servo body visible through the gap between them, the servo lead running off to the right, and the round servo adapter already fitted on the servo's output">
-  <figcaption>The same thing on a real machine, from the other side: housing, cover and both arms, with the MG995 inside and its lead running off to the right. The servo adapter is already on the output here; on this page that does not happen until step 7. <cite>Frame at 0:01 of the video in step 7. Video: Spencer.</cite></figcaption>
-</figure>
-
 {% include step.html n="4" title="Hang the door on its bearings and the race" %}
 
 The shaft is captured at both ends once this is together, so there is only one order it goes in: the holders have to go onto the shaft before anything is bolted down.

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -310,7 +310,7 @@ The servo-side and flap-side plates clamp the MG995 Servo Horn between them. The
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
-  <p><strong>Watch the video below before you finish this step.</strong> Coupling the servo to the door is where a door gets broken: the servo has a fixed range and the door has 80.5° of swing, and forcing the two together out of position can snap it. <cite>Tip: BrickCycleAlice.</cite></p>
+  <p><strong>Watch the video below before you finish this step.</strong> It is possible to break a door here, so see how the coupling is set in the video before you commit to a position. The door only has 80.5° of travel and both ends of it are the door itself meeting the race, so there is nowhere for it to give. <cite>Tip: BrickCycleAlice.</cite></p>
 </div>
 
 The bracket goes on the same long side as the servo-side bearing cover, into the other two inserts in the first render above. The two arms do not take the same screw, because their mounting ears are not the same thickness:

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -202,6 +202,22 @@ The shaft is captured at both ends once this is together, so there is only one o
 2. **Lay the race along the back of the shaft**, on the opposite side from the flap, and bolt each holder down onto its end of it: 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per holder, 4 in total, into the race's four inserts. The holder seats flat against the race's end. The race arches over the shaft with about 0.5 mm of clearance and never touches it; if it does touch, something is not seated.
 3. **Put a cover on each holder**, 3 {% include fastener.html size="M3" variant="countersunk" length="8" %} each, 6 in total, into the three inserts pressed in step 1. The cover's raised rim, 5.00 mm tall, drops into the pocket on top of the bearing and clamps it against the step: if a bearing has not gone fully home against its lip, its cover will not pull flat. Each cover has **two further holes that stay empty here** — they take the screws that hold the flap assembly to the chute core in step 5.
 
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>Check the race is the right way round before any of this is bolted up.</strong> The shaft sits high on the door's axis and the race's step tucks down and under it, so laid together correctly the race and the door read as one flat plane. If they look like a flight of stairs, the race is round the wrong way. Getting it wrong is a lot of screws to undo. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-door-and-race-apart-w1600-a1c66c18ef8b.jpg" alt="The printed chute door lying beside the bearing race before assembly, the door's shaft running along its top edge with the hexagonal spigot at one end, and the race's stepped profile facing the shaft">
+    <figcaption>The two parts before they go together, and the orientation to get right: the race's step goes down and under the shaft. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-door-race-flat-plane-w1600-e407f399bfbc.jpg" alt="The door and race sighted along their length from the hexagonal end of the shaft, the top of the race and the top of the door lying in one continuous flat plane">
+    <figcaption>Right way round, sighted along the joint: one flat plane across both, no step to walk up. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bearing-assembly-blue-full-1cb33257bd5a.png" alt="Two renders, one above the other: on top the chute door with its shaft, the bearing race over the shaft, and the two bearing holders drawn out along the shaft with a blue bearing in each; below, the same parts pushed together so the holders sit on the ends of the race">
   <figcaption>The holders, with their bearings in blue, going onto the ends of the shaft and down onto the race. The covers are not shown. <cite>Rendered from the parts' own geometry in assembly position, not from a build. Render: Balloon.</cite></figcaption>

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -159,8 +159,31 @@ The cover is 6.65 mm thick at the screw, so a 12 mm screw reaches 5.35 mm into t
 
 The two arms land on two other faces of the housing, so they are independent of the servo and can go on before or after it.
 
-- **Lower arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} into the housing's inserts. The arm is 4.25 mm thick at the screws, so an 8 mm one reaches 3.75 mm in.
-- **Side arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} into the housing's inserts. This arm is 8.40 mm thick at the screws, so an 8 mm one would not reach them at all.
+**Lower arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} into the housing's inserts. It is the wider of the two arms, and it is 4.25 mm thick at the screws, so an 8 mm one reaches 3.75 mm in.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-lower-arm-on-w1600-d777cd9b9a60.jpg" alt="The servo bracket housing with the wide lower arm bolted to it, seen from the cover side, the arm's thick end standing proud with a single empty hole in its sloped face">
+    <figcaption>The lower arm on. The empty hole in its raised end is the one that bolts to the chute core later, not now. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-lower-arm-screws-w1600-aebd2878b313.jpg" alt="The same assembly from the servo output end, with two countersunk screw heads visible in the face of the lower arm and the servo's splined output above them">
+    <figcaption>From the output end, with the arm's two countersunk screws driven home. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+**Side arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} into the housing's inserts. This one is the narrow arm and it is 8.40 mm thick at the screws, so an 8 mm one would not reach them at all.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-side-arm-on-w1600-d2fc44863353.jpg" alt="Both arms now on the housing: the wide lower arm across the top and the narrow side arm projecting from the right-hand face with an empty hole in its foot">
+    <figcaption>Side arm added, so both arms are now on. Its foot carries the second empty hole. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-both-arms-underside-w1600-882c2dfe8031.jpg" alt="The finished bracket from below with both arms fitted, two countersunk screw heads in the near face and the servo's output shaft visible between the arms">
+    <figcaption>The finished bracket from below, both arms fitted. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
 
 Each arm has one further hole, in the ear at its far end. Those two are not driven here; they are what bolts the finished bracket to the chute core in step 7, so leave them empty.
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -144,6 +144,17 @@ The cover is 6.65 mm thick at the screw, so a 12 mm screw reaches 5.35 mm into t
   <figcaption>The cover pulled off the housing. The servo goes into the open pocket, and the two lugs the cover screws through are the only fasteners holding it. <cite>Rendered from the part geometry, not from a build. Render: Balloon.</cite></figcaption>
 </figure>
 
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-servo-in-housing-w1600-b7436486902c.jpg" alt="An MG995 servo lying in the open pocket of the printed housing with the cover off, its mounting tabs resting across the two brass-lined lugs and its lead running out of the bottom of the pocket">
+    <figcaption>Servo in, cover still off. Its tabs lie across the two lugs and nothing screws into the servo itself. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-cover-on-w1600-7153a7d8b99c.jpg" alt="The same housing from the corner with the cover screwed down over the servo, two countersunk screw heads in the cover and the servo's splined output standing through the window in it">
+    <figcaption>Cover on, both screws snugged down evenly. That pair is what holds the servo in. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
 {% include step.html n="3" title="Add the bracket arms" %}
 
 The two arms land on two other faces of the housing, so they are independent of the servo and can go on before or after it.

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -273,7 +273,37 @@ Six of the core's 18 inserts belong to this module. Four are used here, two in s
 
 Snug all four down before tightening any of them, then cycle the door by hand through its full swing. It should turn freely on the bearings and not touch the core anywhere; if it binds, slacken off and let the assembly settle square before tightening again.
 
-<div class="img-placeholder">Photos of the flap assembly on the core: sliding it in, bolted down with the door closed and then fully open, the same pair from the other side, and one from the back with the door closed. A half-open door in a finished photo is what a wrong install looks like, so the two ends of the swing are the shots that show this is right.</div>
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-flap-sliding-in-w1600-de953979e4b1.jpg" alt="The flap assembly being offered up to the chute core, one bearing cover standing proud of the core's long side before its screws go in">
+  <figcaption>How it goes in: a cover lands on each long side of the core, and the two screws per cover go in from there. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-flap-closed-w1600-2cf8babd0acb.jpg" alt="The flap bolted to the core, seen down onto the top face, with the door closed so no blade shows below the core">
+    <figcaption>Bolted down, door fully closed: nothing showing below the core. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-flap-open-w1600-740514c1bff8.jpg" alt="The same assembly with the door fully open, the thin door plate hanging down clear of the core">
+    <figcaption>Door fully open, the plate hanging clear. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-flap-closed-other-side-w1600-2b268da4eb66.jpg" alt="The other side of the same assembly, the bearing cover with the hexagonal socket in the middle, door closed">
+    <figcaption>The other side, door closed. This is the cover with the hex socket, so this end faces the servo. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-flap-open-other-side-w1600-f4850a808fe4.jpg" alt="The same side with the door fully open, the door plate hanging below the core">
+    <figcaption>The other side, door open. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-flap-from-back-w1600-542076f9f69f.jpg" alt="The assembly end on from the back with the door closed, four brass inserts in the flat top plate and the bearing race with its chevron sitting between the two holders">
+  <figcaption>From the back with the door closed: the race and its chevron sit between the two holders. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
 
 {% include step.html n="7" title="Build the servo adapter" %}
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -198,10 +198,6 @@ The shaft is captured at both ends once this is together, so there is only one o
 
 **Check which way round the door goes first.** The shaft runs the length of the door's top edge and is Ø19.8 mm, but one end finishes in a hexagonal spigot 12.0 mm across the flats. That hex end is the servo side — it is what the servo adapter's flap-side half slides onto in step 7. The other end is plain round.
 
-1. **Slide a holder onto each end of the shaft**, bearings already seated. The bearing's Ø20 bore takes the Ø19.8 shaft, and the holder's own Ø21.0 mm hole clears the shaft by 0.6 mm all round, so neither should need forcing.
-2. **Lay the race along the back of the shaft**, on the opposite side from the flap, and bolt each holder down onto its end of it: 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per holder, 4 in total, into the race's four inserts. The holder seats flat against the race's end. The race arches over the shaft with about 0.5 mm of clearance and never touches it; if it does touch, something is not seated.
-3. **Put a cover on each holder**, 3 {% include fastener.html size="M3" variant="countersunk" length="8" %} each, 6 in total, into the three inserts pressed in step 1. The cover's raised rim, 5.00 mm tall, drops into the pocket on top of the bearing and clamps it against the step: if a bearing has not gone fully home against its lip, its cover will not pull flat. Each cover has **two further holes that stay empty here** — they take the screws that hold the flap assembly to the chute core in step 5.
-
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p><strong>Check the race is the right way round before any of this is bolted up.</strong> The shaft sits high on the door's axis and the race's step tucks down and under it, so laid together correctly the race and the door read as one flat plane. If they look like a flight of stairs, the race is round the wrong way. Getting it wrong is a lot of screws to undo. <cite>Tip: BrickCycleAlice.</cite></p>
@@ -217,6 +213,16 @@ The shaft is captured at both ends once this is together, so there is only one o
     <figcaption>Right way round, sighted along the joint: one flat plane across both, no step to walk up. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
+
+
+1. **Slide a holder onto each end of the shaft**, bearings already seated. The bearing's Ø20 bore takes the Ø19.8 shaft, and the holder's own Ø21.0 mm hole clears the shaft by 0.6 mm all round, so neither should need forcing.
+2. **Lay the race along the back of the shaft**, on the opposite side from the flap, and bolt each holder down onto its end of it: 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per holder, 4 in total, into the race's four inserts. The holder seats flat against the race's end. The race arches over the shaft with about 0.5 mm of clearance and never touches it; if it does touch, something is not seated.
+3. **Put a cover on each holder**, 3 {% include fastener.html size="M3" variant="countersunk" length="8" %} each, 6 in total, into the three inserts pressed in step 1. The cover's raised rim, 5.00 mm tall, drops into the pocket on top of the bearing and clamps it against the step: if a bearing has not gone fully home against its lip, its cover will not pull flat. Each cover has **two further holes that stay empty here** — they take the screws that hold the flap assembly to the chute core in step 5.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-holder-on-race-end-w1600-71a9cfaaf366.jpg" alt="Close view of one end of the assembled flap: the bearing holder bolted to the end of the bearing race with two countersunk screws in its face, the bearing seated in its bore with the door's shaft through it, and the door plate above">
+  <figcaption>One end, done. The holder is bolted to the end of the race and the shaft runs through its bearing. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bearing-assembly-blue-full-1cb33257bd5a.png" alt="Two renders, one above the other: on top the chute door with its shaft, the bearing race over the shaft, and the two bearing holders drawn out along the shaft with a blue bearing in each; below, the same parts pushed together so the holders sit on the ends of the race">

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -357,6 +357,17 @@ Clock it before you commit: centre the servo (or let it settle at its power-on d
   <figcaption>The same job on a real machine. The disc in frame is the servo adapter from step 7, screwed together with its four countersunk screws, with the hexagonal socket that takes the door's shaft facing the camera; the MG995 sits in its bracket behind it. <cite>Frame from the video below. Video: Spencer.</cite></figcaption>
 </figure>
 
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-bracket-on-core-coupled-w1600-753b3624aba0.jpg" alt="The servo bracket bolted to the chute core with the servo adapter fitted on the servo's output, seen face on, the adapter's four screws and hex socket visible">
+    <figcaption>Bracket bolted on and the adapter fitted to the servo, seen face on. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-bracket-on-core-top-w1600-94ef36ed29c6.jpg" alt="The same assembly from above, the servo in its bracket standing off the chute core with the door hanging below">
+    <figcaption>From above, with the servo standing off the core and the door below. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p>The MG995 only rotates 180°. Install the servo so the door can reach <strong>both</strong> its fully open and fully closed positions inside that range: clock the horn and set the mounting angle so neither extreme falls outside the servo's travel. Before you tighten anything down, cycle the door by hand through both positions to confirm it swings freely and doesn't bind on the bearings or the core.</p>

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -157,7 +157,7 @@ The cover is 6.65 mm thick at the screw, so a 12 mm screw reaches 5.35 mm into t
 
 {% include step.html n="3" title="Add the bracket arms" %}
 
-The two arms land on two other faces of the housing, so they are independent of the servo and can go on before or after it.
+The two arms land on two other faces of the housing.
 
 **Lower arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} into the housing's inserts. It is the wider of the two arms, and it is 4.25 mm thick at the screws, so an 8 mm one reaches 3.75 mm in.
 
@@ -172,7 +172,7 @@ The two arms land on two other faces of the housing, so they are independent of 
   </figure>
 </div>
 
-**Side arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} into the housing's inserts. This one is the narrow arm and it is 8.40 mm thick at the screws, so an 8 mm one would not reach them at all.
+**Side arm:** 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} into the housing's inserts.
 
 <div class="img-row">
   <figure>
@@ -186,11 +186,6 @@ The two arms land on two other faces of the housing, so they are independent of 
 </div>
 
 Each arm has one further hole, in the ear at its far end. Those two are not driven here; they are what bolts the finished bracket to the chute core in step 8, so leave them empty.
-
-<figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-bracket-assembled-full-2c6c3cddb48f.png" alt="Render of the assembled servo bracket seen from the cover side: the cover with its two screw lugs and the window the servo sits behind, the side arm to the right and the lower arm below, each with the single mounting ear that bolts to the chute core">
-  <figcaption>The bracket assembled, seen from the cover side. The two ears sticking out at bottom and right, one on each arm, are the pair that bolt to the chute core. <cite>Rendered from the part geometry in assembly position, not from a build. Render: Balloon.</cite></figcaption>
-</figure>
 
 {% include step.html n="4" title="Hang the door on its bearings and the race" %}
 
@@ -278,11 +273,6 @@ Six of the core's 18 inserts belong to this module. Four are used here, two in s
 
 Snug all four down before tightening any of them, then cycle the door by hand through its full swing. It should turn freely on the bearings and not touch the core anywhere; if it binds, slacken off and let the assembly settle square before tightening again.
 
-<figure>
-  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-flap-fitted-full-3988a30ff4a4.jpg" alt="Photograph of a printed chute core lying face up with the flap assembly already bolted to it: the round bearing cover, its six screw heads and central hex boss, sits on the core's long side, and the brass heads of the core's other heat inserts are visible across the face">
-  <figcaption>What you should have at the end of this step: the flap assembly on the core, held by the bearing cover you can see on the right. The servo bracket has not gone on yet. <cite>Frame at 0:01 of the video in step 8. Video: Spencer.</cite></figcaption>
-</figure>
-
 {% include step.html n="7" title="Build the servo adapter" %}
 
 The servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Drop the horn into the servo-side half **splined sleeve first**: the sleeve sits in the hole in the middle of that half and the two arms lie in the slot around it. It does not fit any other way. Bring the flap-side half down over it and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. The screws cut their own thread in the printed plastic.
@@ -315,6 +305,11 @@ The servo-side and flap-side plates clamp the MG995 Servo Horn between them. The
 </div>
 
 {% include step.html n="8" title="Bolt the servo bracket on and couple it to the door" %}
+
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p><strong>Watch the video below before you finish this step.</strong> Coupling the servo to the door is where a door gets broken: the servo has a fixed range and the door has 80.5° of swing, and forcing the two together out of position can snap it. <cite>Tip: BrickCycleAlice.</cite></p>
+</div>
 
 The bracket goes on the same long side as the servo-side bearing cover, into the other two inserts in the first render above. The two arms do not take the same screw, because their mounting ears are not the same thickness:
 

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -53,7 +53,7 @@ The door module is the moving half of the chute. Build it on the bench as one un
 
 The door pivots on two bearings held in the bearing assembly. The MG995 servo, coupled through the two-piece servo adapter, swings it between its open and closed positions, and the layer's [layer adapter board]({{ '/hardware/assembly/distribution/chute/pcb/' | relative_url }}) controls when it opens, releasing the part only once the chute stack has rotated the funnel into position over the right bin.
 
-Only the servo bracket, steps 2 and 3, comes from a real build. The bearing assembly in step 4 is worked out from the parts rather than reported by anyone who has built one, and the servo adapter still has no order of operations beyond screwing it together. Correct this page as you go; the fastener counts are accurate either way.
+Every step from 2 to 7 now carries photographs of a real build, and the checks called out in steps 4, 5 and 7 come from that build rather than from the geometry. The dimensions quoted are still measured off the parts. Correct this page as you go; the fastener counts are accurate either way.
 
 The fasteners and quantities are in the parts list above and are called out inline at each step.
 
@@ -68,10 +68,10 @@ Four things make it up:
 
 **What each fastener is for.** The list above gives totals for the whole module; this is the split:
 
-- **Bearing assembly, its own:** 10 {% include fastener.html size="M3" variant="heat-insert" %} (4 in the race, 3 in each holder) and 10 {% include fastener.html size="M3" variant="countersunk" length="8" %}. Six hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each; all ten are driven in step 4. The two 6704-2RS bearings go into the holders in step 1. The covers are thin at the rim, so snug their screws down evenly rather than fully tightening one before the others.
+- **Bearing assembly, its own:** 10 {% include fastener.html size="M3" variant="heat-insert" %} (4 in the race, 3 in each holder) and 10 {% include fastener.html size="M3" variant="countersunk" length="8" %}. Six hold the covers to the holders, 3 each, and 4 hold the holders to the race, 2 each; all ten are driven in steps 4 and 5. The two 6704-2RS bearings go into the holders in step 1. The covers are thin at the rim, so snug their screws down evenly rather than fully tightening one before the others.
 - **Servo adapter, its own:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %}, no heat inserts. They hold the servo-side and flap-side halves together with the MG995 Servo Horn clasped between them.
 - **Servo bracket, its own:** 6 {% include fastener.html size="M3" variant="heat-insert" %} in the housing, two on each of three faces, and one screw per insert. 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} hold the lower arm on, 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} hold the side arm on, and 2 {% include fastener.html size="M3" variant="countersunk" length="12" %} hold the cover on. None of them goes through the servo.
-- **Holding the finished module to the chute core:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, plus one screw through each bracket arm's mounting ear, step 7. The two arms are not the same thickness there, so they do not take the same screw: the lower arm's ear is 8.40 mm and takes a {% include fastener.html size="M3" variant="countersunk" length="12" %}, the side arm's is 5.00 mm and takes a {% include fastener.html size="M3" variant="countersunk" length="8" %}. All six go into the core's own heat inserts, so there is nothing to press in here for them.
+- **Holding the finished module to the chute core:** 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} through the two bearing covers, plus one screw through each bracket arm's mounting ear, step 8. The two arms are not the same thickness there, so they do not take the same screw: the lower arm's ear is 8.40 mm and takes a {% include fastener.html size="M3" variant="countersunk" length="12" %}, the side arm's is 5.00 mm and takes a {% include fastener.html size="M3" variant="countersunk" length="8" %}. All six go into the core's own heat inserts, so there is nothing to press in here for them.
 
 {% include step.html n="1" title="Preparation" %}
 
@@ -185,7 +185,7 @@ The two arms land on two other faces of the housing, so they are independent of 
   </figure>
 </div>
 
-Each arm has one further hole, in the ear at its far end. Those two are not driven here; they are what bolts the finished bracket to the chute core in step 7, so leave them empty.
+Each arm has one further hole, in the ear at its far end. Those two are not driven here; they are what bolts the finished bracket to the chute core in step 8, so leave them empty.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/servo-bracket-assembled-full-2c6c3cddb48f.png" alt="Render of the assembled servo bracket seen from the cover side: the cover with its two screw lugs and the window the servo sits behind, the side arm to the right and the lower arm below, each with the single mounting ear that bolts to the chute core">
@@ -196,7 +196,7 @@ Each arm has one further hole, in the ear at its far end. Those two are not driv
 
 The shaft is captured at both ends once this is together, so there is only one order it goes in: the holders have to go onto the shaft before anything is bolted down.
 
-**Check which way round the door goes first.** The shaft runs the length of the door's top edge and is Ø19.8 mm, but one end finishes in a hexagonal spigot 12.0 mm across the flats. That hex end is the servo side — it is what the servo adapter's flap-side half slides onto in step 7. The other end is plain round.
+**Check which way round the door goes first.** The shaft runs the length of the door's top edge and is Ø19.8 mm, but one end finishes in a hexagonal spigot 12.0 mm across the flats. That hex end is the servo side — it is what the servo adapter's flap-side half slides onto in step 8. The other end is plain round.
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
@@ -217,7 +217,6 @@ The shaft is captured at both ends once this is together, so there is only one o
 
 1. **Slide a holder onto each end of the shaft**, bearings already seated. The bearing's Ø20 bore takes the Ø19.8 shaft, and the holder's own Ø21.0 mm hole clears the shaft by 0.6 mm all round, so neither should need forcing.
 2. **Lay the race along the back of the shaft**, on the opposite side from the flap, and bolt each holder down onto its end of it: 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per holder, 4 in total, into the race's four inserts. The holder seats flat against the race's end. The race arches over the shaft with about 0.5 mm of clearance and never touches it; if it does touch, something is not seated.
-3. **Put a cover on each holder**, 3 {% include fastener.html size="M3" variant="countersunk" length="8" %} each, 6 in total, into the three inserts pressed in step 1. The cover's raised rim, 5.00 mm tall, drops into the pocket on top of the bearing and clamps it against the step: if a bearing has not gone fully home against its lip, its cover will not pull flat. Each cover has **two further holes that stay empty here** — they take the screws that hold the flap assembly to the chute core in step 5.
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-holder-on-race-end-w1600-71a9cfaaf366.jpg" alt="Close view of one end of the assembled flap: the bearing holder bolted to the end of the bearing race with two countersunk screws in its face, the bearing seated in its bore with the door's shaft through it, and the door plate above">
@@ -236,12 +235,31 @@ Hung this way the door has **80.5° of swing**, from 10.7° off horizontal at it
   <figcaption>The two ends of the door's swing, 80.5° apart. Grey is the flattest the door goes, with the plate 10.7° off horizontal; orange is the steepest, at 88.9°. The covers are not shown. <cite>Measured and rendered from the parts' own geometry, not from a build. Render: Balloon.</cite></figcaption>
 </figure>
 
-{% include step.html n="5" title="Bolt the flap assembly to the chute core" %}
+{% include step.html n="5" title="Fit the bearing covers" %}
 
-Six of the core's 18 inserts belong to this module. Four are used here, two in step 7:
+**The two covers are not the same part.** The Bearing cover (servo) has an open centre, and it goes on the hex end of the shaft, because the shaft has to come through it to reach the servo adapter. The Bearing cover (covered) is closed and goes on the plain end.
 
-- **2 bearing covers**, 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} in total, 2 per cover, into 5.00 mm of wall. These are the two holes left empty in each cover in step 4.
-- **Servo bracket lower arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="12" %}, and **side arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="8" %} — step 7.
+Put one on each holder with 3 {% include fastener.html size="M3" variant="countersunk" length="8" %} each, 6 in total, into the three inserts pressed in step 1. The cover's raised rim, 5.00 mm tall, drops into the pocket on top of the bearing and clamps it against the step: if a bearing has not gone fully home against its lip, its cover will not pull flat.
+
+Each cover has **two further holes that stay empty here** — they take the screws that hold the flap assembly to the chute core in step 6.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-cover-one-end-w1600-cbc69bf7f4ff.jpg" alt="The flap assembly with a round bearing cover fitted on the near end, its screws driven around the rim, the door plate running away to the right">
+    <figcaption>One end covered. The two holes left empty in the rim are for step 6. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-covers-both-ends-w1600-ffa9c5829cb0.jpg" alt="The whole flap assembly with both covers on, the near cover showing the open centre the shaft comes through and the far cover closed">
+    <figcaption>Both on, and the difference visible: the near one is open for the shaft, the far one is closed. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  </figure>
+</div>
+
+{% include step.html n="6" title="Bolt the flap assembly to the chute core" %}
+
+Six of the core's 18 inserts belong to this module. Four are used here, two in step 8:
+
+- **2 bearing covers**, 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} in total, 2 per cover, into 5.00 mm of wall. These are the two holes left empty in each cover in step 5.
+- **Servo bracket lower arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="12" %}, and **side arm**, 1 {% include fastener.html size="M3" variant="countersunk" length="8" %} — step 8.
 
 <div class="img-row">
   <figure>
@@ -254,7 +272,7 @@ Six of the core's 18 inserts belong to this module. Four are used here, two in s
   </figure>
 </div>
 
-**The covers are what hold the flap on.** Nothing else in the bearing assembly touches the core: the race and the holders are carried by the two covers, which are already screwed to the holders from step 4. Offer the whole assembly up so a cover lands on each long side of the core, and drive 2 screws per cover into the inserts above.
+**The covers are what hold the flap on.** Nothing else in the bearing assembly touches the core: the race and the holders are carried by the two covers, which are already screwed to the holders from step 5. Offer the whole assembly up so a cover lands on each long side of the core, and drive 2 screws per cover into the inserts above.
 
 8 mm is the right length because the cover is 5.00 mm at those holes, so the screw reaches 3.00 mm into the core's blind 5.70 mm insert. Measured off the STLs.
 
@@ -262,10 +280,10 @@ Snug all four down before tightening any of them, then cycle the door by hand th
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/chute-core-flap-fitted-full-3988a30ff4a4.jpg" alt="Photograph of a printed chute core lying face up with the flap assembly already bolted to it: the round bearing cover, its six screw heads and central hex boss, sits on the core's long side, and the brass heads of the core's other heat inserts are visible across the face">
-  <figcaption>What you should have at the end of this step: the flap assembly on the core, held by the bearing cover you can see on the right. The servo bracket has not gone on yet. <cite>Frame at 0:01 of the video in step 7. Video: Spencer.</cite></figcaption>
+  <figcaption>What you should have at the end of this step: the flap assembly on the core, held by the bearing cover you can see on the right. The servo bracket has not gone on yet. <cite>Frame at 0:01 of the video in step 8. Video: Spencer.</cite></figcaption>
 </figure>
 
-{% include step.html n="6" title="Build the servo adapter" %}
+{% include step.html n="7" title="Build the servo adapter" %}
 
 The servo-side and flap-side plates clamp the MG995 Servo Horn between them. The horn ships with the servo, it isn't printed. Drop the horn into the servo-side half **splined sleeve first**: the sleeve sits in the hole in the middle of that half and the two arms lie in the slot around it. It does not fit any other way. Bring the flap-side half down over it and drive 4 {% include fastener.html size="M3" variant="countersunk" length="8" %} screws through the flap side (it's the half with the visible screw holes) into the servo side. The screws cut their own thread in the printed plastic.
 
@@ -296,7 +314,7 @@ The servo-side and flap-side plates clamp the MG995 Servo Horn between them. The
   </figure>
 </div>
 
-{% include step.html n="7" title="Bolt the servo bracket on and couple it to the door" %}
+{% include step.html n="8" title="Bolt the servo bracket on and couple it to the door" %}
 
 The bracket goes on the same long side as the servo-side bearing cover, into the other two inserts in the first render above. The two arms do not take the same screw, because their mounting ears are not the same thickness:
 
@@ -309,7 +327,7 @@ Clock it before you commit: centre the servo (or let it settle at its power-on d
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/door-module-servo-video-frame-full-1f27d2aaa634.jpg" alt="Photograph of a real door module part-way through assembly: a hand holds the assembled servo adapter, a white disc with a hexagonal boss in the middle and four countersunk screws around it, in front of the MG995 in its printed bracket">
-  <figcaption>The same job on a real machine. The disc in frame is the servo adapter from step 6, screwed together with its four countersunk screws, with the hexagonal socket that takes the door's shaft facing the camera; the MG995 sits in its bracket behind it. <cite>Frame from the video below. Video: Spencer.</cite></figcaption>
+  <figcaption>The same job on a real machine. The disc in frame is the servo adapter from step 7, screwed together with its four countersunk screws, with the hexagonal socket that takes the door's shaft facing the camera; the MG995 sits in its bracket behind it. <cite>Frame from the video below. Video: Spencer.</cite></figcaption>
 </figure>
 
 <div class="callout callout-warning">

--- a/docs/src/content/hardware/assembly/distribution/chute/door-module.md
+++ b/docs/src/content/hardware/assembly/distribution/chute/door-module.md
@@ -125,11 +125,11 @@ One more sub-assembly goes together here, before the step that uses it, and it t
 
 <div class="prep-item">
   <div class="prep-item-body">
-    <p><strong>The two 6704-2RS bearings:</strong> one into the <strong>bearing holder (left)</strong>, one into the <strong>bearing holder (right)</strong>. There is no wrong way round. Push each one square to the bottom of the bore.</p>
+    <p><strong>The two 6704-2RS bearings:</strong> one into the <strong>bearing holder (left)</strong>, one into the <strong>bearing holder (right)</strong>. There is no wrong way round. Push each one square into the bore until it stops. <strong>Home is not the bottom of the pocket:</strong> the bearing comes up against a small lip inside the bore and sits proud of the floor, so stop when it stops rather than pushing for flush.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bearing-into-holder-blue-full-8cb4f2b8771b.png" alt="Two renders of the left bearing holder, one above the other: on top a 6704-2RS bearing, coloured blue, lined up with the mouth of the holder's bore, below it the same blue bearing pushed down to the bottom of the pocket">
-    <figcaption>Lined up with the bore, then seated at the bottom of it. The left holder is shown; the right one takes its bearing the same way. <cite>The bearing is coloured blue to pick it out. Rendered from the holder's own geometry, not from a build. Render: Balloon.</cite></figcaption>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-door-module-bearings-in-holders-w1600-180e121b8951.jpg" alt="Both printed bearing holders with a 6704-2RS bearing pushed into each bore, a ring of printed plastic still visible around the bearing's outer race, and three brass heat inserts around each face">
+    <figcaption>Both holders with their bearings pushed home. The ring of plastic still showing around each bearing is the lip it has stopped against. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -171,7 +171,7 @@ The shaft is captured at both ends once this is together, so there is only one o
 
 1. **Slide a holder onto each end of the shaft**, bearings already seated. The bearing's Ø20 bore takes the Ø19.8 shaft, and the holder's own Ø21.0 mm hole clears the shaft by 0.6 mm all round, so neither should need forcing.
 2. **Lay the race along the back of the shaft**, on the opposite side from the flap, and bolt each holder down onto its end of it: 2 {% include fastener.html size="M3" variant="countersunk" length="8" %} per holder, 4 in total, into the race's four inserts. The holder seats flat against the race's end. The race arches over the shaft with about 0.5 mm of clearance and never touches it; if it does touch, something is not seated.
-3. **Put a cover on each holder**, 3 {% include fastener.html size="M3" variant="countersunk" length="8" %} each, 6 in total, into the three inserts pressed in step 1. The cover's raised rim, 5.00 mm tall, drops into the pocket on top of the bearing and clamps it against the step: if a bearing is not all the way down, its cover will not pull flat. Each cover has **two further holes that stay empty here** — they take the screws that hold the flap assembly to the chute core in step 5.
+3. **Put a cover on each holder**, 3 {% include fastener.html size="M3" variant="countersunk" length="8" %} each, 6 in total, into the three inserts pressed in step 1. The cover's raised rim, 5.00 mm tall, drops into the pocket on top of the bearing and clamps it against the step: if a bearing has not gone fully home against its lip, its cover will not pull flat. Each cover has **two further holes that stay empty here** — they take the screws that hold the flap assembly to the chute core in step 5.
 
 <figure>
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bearing-assembly-blue-full-1cb33257bd5a.png" alt="Two renders, one above the other: on top the chute door with its shaft, the bearing race over the shaft, and the two bearing holders drawn out along the shaft with a blue bearing in each; below, the same parts pushed together so the holders sit on the ends of the race">


### PR DESCRIPTION
Two chute pages rebuilt around BrickCycleAlice's photos of her own build, replacing renders where a real part says it better and adding the checks she hit on the way.

**Requested by BrickCycleAlice (@brickcyclealice)**, over a run of instructions in one thread, and by **barthel (@uwe_barthel)** [in review](https://discord.com/channels/1430279849171222682/1547548160262545469/1547573059819413525): *"Remove the first of the doubled images on chute core side and add a "the finished result" section (as we do in bin frame). Move the last photo in the finished result section and use it as preview image (as we do in bin frame roo)."* Each instruction is linked on the change it produced.

## Chute core

[Step 1](https://discord.com/channels/1430279849171222682/1547526128942583838/1547546044533833799): the three pocket renders replaced by photos of a printed core with the inserts in. Which photo is which face was settled by counting brass against the documented 8 + 6 + 4, not by shape, since the long sides are mirror images: **32** is the 8 side (its tell is the lone insert in the raised square pocket), **30** the 6 side, **33** the rear panel.

Its [built-core photo](https://discord.com/channels/1430279849171222682/1547526128942583838/1547569567545561088) of hers closes the page. It replaces the placeholder that stood after step 2, sits under a new `## The finished result` heading in the pattern the bin frame pages use, and is the page's `og_image`. That shape is [barthel's](https://discord.com/channels/1430279849171222682/1547548160262545469/1547573059819413525): the finished shot at the foot rather than duplicated at the top, and the same image doing the preview. The caption names the layer connectors, which [she pointed out](https://discord.com/channels/1430279849171222682/1547526128942583838/1547572315909390467) are in the shot and go on the top of each chute; the layer adapter board is the only one of the four not in it, since she does not have a board yet.

## Door module

- [Step 1](https://discord.com/channels/1430279849171222682/1547526128942583838/1547546693736603739): insert renders replaced by **35** (servo bracket housing), **36** (bearing race), **38** (bearing holder), and **37** added as her tip — with no bench vice, a holder stands in the housing's pocket while you press its inserts.
- [Step 2](https://discord.com/channels/1430279849171222682/1547526128942583838/1547548046467014676): **42** servo in the pocket, **43** cover screwed down.
- [Step 3](https://discord.com/channels/1430279849171222682/1547526128942583838/1547548300666863646) split per arm, each with its own screw line and photos: lower arm 2 × M3 × 8 with **45** and **44**, side arm 2 × M3 × 12 with **47** and **46**. Which arm is which came off the STLs: the lower arm is the wide one (41.6 mm across, 4.25 mm at its screws), the side arm the narrow one (16.7 mm, 8.40 mm). [Spencer's bench frame removed](https://discord.com/channels/1430279849171222682/1547526128942583838/1547548917170700311) because it shows the adapter already fitted, and [two sentences and the render dropped](https://discord.com/channels/1430279849171222682/1547526128942583838/1547556249615212606).
- [Step 4](https://discord.com/channels/1430279849171222682/1547526128942583838/1547550169891864607): her orientation warning ahead of the assembly list, with **53** and **54** — the race's step tucks under the shaft, and right way round the two read as one flat plane rather than a staircase. [**50**](https://discord.com/channels/1430279849171222682/1547526128942583838/1547550533689155614) closes the step with a holder bolted to the race's end. The [bearing seating is corrected](https://discord.com/channels/1430279849171222682/1547526128942583838/1547547734054146141): the 6704 stops on a small internal lip and does **not** bottom out, which the page and its render had both said it did. **49** replaces that render.
- [Step 5 is new](https://discord.com/channels/1430279849171222682/1547526128942583838/1547551232107745280), fitting the covers, with **51** and **52**. It also states something the page never did: the two covers are different parts. `bearing-cover-servo` is open in the middle and must go on the hex end, `bearing-cover-covered` is closed.
- [Step 7 is new](https://discord.com/channels/1430279849171222682/1547526128942583838/1547547230850916412), the servo adapter lifted out of Preparation into its own step before the coupling, with **39** and **40**. It carries [her hole-pattern tip](https://discord.com/channels/1430279849171222682/1547526128942583838/1547548917170700311): the four screws sit on a 15 mm radius at ±42° and ±138°, so the gaps alternate 84° and 96° and the flap side only drops on in two of the four quarter turns. Measured off both STLs.
- [Step 8](https://discord.com/channels/1430279849171222682/1547526128942583838/1547553059054288997) opens with a warning to watch the video before committing to a coupling position, because a door can be broken there.
- [Spencer's half-open flap frame removed](https://discord.com/channels/1430279849171222682/1547526128942583838/1547552519134117949) from the flap-to-core step: a wrong install produces a result that looks like it. A placeholder marks the photos that will replace it.
- [Step 6 gets the flap on the core](https://discord.com/channels/1430279849171222682/1547526128942583838/1547570234767048785): her photos of the assembly going in, then both ends of the door's swing from each side, then the back. These are the shots that make a wrong install visible, which is why the frame above came off.


Fitting the covers becoming its own step pushed the later steps to 6, 7 and 8; every cross-reference moved with them. The page's health warning is rewritten too — it said the bearing assembly was worked out from the parts rather than reported by anyone who had built one, which today's photos and corrections make false.

## Checks

`npm run check` 0 errors, `docs/scripts/validate_images.py` clean, `docs/scripts/validate_credits.py` at the same 8 failures it reports on `main`, none on these two pages. Every retired render is still hosted on the parts namespace.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547546044533833799
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547546693736603739
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547547230850916412
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547547734054146141
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547548046467014676
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547548300666863646
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547548917170700311
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547550169891864607
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547550533689155614
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547551232107745280
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547552076366745600
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547552519134117949
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547553059054288997
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547555462138957834
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547556249615212606
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547569567545561088
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547570234767048785
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547572055384395907
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547572315909390467
request: https://discord.com/channels/1430279849171222682/1547548160262545469/1547573059819413525
request: https://discord.com/channels/1430279849171222682/1547548160262545469/1547595849901805789
preview: /hardware/assembly/distribution/chute/chute-core/
preview: /hardware/assembly/distribution/chute/door-module/
-->


