### PR TITLE
docs: the last assembly images move out of the catalog and onto their pages

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -644,6 +644,11 @@ Guide the rest of the ribbon cable around the side of the Top interface chute mo
 
 Screw the Ribbon cable clamp lightly to the Cable cage bracket (cable mount) with one {% include fastener.html size="M3" variant="socket-button" length="10" %} screw, clamping the ribbon cable between the two.
 
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/spencer-image2-full-adb0f1993da6.png" alt="Onshape render of the cable-mount cage bracket (teal) with the ribbon cable clamp (purple) bolted to its post, one M3 hole visible through both">
+  <figcaption>The clamp (purple) on the bracket's post (teal), and the one M3 that goes through both. The ribbon cable is not shown. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
+</figure>
+
 Check that the chute can rotate fully to the limit switch in both directions, then tighten the Ribbon cable clamp screw. Use a long {% include fastener.html size="M3" variant="flat" length="40" %} screw through the Cable clamp (inner) into the {% include fastener.html size="M3" variant="nut" %} in the bottom of the Cable clamp (outer) to secure that end.
 
 {% include step.html n="12" title="Attach the cable cage bottom" %}

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -12,8 +12,10 @@ warning: >-
   **AI-generated first draft, mounting order still unbuilt.** Written from the machine assembly
   tree in the [parts calculator](https://parts-calculator.basically.website/assembly?focus=light-post),
   not from an actual build. The two screws into the NEMA bracket, and the three that join the
-  post to the adapter, are now measured off the part geometry. The assembly order, the COB
-  plate's retention, and every photograph are still missing. Fill it in as you build.
+  post to the adapter, are now measured off the part geometry, and Spencer's bench photographs
+  below are of a built post. The order the parts go together in, how the cap is retained, and
+  how the post is aimed are still missing. Fill it in as you build.
+og_image: https://assets.basically.website/sorter-parts/light-post-assembled-full-2b59e7e84bdb.jpg
 parts_needed:
   - part: light-post
     qty: 1
@@ -48,6 +50,11 @@ The light post is a vertical printed post carrying a 50 mm COB LED plate, which 
 
 The fasteners and quantities in the parts list come from the parts registry and are called out inline at each step. **The list above is one post's worth**, and the machine takes 2, one each on C2 and C3.
 
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/light-post-assembled-full-2b59e7e84bdb.jpg" alt="A finished light post on the bench: the black printed post with the 50 mm COB plate on its end, and the red and black leads running out of the post to a DC barrel plug">
+  <figcaption>A finished post: the plate on the end, the leads leaving the bottom on a barrel plug. <cite>Photo: Spencer.</cite></figcaption>
+</figure>
+
 {% include fastener-legend.html %}
 
 {% include step.html n="1" title="Preparation" %}
@@ -74,7 +81,9 @@ The post and the cap adapter follow the feeder colour.
 
 {% include step.html n="2" title="Screw the adapter to the post" %}
 
-All 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws join the Light post cap adapter down onto the Light post — the cap takes none of them. Measured off the two STLs: the post's top face carries 3 self-tapping pilot holes, 2.8 mm across, spaced 120° apart on a 12.1 mm radius; the adapter has a matching 3.4 mm clearance hole over each one. Screw down through the adapter into the post.
+Put the COB plate on the post's end first, leads down through the centre, then the Light post cap adapter over it. All 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws go down through the adapter and the plate into the post, so the plate is clamped between the two. The cap takes none of them.
+
+Measured off the two STLs: the post's top face carries 3 self-tapping pilot holes, 2.8 mm across, spaced 120° apart on a 12.1 mm radius; the adapter has a matching 3.4 mm clearance hole over each one.
 
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-parts/post-iso-render-full-d45cabf034b8.png" alt="Angled render of the post's top, with the adapter's ring seated over it and two of the three screw pockets visible">
@@ -83,20 +92,32 @@ All 3 {% include fastener.html size="M3" variant="countersunk" length="12" %} sc
 
 **Not recorded:** which way the lobed boss lines up on the adapter — the geometry rules out the two wrong 120°/240° rotations if you match it by eye, but nobody has confirmed which adapter feature it keys to. <span class="fastener-todo">fastener not recorded</span>
 
-<div class="img-placeholder">Image coming</div>
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/light-post-top-cap-off-full-d076a7bff4a1.jpg" alt="The end of the post with the cap off: the aluminium back of the COB plate with the black cap adapter on it, three countersunk screws going down through both into the post, and the leads coming up through the centre hole">
+    <figcaption>The joint from the back, cap off: the adapter on the plate, its three screws through both into the post. <cite>Photo: Spencer.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/light-post-led-side-full-428b89ff9243.jpg" alt="The LED side of the COB plate, close up: the post's forked end holds the plate at its centre, with the leads passing through the centre hole">
+    <figcaption>The same joint from the front, the post's forked end at the plate's centre. <cite>Photo: Spencer.</cite></figcaption>
+  </figure>
+</div>
 
-{% include step.html n="3" title="Fit the cap and the COB plate" %}
+{% include step.html n="3" title="Fit the cap over it" %}
 
-The Light post cap has no screw holes of its own anywhere in its geometry — it fits over the post-and-adapter assembly without fasteners, so it needs no heat insert either. The 50 mm COB plate mounts inside it, facing across the channel.
+The Light post cap has no screw holes of its own anywhere in its geometry — it fits over the post-and-adapter assembly without fasteners, so it needs no heat insert either. The plate faces across the channel, LEDs outward.
 
-**Not recorded:** how the cap is retained (snap or friction fit — the geometry doesn't say which) and what holds the COB plate in place. <span class="fastener-todo">fastener not recorded</span>
+**Not recorded:** how the cap is retained (snap or friction fit — the geometry doesn't say which). <span class="fastener-todo">fastener not recorded</span>
 
 <div class="callout callout-warning">
   <span class="callout-icon" aria-hidden="true">⚠</span>
   <p><b>The C-channel COB light boards need a current-limiting resistor.</b> <b>220&#8486;, 1/4 W, in series, one per board.</b> Wired straight to 24V a 50 mm COB plate pulls about 0.5A and melts its printed mount. A board fed from a basically board v1.3 LED header already has one on the board. Full detail: <a href="{{ '/hardware/electronics/#43--leds-from-basically-board-v13' | relative_url }}">LEDs, on the wire harness page</a>.</p>
 </div>
 
-<div class="img-placeholder">Image coming</div>
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/light-post-led-side-centre-full-b25b6589047d.jpg" alt="The LED side of the COB plate straight on: the post's forked end at the centre with the leads leaving through it">
+  <figcaption>The face that lights the channel, straight on. The leads leave through the centre of the plate. <cite>Photo: Spencer.</cite></figcaption>
+</figure>
 
 {% include step.html n="4" title="Bolt the post to the NEMA bracket" %}
 

--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -98,6 +98,19 @@ The plunger lands on the board's reset button, so the button can be pressed with
   </figure>
 </div>
 
+What that buys you is easier to see in section, once the cover is on: the plunger stands proud of the lid, the retainer holds it in the slot, and its foot sits over the button on the board.
+
+<div class="img-row">
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/ctrl-board-housing-assembly-render-full-6f4acadd3ffc.png" alt="Onshape render of the control board housing, closed, standing on a length of 2020 extrusion, with the honeycomb fan vent and the square plunger head in the cover">
+    <figcaption>The housing closed. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
+  </figure>
+  <figure>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-parts/ctrl-board-housing-plunger-section-full-a5319da2b902.png" alt="Section through the closed housing at the plunger: the plunger passes down through the cover, the retainer holds it in the slot, and its foot stands over the reset button on the board below">
+    <figcaption>The same housing cut at the plunger: through the cover, held by the retainer, standing over the board. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
+  </figure>
+</div>
+
 {% include step.html n="5" title="Plug the fan into a GPIO-controlled port" %}
 
 Disconnect the board from its 24 V supply before wiring the fan or bridging the jumper. The fan runs off one of the board's four LED ports (24 V switched to ground by a Pico-driven MOSFET) — red wire goes to +V.

--- a/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
+++ b/docs/src/content/hardware/electronics/installation/orange-pi-mount.md
@@ -9,6 +9,7 @@ lede: The Orange Pi 5 standing off its mount, the 40 mm fan on its arm above it,
 permalink: /hardware/electronics/installation/orange-pi-mount/
 author: barthel
 contributors: [spencer]
+og_image: https://assets.basically.website/sorter-parts/orange-pi-mount-v1-render-full-d5893e241c96.png
 warning: >-
   **AI-generated first draft.** Written from the machine assembly tree in the [parts
   calculator](https://parts-calculator.basically.website/assembly?focus=orange-pi-mount), not
@@ -42,6 +43,11 @@ The fasteners and quantities in the parts list come from the parts calculator an
 {% include fastener-legend.html %}
 
 One per machine. Which Orange Pi 5 to buy, how much RAM and storage it needs, the WiFi module, the USB hub and cooling are all on the [Orange Pi 5]({{ '/hardware/orange-pi-5/' | relative_url }}) page. This page is only about bolting it to the machine, and it is close to the [control board housing]({{ '/hardware/electronics/installation/control-board-housing/' | relative_url }}): 6 inserts, 4 standoffs, 4 M3 screws under the Pi, a printed arm holding the 40 mm fan over it on 6 more, and 2 M5 into the frame.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-parts/orange-pi-mount-v1-render-full-d5893e241c96.png" alt="Onshape render of the two printed parts of the Orange Pi mount: the blue plate with its rectangular cutout and corner screw holes, and the grey fan arm standing on its front edge, reaching back over the plate with the round fan opening in its top">
+  <figcaption>The two printed parts: the plate the Pi stands off (blue) and the fan arm over it (grey). The Pi, the standoffs and the fan are not shown. <cite>Rendered from the part geometry, not from a build. Render: Spencer.</cite></figcaption>
+</figure>
 
 {% include step.html n="1" title="Preparation" %}
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -6144,28 +6144,6 @@
           "note": "The cap just sits on the adapter."
         }
       ],
-      "images": [
-        {
-          "url": "https://assets.basically.website/sorter-parts/light-post-assembled-full-2b59e7e84bdb.jpg",
-          "alt": "A finished light post on the bench: the black printed post with the 50 mm COB plate on its end, and the red and black leads running out of the post to a DC barrel plug",
-          "caption": "The light post, assembled."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/light-post-top-cap-off-full-d076a7bff4a1.jpg",
-          "alt": "The end of the post with the cap off: the aluminium back of the COB plate with the black cap adapter on it, three countersunk screws going down through both into the post, and the leads coming up through the centre hole",
-          "caption": "Cap off: the adapter and its three M3 × 12 through the plate into the post."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/light-post-led-side-full-428b89ff9243.jpg",
-          "alt": "The LED side of the COB plate, close up: the post's forked end holds the plate at its centre, with the leads passing through the centre hole",
-          "caption": "LED side: the post's forked end at the plate's centre."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/light-post-led-side-centre-full-b25b6589047d.jpg",
-          "alt": "The LED side of the COB plate straight on: the post's forked end at the centre with the leads leaving through it",
-          "caption": "LED side, straight on."
-        }
-      ],
       "versions": [
         {
           "version": "1",
@@ -6715,13 +6693,6 @@
           "qty": 1,
           "method": "insert",
           "note": "Single M3 into the bracket's heat-set insert. The clamp's lip hooks under the post's underside (raised in v2, sorter-v2 #403) to stop the clamp rotating on the single screw."
-        }
-      ],
-      "images": [
-        {
-          "url": "https://assets.basically.website/sorter-parts/spencer-image2-full-adb0f1993da6.png",
-          "alt": "Onshape render of the cable-mount cage bracket (teal) with the ribbon cable clamp (purple) bolted to its post, one M3 hole visible through both",
-          "caption": "The cable-mount bracket and ribbon clamp, assembled."
         }
       ]
     },
@@ -9869,18 +9840,6 @@
           "note": "The fan's four [[hw:scr-m3-12-bhcs]] cut their own threads in the cover; no inserts there."
         }
       ],
