### PR TITLE
docs: bottom interface gains the layer connectors, and C-channel gets its gear photos

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/bin-frame/bottom-interface.md
@@ -24,7 +24,13 @@ parts_needed:
     qty: 3
   - part: ls-hold-in-place
     qty: 3
+  - part: layer-connector-1
+    qty: 1
+  - part: layer-connector-2
+    qty: 1
   - part: hsi-m3
+    qty: 2
+  - part: scr-m3-8-cs
     qty: 2
   - part: hsi-m4
     qty: 8
@@ -51,7 +57,7 @@ The bottom interface is the Lazy Susan bearing assembly the chute rests and spin
   </figure>
 </div>
 
-The parts list above is only the Lazy Susan bearing stack and the extrusion mounts added in steps 4 to 8. The fasteners and quantities below are called out inline at each step.
+The parts list above is only the Lazy Susan bearing stack and the extrusion mounts added in steps 5 to 9. The fasteners and quantities below are called out inline at each step.
 
 {% include fastener-legend.html %}
 
@@ -120,6 +126,10 @@ Press the heat inserts into both printed parts while they are still loose. See [
     <figure>
       <img class="doc-figure" src="https://assets.basically.website/sorter-parts/bottom-interface-chute-mount-m3-pocket-photo-full-ea22d619b316.png" alt="Close photo of the same raised tab on a printed chute mount, with a red circle around the empty pocket in it">
       <figcaption>The same pocket on a printed part, empty. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+    </figure>
+    <figure>
+      <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-chute-mount-m3-insert-fitted-w1600-817f55921507.jpg" alt="The same raised tab on the chute mount with its brass M3 heat insert pressed in flush">
+      <figcaption>And with the insert in. <cite>Photo: BrickCycleAlice.</cite></figcaption>
     </figure>
   </div>
 </div>
@@ -231,7 +241,18 @@ The bearing stack is now complete:
   <figcaption><cite>Photo: Spencer.</cite></figcaption>
 </figure>
 
-{% include step.html n="4" title="Bolt a hold in place to each mount" %}
+{% include step.html n="4" title="Add the two layer connectors" %}
+
+A [Layer connector A and a Layer connector B]({{ '/hardware/assembly/distribution/chute/layer-connectors/' | relative_url }}) go onto the chute mount, one on each side face, into the two M3 inserts pressed in step 1. One {% include fastener.html size="M3" variant="countersunk" length="8" %} each. They are the same pair that joins every chute to the one above it; here they are what the bottommost chute lands on.
+
+With them on, the bearing stack is complete: chute mount, Lazy Susan, washer and bottom static, plus the connectors that carry the layer above.
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-bottom-interface-layer-connectors-on-w1600-916a76546669.jpg" alt="The finished bearing stack: the square chute mount standing on the round Lazy Susan and bottom static, with a layer connector bolted to the raised tab on each side face">
+  <figcaption>The completed stack, both connectors on. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+{% include step.html n="5" title="Bolt a hold in place to each mount" %}
 
 Bolt a hold in place onto each mount with one {% include fastener.html size="M5" variant="socket-button" length="16" %}, before either part touches the extrusion.
 
@@ -246,7 +267,7 @@ Bolt a hold in place onto each mount with one {% include fastener.html size="M5"
   </figure>
 </div>
 
-{% include step.html n="5" title="Prestart the T-nuts" %}
+{% include step.html n="6" title="Prestart the T-nuts" %}
 
 Drop an {% include fastener.html size="M5" variant="socket-button" length="16" %} through each of the mount's two counterbored holes and start a {% include fastener.html size="M5" variant="t-nut" %} on the end, two or three turns. Leave them loose enough to swing.
 
@@ -263,7 +284,7 @@ Drop an {% include fastener.html size="M5" variant="socket-button" length="16" %
 
 Roll-in nuts enter the slot anywhere along it. Slide-in nuts don't, and have to go into the spoke before the frame is built: see [Fitting T-nuts]({{ '/hardware/helpers/t-nuts/' | relative_url }}).
 
-{% include step.html n="6" title="Slide the mount onto the spoke" %}
+{% include step.html n="7" title="Slide the mount onto the spoke" %}
 
 Slide the mount onto a B spoke (158 mm) already in the frame, T-nuts into the extrusion slot. Push up on each nut with a screwdriver as it goes, so it seats square.
 
@@ -278,7 +299,7 @@ Slide the mount onto a B spoke (158 mm) already in the frame, T-nuts into the ex
   </figure>
 </div>
 
-{% include step.html n="7" title="Tighten" %}
+{% include step.html n="8" title="Tighten" %}
 
 Tighten both {% include fastener.html size="M5" variant="socket-button" length="16" %} screws into the T-nuts.
 
@@ -293,7 +314,7 @@ Tighten both {% include fastener.html size="M5" variant="socket-button" length="
   </figure>
 </div>
 
-{% include step.html n="8" title="Repeat for the other two mounts" %}
+{% include step.html n="9" title="Repeat for the other two mounts" %}
 
 Nine {% include fastener.html size="M5" variant="socket-button" length="16" %} and six {% include fastener.html size="M5" variant="t-nut" %} across all three.
 

--- a/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
+++ b/docs/src/content/hardware/assembly/feeder/arranging-c-channels.md
@@ -29,7 +29,7 @@ parts_needed:
     <p><strong>Build all four <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">C-channels</a> before you start.</strong> They're required components of this page, not optional or covered here — this page arranges and heights four already-built channels, it doesn't build them. Three with the faceted rotor, one with the finned one.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished C-channel: the grey finned rotor sitting down in the grey stator ring, with the stepper motor and its lead standing off one side">
     <figcaption>A finished C-channel, from the C-channel page. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/feeder/bulk-input.md
+++ b/docs/src/content/hardware/assembly/feeder/bulk-input.md
@@ -23,7 +23,7 @@ parts_needed:
     <p><strong>Build a <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">C-channel</a> before you start.</strong> It's a required component of this page, not optional or covered here — Step 2 slides the Bulk cap onto one, it doesn't build one.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished C-channel: the grey finned rotor sitting down in the grey stator ring, with the stepper motor and its lead standing off one side">
     <figcaption>A finished C-channel, from the C-channel page (pictured with the finned rotor; C1 takes the faceted one). <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -129,19 +129,21 @@ Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3"
 
 Fasten the NEMA bracket to the underside of the stator with 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws.
 
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-bracket-under-stator-w1600-c45a38f08e69.jpg" alt="The stator ring seen from underneath with the three-armed NEMA bracket fastened across it, each arm reaching the rim">
+  <figcaption>The bracket on the underside of the stator, arms out to the rim. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
 Then lower the rotor, output gear and all, onto the raised hub in the middle of the bracket, so the 130T comes down into mesh with the idler.
 
 Turn the stage by hand before wiring it. The train should run without a tight spot anywhere in a full revolution.
 
 <figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
-  <figcaption>The finished stage, here the classification one with the finned rotor. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished channel: the finned rotor sitting down in the grey stator ring with the stepper motor and its lead standing off one side">
+  <figcaption>The finished stage, rotor down in the stator with the stepper on the outside. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
-{% include step.html n="6" title="Hang the camera lamp over the channel" %}
+## Next steps
 
-C2, C3 and the classification channel each carry a camera lamp: an arm mounted to the channel, a shaded lamp on the end of it and a camera looking down through the middle. It has its own page, [camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }}), and none of its screws are in the list above. Skip this step on C1, the bulk bucket, which takes no lamp.
-
-The light post and the overhead camera mount that used to do this job were retired on 2026-09-02. Their pages are still up for machines already built that way.
-
-Once all four are built, see [arranging C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}) for how they sit together.
+- **[Build a camera lamp]({{ '/hardware/assembly/feeder/camera-lamp/' | relative_url }})** for this channel if it needs one. C2, C3 and the classification channel each carry one, an arm mounted to the channel with a shaded lamp and a camera looking down through the middle. C1, the bulk bucket, takes none. The lamp goes on once the channels are mounted, not now, and none of its screws are in the list above. It replaces the [light post]({{ '/hardware/assembly/feeder/light-post/' | relative_url }}) and the [overhead camera mount]({{ '/hardware/assembly/feeder/camera-mount/' | relative_url }}), whose pages are still up for machines already built that way.
+- **[Arrange the C-channels]({{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }})** once all four are built, for how they stand together.

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -121,8 +121,8 @@ Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3"
 </figure>
 
 <figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-step4-mounting-face-w1600-5f972ded599d.jpg" alt="Close view of the mounting face on a large grey printed part, two countersunk screws driven at the edge with further mounting holes beside them">
-  <figcaption>Closer on the mounting face, two screws home. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-step4-mounting-face-w1600-5f972ded599d.jpg" alt="Close view of the grey NEMA bracket, two countersunk screws driven near the edge with further mounting holes beside them">
+  <figcaption>Closer on the NEMA bracket, two screws home. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 {% include step.html n="5" title="Mount the stator, then drop in the rotor" %}

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -66,7 +66,8 @@ Press both bearings into their gears first, while the parts are loose and you ca
     <p><strong>Output gear (130T):</strong> one 6806-2RS bearing, 30 mm bore.</p>
   </div>
   <figure class="prep-item-figure">
-    <div class="img-placeholder">Image coming</div>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-output-gear-bearing-pressed-w1600-238c650067c4.jpg" alt="The 130-tooth output gear lying flat with a black-sealed 6806 bearing pressed into its six-spoke hub">
+    <figcaption>The output gear with its bearing pressed home. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -75,7 +76,8 @@ Press both bearings into their gears first, while the parts are loose and you ca
     <p><strong>Idler gear (24T):</strong> one 608-2RS bearing.</p>
   </div>
   <figure class="prep-item-figure">
-    <div class="img-placeholder">Image coming</div>
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-idler-gear-bearing-pressed-w1600-77f822b4b777.jpg" alt="The 24-tooth idler gear with a black-sealed 608 bearing pressed into its centre, seen from above">
+    <figcaption>The idler gear with its 608 in. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
 
@@ -116,6 +118,11 @@ Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3"
 <figure class="single-figure">
   <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-idler-gear-and-motor-on-nema-bracket-w1600-dfefb06e2166.jpg" alt="The three-armed grey NEMA bracket seen from above, with the 24-tooth idler gear sitting on its post with the 608 bearing uppermost, the stepper motor bolted to the outer end of the bracket, and the raised hub at the centre of the bracket">
   <figcaption>Idler on its post, bearing up, with the stepper bolted on beside it. <cite>Photo: BrickCycleAlice.</cite></figcaption>
+</figure>
+
+<figure class="single-figure">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-step4-mounting-face-w1600-5f972ded599d.jpg" alt="Close view of the mounting face on a large grey printed part, two countersunk screws driven at the edge with further mounting holes beside them">
+  <figcaption>Closer on the mounting face, two screws home. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 
 {% include step.html n="5" title="Mount the stator, then drop in the rotor" %}

--- a/docs/src/content/hardware/assembly/feeder/camera-lamp.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-lamp.md
@@ -53,7 +53,7 @@ parts_needed:
     <p><strong>Build a <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">C-channel</a> before you start.</strong> The lamp hangs over one, on an arm that mounts to it. This page builds the lamp, not the channel.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished C-channel: the grey finned rotor sitting down in the grey stator ring, with the stepper motor and its lead standing off one side">
     <figcaption>A finished C-channel, from the C-channel page. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/feeder/camera-mount.md
+++ b/docs/src/content/hardware/assembly/feeder/camera-mount.md
@@ -40,7 +40,7 @@ parts_needed:
     <p><strong>Build a <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">C-channel</a> before you start.</strong> It's a required component of this page, not optional or covered here — Step 2 clamps the rod mounts onto one, it doesn't build one.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished C-channel: the grey finned rotor sitting down in the grey stator ring, with the stepper motor and its lead standing off one side">
     <figcaption>A finished C-channel, from the C-channel page. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
+++ b/docs/src/content/hardware/assembly/feeder/classification-chamber/index.md
@@ -37,7 +37,7 @@ parts_needed:
     <p><strong>Build a <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">classification C-channel</a> before you start.</strong> It's a required component of this page. Step 2 below walks through building it, using the C-channel page's own steps, with the finned rotor rather than faceted — Step 3 then bolts the chamber's own parts onto it.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished C-channel: the grey finned rotor sitting down in the grey stator ring, with the stepper motor and its lead standing off one side">
     <figcaption>A finished classification C-channel, from the C-channel page. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>
@@ -96,7 +96,7 @@ The parts are in the list above. Most fasteners for this stage still aren't reco
 Build the classification channel as a normal [C-channel]({{ '/hardware/assembly/feeder/c-channel/' | relative_url }}), but with the finned rotor rather than a faceted one. Nothing else about it differs, colour included.
 
 <figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished C-channel: the grey finned rotor sitting down in the grey stator ring, with the stepper motor and its lead standing off one side">
   <figcaption>The classification channel, finned rotor fitted in the stator. Same photo as the C-channel page's step 5, since it's the same build. <cite>Photo: BrickCycleAlice.</cite></figcaption>
 </figure>
 

--- a/docs/src/content/hardware/assembly/feeder/light-post.md
+++ b/docs/src/content/hardware/assembly/feeder/light-post.md
@@ -39,7 +39,7 @@ parts_needed:
     <p><strong>Build a <a href="{{ '/hardware/assembly/feeder/c-channel/' | relative_url }}">C-channel</a> before you start.</strong> It's a required component of this page, not optional or covered here — Step 4 bolts the post onto one's NEMA bracket, it doesn't build one.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished C-channel: the grey finned rotor sitting down in the grey stator ring, with the stepper motor and its lead standing off one side">
     <figcaption>A finished C-channel, from the C-channel page. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>

--- a/docs/src/content/hardware/assembly/feeder/output-guides.md
+++ b/docs/src/content/hardware/assembly/feeder/output-guides.md
@@ -24,7 +24,7 @@ parts_needed:
     <p><strong>Build and <a href="{{ '/hardware/assembly/feeder/arranging-c-channels/' | relative_url }}">arrange the C-channels</a> before you start.</strong> It's a required stage before this page, not optional or covered here — a guide only goes in once its channel and the one below it are standing at their final heights.</p>
   </div>
   <figure class="prep-item-figure">
-    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-stator-and-rotor-fitted-w1600-60758bbee2d5.jpg" alt="A finished C-channel seen from above: the white finned classification rotor sitting inside the grey stator ring, with the stepper motor projecting from the right-hand side">
+    <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-c-channel-finished-stage-w1600-9bd3719c4180.jpg" alt="A finished C-channel: the grey finned rotor sitting down in the grey stator ring, with the stepper motor and its lead standing off one side">
     <figcaption>A finished C-channel, from the C-channel page. <cite>Photo: BrickCycleAlice.</cite></figcaption>
   </figure>
 </div>


### PR DESCRIPTION
Two more pages get photographs from BrickCycleAlice's build, and the C-channel page loses a step that was in the wrong place.

**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1547526128942583838/1547573759299420183):** "Let's call this photo 89. This will be a new pr, the pages it will cover bottom interface and c channel", and closed [here](https://discord.com/channels/1430279849171222682/1547526128942583838/1547579703576100976): "that's it for that pr for the two pages."

## Bottom interface

- **A new step 4, "Add the two layer connectors"**, [asked for here](https://discord.com/channels/1430279849171222682/1547526128942583838/1547575999384784916): "use image 89 to show how two layer connectors are added. They will be a step after step 3. This completes the bearing stack." The old steps 4 to 8 become 5 to 9, and the sentence about the parts list moved with them.
- The page's parts list gains the two connectors and their screws, which it did not carry. One {% raw %}M3 × 8{% endraw %} countersunk per connector, because the chute mount has one M3 insert per side face where the chute core has two per connector: [confirmed](https://discord.com/channels/1430279849171222682/1547526128942583838/1547578435331948566), "Screw length is correct".
- **Photo 90** joins the M3 pocket pair in step 1, [her words](https://discord.com/channels/1430279849171222682/1547526128942583838/1547575553681391687): "it is a the heat inserts installed on the chute mount". The page already showed that tab with an empty pocket and a render of it; this is the same tab with the insert in.

## C-channel

[Asked for here](https://discord.com/channels/1430279849171222682/1547526128942583838/1547578435331948566) and [here](https://discord.com/channels/1430279849171222682/1547526128942583838/1547579381516476426).

- **Step 1's two `Image coming` placeholders are filled**: the 130T output gear with its 6806 pressed in, and the 24T idler with its 608.
- **Step 4** gains a close view of the NEMA bracket. I could not tell the part from the frame and captioned it plainly; she [named it](https://discord.com/channels/1430279849171222682/1547526128942583838/1547579526249193542) and the caption now says so.
- **Step 5** gains the NEMA bracket fastened under the stator, and its closing photo is replaced by a newer finished stage.
- **Step 6 is gone.** In her words: "I don't think we should have step 6 here, there is no need for camera lamps to be installed until the c channels are mounted. Just do the usual 'next steps - build a camera lamp'." It is now a **Next steps** list pointing at the camera lamp page and at arranging C-channels. Everything the step said that a builder still needs is in that bullet: C1 takes no lamp, the lamp's screws are not in this page's parts list, and it replaces the retired light post and overhead camera mount. The photo removed from step 5 is still in use on the camera lamp page, so nothing is orphaned.

## Checks

`npm run check` 0 errors, `docs/scripts/validate_images.py` clean, `docs/scripts/validate_credits.py` at the same 8 failures it reports on `main`, none on these two pages.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547573759299420183
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547575553681391687
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547575999384784916
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547578435331948566
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547579381516476426
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547579526249193542
request: https://discord.com/channels/1430279849171222682/1547526128942583838/1547579703576100976
preview: /hardware/assembly/distribution/bin-frame/bottom-interface/
preview: /hardware/assembly/feeder/c-channel/
-->
