### PR TITLE
parts-calculator: the changes banner counts only open changes

### DIFF
--- a/parts-calculator/src/lib/filament.ts
+++ b/parts-calculator/src/lib/filament.ts
@@ -444,6 +444,10 @@ export function commitUrl(commit: string | null | undefined): string | null {
 export const SETTINGS = raw.settings as Settings;
 export const SECTIONS = raw.sections as Section[];
 export const CHANGES = ((raw as Record<string, unknown>).changes ?? []) as PlannedChange[];
+/** The changes still outstanding. A change with `status: 'complete'` is
+ *  already in the models, so it is history, not something to wait for before
+ *  printing: everything that counts or warns about changes counts these. */
+export const OPEN_CHANGES = CHANGES.filter((change) => change.status !== 'complete');
 export const FOLDERS = ((raw as Record<string, unknown>).folders ?? []) as Folder[];
 export const COLOR_ROLES = raw.color_roles as ColorRoleDef[];
 /** A blessed moment of a node's whole subtree — resolved against history like
@@ -464,8 +468,7 @@ export const ASSEMBLIES = (raw.assemblies ?? []) as Assembly[];
 export const PARTS = raw.parts as unknown as Part[];
 export const MERGES = ((raw as Record<string, unknown>).merges ?? []) as CatalogMerge[];
 export function plannedChangesFor(kind: ChangeTargetKind, id: string): PlannedChange[] {
-	return CHANGES.filter((change) => {
-		if (change.status === 'complete') return false;
+	return OPEN_CHANGES.filter((change) => {
 		if (change.targets[kind]?.includes(id)) return true;
 		if (kind !== 'parts') return false;
 		const part = PARTS.find((candidate) => candidate.id === id);

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -2,7 +2,7 @@
 	import {
 		PARTS,
 		SECTIONS,
-		CHANGES,
+		OPEN_CHANGES,
 		COLOR_ROLES,
 		SETTINGS,
 		STORE_URL,
@@ -767,10 +767,12 @@
 			</div>
 
 			{#if activeTab === 'parts'}
-				<a href="/changes" class="mb-4 flex items-center justify-between gap-4 border border-warning/60 bg-warning/[0.08] px-4 py-3 text-sm text-text transition-colors hover:bg-warning/[0.14]">
-					<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
-					<span class="shrink-0 font-semibold text-primary">View {CHANGES.length} potential changes →</span>
-				</a>
+				{#if OPEN_CHANGES.length}
+					<a href="/changes" class="mb-4 flex items-center justify-between gap-4 border border-warning/60 bg-warning/[0.08] px-4 py-3 text-sm text-text transition-colors hover:bg-warning/[0.14]">
+						<span><b>Changes and improvements are tracked for some parts.</b> Review what is planned before printing.</span>
+						<span class="shrink-0 font-semibold text-primary">View {OPEN_CHANGES.length} potential {OPEN_CHANGES.length === 1 ? 'change' : 'changes'} →</span>
+					</a>
+				{/if}
 				<div class="mb-4 flex flex-wrap items-center gap-2">
 					<div class="inline-flex border border-border">
 						<button

--- a/parts-calculator/src/routes/changes/+page.svelte
+++ b/parts-calculator/src/routes/changes/+page.svelte
@@ -6,7 +6,7 @@
 	import ImageStrip from '$lib/components/ImageStrip.svelte';
 	import PartDetailModal from '$lib/components/PartDetailModal.svelte';
 	import Seo from '$lib/components/Seo.svelte';
-	import { ASSEMBLIES, CHANGES, HARDWARE, PARTS, SECTIONS, fmtDate, hardwareImage, type ChangeTargetKind, type Part, type PartVersion, type PlannedChange } from '$lib/filament';
+	import { ASSEMBLIES, CHANGES, HARDWARE, OPEN_CHANGES, PARTS, SECTIONS, fmtDate, hardwareImage, type ChangeTargetKind, type Part, type PartVersion, type PlannedChange } from '$lib/filament';
 	import { LASER_CUT_PARTS } from '$lib/lasercut';
 
 	const partNames = new Map(PARTS.map((part) => [part.id, part.name]));
@@ -19,7 +19,7 @@
 		if (priority) return priority;
 		return Number(b.condition === 'broken') - Number(a.condition === 'broken');
 	}
-	const plannedChanges = CHANGES.filter((change) => change.status !== 'complete').sort(byPriority);
+	const plannedChanges = [...OPEN_CHANGES].sort(byPriority);
 	const completedChanges = CHANGES.filter((change) => change.status === 'complete').sort((a, b) =>
 		(b.completed_at ?? '').localeCompare(a.completed_at ?? '') || a.name.localeCompare(b.name)
 	);


### PR DESCRIPTION
The banner above the parts list on `/` counted `CHANGES.length`, which is every entry in the catalog's `changes` list including the ones already marked `status: "complete"`. Right now that is 29 entries, 7 of them complete, so it advertised 29 potential changes when only 22 are actually outstanding. The `/changes` page it links to has always split the two, so the number on the banner disagreed with the page one click away.

**What changed**

- `OPEN_CHANGES` is now exported from `src/lib/filament.ts`: `CHANGES` minus anything with `status: 'complete'`. That predicate already existed in two places and is now one.
- The banner counts `OPEN_CHANGES.length` (22), singularises at one, and is hidden entirely when nothing is open, instead of reading "View 0 potential changes".
- `/changes` and `plannedChangesFor()` (the per-part warnings) both use the shared constant. Neither changes behaviour, both were already filtering completes out.

No catalog data touched, so no regenerate. `npm run check` is clean.

Reported by zed0 in #balloon-does-docs: https://discord.com/channels/1430279849171222682/1536088194557419660/1547873739444592651

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1536088194557419660/1547873739444592651
preview: /
-->
