### PR TITLE
parts-calculator: a product photo for dupont-lead-2p-1m

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -5508,7 +5508,8 @@
       "note": "Sold male-to-female: cut the male plug off and discard it. Any 22 AWG pair plus a 2-pin Dupont housing does the same job if you own a crimp tool.",
       "alternative": "Your own 22 AWG pair plus a 2-pin 2.54 mm Dupont housing and two crimps",
       "created_at": "2026-09-10",
-      "updated_at": "2026-09-10",
+      "updated_at": "2026-09-12",
+      "image_url": "https://assets.basically.website/sorter-parts/dupont-lead-2p-1m-full-1d6495f8bb1b.jpg",
       "attributes": [
         {
           "label": "Pitch",

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -23085,7 +23085,7 @@
 			"description": "A metre of 22 AWG red and black with a 2-pin 2.54 mm Dupont housing crimped on. One of these is a whole LED drop: the Dupont end pushes onto an LED header (J8 to J11), the far end goes into the strip connector. The pack is male-to-female, so cut the male plug off and discard it.",
 			"note": "Sold male-to-female: cut the male plug off and discard it. Any 22 AWG pair plus a 2-pin Dupont housing does the same job if you own a crimp tool.",
 			"created_at": "2026-09-10",
-			"updated_at": "2026-09-10",
+			"updated_at": "2026-09-12",
 			"attributes": [
 				{
 					"label": "Pitch",
@@ -23127,7 +23127,7 @@
 			"caption": "Cut the male end off and it is one LED drop.",
 			"docs_page": "/hardware/electronics/led-drop/",
 			"conflicts": null,
-			"image": null
+			"image": "https://assets.basically.website/sorter-parts/dupont-lead-2p-1m-full-1d6495f8bb1b.jpg"
 		},
 		{
 			"id": "endstop-mechanical",


### PR DESCRIPTION
<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1477417230235861104/1548228816428863531
preview: /
-->
`dupont-lead-2p-1m` has rendered a grey "no image" tile since it went into the catalog with #619, because the Amazon listing would not fetch from the box the generator runs on. It fetches now, so the part has a photo.

**Requested by barthel (@uwe_barthel) [from Discord](https://discord.com/channels/1430279849171222682/1477417230235861104/1548228816428863531): "dupont-lead-2p-1m has no image. Please find an image and add it to the parts catalog."**

## The image

`https://assets.basically.website/sorter-parts/dupont-lead-2p-1m-full-1d6495f8bb1b.jpg`, 1500 x 1500, published with `scripts/publish_assets.py --upload` under the part id like every other COTS photo.

It is the listing's own photo for **the variant the catalog sources**, not the brand's family shot: red and black 22 AWG, a male end and a female end, and two loose 2-pin shells. The generic Kidisoii image that the search surfaces first shows blue, yellow, white and brown leads as well, which is a different variant and would have been misleading on a card that says "red and black".

**Where it came from.** Plain `curl` on `amazon.com/dp/B0CCTZJZZ3` still gets the CAPTCHA page, which is what `scripts/fetch_product_images.py` runs into, so this was done by hand: rendered the listing to confirm the variant (`5Pcs MF 2P-100CM`, Kidisoii, currently unavailable), read the gallery's image ids off the page through a reader proxy, and pulled the hi-res file from `m.media-amazon.com` directly. That CDN is not blocked from here, only the listing HTML is. `fetch_product_images.py` is untouched; making it work against Amazon's bot wall is a separate job.

The `updated_at` stamp moves to 2026-09-12. Nothing else on the part changes, and `catalog/generate.py --metadata-only` wrote the generated file (two lines: the stamp and the image).

## One thing the photo raises, not changed here

The catalog description says the lead arrives "with a 2-pin 2.54 mm Dupont housing crimped on". The listing's own text says the pack is 10 pre-crimped wires plus 10 separate 2-pin shells and that you "insert the pins into the shell", and the photo shows two empty shells alongside the assembled leads. If that is right, the builder pushes the terminals into the housing themselves (no tool, but it is a step), and the description and `alternative` both want a word changing. I have not touched either in this PR, since it is a reading of a listing rather than something anybody has had in their hands.
