### PR TITLE
parts+docs: the control board housing fan screw length (ON HOLD, see banner)

### DIFF
--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -26,7 +26,7 @@ parts_needed:
     qty: 8
   - part: scr-m3-6-bhcs
     qty: 4
-  - part: scr-m3-12-bhcs
+  - part: scr-m3-16-shcs
     qty: 4
   - part: scr-m3-12-cs
     qty: 4
@@ -78,7 +78,7 @@ Sit the board on the four inner bosses and fix it with 4 {% include fastener.htm
 
 {% include step.html n="3" title="Fit the fan inside the cover" %}
 
-Fan on the inside of the cover, over the vent, label facing into the enclosure so it blows inwards. 4 {% include fastener.html size="M3" variant="button" length="12" %} screws, self-tapping into the plastic. Route the lead to the corner cutout.
+Fan on the inside of the cover, over the vent, label facing into the enclosure so it blows inwards. 4 {% include fastener.html size="M3" variant="button" length="16" %} screws, self-tapping into the cover's four bosses. Route the lead to the corner cutout.
 
 <div class="img-row">
   <figure>

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -2817,11 +2817,11 @@
       "id": "ctrl-board-housing-cover",
       "uid": "ksh2",
       "name": "Control Board Housing — Cover",
-      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 × 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 × 12 mm button head screws, and the plunger passes through it.",
+      "description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 × 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 × 16 mm socket/button head screws, and the plunger passes through it.",
       "internal_notes": "From 'control board housing.zip' (Sorter V2 STLs, 2026-08-22). Exists only inside candidate rns2 on ctrl-board-mount, so quantities stay empty and it stays out of the bundle until that candidate is promoted.",
       "version": "1",
       "created_at": "2026-08-22",
-      "updated_at": "2026-08-23",
+      "updated_at": "2026-09-12",
       "quantities": {
         "electronics": 1
       },
@@ -3387,9 +3387,9 @@
       "category": "Screws",
       "alternative": "Socket or button head",
       "image_url": "https://assets.basically.website/sorter-parts/scr-m3-16-shcs-full-26e52d7d5bcd.png",
-      "description": "No longer the C-channel stepper screw — those are countersunk (scr-m3-16-cs). Holds the 40 mm fan arm to the Orange Pi mount (2, into the mount's front-edge inserts) and the fan to the arm (4, self-tapping). The top-interface docs call for 2 to mount the roller-lever limit switch into its housing's inserts, though the limit-switch assembly records M3 × 12 button heads for that joint — one of the two is wrong; settle it at the bench.",
+      "description": "No longer the C-channel stepper screw — those are countersunk (scr-m3-16-cs). Holds the 40 mm fan arm to the Orange Pi mount (2, into the mount's front-edge inserts), the fan to the arm (4, self-tapping), and the 40 mm fan to the control board housing cover (4, self-tapping into the cover's bosses). The top-interface docs call for 2 to mount the roller-lever limit switch into its housing's inserts, though the limit-switch assembly records M3 × 12 button heads for that joint — one of the two is wrong; settle it at the bench.",
       "created_at": "2026-07-18",
-      "updated_at": "2026-09-01",
+      "updated_at": "2026-09-12",
       "attributes": [
         {
           "label": "Thread",
@@ -5724,9 +5724,9 @@
       },
       "name": "40 mm 24 V fan (WINSINN 4010)",
       "category": "Electronics",
-      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 × 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
+      "description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 × 16 mm socket/button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
       "created_at": "2026-08-22",
-      "updated_at": "2026-08-23",
+      "updated_at": "2026-09-12",
       "attributes": [
         {
           "label": "Size",
@@ -10039,8 +10039,8 @@
     },
     {
       "id": "ctrl-board-mount",
-      "uid": "rns2",
-      "version": "2",
+      "uid": "60ni",
+      "version": "3",
       "name": "basically Embedded Control Board Housing",
       "description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base — no bracket, no standoffs — and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
       "docs": "/hardware/electronics/installation/control-board-housing/",
@@ -10082,7 +10082,7 @@
           "qty": 1
         },
         {
-          "part": "scr-m3-12-bhcs",
+          "part": "scr-m3-16-shcs",
           "qty": 4
         },
         {
@@ -10097,7 +10097,7 @@
       "joining": [
         {
           "method": "self-tap",
-          "note": "The fan's four [[hw:scr-m3-12-bhcs]] cut their own threads in the cover; no inserts there."
+          "note": "The fan's four [[hw:scr-m3-16-shcs]] cut their own threads in the cover's bosses; no inserts there."
         }
       ],
       "versions": [
@@ -10156,6 +10156,13 @@
           "date": "2026-08-23",
           "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 × 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
           "commit": "9ff8a1e3"
+        },
+        {
+          "version": "3",
+          "date": "2026-09-12",
+          "message": "The fan's four screws go from M3 × 12 mm to M3 × 16 mm. The cover's fan bosses are 2.5 mm tall nubs standing off the inner face of the lid, each on a 2.5 mm pilot hole that runs 6.5 mm deep in total (2.5 mm through the nub, 4 mm into the 5 mm lid plate) and is blind with 1 mm of lid above it. The 4010 fan is 10 mm thick, so a 12 mm screw reaches only 2 mm in and takes the whole of that in the nub, whose wall is 1.75 mm; a 16 mm screw engages 6 mm, through the nub and 3.5 mm into the solid lid, stopping 0.5 mm short of the blind end. Reported from a build where a nub snapped off under a 12 mm screw. Nothing else in the assembly changes.",
+          "breaking": false,
+          "commit": null
         }
       ]
     },

--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -10153,9 +10153,72 @@
         },
         {
           "version": "2",
+          "uid": "rns2",
           "date": "2026-08-23",
           "message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 × 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
-          "commit": "9ff8a1e3"
+          "commit": "9ff8a1e3",
+          "lines": [
+            {
+              "part": "ctrl-board-housing-base",
+              "qty": 1,
+              "uid": "204b"
+            },
+            {
+              "part": "ctrl-board-basically",
+              "qty": 1,
+              "uid": "yugu"
+            },
+            {
+              "part": "scr-m3-6-bhcs",
+              "qty": 4,
+              "uid": "e04c"
+            },
+            {
+              "part": "ctrl-board-housing-cover",
+              "qty": 1,
+              "uid": "ksh2"
+            },
+            {
+              "part": "scr-m3-12-cs",
+              "qty": 4,
+              "uid": "0a9x"
+            },
+            {
+              "part": "ctrl-board-housing-plunger",
+              "qty": 1,
+              "uid": "cljt"
+            },
+            {
+              "part": "ctrl-board-housing-plunger-retainer",
+              "qty": 1,
+              "uid": "g9sx"
+            },
+            {
+              "part": "scr-m3-8-cs",
+              "qty": 2,
+              "uid": "l6br"
+            },
+            {
+              "part": "fan-40mm-24v",
+              "qty": 1,
+              "uid": "7o57"
+            },
+            {
+              "part": "scr-m3-12-bhcs",
+              "qty": 4,
+              "uid": "izrb"
+            },
+            {
+              "part": "scr-m5-16-shcs",
+              "qty": 2,
+              "uid": "2e0s"
+            },
+            {
+              "part": "tnut-m5-2020",
+              "qty": 2,
+              "uid": "bpwm"
+            }
+          ]
         },
         {
           "version": "3",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -4437,8 +4437,8 @@
 		},
 		{
 			"id": "ctrl-board-mount",
-			"uid": "rns2",
-			"version": "2",
+			"uid": "60ni",
+			"version": "3",
 			"name": "basically Embedded Control Board Housing",
 			"description": "The basically Embedded Control Board closed into a two-part printed housing that bolts to the 2020 extrusion. The board screws straight to the base \u2014 no bracket, no standoffs \u2014 and the cover carries a 40 mm 24 V fan and a plunger that reaches the board's reset button from outside.",
 			"docs": "/hardware/electronics/installation/control-board-housing/",
@@ -4480,7 +4480,7 @@
 					"qty": 1
 				},
 				{
-					"part": "scr-m3-12-bhcs",
+					"part": "scr-m3-16-shcs",
 					"qty": 4
 				},
 				{
@@ -4495,7 +4495,7 @@
 			"joining": [
 				{
 					"method": "self-tap",
-					"note": "The fan's four [[hw:scr-m3-12-bhcs]] cut their own threads in the cover; no inserts there."
+					"note": "The fan's four [[hw:scr-m3-16-shcs]] cut their own threads in the cover's bosses; no inserts there."
 				}
 			],
 			"versions": [
@@ -4554,7 +4554,77 @@
 					"uid": "rns2",
 					"date": "2026-08-23",
 					"message": "The printed housing replaces the bracket and standoffs. The board bolts straight to the base on four of its eight heat inserts; the cover closes onto the other four, carries the 40 mm 24 V fan on self-tapping M3 \u00d7 12 mm button heads, and holds a plunger over the board's reset button. Adopted from candidate rns2 after a test print.",
-					"commit": "9ff8a1e3"
+					"commit": "9ff8a1e3",
+					"lines": [
+						{
+							"part": "ctrl-board-housing-base",
+							"qty": 1,
+							"uid": "204b"
+						},
+						{
+							"part": "ctrl-board-basically",
+							"qty": 1,
+							"uid": "yugu"
+						},
+						{
+							"part": "scr-m3-6-bhcs",
+							"qty": 4,
+							"uid": "e04c"
+						},
+						{
+							"part": "ctrl-board-housing-cover",
+							"qty": 1,
+							"uid": "ksh2"
+						},
+						{
+							"part": "scr-m3-12-cs",
+							"qty": 4,
+							"uid": "0a9x"
+						},
+						{
+							"part": "ctrl-board-housing-plunger",
+							"qty": 1,
+							"uid": "cljt"
+						},
+						{
+							"part": "ctrl-board-housing-plunger-retainer",
+							"qty": 1,
+							"uid": "g9sx"
+						},
+						{
+							"part": "scr-m3-8-cs",
+							"qty": 2,
+							"uid": "l6br"
+						},
+						{
+							"part": "fan-40mm-24v",
+							"qty": 1,
+							"uid": "7o57"
+						},
+						{
+							"part": "scr-m3-12-bhcs",
+							"qty": 4,
+							"uid": "izrb"
+						},
+						{
+							"part": "scr-m5-16-shcs",
+							"qty": 2,
+							"uid": "2e0s"
+						},
+						{
+							"part": "tnut-m5-2020",
+							"qty": 2,
+							"uid": "bpwm"
+						}
+					]
+				},
+				{
+					"version": "3",
+					"uid": "60ni",
+					"date": "2026-09-12",
+					"message": "The fan's four screws go from M3 \u00d7 12 mm to M3 \u00d7 16 mm. The cover's fan bosses are 2.5 mm tall nubs standing off the inner face of the lid, each on a 2.5 mm pilot hole that runs 6.5 mm deep in total (2.5 mm through the nub, 4 mm into the 5 mm lid plate) and is blind with 1 mm of lid above it. The 4010 fan is 10 mm thick, so a 12 mm screw reaches only 2 mm in and takes the whole of that in the nub, whose wall is 1.75 mm; a 16 mm screw engages 6 mm, through the nub and 3.5 mm into the solid lid, stopping 0.5 mm short of the blind end. Reported from a build where a nub snapped off under a 12 mm screw. Nothing else in the assembly changes.",
+					"breaking": false,
+					"commit": null
 				}
 			]
 		},