-      "images": [
-        {
-          "url": "https://assets.basically.website/sorter-parts/ctrl-board-housing-assembly-render-full-6f4acadd3ffc.png",
-          "alt": "Onshape render of the control board housing, closed",
-          "caption": "The housing closed, from Onshape: fan vent and plunger in the cover."
-        },
-        {
-          "url": "https://assets.basically.website/sorter-parts/ctrl-board-housing-plunger-section-full-a5319da2b902.png",
-          "alt": "Section through the housing at the plunger",
-          "caption": "Section at the plunger: through the cover, held by the retainer (blue), over the board."
-        }
-      ],
       "versions": [
         {
           "version": "1",
@@ -10011,13 +9970,6 @@
           "thread_mm": 12,
           "draft": true,
           "note": "The fan sits on the flat top face of the arm over its 38 mm opening, on the standard 32 x 32 mm pattern. The four 2.50 mm pilots run right through the 12.0 mm plate; the screws cut their own thread in it, no inserts. Measured off the STL, not from a build."
-        }
-      ],
-      "images": [
-        {
-          "url": "https://assets.basically.website/sorter-parts/orange-pi-mount-v1-render-full-d5893e241c96.png",
-          "alt": "Onshape render of the Orange Pi's v1 extrusion mount and fan bracket",
-          "caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
         }
       ],
       "versions": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -671,28 +671,6 @@
 					"note": "The cap just sits on the adapter."
 				}
 			],
