### PR TITLE
docs(top-interface): remove the duplicate og_image key that broke the frontmatter

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -10,7 +10,6 @@ permalink: /hardware/assembly/distribution/top-interface/
 og_image: https://assets.basically.website/sorter-docs/assembly-top-interface-framing-4-full-b9ae16940954.jpg
 author: zed0
 contributors: [barthel, brickcyclealice]
-og_image: https://assets.basically.website/sorter-docs/assembly-top-interface-framing-4-full-b9ae16940954.jpg
 parts_needed:
   - part: interface-upper-fixed-section
     qty: 1


### PR DESCRIPTION
`top-interface.md` picked up a second `og_image:` line in #620. js-yaml throws on a duplicated mapping key, so `parseFrontmatter` in `docs/src/lib/server/content.ts` swallowed the error and fell back to its flat `key: value` reader, which turns every value into a string. On the live page that meant:

- **Parts needed is gone entirely.** `parts_needed:` parsed as the empty string, so all 54 entries disappeared and the section never rendered.
- **Tools needed renders one bullet per letter.** `tools_needed: [Hex key, Soldering iron or heat-set insert press]` became the literal string, and the template iterated its characters.
- **The byline** read `[barthel, brickcyclealice]` as a single contributor name.

This deletes the duplicate line. Nothing else changes, and the remaining `og_image:` is byte-identical to the one removed.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1547532333983465473/1547591718092939347):** "https://docs.basically.website/hardware/assembly/distribution/top-interface/ is broken"

The duplicate came in with #620, whose merged diff re-added the line at its old position while `main` already carried it at line 10 after #623 moved it.

## Checks

`npm run check` 0 errors (same 4 pre-existing a11y warnings in `Requirements.svelte`), `docs/scripts/validate_images.py` clean at 245 assets. Against `npm run dev` locally the page now renders **Parts needed** with 54 rows and **Tools needed** as two items.

Worth someone's judgement separately: that `catch` in `parseFrontmatter` turns a YAML error into a silently half-rendered page, and no check caught it. Failing the build, or at least warning, would have.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1547532333983465473/1547591718092939347
preview: /hardware/assembly/distribution/top-interface/
-->
