### PR TITLE
docs: the top interface's lead figure repeated its own result photo

### DIFF
--- a/docs/src/content/hardware/assembly/distribution/top-interface.md
+++ b/docs/src/content/hardware/assembly/distribution/top-interface.md
@@ -124,11 +124,6 @@ tools_needed: [Hex key, Soldering iron or heat-set insert press]
 
 The top interface holds a chute that rotates on a lazy-susan bearing to aim incoming parts at whichever bin layer is currently selected. A NEMA 23 stepper drives the rotation through a small gear train (steps 6 and 9), and a limit switch and hammer (steps 4, 6, 8) give it a fixed reference point to home against, since the stepper alone has no way to know which way it is pointed. Everything on this page bolts onto the Top plate, which then sits on the hex frame built on the bin-frame page.
 
-<figure class="single-figure">
-  <img class="doc-figure" src="https://assets.basically.website/sorter-docs/assembly-top-interface-framing-4-full-b9ae16940954.jpg" alt="The finished top interface seen from above: the hexagonal aluminum frame around the plywood Top plate, six interface ribs radiating from the centre, and the white chute mount in the middle">
-  <figcaption>What this page builds, finished: the interface under its hex frame, ready for the top layer. <cite>Photo: zed0.</cite></figcaption>
-</figure>
-
 <div class="prep-item">
   <div class="prep-item-body">
     <p><strong>Have a <a href="{{ '/hardware/assembly/distribution/bin-frame/hex-frame/' | relative_url }}">hex frame</a> ready by step 13.</strong> It's a required component of this page — step 13 places one onto the assembly, it doesn't build one. The rest of this page (steps 1-12, 14+) doesn't need it.</p>


### PR DESCRIPTION
**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1547315250515157095/1547602127243710644): "Remove the first instance of the image `assembly-top-interface-framing-4-full-b9ae16940954.jpg` from the top interface".**

That picture was on `top-interface.md` **three times**: as the lead figure under the intro, in step 13 under a second name (`assembly-top-interface-framing-3-full-b9ae16940954.jpg`, byte-identical, captioned "A hex frame lowered onto the interface assembly"), and in the finished result at the foot of the page. This removes the first of the three, the lead figure.

`og_image` already points at the result copy, so the page's link preview is unchanged.

**Still duplicated, not touched here:** step 13 and the finished result are the same bytes under two names. Flagged to barthel [in the thread](https://discord.com/channels/1430279849171222682/1547315250515157095/1547602127243710644); one of the two wants a different photo rather than a deletion, which is a decision rather than a fix.

This follows sorter-v2#612, which merged at 09:14 UTC while the thread was still running.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1547315250515157095/1547602127243710644
preview: /hardware/assembly/distribution/top-interface/
-->