-			"images": [
-				{
-					"url": "https://assets.basically.website/sorter-parts/light-post-assembled-full-2b59e7e84bdb.jpg",
-					"alt": "A finished light post on the bench: the black printed post with the 50 mm COB plate on its end, and the red and black leads running out of the post to a DC barrel plug",
-					"caption": "The light post, assembled."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/light-post-top-cap-off-full-d076a7bff4a1.jpg",
-					"alt": "The end of the post with the cap off: the aluminium back of the COB plate with the black cap adapter on it, three countersunk screws going down through both into the post, and the leads coming up through the centre hole",
-					"caption": "Cap off: the adapter and its three M3 \u00d7 12 through the plate into the post."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/light-post-led-side-full-428b89ff9243.jpg",
-					"alt": "The LED side of the COB plate, close up: the post's forked end holds the plate at its centre, with the leads passing through the centre hole",
-					"caption": "LED side: the post's forked end at the plate's centre."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/light-post-led-side-centre-full-b25b6589047d.jpg",
-					"alt": "The LED side of the COB plate straight on: the post's forked end at the centre with the leads leaving through it",
-					"caption": "LED side, straight on."
-				}
-			],
 			"versions": [
 				{
 					"version": "1",
@@ -1246,13 +1224,6 @@
 					"qty": 1,
 					"method": "insert",
 					"note": "Single M3 into the bracket's heat-set insert. The clamp's lip hooks under the post's underside (raised in v2, sorter-v2 #403) to stop the clamp rotating on the single screw."
-				}
-			],
-			"images": [
-				{
-					"url": "https://assets.basically.website/sorter-parts/spencer-image2-full-adb0f1993da6.png",
-					"alt": "Onshape render of the cable-mount cage bracket (teal) with the ribbon cable clamp (purple) bolted to its post, one M3 hole visible through both",
-					"caption": "The cable-mount bracket and ribbon clamp, assembled."
 				}
 			]
 		},
