### PR TITLE
parts-calculator: name the LEGO colour each filament colour matches

### DIFF
--- a/parts-calculator/src/lib/bambu-colors.ts
+++ b/parts-calculator/src/lib/bambu-colors.ts
@@ -2,42 +2,58 @@
  * Bambu Lab PLA Matte color palette — names + hex from Bambu's official
  * PLA Matte hex-code table. Used by the filament color pickers so choices map to
  * actual orderable Bambu filament.
+ *
+ * `lego` is the nearest LEGO color, in BrickLink naming, for people who know
+ * "light bluish gray" but not "Ash Gray". It is only set where the match is a
+ * real one: nearest BrickLink solid color by CIEDE2000 over the two hexes, kept
+ * only at dE <= 6, which is close enough that the two read as the same color.
+ * A filament with no close LEGO counterpart (Plum, Scarlet Red, Marine Blue,
+ * Bone White...) has no `lego` and shows nothing, rather than a misleading
+ * "closest". Charcoal is the one hand-set entry: pure #000000 against LEGO
+ * Black #05131D computes as dE 7.9 because dE is exaggerated at the black end,
+ * and in filament it is simply black.
  */
-export type BambuColor = { id: string; name: string; hex: string };
+export type BambuColor = {
+	id: string;
+	name: string;
+	hex: string;
+	/** nearest LEGO color in BrickLink naming, only where it is a real match */
+	lego?: { name: string; hex: string; de: number };
+};
 
 export const DEFAULT_COLOR_ID = 'charcoal';
 
 export const BAMBU_COLORS: readonly BambuColor[] = [
 	// whites / tans / browns
-	{ id: 'ivory-white', name: 'Ivory White', hex: '#FFFFFF' },
+	{ id: 'ivory-white', name: 'Ivory White', hex: '#FFFFFF', lego: { name: 'White', hex: '#FFFFFF', de: 0.0 } },
 	{ id: 'bone-white', name: 'Bone White', hex: '#CBC6B8' },
-	{ id: 'desert-tan', name: 'Desert Tan', hex: '#E8DBB7' },
+	{ id: 'desert-tan', name: 'Desert Tan', hex: '#E8DBB7', lego: { name: 'Tan', hex: '#E4CD9E', de: 5.1 } },
 	{ id: 'latte-brown', name: 'Latte Brown', hex: '#D3B7A7' },
-	{ id: 'caramel', name: 'Caramel', hex: '#AE835B' },
-	{ id: 'terracotta', name: 'Terracotta', hex: '#B15533' },
-	{ id: 'dark-brown', name: 'Dark Brown', hex: '#7D6556' },
-	{ id: 'dark-chocolate', name: 'Dark Chocolate', hex: '#4D3324' },
+	{ id: 'caramel', name: 'Caramel', hex: '#AE835B', lego: { name: 'Medium Nougat', hex: '#AA7D55', de: 2.0 } },
+	{ id: 'terracotta', name: 'Terracotta', hex: '#B15533', lego: { name: 'Dark Nougat', hex: '#AD6140', de: 3.8 } },
+	{ id: 'dark-brown', name: 'Dark Brown', hex: '#7D6556', lego: { name: 'Medium Brown', hex: '#755945', de: 4.8 } },
+	{ id: 'dark-chocolate', name: 'Dark Chocolate', hex: '#4D3324', lego: { name: 'Brown', hex: '#583927', de: 3.0 } },
 	// purples / pinks / orange / yellow
 	{ id: 'lilac-purple', name: 'Lilac Purple', hex: '#AE96D4' },
-	{ id: 'sakura-pink', name: 'Sakura Pink', hex: '#E8AFCF' },
+	{ id: 'sakura-pink', name: 'Sakura Pink', hex: '#E8AFCF', lego: { name: 'Bright Pink', hex: '#E4ADC8', de: 1.6 } },
 	{ id: 'mandarin-orange', name: 'Mandarin Orange', hex: '#F99963' },
-	{ id: 'lemon-yellow', name: 'Lemon Yellow', hex: '#F7D959' },
+	{ id: 'lemon-yellow', name: 'Lemon Yellow', hex: '#F7D959', lego: { name: 'Yellow', hex: '#F2CD37', de: 3.6 } },
 	{ id: 'plum', name: 'Plum', hex: '#950051' },
 	// reds / greens
 	{ id: 'scarlet-red', name: 'Scarlet Red', hex: '#DE4343' },
 	{ id: 'dark-red', name: 'Dark Red', hex: '#BB3D43' },
 	{ id: 'dark-green', name: 'Dark Green', hex: '#68724D' },
 	{ id: 'grass-green', name: 'Grass Green', hex: '#61C680' },
-	{ id: 'apple-green', name: 'Apple Green', hex: '#C2E189' },
+	{ id: 'apple-green', name: 'Apple Green', hex: '#C2E189', lego: { name: 'Yellowish Green', hex: '#DFEEA5', de: 5.5 } },
 	// blues
 	{ id: 'ice-blue', name: 'Ice Blue', hex: '#A3D8E1' },
-	{ id: 'sky-blue', name: 'Sky Blue', hex: '#56B7E6' },
+	{ id: 'sky-blue', name: 'Sky Blue', hex: '#56B7E6', lego: { name: 'Sky Blue', hex: '#7DBFDD', de: 5.1 } },
 	{ id: 'marine-blue', name: 'Marine Blue', hex: '#0078BF' },
-	{ id: 'dark-blue', name: 'Dark Blue', hex: '#042F56' },
+	{ id: 'dark-blue', name: 'Dark Blue', hex: '#042F56', lego: { name: 'Dark Blue', hex: '#0A3463', de: 2.3 } },
 	// grays / black
-	{ id: 'ash-gray', name: 'Ash Gray', hex: '#9B9EA0' },
-	{ id: 'nardo-gray', name: 'Nardo Gray', hex: '#757575' },
-	{ id: 'charcoal', name: 'Charcoal', hex: '#000000' }
+	{ id: 'ash-gray', name: 'Ash Gray', hex: '#9B9EA0', lego: { name: 'Light Bluish Gray', hex: '#A0A5A9', de: 2.4 } },
+	{ id: 'nardo-gray', name: 'Nardo Gray', hex: '#757575', lego: { name: 'Dark Bluish Gray', hex: '#6C6E68', de: 5.0 } },
+	{ id: 'charcoal', name: 'Charcoal', hex: '#000000', lego: { name: 'Black', hex: '#05131D', de: 0 } }
 ];
 
 export function getBambuColor(id: string | null | undefined): BambuColor {

--- a/parts-calculator/src/lib/components/ColorPicker.svelte
+++ b/parts-calculator/src/lib/components/ColorPicker.svelte
@@ -36,7 +36,7 @@
 		<span class="min-w-0 flex-1 leading-tight">
 			{current.name}
 			{#if current.lego}
-				<span class="block truncate text-[11px] text-text-muted">LEGO {current.lego.name}</span>
+				<span class="block text-[11px] leading-tight text-text-muted">LEGO {current.lego.name}</span>
 			{/if}
 		</span>
 		<span class="text-text-muted">▾</span>

--- a/parts-calculator/src/lib/components/ColorPicker.svelte
+++ b/parts-calculator/src/lib/components/ColorPicker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { BAMBU_COLORS, getBambuColor } from '$lib/bambu-colors';
+	import { BAMBU_COLORS, getBambuColor, type BambuColor } from '$lib/bambu-colors';
 
 	let {
 		value = $bindable(),
@@ -8,6 +8,10 @@
 
 	let open = $state(false);
 	const current = $derived(getBambuColor(value));
+
+	// LEGO builders know "light bluish gray", not "Ash Gray", so every swatch that
+	// has a real LEGO counterpart names it (BrickLink naming, see bambu-colors.ts).
+	const legoTitle = (c: BambuColor) => (c.lego ? `${c.name} · LEGO ${c.lego.name}` : c.name);
 
 	function pick(id: string) {
 		value = id;
@@ -28,8 +32,13 @@
 		class="setup-control flex w-full items-center gap-2 px-3 text-left text-sm"
 		onclick={() => (open = !open)}
 	>
-		<span class="h-5 w-5 border border-border" style="background:{current.hex}"></span>
-		<span class="flex-1">{current.name}</span>
+		<span class="h-5 w-5 shrink-0 border border-border" style="background:{current.hex}"></span>
+		<span class="min-w-0 flex-1 leading-tight">
+			{current.name}
+			{#if current.lego}
+				<span class="block truncate text-[11px] text-text-muted">LEGO {current.lego.name}</span>
+			{/if}
+		</span>
 		<span class="text-text-muted">▾</span>
 	</button>
 
@@ -40,7 +49,7 @@
 			{#each BAMBU_COLORS as c (c.id)}
 				<button
 					type="button"
-					title={c.name}
+					title={legoTitle(c)}
 					onclick={() => pick(c.id)}
 					class="h-7 w-7 border {c.id === value
 						? 'border-primary ring-2 ring-primary'

--- a/parts-calculator/src/lib/components/PartDetail.svelte
+++ b/parts-calculator/src/lib/components/PartDetail.svelte
@@ -119,7 +119,7 @@
 		<StlViewer bind:this={viewer} url={activeStl} color={getBambuColor(colorId).hex} mark={stamp} heightClass={variant === 'modal' ? 'h-[45vh] lg:h-[76vh]' : 'h-[60vh]'} />
 		<div class="pointer-events-none absolute inset-x-3 top-3 flex flex-wrap items-start justify-between gap-2">
 			<IdStamp where="viewport" uid={candidate?.uid ?? part.uid} {stamps} bind:on={stampOn} bind:faceIdx onView={() => viewer?.viewMark()} onReset={() => viewer?.resetView()} />
-			<div class="pointer-events-auto ml-auto w-48 border border-border bg-[var(--color-surface)]/95 px-2.5 py-1.5 shadow-sm backdrop-blur"><ColorPicker bind:value={colorId} label="Preview color" /></div>
+			<div class="pointer-events-auto ml-auto w-56 border border-border bg-[var(--color-surface)]/95 px-2.5 py-1.5 shadow-sm backdrop-blur"><ColorPicker bind:value={colorId} label="Preview color" /></div>
 		</div>
 		{/snippet}
 

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -1040,7 +1040,7 @@
 							<td>
 								<span class="flex items-center gap-2">
 									<span class="pl-chip pl-chip-lg" style="background:{line.color?.hex ?? 'repeating-linear-gradient(45deg,#ccc,#ccc 3px,#eee 3px,#eee 6px)'}"></span>
-									<span class="leading-tight">{line.label}<br><span class="pl-buy-sub">{grams(line.grams)}{#if line.color?.lego} · LEGO {line.color.lego.name}{/if}</span></span>
+									<span class="leading-tight">{line.label}<br><span class="pl-buy-sub">{grams(line.grams)}</span>{#if line.color?.lego}<br><span class="pl-buy-lego">LEGO {line.color.lego.name}</span>{/if}</span>
 								</span>
 							</td>
 							<td class="pl-num pl-num-strong">{line.spools}</td>
@@ -1285,6 +1285,8 @@
 	.pl-buy .pl-num { text-align: right; font-variant-numeric: tabular-nums; }
 	.pl-buy .pl-num-strong { font-weight: 500; }
 	.pl-buy-sub { font-size: 0.8125rem; color: color-mix(in oklab, var(--color-text-muted) 85%, transparent); }
+	/* the LEGO colour this filament matches, for people who shop in brick colours */
+	.pl-buy-lego { font-size: 0.6875rem; white-space: nowrap; color: color-mix(in oklab, var(--color-text-muted) 75%, transparent); }
 	.pl-buy-empty { text-align: center; color: var(--color-text-muted); padding: 1.25rem; }
 	.pl-buy tfoot td {
 		border-top: 1px solid var(--color-border);

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -595,6 +595,11 @@
 					Each color picker sets every part in that group. Parts that must be a specific color —
 					stators, rotors, light post caps, the classification dome, the lazy-Susan chute mount — keep
 					their required color and aren't affected.
+					<span class="mt-2 block border-t border-border pt-2">
+						Names are Bambu Lab PLA Matte. The grey line under a color is the LEGO color it matches,
+						in BrickLink naming, so Ash Gray is light bluish gray. Only colors with a genuinely close
+						LEGO counterpart show one.
+					</span>
 				</Popover>
 			</div>
 			<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">

--- a/parts-calculator/src/routes/+page.svelte
+++ b/parts-calculator/src/routes/+page.svelte
@@ -1040,7 +1040,7 @@
 							<td>
 								<span class="flex items-center gap-2">
 									<span class="pl-chip pl-chip-lg" style="background:{line.color?.hex ?? 'repeating-linear-gradient(45deg,#ccc,#ccc 3px,#eee 3px,#eee 6px)'}"></span>
-									<span class="leading-tight">{line.label}<br><span class="pl-buy-sub">{grams(line.grams)}</span></span>
+									<span class="leading-tight">{line.label}<br><span class="pl-buy-sub">{grams(line.grams)}{#if line.color?.lego} · LEGO {line.color.lego.name}{/if}</span></span>
 								</span>
 							</td>
 							<td class="pl-num pl-num-strong">{line.spools}</td>


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1487518366020276397/1547695254403293184
request: https://discord.com/channels/1430279849171222682/1547695254403293184/1547887027117367419
preview: /
-->
**Requested by BrickCycleAlice (@brickcyclealice) [from Discord](https://discord.com/channels/1430279849171222682/1547695254403293184/1547887027117367419):** "can we put a tool tip somewhere near ash grey somewhere in the parts calculator so that Lego people can understand what ash grey means, in Lego talk, bricklink naming convention is fined".

It came out of [barthel asking which Bambu grey the stators and rotors take](https://discord.com/channels/1430279849171222682/1487518366020276397/1547695254403293184) and [Alice then asking how those greys sit against LEGO's own](https://discord.com/channels/1430279849171222682/1547695254403293184/1547878107027869697): the answer people actually want is "light bluish gray", which nothing in the calculator said.

### What changes

- `BambuColor` gains an optional `lego: { name, hex, de }`.
- The colour picker shows `LEGO Light Bluish Gray` in muted text under the colour's name, and each swatch's tooltip reads `Ash Gray · LEGO Light Bluish Gray`. That picker is also the **Preview color** control on every part page, so opening the stator now says what Ash Gray is in brick terms.
- **What to order** names it under each spool line too, since that is the list somebody takes to a shop, and it is visible without opening a panel.
- The existing **Colors** info popover explains the line in one sentence.

### How the mapping was made

Nearest BrickLink solid colour to each filament hex by **CIEDE2000**, kept only at **ΔE ≤ 6**, so the label is a claim that the two read as the same colour rather than "here is the closest thing in the list". BrickLink names and hexes come from the colour reference in the sorter's own parts catalog (BrickLink colour ids, so the naming is BrickLink's); trans, chrome, pearl, speckle, Modulex and theme-only colours (Bionicle, Fabuland, Clikits) were excluded as candidates.

The 14 that get a label:

| Filament (PLA Matte) | LEGO (BrickLink) | ΔE2000 |
|---|---|---|
| Ivory White `#FFFFFF` | White `#FFFFFF` | 0.0 |
| Desert Tan `#E8DBB7` | Tan `#E4CD9E` | 5.1 |
| Caramel `#AE835B` | Medium Nougat `#AA7D55` | 2.0 |
| Terracotta `#B15533` | Dark Nougat `#AD6140` | 3.8 |
| Dark Brown `#7D6556` | Medium Brown `#755945` | 4.8 |
| Dark Chocolate `#4D3324` | Brown `#583927` | 3.0 |
| Sakura Pink `#E8AFCF` | Bright Pink `#E4ADC8` | 1.6 |
| Lemon Yellow `#F7D959` | Yellow `#F2CD37` | 3.6 |
| Apple Green `#C2E189` | Yellowish Green `#DFEEA5` | 5.5 |
| Sky Blue `#56B7E6` | Sky Blue `#7DBFDD` | 5.1 |
| Dark Blue `#042F56` | Dark Blue `#0A3463` | 2.3 |
| Ash Gray `#9B9EA0` | Light Bluish Gray `#A0A5A9` | 2.4 |
| Nardo Gray `#757575` | Dark Bluish Gray `#6C6E68` | 5.0 |
| Charcoal `#000000` | Black `#05131D` | (hand-set) |

Charcoal is the one hand-set entry: `#000000` against LEGO Black `#05131D` computes as ΔE 7.9 because the metric exaggerates differences at the black end, and in filament it is simply black.

The 11 with no close counterpart show nothing rather than a misleading "closest": Bone White (nearest Very Light Gray, ΔE 7.1), Latte Brown (Light Nougat, 10.5), Lilac Purple (Light Lilac, 7.5), Mandarin Orange (Nougat, 7.9), Plum (Magenta, 10.0), Scarlet Red (Dark Salmon, 8.8), Dark Red (Red, 11.3), Dark Green (Dark Gray, 7.5), Grass Green (Medium Green, 6.3), Ice Blue (Aqua, 6.6), Marine Blue (Dark Azure, 7.4).

One caveat that belongs to the eye and not the numbers: matte PLA beside glossy ABS reads flatter and slightly lighter than the hex suggests.

`npm run check` passes (0 errors, 0 warnings).
