### PR TITLE
docs: warn about stripping the fan bosses in control board housing step 3

### DIFF
--- a/docs/src/content/hardware/electronics/installation/control-board-housing.md
+++ b/docs/src/content/hardware/electronics/installation/control-board-housing.md
@@ -80,6 +80,11 @@ Sit the board on the four inner bosses and fix it with 4 {% include fastener.htm
 
 Fan on the inside of the cover, over the vent, label facing into the enclosure so it blows inwards. 4 {% include fastener.html size="M3" variant="button" length="12" %} screws, self-tapping into the plastic. Route the lead to the corner cutout.
 
+<div class="callout callout-warning">
+  <span class="callout-icon" aria-hidden="true">⚠</span>
+  <p>Take these four by hand. They cut their own thread in a printed boss only 6 mm across, and the boss snaps off long before the screw gives. Use a hand driver rather than a power tool, and stop as soon as the fan is pulled down onto the cover. If a screw stops turning before the fan is seated, back it out and clear the hole rather than forcing it. A bottomed screw is what breaks the boss.</p>
+</div>
+
 <div class="img-row">
   <figure>
     <img src="https://assets.basically.website/sorter-docs/assembly-control-board-housing-fan-in-cover-w1600-73bbe941cbdb.jpg" alt="The inside of the printed cover with the 40 mm WINSINN fan screwed down over its vent opening on four screws, its red and black lead running off to the left, and the rectangular plunger slot beside it">


### PR DESCRIPTION
Step 3 of the control board housing page has the builder run four self-tapping screws into small printed bosses in the cover, with nothing on the page saying how easy that is to overdo.

Asked for by **barthel** (@uwe_barthel): ["Add a warning to Step 3, 'Fit the fan inside the cover,' on the 'Control board housing' page, advising users to tighten the screws carefully so as not to strip the printed threads/nubs."](https://discord.com/channels/1430279849171222682/1548126898620731524/1548221325208723518)

### What it adds

One `callout callout-warning` inside step 3, between the instruction and the photo, so it sits at the point where hands are on the risk rather than ahead of it. Same markup as the existing warnings on `top-interface.md` and `install-bins.md`.

> Take these four by hand. They cut their own thread in a printed boss only 6 mm across, and the boss snaps off long before the screw gives. Use a hand driver rather than a power tool, and stop as soon as the fan is pulled down onto the cover. If a screw stops turning before the fan is seated, back it out and clear the hole rather than forcing it. A bottomed screw is what breaks the boss.

### Why those specifics

This is a live failure, not a hypothetical. Daddy-O's Bricks - Bill [reported snapping a fan nub off](https://discord.com/channels/1430279849171222682/1487518366020276397/1548126898620731524) in #balloon-general on 2026-09-12 and went on to break two more on the same cover, each time with a screw that stopped turning and then kept being turned. So the warning names that specific sequence (screw stops early, builder forces it, boss goes) rather than saying "be careful".

The 6 mm figure is the boss's outside diameter measured off the pinned `ctrl-board-housing-cover` STL (`stl_hash` 462b0290…); the bore through it is 2.5 mm, which leaves a 1.75 mm wall. No fastener spec is touched by this PR, and the M3 × 12 on the page is unchanged and correct.

### Checks

`npm run check` 0 errors (4 pre-existing a11y warnings in `Requirements.svelte`, untouched), `scripts/validate_images.py` clean, and the callout renders in the right place on `npm run dev`.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1548126898620731524/1548221325208723518
preview: /hardware/electronics/installation/control-board-housing/
-->