@@ -4420,18 +4391,6 @@
 					"note": "The fan's four [[hw:scr-m3-12-bhcs]] cut their own threads in the cover; no inserts there."
 				}
 			],
-			"images": [
-				{
-					"url": "https://assets.basically.website/sorter-parts/ctrl-board-housing-assembly-render-full-6f4acadd3ffc.png",
-					"alt": "Onshape render of the control board housing, closed",
-					"caption": "The housing closed, from Onshape: fan vent and plunger in the cover."
-				},
-				{
-					"url": "https://assets.basically.website/sorter-parts/ctrl-board-housing-plunger-section-full-a5319da2b902.png",
-					"alt": "Section through the housing at the plunger",
-					"caption": "Section at the plunger: through the cover, held by the retainer (blue), over the board."
-				}
-			],
 			"versions": [
 				{
 					"version": "1",
@@ -4563,13 +4522,6 @@
 					"thread_mm": 12,
 					"draft": true,
 					"note": "The fan sits on the flat top face of the arm over its 38 mm opening, on the standard 32 x 32 mm pattern. The four 2.50 mm pilots run right through the 12.0 mm plate; the screws cut their own thread in it, no inserts. Measured off the STL, not from a build."
-				}
-			],
-			"images": [
-				{
-					"url": "https://assets.basically.website/sorter-parts/orange-pi-mount-v1-render-full-d5893e241c96.png",
-					"alt": "Onshape render of the Orange Pi's v1 extrusion mount and fan bracket",
-					"caption": "The v1 mounting, from Onshape: the board's plate (blue) and the shared fan bracket (grey)."
 				}
 			],
 			"versions": [


### PR DESCRIPTION
**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1547571868389609552/1547576232885883011):** *"Check the other assemblies in the same way. If they contain images that haven't been added to the documentation yet, create a PR to add them there. If a documentation page is missing for an assembly, please create it with the AI Warning and add the images right away. Then remove the images from the parts calculator assembly tree in the same PR as the documentation update."*

