### PR TITLE
parts+docs: the C-channel's two deep bracket-to-stator holes take an M3 x 16

### DIFF
--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -37,9 +37,9 @@ parts_needed:
   - part: brg-608-2rs
     qty: 4
   - part: scr-m3-12-cs
-    qty: 40
+    qty: 32
   - part: scr-m3-16-cs
-    qty: 12
+    qty: 20
   - part: scr-m3-8-cs
     qty: 4
 ---
@@ -120,7 +120,7 @@ Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3"
 
 {% include step.html n="5" title="Mount the stator, then drop in the rotor" %}
 
-Fasten the NEMA bracket to the underside of the stator with 4 {% include fastener.html size="M3" variant="countersunk" length="12" %} screws.
+Fasten the NEMA bracket to the underside of the stator with 4 screws, in two lengths. The two at the tips of the narrow arms take an {% include fastener.html size="M3" variant="countersunk" length="12" %}; the two on the wide plate the stepper sits on take an {% include fastener.html size="M3" variant="countersunk" length="16" %}, because the bracket is thicker at those two and a 12 mm barely bites.
 
 Then lower the rotor, output gear and all, onto the raised hub in the middle of the bracket, so the 130T comes down into mesh with the idler.
 

--- a/docs/src/content/hardware/assembly/feeder/c-channel.md
+++ b/docs/src/content/hardware/assembly/feeder/c-channel.md
@@ -120,7 +120,7 @@ Then fasten the NEMA 17 to the bracket with 3 {% include fastener.html size="M3"
 
 {% include step.html n="5" title="Mount the stator, then drop in the rotor" %}
 
-Fasten the NEMA bracket to the underside of the stator with 4 screws, in two lengths. The two at the tips of the narrow arms take an {% include fastener.html size="M3" variant="countersunk" length="12" %}; the two on the wide plate the stepper sits on take an {% include fastener.html size="M3" variant="countersunk" length="16" %}, because the bracket is thicker at those two and a 12 mm barely bites.
+Fasten the NEMA bracket to the underside of the stator with 4 screws, in two lengths. The two at the tips of the narrow arms take an {% include fastener.html size="M3" variant="countersunk" length="12" %} screw. The two on the wide plate the stepper sits on take an {% include fastener.html size="M3" variant="countersunk" length="16" %} instead, because the bracket is thicker at those two and a 12 mm barely bites.
 
 Then lower the rotor, output gear and all, onto the raised hub in the middle of the bracket, so the 130T comes down into mesh with the idler.
 

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -8938,8 +8938,8 @@
     },
     {
       "id": "c-channel",
-      "uid": "4tvc",
-      "version": "3",
+      "uid": "kuei",
+      "version": "4",
       "name": "C-channel drive",
       "description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine — 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
       "docs": "/hardware/assembly/feeder/c-channel/",
@@ -9052,6 +9052,13 @@
           "message": "The screws are all countersunk — socket/button was recorded wrong. The idler's 608 bearing is a line of its own with its press fit as a connection, and the screw joints carry measured pass-through and thread depths. Connections bench-confirmed and listed in assembly order.",
           "breaking": false,
           "commit": "441d9114"
+        },
+        {
+          "version": "4",
+          "date": "2026-09-10",
+          "message": "The two bracket-to-stator screws on the wide motor plate go to M3 x 16 countersunk. The bracket's four stator holes come in two depths and all four were specified at 12 mm: over the 8.45 mm pass-through the head leaves 1.85 mm in the stator's 10 mm thread, under the 2 mm minimum bite the site's own fit math applies, and Extremetaz reported it as marginal on a build. The two arm holes (6.45 mm pass-through, 3.85 mm bite) keep the 12 mm.",
+          "breaking": false,
+          "commit": null
         }
       ],
       "lines": [
@@ -9081,7 +9088,7 @@
         },
         {
           "part": "scr-m3-16-cs",
-          "qty": 3
+          "qty": 5
         },
         {
           "part": "scr-m3-8-cs",
@@ -9089,7 +9096,7 @@
         },
         {
           "part": "scr-m3-12-cs",
-          "qty": 4
+          "qty": 2
         }
       ],
       "connections": [
@@ -9123,17 +9130,18 @@
           "qty": 2,
           "method": "self-tap",
           "through_mm": 6.45,
-          "thread_mm": 10
+          "thread_mm": 10,
+          "note": "The two holes at the tips of the bracket's narrow arms."
         },
         {
           "from": "nema-bracket",
           "to": "stator",
-          "via": "scr-m3-12-cs",
+          "via": "scr-m3-16-cs",
           "qty": 2,
           "method": "self-tap",
           "through_mm": 8.45,
           "thread_mm": 10,
-          "note": "The bracket's four stator holes come in two depths: two at 6.45 mm, two at 8.45 mm."
+          "note": "The bracket's four stator holes come in two depths: two at 6.45 mm, two at 8.45 mm. The deeper pair needs the 16 mm."
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -9048,10 +9048,58 @@
         },
         {
           "version": "3",
+          "uid": "4tvc",
           "date": "2026-09-01",
           "message": "The screws are all countersunk — socket/button was recorded wrong. The idler's 608 bearing is a line of its own with its press fit as a connection, and the screw joints carry measured pass-through and thread depths. Connections bench-confirmed and listed in assembly order.",
           "breaking": false,
-          "commit": "441d9114"
+          "commit": "441d9114",
+          "lines": [
+            {
+              "part": "idler-gear",
+              "qty": 1,
+              "uid": "7bv7"
+            },
+            {
+              "part": "brg-608-2rs",
+              "qty": 1,
+              "uid": "mi1l"
+            },
+            {
+              "part": "nema-bracket",
+              "qty": 1,
+              "uid": "x09t"
+            },
+            {
+              "part": "motor-nema17",
+              "qty": 1,
+              "uid": "w7pq"
+            },
+            {
+              "part": "input-gear",
+              "qty": 1,
+              "uid": "70ul"
+            },
+            {
+              "part": "stator",
+              "qty": 1,
+              "uid": "n6bm"
+            },
+            {
+              "part": "scr-m3-16-cs",
+              "qty": 3,
+              "uid": "bdi4"
+            },
+            {
+              "part": "scr-m3-8-cs",
+              "qty": 1,
+              "uid": "l6br"
+            },
+            {
+              "part": "scr-m3-12-cs",
+              "qty": 4,
+              "uid": "0a9x"
+            }
+          ]
         },
         {
           "version": "4",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -3482,8 +3482,8 @@
 		},
 		{
 			"id": "c-channel",
-			"uid": "4tvc",
-			"version": "3",
+			"uid": "kuei",
+			"version": "4",
 			"name": "C-channel drive",
 			"description": "One C-channel drive unit: stator, NEMA bracket, gear train and stepper. 4 per machine \u2014 3 in the feeder plus the classification channel's. Drives a rotor unit, which differs by location and is not part of this node.",
 			"docs": "/hardware/assembly/feeder/c-channel/",
@@ -3596,7 +3596,62 @@
 					"date": "2026-09-01",
 					"message": "The screws are all countersunk \u2014 socket/button was recorded wrong. The idler's 608 bearing is a line of its own with its press fit as a connection, and the screw joints carry measured pass-through and thread depths. Connections bench-confirmed and listed in assembly order.",
 					"breaking": false,
-					"commit": "441d9114"
+					"commit": "441d9114",
+					"lines": [
+						{
+							"part": "idler-gear",
+							"qty": 1,
+							"uid": "7bv7"
+						},
+						{
+							"part": "brg-608-2rs",
+							"qty": 1,
+							"uid": "mi1l"
+						},
+						{
+							"part": "nema-bracket",
+							"qty": 1,
+							"uid": "x09t"
+						},
+						{
+							"part": "motor-nema17",
+							"qty": 1,
+							"uid": "w7pq"
+						},
+						{
+							"part": "input-gear",
+							"qty": 1,
+							"uid": "70ul"
+						},
+						{
+							"part": "stator",
+							"qty": 1,
+							"uid": "n6bm"
+						},
+						{
+							"part": "scr-m3-16-cs",
+							"qty": 3,
+							"uid": "bdi4"
+						},
+						{
+							"part": "scr-m3-8-cs",
+							"qty": 1,
+							"uid": "l6br"
+						},
+						{
+							"part": "scr-m3-12-cs",
+							"qty": 4,
+							"uid": "0a9x"
+						}
+					]
+				},
+				{
+					"version": "4",
+					"uid": "kuei",
+					"date": "2026-09-10",
+					"message": "The two bracket-to-stator screws on the wide motor plate go to M3 x 16 countersunk. The bracket's four stator holes come in two depths and all four were specified at 12 mm: over the 8.45 mm pass-through the head leaves 1.85 mm in the stator's 10 mm thread, under the 2 mm minimum bite the site's own fit math applies, and Extremetaz reported it as marginal on a build. The two arm holes (6.45 mm pass-through, 3.85 mm bite) keep the 12 mm.",
+					"breaking": false,
+					"commit": null
 				}
 			],
 			"lines": [
@@ -3626,7 +3681,7 @@
 				},
 				{
 					"part": "scr-m3-16-cs",
-					"qty": 3
+					"qty": 5
 				},
 				{
 					"part": "scr-m3-8-cs",
@@ -3634,7 +3689,7 @@
 				},
 				{
 					"part": "scr-m3-12-cs",
-					"qty": 4
+					"qty": 2
 				}
 			],
 			"connections": [
@@ -3668,17 +3723,18 @@
 					"qty": 2,
 					"method": "self-tap",
 					"through_mm": 6.45,
-					"thread_mm": 10
+					"thread_mm": 10,
+					"note": "The two holes at the tips of the bracket's narrow arms."
 				},
 				{
 					"from": "nema-bracket",
 					"to": "stator",
-					"via": "scr-m3-12-cs",
+					"via": "scr-m3-16-cs",
 					"qty": 2,
 					"method": "self-tap",
 					"through_mm": 8.45,
 					"thread_mm": 10,
-					"note": "The bracket's four stator holes come in two depths: two at 6.45 mm, two at 8.45 mm."
+					"note": "The bracket's four stator holes come in two depths: two at 6.45 mm, two at 8.45 mm. The deeper pair needs the 16 mm."
 				}
 			]
 		},


