### PR TITLE
catalog: the camera lamp parts still counted four lamps, not three

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5871,7 +5871,7 @@
       "created_at": "2026-09-02",
       "description": "Top half of the clasp that holds a camera board inside the Camera lamp.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {
@@ -5888,7 +5888,7 @@
       "created_at": "2026-09-02",
       "description": "Bottom half of the clasp that holds a camera board inside the Camera lamp.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {
@@ -5905,7 +5905,7 @@
       "created_at": "2026-09-02",
       "description": "Mounts the Camera lamp arm onto a C-channel.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {
@@ -5922,7 +5922,7 @@
       "created_at": "2026-09-02",
       "description": "The arm that hangs the camera and the shaded lamp over a C-channel.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {
@@ -5939,7 +5939,7 @@
       "created_at": "2026-09-02",
       "description": "Ties the arm to the C-channel arm mount: four through holes, two into each.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {
@@ -5956,7 +5956,7 @@
       "created_at": "2026-09-02",
       "description": "Ties the arm to the C-channel arm mount: four through holes, two into each.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {
@@ -5973,7 +5973,7 @@
       "created_at": "2026-09-02",
       "description": "The ring on the end of the Camera lamp arm; four through holes into the arm.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {
@@ -5990,7 +5990,7 @@
       "created_at": "2026-09-02",
       "description": "The white reflector that bounces the LED light down onto the channel.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {
@@ -6007,7 +6007,7 @@
       "created_at": "2026-09-02",
       "description": "Friction-fits onto the inner reflector and retains an LED strip. Six per lamp.",
       "quantities": {
-        "feeder": 18,
+        "feeder": 12,
         "classification-channel": 6
       },
       "color": {
@@ -6024,7 +6024,7 @@
       "created_at": "2026-09-02",
       "description": "The cover that goes over the reflector; the outside of the shaded lamp.",
       "quantities": {
-        "feeder": 3,
+        "feeder": 2,
         "classification-channel": 1
       },
       "color": {

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -18131,7 +18131,7 @@
 			"uid": "u816",
 			"name": "Camera clasp top",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,
@@ -18246,7 +18246,7 @@
 			"uid": "zub8",
 			"name": "Camera clasp bottom",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,
@@ -18383,7 +18383,7 @@
 			"uid": "yswm",
 			"name": "C-channel arm mount",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,
@@ -18516,7 +18516,7 @@
 			"uid": "4ata",
 			"name": "Camera lamp arm",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,
@@ -18652,7 +18652,7 @@
 			"uid": "ntbe",
 			"name": "Arm bracket A",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,
@@ -18787,7 +18787,7 @@
 			"uid": "g2mu",
 			"name": "Arm bracket B",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,
@@ -18922,7 +18922,7 @@
 			"uid": "sb0m",
 			"name": "Camera lamp ring",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,
@@ -19059,7 +19059,7 @@
 			"uid": "4vio",
 			"name": "Lamp inner reflector",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,
@@ -19225,7 +19225,7 @@
 			"uid": "l5qn",
 			"name": "Inner reflector LED hook",
 			"quantities": {
-				"feeder": 18,
+				"feeder": 12,
 				"classification-channel": 6
 			},
 			"assembly": null,
@@ -19277,7 +19277,7 @@
 			"uid": "8zqy",
 			"name": "Lamp outer cover",
 			"quantities": {
-				"feeder": 3,
+				"feeder": 2,
 				"classification-channel": 1
 			},
 			"assembly": null,


### PR DESCRIPTION
**Reported by barthel (@uwe_barthel)** in [#bom](https://discord.com/channels/1430279849171222682/1477417230235861104/1547688367154536549):

> In the parts catalog, the components of the camera lamp are listed three times in the feeder section and once more in the classification channel. Does that mean the entire machine gets four camera lamps? I think there are too many parts for one camera lamp in the feeder, since the bulk bucket channel doesn't get one, right?

He is right on both counts.

## What was wrong

[#604](https://github.com/basicallysource/sorter-v2/pull/604) (`93451a97`, 2026-09-08) took the camera lamp off C1 after Jon confirmed the machine takes three. It removed the `camera-lamp` line from the `bulk-bucket` assembly, stamped it v5, and rewrote the descriptions and the docs pages. It did not touch the per-part `quantities`, which is the field the calculator actually counts and prices off, so every camera lamp part has read `feeder: 3, classification-channel: 1` since. #604's own body spells out the intended numbers ("3 each of the mount, arm, brackets A and B, ring, both clasp halves, reflector and cover, 18 LED hooks rather than 24") and then leaves them unwritten.

The mismatch was visible, not just latent. `buildUses()` places each part into the assembly tree up to the number the sections call for and files the remainder under **"Not in the assembly tree yet"**, so every camera lamp part carried a phantom extra use. Walking the tree from `machine` against `origin/main`:

`camera-lamp-arm` quantities say 4, tree places 3. Same for the mount, both brackets, the ring, both clasp halves, the inner reflector and the outer cover. `inner-reflector-led-hook` says 24, tree places 18.

## What changed

Ten printed parts, `quantities.feeder` only. Nothing else in the catalog moves.

`c-channel-arm-mount`, `camera-lamp-arm`, `arm-bracket-a`, `arm-bracket-b`, `camera-lamp-ring`, `camera-clasp-bottom`, `camera-clasp-top`, `lamp-inner-reflector`, `lamp-outer-cover`: `3` becomes `2`. Each is 1 per lamp, and the feeder holds two lamps (C2 and C3). With `classification-channel: 1` unchanged that is 3 per machine.

`inner-reflector-led-hook`: `18` becomes `12`. It is 6 per lamp, so 12 in the feeder and 6 in the classification channel, 18 per machine.

All ten are used only inside `camera-lamp`, so nothing else is affected. The OV9732 was already correct at 2 per machine, and the IMX415 at 1.

## No version stamp

`VERSIONING.md`'s stamp rule covers an assembly's `lines` and a part's `uid`. Neither moves here: no geometry changed, no membership changed, and the assembly that owns the lines (`bulk-bucket`) was already stamped v5 by #604. This commit only corrects the count field that should have moved with it. `check_versioning.py` agrees.

## Checks

`generate.py --metadata-only` regenerated `catalog.generated.json` in the same commit; the diff is exactly the same ten lines. Its three self-checks pass (`check_generated_pins.py` on 115 pinned parts, `check_versioning.py`, `check_connections.py` on 59 edges). `npm run check` is clean, 0 errors 0 warnings over 4389 files. Re-walked the tree afterwards: quantities and tree placements now agree for all ten parts.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1477417230235861104/1547688367154536549
preview: /assembly?focus=camera-lamp
-->