@@ -16839,10 +16909,10 @@
 			"folder": null,
 			"variant_group": null,
 			"variant_name": null,
-			"description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 \u00d7 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 \u00d7 12 mm button head screws, and the plunger passes through it.",
+			"description": "Cover of the basically Embedded Control Board housing. Screws to the base with four M3 \u00d7 12 mm countersunk screws, carries the 40 mm 24 V fan on four self-tapping M3 \u00d7 16 mm socket/button head screws, and the plunger passes through it.",
 			"version": "1",
 			"created_at": "2026-08-22",
-			"updated_at": "2026-08-23",
+			"updated_at": "2026-09-12",
 			"versions": [
 				{
 					"version": "1",
@@ -20544,10 +20614,10 @@
 			},
 			"name": "M3 \u00d7 16 mm socket/button head",
 			"category": "Screws",
-			"description": "No longer the C-channel stepper screw \u2014 those are countersunk (scr-m3-16-cs). Holds the 40 mm fan arm to the Orange Pi mount (2, into the mount's front-edge inserts) and the fan to the arm (4, self-tapping). The top-interface docs call for 2 to mount the roller-lever limit switch into its housing's inserts, though the limit-switch assembly records M3 \u00d7 12 button heads for that joint \u2014 one of the two is wrong; settle it at the bench.",
+			"description": "No longer the C-channel stepper screw \u2014 those are countersunk (scr-m3-16-cs). Holds the 40 mm fan arm to the Orange Pi mount (2, into the mount's front-edge inserts), the fan to the arm (4, self-tapping), and the 40 mm fan to the control board housing cover (4, self-tapping into the cover's bosses). The top-interface docs call for 2 to mount the roller-lever limit switch into its housing's inserts, though the limit-switch assembly records M3 \u00d7 12 button heads for that joint \u2014 one of the two is wrong; settle it at the bench.",
 			"note": null,
 			"created_at": "2026-07-18",
-			"updated_at": "2026-09-01",
+			"updated_at": "2026-09-12",
 			"attributes": [
 				{
 					"label": "Thread",
@@ -23336,10 +23406,10 @@
 			},
 			"name": "40 mm 24 V fan (WINSINN 4010)",
 			"category": "Electronics",
-			"description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 \u00d7 12 mm button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
+			"description": "40 x 40 x 10 mm axial fan, 24 V, on the control board housing cover; mounted with four self-tapping M3 \u00d7 16 mm socket/button head screws. Comes with an XH2.54 2-pin lead, which plugs straight into one of the board's LED ports.",
 			"note": null,
 			"created_at": "2026-08-22",
-			"updated_at": "2026-08-23",
+			"updated_at": "2026-09-12",
 			"attributes": [
 				{
 					"label": "Size",


### PR DESCRIPTION
> [!WARNING]
> **On hold, do not mark ready.** The 16 mm figure assumes the fan bears on the four nub end faces and stands 2.5 mm off the lid. Daddy-O's Bricks - Bill, who has the parts in front of him, reports that the nubs instead recess into the recesses in the fan's corners so the fan sits flush. If that is right there is only 7.5 mm of fan above the thread, the longest usable screw is 14 mm, **M3 x 16 would bottom out** and the existing M3 x 12 is correct with 4.5 mm of bite. Waiting on two bench measurements: whether a dry-fitted fan sits flush or stands off, and how deep a screw actually goes into a bare nub hole on a real print.
>
> The cover geometry in this PR body is verified three ways against the pinned STL and is not in question. What is in question is how the fan sits on it.

The control board housing's fan is specified as four self-tapping M3 × 12 mm button heads. It should be M3 × 16 mm.

Asked for by **Daddy-O's Bricks - Bill** (@daddyosbricksbill), who [snapped one of the cover's fan nubs off with a 12 mm screw](https://discord.com/channels/1430279849171222682/1487518366020276397/1548126898620731524) and asked whether the joint takes 12 or 10.

### What the geometry says

Measured off the current `ctrl-board-housing-cover` STL (`stl_hash` 462b0290…, pulled from the asset service). The four fan bosses sit on a 32.0 × 32.0 mm pattern, standard for a 40 mm fan, and each one is:

- a **2.5 mm tall nub**, ⌀6.0 mm, standing off the inner face of the lid
- with a **⌀2.5 mm pilot hole** running **6.5 mm deep in total**: 2.5 mm through the nub, then 4 mm up into the 5 mm lid plate
- blind, closing flat at 1 mm below the outer face

The nub wall is therefore 1.75 mm.

### Why 12 mm is wrong

The WINSINN 4010 is 40 × 40 × 10 mm ([manufacturer page](https://winsinn.com/40mm-fan-4010/)), so the screw does nothing for its first 10 mm.

- **M3 × 10** leaves 0 mm of thread in plastic.
- **M3 × 12** leaves 2 mm, and all 2 mm of it lands inside the 1.75 mm-walled nub. That is the joint that failed.
- **M3 × 16** leaves 6 mm: through the nub and 3.5 mm into the solid lid plate, stopping 0.5 mm short of the blind end. That 0.5 mm margin reads as the design intent.

It does not actually bottom out at 12 mm, as reported; there is 6.5 mm of hole. The likely cause of the hard stop is the tapered lead of the self-tapper binding in a pilot that printed undersize.

### Corroboration elsewhere on the machine

The machine's other 40 mm fan, on `fan-bracket-40mm`, has an 11 mm pilot and the catalog already calls for **M3 × 16 self-tapping** into it, for the same 6 mm of engagement. Measured off that STL too.

### What changed

- `ctrl-board-mount` stamped **v2 → v3** (new uid `60ni`, `breaking: false`, `commit: null` for the post-merge stamp): the fan line goes `scr-m3-12-bhcs` → `scr-m3-16-shcs`, qty 4 unchanged, and the `joining` note follows it. Nothing else in the assembly moves.
- Descriptions updated on `ctrl-board-housing-cover`, `fan-40mm-24v` and `scr-m3-16-shcs`.
- Control board housing page: `parts_needed` and step 3's fastener chip.
- `catalog.generated.json` regenerated with `generate.py --metadata-only`; its own pin, versioning and connection checks pass.

Nothing about the cover's geometry is wrong, so there is no `changes` entry and no `cad` issue here. The catalog could say the fix, so it says it.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1487518366020276397/1548126898620731524
request: https://discord.com/channels/1430279849171222682/1548126898620731524/1548131934872281131
preview: /hardware/electronics/installation/control-board-housing/
-->