### PR DESCRIPTION
**Requested by Extremetaz (@extremetaz) [from Discord](https://discord.com/channels/1430279849171222682/1525928562971115601/1547585009034985583): "I'm going through the c-channel assembly doc as I progress here and I note that at step 5 m3x12 countersunk is prescribed at all 4 points in fastening the stator to the bracket. 12mm in countersunk works for the two holes on the arms however it is marginal for the two at the trunk of the bracket. Recommend we upsize these two to 16mm."**

He is right, and the catalog already held the evidence without anyone drawing the conclusion from it.

## Measured

Off the pinned masters `nema-bracket-8b2bea87360e.stl` (v2) and `stator-323b2d1f94a5.stl`, in shared assembly coordinates. The bracket's four Ø3.4 clearance holes sit on the stator's four thread-forming holes, and the four are not the same joint four times: two are plain countersinks in the 8 mm arms, two are countersinks at the top of a Ø6.4 counterbore through the thicker plate the stepper sits on.

| | arm pair, (111.4, 5.7) and (-67.0, 89.2) | trunk pair, (-13.7, -110.9) and (-76.4, -81.5) |
|---|---|---|
| head seat, i.e. countersink mouth | z −19.00, the bracket's own bottom face | z −12.15, 6.85 mm up a Ø6.4 counterbore |
| bracket face against the stator | z −11.00 | z −2.20 |
| head seat to that face | **8.00 mm** | **9.95 mm** |
| stator thread-forming hole | z −11.00 to −1.00, 10 mm deep | z −2.20 to +7.80, 10 mm deep |
| thread an M3 × 12 CS reaches | 4.00 mm | **2.05 mm** |
| thread an M3 × 16 CS reaches | 8.00 mm (2.00 mm spare) | 6.05 mm (3.95 mm spare) |

The asymmetry was already recorded: `c-channel` v3 (#516) split this joint into two `connections` edges with `through_mm` 6.45 and 8.45, and a note saying so. `through_mm` excludes the countersink cone by definition, which is the same 8.00 and 9.95 measured above less the 1.55/1.50 mm cones. What did not follow was the fastener, and both edges kept pointing at `scr-m3-12-cs`.

**The site has been rendering that joint as out of range since.** `ConnectionBraces.svelte` computes a valid length as `through_mm + 2 mm` minimum bite up to `through_mm + thread_mm`, and `screwTravel` in `src/lib/filament.ts` gives an M3 countersunk 12 a travel of 12 − 1.7 = 10.3 mm against a 10.45 mm minimum on the 8.45 mm edge. So the [assembly page](https://parts-calculator.basically.website/assembly?focus=c-channel) already said this in orange, on the deeper of the two edges. Extremetaz found it with a screwdriver first.

## The change

- **`c-channel` v3 → v4.** `scr-m3-12-cs` 4 → 2, `scr-m3-16-cs` 3 → 5, and the 8.45 mm edge's `via` moves to the 16. Both lengths were already lines on this assembly, so nothing new enters the BOM. Not breaking: a channel built before this is still a channel.
- **v4's `commit` is left `null` deliberately**, for whoever runs `stamp_versions.py` after the merge. The board squashes, so a hash written on a branch is unreachable afterwards and reds the next Pages build (sorter-v2#559).
- **Docs step 5** now says which two holes take which length and how to tell them apart, and the frontmatter counts follow: 40 → 32 × M3 × 12 CS and 12 → 20 × M3 × 16 CS per machine.

## Not filed as a defect

The bracket is fine as printed and a 16 fits both holes with room at the bottom, so this is the catalog naming the wrong fastener rather than a CAD problem: the fix is the edit, not a `changes` entry or a `cad` issue. Same class of error as the output gear's M3 × 8 that reached nothing (#378, #386), and worth the same general check on any countersunk joint, because a countersunk screw's nominal length includes its head.

Unrelated and still open on these same four stator holes: `open-stator-bracket-holes` (P0, broken), the Ø2.4 pilots that are under M3's thread root. This PR does not touch it.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1525928562971115601/1547585009034985583
preview: /hardware/assembly/feeder/c-channel/
-->