Follows [his earlier ask](https://discord.com/channels/1430279849171222682/1536088194557419660/1547571868389609552) that produced #622, which did the camera lamp: *"I want to prevent a situation where we suddenly end up with multiple places where built elements appear that could potentially be out of sync."*

## The sweep

Five assemblies carried `images` after #622 took the camera lamp's out. Four of them at the top level, and **none of those eight images was on the docs page that builds the thing** (checked URL by URL against each page's assets). Every one has a docs page already, so no new page was needed.

| Assembly | Images | Where they went |
|---|---|---|
| Light post | 4 photos | `/hardware/assembly/feeder/light-post/`, overview + steps 2 and 3 |
| Cage bracket (cable mount) + ribbon clamp | 1 render | `/hardware/assembly/distribution/top-interface/`, step 11 |
| basically Embedded Control Board Housing | 2 renders | `/hardware/electronics/installation/control-board-housing/`, step 4 |
| Orange Pi mount | 1 render | `/hardware/electronics/installation/orange-pi-mount/`, overview |

### Light post

The page's own warning said *"every photograph are still missing"* and it had five `Image coming` placeholders. [Spencer's four bench photos](https://github.com/basicallysource/sorter-v2/commit/271ea214173484a33b0166e4cc4c98a4eaa29b69) fill three of them, and the warning is corrected.

They also settle two things the page had open or wrong. Step 2 said the three M3 × 12 *"join the Light post cap adapter down onto the Light post"* and step 3 said the COB plate *"mounts inside"* the cap, with **"what holds the COB plate in place"** listed as not recorded. The photograph shows the plate clamped between the adapter and the post's end by those same three screws, which is also what the assembly's own `connections` entry says (*"Down through the adapter's three clearance holes and the COB plate clamped under it"*) and what Spencer wrote when he added them: *"The three M3 x 12 clamp the cap adapter and the COB plate down onto the post."* Steps 2 and 3 now say that, and the "not recorded" line is trimmed to the cap, which is still genuinely unrecorded.

This page is retired (the [camera lamp](https://docs.basically.website/hardware/assembly/feeder/camera-lamp/) replaced it on 2026-09-02) and is kept for machines already built this way, which is exactly why the photos should be on it rather than only in the catalog.

### Top interface

Step 11 already told you to *"Screw the Ribbon cable clamp lightly to the Cable cage bracket (cable mount) with one M3 × 10 screw"* and had no picture of that joint. Spencer's render, [added to the catalog in #589](https://github.com/basicallysource/sorter-v2/pull/589), shows exactly it.

### Control board housing

The page has a full set of Spencer's build photos, so the two renders had to earn their place rather than repeat one. They go into step 4, where the plunger and its retainer are fitted and where the page explains that *"the plunger lands on the board's reset button, so the button can be pressed with the housing shut"* — the section is the only image anywhere that shows that actually happening, and the closed render orients the cut.

### Orange Pi mount

No overview figure and no `og_image` at all. The render of the two printed parts is now both.

## Left in place, deliberately

Two nested `images` lists survive, and I do not think either is the duplication barthel is after:

- `meanwell-psu-box` → `candidates[0]`: the v2 PSU housing render. A candidate that is *"being test-printed; may become the next version"*, so it is a proposal, not a built element, and no docs page describes it.
- `ctrl-board-mount` → `versions[1]`: the v1 mounting render, on the superseded version. That is history the version view renders; the docs page documents the current housing only.

Say the word and both come out too.

## Checks

- `python3 scripts/validate_images.py` — 233 assets, all content-addressed and hash-matched. The `sorter-parts` URLs are referenced as they are; nothing was re-uploaded and nothing was deleted from either bucket.
- `python3 scripts/validate_credits.py` — 8 uncredited images, the same 8 as on `main` (`top-interface.md` × 3, `arranging-c-channels.md` × 4, `camera-calibration.md`). Every image added here carries a `<cite>`; none of the pre-existing failures is on a line this PR touches.
- `python3 scripts/validate_frontmatter.py` — 4 errors, all pre-existing and all on pages this PR does not touch.
- `npm run check` in both `docs/` and `parts-calculator/` — 0 errors.
- `python3 catalog/generate.py --metadata-only` — clean, and its pin, versioning and connection checks pass. No `lines` changed, so no version stamp.

Not stacked on #622: both branch off `main` and they touch different assemblies, so they can land in either order.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1547571868389609552/1547576232885883011
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1547571868389609552
preview: /hardware/assembly/feeder/light-post/
preview: /hardware/electronics/installation/control-board-housing/
preview: /hardware/electronics/installation/orange-pi-mount/
preview: /hardware/assembly/distribution/top-interface/
-->
