### PR TITLE
catalog: a docs link on every assembly, and the camera lamp's images only in the docs

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6219,7 +6219,7 @@
       "version": "1",
       "name": "External distribution-frame bracket",
       "description": "Three parts that bolt together into one external bracket. 6 per distribution frame (per layer). The cover clips on and takes no screws. The top interface uses only the side and cover from this set, no bottom vertical, see the interface assembly.",
-      "docs": "/hardware/helpers/external-bracket/",
+      "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
       "joining": [
         {
           "method": "self-tap",
@@ -6453,6 +6453,7 @@
       "version": "1",
       "name": "Chute bearing assembly",
       "description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 × 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
+      "docs": "/hardware/assembly/distribution/chute/door-module/",
       "lines": [
         {
           "part": "bearing-race",
@@ -6516,7 +6517,7 @@
       "version": "1",
       "name": "Servo assembly (MG995)",
       "description": "The MG995 servo in its bracket: lower arm, side arm, cover, housing. Bolts to the chute core's two arm inserts as a unit.",
-      "docs": "/hardware/assembly/distribution/chute/mg995-servo/servo-mount/",
+      "docs": "/hardware/assembly/distribution/chute/door-module/",
       "lines": [
         {
           "part": "servo-bracket-lower-arm",
@@ -6893,6 +6894,7 @@
       "version": "2",
       "name": "Camera extension",
       "description": "Classification-channel camera extension for the 4K camera module: the 50 mm extension tube, its mount, and the camera. 1 per machine. Unused since 2026-09-02: the Camera lamp replaced the light post, the overhead camera mount, the classification dome and the camera & LED insert. Do not re-add from old docs or photos.",
+      "docs": "/hardware/assembly/feeder/classification-chamber/",
       "lines": [
         {
           "part": "camera-extension",
@@ -7048,6 +7050,7 @@
       "version": "2",
       "name": "Superstructure",
       "description": "What the feeder and the electronics mount onto: the top plate, the top interface, the distribution layers between the interfaces, and the bottom interface.",
+      "docs": "/hardware/assembly/distribution/",
       "lines": [
         {
           "part": "top-plate",
@@ -7307,6 +7310,7 @@
       "version": "1",
       "name": "Channel 3 support",
       "description": "One of C-channel 3's three standoffs: a foot and the leg the channel dovetails onto. Unused since 2026-09-02: the layout guide, support legs and dovetail adapters replaced the prototype foot/leg/leg-extension supports. Do not re-add from old docs or photos.",
+      "docs": "/hardware/assembly/feeder/arranging-c-channels/",
       "lines": [
         {
           "part": "foot",
@@ -7333,6 +7337,7 @@
       "version": "1",
       "name": "Channel 2 support",
       "description": "One of C-channel 2's three standoffs: a foot, one leg extension, and the leg the channel dovetails onto. Unused since 2026-09-02: the layout guide, support legs and dovetail adapters replaced the prototype foot/leg/leg-extension supports. Do not re-add from old docs or photos.",
+      "docs": "/hardware/assembly/feeder/arranging-c-channels/",
       "lines": [
         {
           "part": "foot",
@@ -7370,6 +7375,7 @@
       "version": "1",
       "name": "Bulk bucket support",
       "description": "One of the bulk bucket's three standoffs — the tallest stack: a foot, two leg extensions, and the leg. Unused since 2026-09-02: the layout guide, support legs and dovetail adapters replaced the prototype foot/leg/leg-extension supports. Do not re-add from old docs or photos.",
+      "docs": "/hardware/assembly/feeder/arranging-c-channels/",
       "lines": [
         {
           "part": "foot",
@@ -7414,6 +7420,7 @@
       "version": "5",
       "name": "C-channel 1 - Bulk bucket",
       "description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor and the Bulk cap, standing on the tallest supports. No output guide: the Bulk cap has one built into it. No camera lamp either: C1 is fed in bulk and nothing reads vision off it.",
+      "docs": "/hardware/assembly/feeder/bulk-input/",
       "lines": [
         {
           "assembly": "channel-one-support-structure",
@@ -7599,6 +7606,7 @@
       "version": "4",
       "name": "C-channel 2",
       "description": "A feeder channel: a C-channel drive with the faceted rotor, the Short and Angled Output Guide and a Camera lamp, standing on three supports.",
+      "docs": "/hardware/assembly/feeder/arranging-c-channels/",
       "lines": [
         {
           "assembly": "channel-two-support-structure",
@@ -7770,6 +7778,7 @@
       "version": "4",
       "name": "C-channel 3",
       "description": "A feeder channel: a C-channel drive with the faceted rotor, the Short and Angled Output Guide and a Camera lamp, standing on three supports.",
+      "docs": "/hardware/assembly/feeder/arranging-c-channels/",
       "lines": [
         {
           "assembly": "channel-three-support-structure",
@@ -7941,6 +7950,7 @@
       "version": "1",
       "name": "Camera & LED insert assembly",
       "description": "The Camera & LED insert print with the camera extension assembled into it; the loaded insert drops into the classification dome. Unused since 2026-09-02: the Camera lamp replaced the light post, the overhead camera mount, the classification dome and the camera & LED insert. Do not re-add from old docs or photos.",
+      "docs": "/hardware/assembly/feeder/classification-chamber/",
       "lines": [
         {
           "part": "camera-led-insert",
@@ -8409,6 +8419,7 @@
       "version": "1",
       "name": "External bracket with foot cover",
       "description": "The bottom bin layer's corner segment: the side bracket with the foot cover, which stands in for the cover and the bottom vertical the other frames use.",
+      "docs": "/hardware/assembly/distribution/bin-frame/bottom-layer/",
       "lines": [
         {
           "part": "ext-bracket-left",
@@ -8440,6 +8451,7 @@
       "version": "1",
       "name": "Outer hex frame (bottom layer)",
       "description": "The outer hexagon of the lowest bin layer: six foot-cover corners with six A extrusions slid between them.",
+      "docs": "/hardware/assembly/distribution/bin-frame/bottom-layer/",
       "lines": [
         {
           "assembly": "external-bracket-with-foot",
@@ -9172,6 +9184,7 @@
       "version": "2",
       "name": "Rotor unit (faceted)",
       "description": "The faceted rotor with the Output gear (130T) bolted on. Assembled once as a unit; a C-channel drive spins it.",
+      "docs": "/hardware/assembly/feeder/c-channel/",
       "lines": [
         {
           "part": "rotor-faceted",
@@ -9248,6 +9261,7 @@
       "version": "2",
       "name": "Rotor unit (finned)",
       "description": "The finned rotor with the Output gear (130T) bolted on. Assembled once as a unit; the classification channel's C-channel drive spins it.",
+      "docs": "/hardware/assembly/feeder/c-channel/",
       "lines": [
         {
           "part": "rotor-finned",
@@ -9505,6 +9519,7 @@
       "version": "2",
       "name": "External bracket with support",
       "description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, with the snap-on cover.",
+      "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
       "lines": [
         {
           "part": "ext-bracket-cover",
@@ -9583,6 +9598,7 @@
       "version": "1",
       "name": "Outer hex frame",
       "description": "Six External bracket with support corners with six A extrusions slid between them, closing the hexagon.",
+      "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
       "lines": [
         {
           "assembly": "external-bracket-with-support",
@@ -9621,6 +9637,7 @@
       "version": "1",
       "name": "Inner hex frame",
       "description": "The inner hexagon: six B spokes with six crossbeams and twelve 90-degree brackets.",
+      "docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
       "lines": [
         {
           "part": "ext-2020-bh",
@@ -10333,6 +10350,7 @@
       "version": "2",
       "name": "Adapted camera module",
       "description": "A camera board clasped between the printed top and bottom halves, ready to snap into the Camera lamp arm.",
+      "docs": "/hardware/assembly/feeder/camera-lamp/",
       "params": {
         "camera": {
           "default": "cam-ov9732",
@@ -10410,6 +10428,7 @@
       "version": "1",
       "name": "Camera lamp arm",
       "description": "The arm that hangs the camera and lamp over a C-channel: the C-channel arm mount, the arm, brackets A and B tying them together, and the camera lamp ring.",
+      "docs": "/hardware/assembly/feeder/camera-lamp/",
       "lines": [
         {
           "part": "c-channel-arm-mount",
@@ -10485,6 +10504,7 @@
       "version": "1",
       "name": "Reflector with LED hooks",
       "description": "The white inner reflector with its six LED hooks friction-fitted on.",
+      "docs": "/hardware/assembly/feeder/camera-lamp/",
       "lines": [
         {
           "part": "lamp-inner-reflector",
@@ -10511,6 +10531,7 @@
       "version": "1",
       "name": "Shaded lamp",
       "description": "The channel lamp: the reflector with its LED hooks, under the outer cover.",
+      "docs": "/hardware/assembly/feeder/camera-lamp/",
       "lines": [
         {
           "assembly": "reflector-with-led-hooks",
@@ -10537,6 +10558,7 @@
       "version": "1",
       "name": "Camera lamp",
       "description": "The per-channel camera and light: the arm with its ring, the adapted camera module snapped in, and the shaded lamp over the top. Three per machine, on C-channels 2 and 3 and the classification channel; the bulk bucket has none. Which camera it carries is a parameter.",
+      "docs": "/hardware/assembly/feeder/camera-lamp/",
       "params": {
         "camera": {
           "default": "cam-ov9732",
@@ -10575,43 +10597,6 @@
           "method": "gravity",
           "note": "The lamp sits over the top of the arm."
         }
-      ],
-      "images": [
-        {
-          "url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-on-channel-full-fb1aaa6d8462.jpg",
-          "alt": "A camera lamp mounted over a C-channel: the gray shaded lamp on its arm above the channel, with the white funnel of the rotor beside it",
-          "caption": "On the machine, over a C-channel."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-lit-full-590dd8686f25.jpg",
-          "alt": "The lamp lit, seen from below: the LED strips ring the white inner reflector under the gray cover, with the arm silhouetted through the centre opening",
-          "caption": "Lit: the LED strips around the reflector."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-mounted-wide-full-0e2a50c0e1e5.jpg",
-          "alt": "A wider view of the camera lamp on its arm over the channel, leads cable-tied along the arm down to the drive",
-          "caption": "The arm carries the leads down to the channel."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-camera-seated-full-a6fff6fecc23.jpg",
-          "alt": "The top of the shaded lamp with the camera board seated in its clasp recess at the centre, lead plugged in",
-          "caption": "The camera board seated in the clasp, from above."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-top-full-edc4616e7088.png",
-          "alt": "Onshape render of the assembled camera lamp from above: the cover with the camera opening, on the arm and brackets",
-          "caption": "Render, from above."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-side-full-2a681306f3a9.png",
-          "alt": "Onshape render of the camera lamp in profile: the lamp overhanging on the angled arm, brackets along the joints",
-          "caption": "Render, in profile."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-underside-full-0e2b1e5a0fb9.png",
-          "alt": "Onshape render of the camera lamp from below: the reflector and ring inside the cover, the hooks around the rim, the arm reaching up",
-          "caption": "Render, the underside."
-        }
       ]
     },
     {
@@ -10620,6 +10605,7 @@
       "version": "1",
       "name": "Channel 1 support structure",
       "description": "Channel 1 support: the layout guide its three legs stand in, and a dovetail adapter on each leg.",
+      "docs": "/hardware/assembly/feeder/arranging-c-channels/",
       "lines": [
         {
           "part": "layout-guide",
@@ -10657,6 +10643,7 @@
       "version": "1",
       "name": "Channel 2 support structure",
       "description": "Channel 2 support: the layout guide its three legs stand in, and a dovetail adapter on each leg.",
+      "docs": "/hardware/assembly/feeder/arranging-c-channels/",
       "lines": [
         {
           "part": "layout-guide",
@@ -10694,6 +10681,7 @@
       "version": "1",
       "name": "Channel 3 support structure",
       "description": "Channel 3 support: the layout guide its three legs stand in, and a dovetail adapter on each leg.",
+      "docs": "/hardware/assembly/feeder/arranging-c-channels/",
       "lines": [
         {
           "part": "layout-guide",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -747,7 +747,7 @@
 			"version": "1",
 			"name": "External distribution-frame bracket",
 			"description": "Three parts that bolt together into one external bracket. 6 per distribution frame (per layer). The cover clips on and takes no screws. The top interface uses only the side and cover from this set, no bottom vertical, see the interface assembly.",
-			"docs": "/hardware/helpers/external-bracket/",
+			"docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
 			"joining": [
 				{
 					"method": "self-tap",
@@ -983,6 +983,7 @@
 			"version": "1",
 			"name": "Chute bearing assembly",
 			"description": "The flap's bearing assembly: left + right bearing holders, the race between them, and the covers. Carries 10 M3 inserts and the two flap bearings, one screw per insert: 6 M3 \u00d7 8 hold the covers to the holders (3 each), 4 hold the holders to the race (2 each).",
+			"docs": "/hardware/assembly/distribution/chute/door-module/",
 			"lines": [
 				{
 					"part": "bearing-race",
@@ -1046,7 +1047,7 @@
 			"version": "1",
 			"name": "Servo assembly (MG995)",
 			"description": "The MG995 servo in its bracket: lower arm, side arm, cover, housing. Bolts to the chute core's two arm inserts as a unit.",
-			"docs": "/hardware/assembly/distribution/chute/mg995-servo/servo-mount/",
+			"docs": "/hardware/assembly/distribution/chute/door-module/",
 			"lines": [
 				{
 					"part": "servo-bracket-lower-arm",
@@ -1425,6 +1426,7 @@
 			"version": "2",
 			"name": "Camera extension",
 			"description": "Classification-channel camera extension for the 4K camera module: the 50 mm extension tube, its mount, and the camera. 1 per machine. Unused since 2026-09-02: the Camera lamp replaced the light post, the overhead camera mount, the classification dome and the camera & LED insert. Do not re-add from old docs or photos.",
+			"docs": "/hardware/assembly/feeder/classification-chamber/",
 			"lines": [
 				{
 					"part": "camera-extension",
@@ -1582,6 +1584,7 @@
 			"version": "2",
 			"name": "Superstructure",
 			"description": "What the feeder and the electronics mount onto: the top plate, the top interface, the distribution layers between the interfaces, and the bottom interface.",
+			"docs": "/hardware/assembly/distribution/",
 			"lines": [
 				{
 					"part": "top-plate",
@@ -1843,6 +1846,7 @@
 			"version": "1",
 			"name": "Channel 3 support",
 			"description": "One of C-channel 3's three standoffs: a foot and the leg the channel dovetails onto. Unused since 2026-09-02: the layout guide, support legs and dovetail adapters replaced the prototype foot/leg/leg-extension supports. Do not re-add from old docs or photos.",
+			"docs": "/hardware/assembly/feeder/arranging-c-channels/",
 			"lines": [
 				{
 					"part": "foot",
@@ -1869,6 +1873,7 @@
 			"version": "1",
 			"name": "Channel 2 support",
 			"description": "One of C-channel 2's three standoffs: a foot, one leg extension, and the leg the channel dovetails onto. Unused since 2026-09-02: the layout guide, support legs and dovetail adapters replaced the prototype foot/leg/leg-extension supports. Do not re-add from old docs or photos.",
+			"docs": "/hardware/assembly/feeder/arranging-c-channels/",
 			"lines": [
 				{
 					"part": "foot",
@@ -1906,6 +1911,7 @@
 			"version": "1",
 			"name": "Bulk bucket support",
 			"description": "One of the bulk bucket's three standoffs \u2014 the tallest stack: a foot, two leg extensions, and the leg. Unused since 2026-09-02: the layout guide, support legs and dovetail adapters replaced the prototype foot/leg/leg-extension supports. Do not re-add from old docs or photos.",
+			"docs": "/hardware/assembly/feeder/arranging-c-channels/",
 			"lines": [
 				{
 					"part": "foot",
@@ -1950,6 +1956,7 @@
 			"version": "5",
 			"name": "C-channel 1 - Bulk bucket",
 			"description": "The top channel, where bulk is dumped in: a C-channel drive with the faceted rotor and the Bulk cap, standing on the tallest supports. No output guide: the Bulk cap has one built into it. No camera lamp either: C1 is fed in bulk and nothing reads vision off it.",
+			"docs": "/hardware/assembly/feeder/bulk-input/",
 			"lines": [
 				{
 					"assembly": "channel-one-support-structure",
@@ -2136,6 +2143,7 @@
 			"version": "4",
 			"name": "C-channel 2",
 			"description": "A feeder channel: a C-channel drive with the faceted rotor, the Short and Angled Output Guide and a Camera lamp, standing on three supports.",
+			"docs": "/hardware/assembly/feeder/arranging-c-channels/",
 			"lines": [
 				{
 					"assembly": "channel-two-support-structure",
@@ -2308,6 +2316,7 @@
 			"version": "4",
 			"name": "C-channel 3",
 			"description": "A feeder channel: a C-channel drive with the faceted rotor, the Short and Angled Output Guide and a Camera lamp, standing on three supports.",
+			"docs": "/hardware/assembly/feeder/arranging-c-channels/",
 			"lines": [
 				{
 					"assembly": "channel-three-support-structure",
@@ -2480,6 +2489,7 @@
 			"version": "1",
 			"name": "Camera & LED insert assembly",
 			"description": "The Camera & LED insert print with the camera extension assembled into it; the loaded insert drops into the classification dome. Unused since 2026-09-02: the Camera lamp replaced the light post, the overhead camera mount, the classification dome and the camera & LED insert. Do not re-add from old docs or photos.",
+			"docs": "/hardware/assembly/feeder/classification-chamber/",
 			"lines": [
 				{
 					"part": "camera-led-insert",
@@ -2949,6 +2959,7 @@
 			"version": "1",
 			"name": "External bracket with foot cover",
 			"description": "The bottom bin layer's corner segment: the side bracket with the foot cover, which stands in for the cover and the bottom vertical the other frames use.",
+			"docs": "/hardware/assembly/distribution/bin-frame/bottom-layer/",
 			"lines": [
 				{
 					"part": "ext-bracket-left",
@@ -2980,6 +2991,7 @@
 			"version": "1",
 			"name": "Outer hex frame (bottom layer)",
 			"description": "The outer hexagon of the lowest bin layer: six foot-cover corners with six A extrusions slid between them.",
+			"docs": "/hardware/assembly/distribution/bin-frame/bottom-layer/",
 			"lines": [
 				{
 					"assembly": "external-bracket-with-foot",
@@ -3717,6 +3729,7 @@
 			"version": "2",
 			"name": "Rotor unit (faceted)",
 			"description": "The faceted rotor with the Output gear (130T) bolted on. Assembled once as a unit; a C-channel drive spins it.",
+			"docs": "/hardware/assembly/feeder/c-channel/",
 			"lines": [
 				{
 					"part": "rotor-faceted",
@@ -3794,6 +3807,7 @@
 			"version": "2",
 			"name": "Rotor unit (finned)",
 			"description": "The finned rotor with the Output gear (130T) bolted on. Assembled once as a unit; the classification channel's C-channel drive spins it.",
+			"docs": "/hardware/assembly/feeder/c-channel/",
 			"lines": [
 				{
 					"part": "rotor-finned",
@@ -4053,6 +4067,7 @@
 			"version": "2",
 			"name": "External bracket with support",
 			"description": "One corner segment of the outer hex: the side bracket screwed to the bottom vertical, with the snap-on cover.",
+			"docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
 			"lines": [
 				{
 					"part": "ext-bracket-cover",
@@ -4132,6 +4147,7 @@
 			"version": "1",
 			"name": "Outer hex frame",
 			"description": "Six External bracket with support corners with six A extrusions slid between them, closing the hexagon.",
+			"docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
 			"lines": [
 				{
 					"assembly": "external-bracket-with-support",
@@ -4170,6 +4186,7 @@
 			"version": "1",
 			"name": "Inner hex frame",
 			"description": "The inner hexagon: six B spokes with six crossbeams and twelve 90-degree brackets.",
+			"docs": "/hardware/assembly/distribution/bin-frame/hex-frame/",
 			"lines": [
 				{
 					"part": "ext-2020-bh",
@@ -4888,6 +4905,7 @@
 			"version": "2",
 			"name": "Adapted camera module",
 			"description": "A camera board clasped between the printed top and bottom halves, ready to snap into the Camera lamp arm.",
+			"docs": "/hardware/assembly/feeder/camera-lamp/",
 			"params": {
 				"camera": {
 					"default": "cam-ov9732",
@@ -4966,6 +4984,7 @@
 			"version": "1",
 			"name": "Camera lamp arm",
 			"description": "The arm that hangs the camera and lamp over a C-channel: the C-channel arm mount, the arm, brackets A and B tying them together, and the camera lamp ring.",
+			"docs": "/hardware/assembly/feeder/camera-lamp/",
 			"lines": [
 				{
 					"part": "c-channel-arm-mount",
@@ -5041,6 +5060,7 @@
 			"version": "1",
 			"name": "Reflector with LED hooks",
 			"description": "The white inner reflector with its six LED hooks friction-fitted on.",
+			"docs": "/hardware/assembly/feeder/camera-lamp/",
 			"lines": [
 				{
 					"part": "lamp-inner-reflector",
@@ -5067,6 +5087,7 @@
 			"version": "1",
 			"name": "Shaded lamp",
 			"description": "The channel lamp: the reflector with its LED hooks, under the outer cover.",
+			"docs": "/hardware/assembly/feeder/camera-lamp/",
 			"lines": [
 				{
 					"assembly": "reflector-with-led-hooks",
@@ -5093,6 +5114,7 @@
 			"version": "1",
 			"name": "Camera lamp",
 			"description": "The per-channel camera and light: the arm with its ring, the adapted camera module snapped in, and the shaded lamp over the top. Three per machine, on C-channels 2 and 3 and the classification channel; the bulk bucket has none. Which camera it carries is a parameter.",
+			"docs": "/hardware/assembly/feeder/camera-lamp/",
 			"params": {
 				"camera": {
 					"default": "cam-ov9732",
@@ -5131,43 +5153,6 @@
 					"method": "gravity",
 					"note": "The lamp sits over the top of the arm."
 				}
-			],
-			"images": [
-				{
-					"url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-on-channel-full-fb1aaa6d8462.jpg",
-					"alt": "A camera lamp mounted over a C-channel: the gray shaded lamp on its arm above the channel, with the white funnel of the rotor beside it",
-					"caption": "On the machine, over a C-channel."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-lit-full-590dd8686f25.jpg",
-					"alt": "The lamp lit, seen from below: the LED strips ring the white inner reflector under the gray cover, with the arm silhouetted through the centre opening",
-					"caption": "Lit: the LED strips around the reflector."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-mounted-wide-full-0e2a50c0e1e5.jpg",
-					"alt": "A wider view of the camera lamp on its arm over the channel, leads cable-tied along the arm down to the drive",
-					"caption": "The arm carries the leads down to the channel."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-camera-seated-full-a6fff6fecc23.jpg",
-					"alt": "The top of the shaded lamp with the camera board seated in its clasp recess at the centre, lead plugged in",
-					"caption": "The camera board seated in the clasp, from above."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-top-full-edc4616e7088.png",
-					"alt": "Onshape render of the assembled camera lamp from above: the cover with the camera opening, on the arm and brackets",
-					"caption": "Render, from above."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-side-full-2a681306f3a9.png",
-					"alt": "Onshape render of the camera lamp in profile: the lamp overhanging on the angled arm, brackets along the joints",
-					"caption": "Render, in profile."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/pub-img-camera-lamp-render-underside-full-0e2b1e5a0fb9.png",
-					"alt": "Onshape render of the camera lamp from below: the reflector and ring inside the cover, the hooks around the rim, the arm reaching up",
-					"caption": "Render, the underside."
-				}
 			]
 		},
 		{
@@ -5176,6 +5161,7 @@
 			"version": "1",
 			"name": "Channel 1 support structure",
 			"description": "Channel 1 support: the layout guide its three legs stand in, and a dovetail adapter on each leg.",
+			"docs": "/hardware/assembly/feeder/arranging-c-channels/",
 			"lines": [
 				{
 					"part": "layout-guide",
@@ -5213,6 +5199,7 @@
 			"version": "1",
 			"name": "Channel 2 support structure",
 			"description": "Channel 2 support: the layout guide its three legs stand in, and a dovetail adapter on each leg.",
+			"docs": "/hardware/assembly/feeder/arranging-c-channels/",
 			"lines": [
 				{
 					"part": "layout-guide",
@@ -5250,6 +5237,7 @@
 			"version": "1",
 			"name": "Channel 3 support structure",
 			"description": "Channel 3 support: the layout guide its three legs stand in, and a dovetail adapter on each leg.",
+			"docs": "/hardware/assembly/feeder/arranging-c-channels/",
 			"lines": [
 				{
 					"part": "layout-guide",


### PR DESCRIPTION
**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1536088194557419660/1547571868389609552):** *"Go through all the elements in the assembly tree in the Parts Calculator and add links to the documentation (e.g., Camera lamp). Remove the images for Camera lamp, because they are (also) included in the documentation. I want to prevent a situation where we suddenly end up with multiple places where built elements appear that could potentially be out of sync."*

## A docs link on every assembly

The mechanism was already there: an assembly with a `docs` path renders an **In Docs** link on its tree node and in its detail panel. 36 of 61 assemblies had one, 25 did not. All 61 do now, and every one of the 24 distinct routes returns 200 on `docs.basically.website`.

Where the 25 went:

| Assembly | Page |
|---|---|
| C-channel 1 - Bulk bucket | `/hardware/assembly/feeder/bulk-input/` |
| C-channel 2, C-channel 3 | `/hardware/assembly/feeder/arranging-c-channels/` |
| Channel 1/2/3 support structure | `/hardware/assembly/feeder/arranging-c-channels/` |
| Channel 2 support, Channel 3 support, Bulk bucket support (retired) | `/hardware/assembly/feeder/arranging-c-channels/` |
| Rotor unit (faceted), Rotor unit (finned) | `/hardware/assembly/feeder/c-channel/` |
| Camera lamp, Camera lamp arm, Adapted camera module, Shaded lamp, Reflector with LED hooks | `/hardware/assembly/feeder/camera-lamp/` |
| Camera extension, Camera & LED insert assembly (retired) | `/hardware/assembly/feeder/classification-chamber/` |
| Superstructure | `/hardware/assembly/distribution/` |
| Inner hex frame, Outer hex frame, External bracket with support | `/hardware/assembly/distribution/bin-frame/hex-frame/` |
| Outer hex frame (bottom layer), External bracket with foot cover | `/hardware/assembly/distribution/bin-frame/bottom-layer/` |
| Chute bearing assembly | `/hardware/assembly/distribution/chute/door-module/` |

Each one is the page that actually builds that assembly, not the nearest section index: the rotor units go to the C-channel page because [step 2 there bolts the output gear to the rotor](https://docs.basically.website/hardware/assembly/feeder/c-channel/), the chute bearing goes to the door module page because [step 4 there hangs the door on its bearings](https://docs.basically.website/hardware/assembly/distribution/chute/door-module/), and the retired supports go to `arranging-c-channels` because that page carries the callout saying they were replaced on 2026-09-02.

Links are page-level, not `#step-N` anchors, on purpose: step numbers move when a page is edited and a stale anchor is exactly the drift this PR is trying to remove.

## Two links that were already broken

| Assembly | Was | Now |
|---|---|---|
| External distribution-frame bracket | `/hardware/helpers/external-bracket/` — **404**, no such page and no redirect | `/hardware/assembly/distribution/bin-frame/hex-frame/` |
| Servo assembly (MG995) | `/hardware/assembly/distribution/chute/mg995-servo/servo-mount/` — 301 only, via `docs/static/_redirects` | `/hardware/assembly/distribution/chute/door-module/` |

## The Camera lamp's images

Removed, all seven. Every one is already on the [camera lamp page](https://docs.basically.website/hardware/assembly/feeder/camera-lamp/), and the three renders are byte-identical, same content hash on both buckets:

- `camera-lamp-render-top-full-edc4616e7088.png`
- `camera-lamp-render-side-full-2a681306f3a9.png`
- `camera-lamp-render-underside-full-0e2b1e5a0fb9.png`

The four photographs are the same shots served as the docs site's `w1600` variants (`camera-lamp-on-channel`, `camera-lamp-lit-from-below`, `camera-lamp-mounted-wide`, `camera-lamp-camera-seated`). Nothing is deleted from either bucket; only the catalog's copy of the list goes.

Four other assemblies still carry `images` — Light post, Cage bracket (cable mount) + ribbon clamp, basically Embedded Control Board Housing, Orange Pi mount. Left alone, because this request named the camera lamp; they are the same question and worth a look separately.

## Checks

- `python3 catalog/generate.py --metadata-only` — clean, and its own pin, versioning and connection checks pass.
- `npm run check` — 0 errors, 0 warnings.
- No `lines` changed, so no version stamp: this is metadata only.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1547571868389609552
preview: /assembly?focus=camera-lamp
-->
