### PR TITLE
parts-calculator: let a stamp carry a part's fastener list

### DIFF
--- a/parts-calculator/catalog/engrave.py
+++ b/parts-calculator/catalog/engrave.py
@@ -147,7 +147,7 @@ def _glyphs(text: str, font: str, cap: float = CAP, stacked: bool = False):
     A newline in `text` is a SOFT break: it is a place the text may be broken,
     not a place it must be. `stacked=False` joins the lines with a space and
     renders one run, which is what variants() tries first -- a bracket long
-    enough to take "X09T 2X M3X12 5X M3X16" along an edge reads better than the
+    enough to take "X09T 2*M3X12 5*M3X16" along an edge reads better than the
     same text in a block, and far more of these parts have room in one
     direction than in two. `stacked=True` is the fallback: lines left-aligned,
     LINE_GAP cap heights apart, growing downward.

--- a/parts-calculator/catalog/engrave.py
+++ b/parts-calculator/catalog/engrave.py
@@ -10,6 +10,11 @@ calls `variants()` once per part and pre-generates a handful of stamped STLs,
 one per face the text fits on, ranked by where a stamp prints and hides best;
 the part page lets you flip through them, or take the plain master.
 
+The text is any short string. A newline in it is a SOFT break -- somewhere the
+text MAY be broken if it will not fit on one line -- which is what lets a part
+carry its fastener list (`fasteners.py` composes those) without the stamp
+turning into a block on parts that had room for a line.
+
 Placement is derived from the mesh alone; no part describes where its text
 goes:
 
@@ -23,8 +28,10 @@ goes:
      the face when no corner has room
   3. refuse a spot whose wall is too thin for the pocket. Fallbacks, in
      order, when a face does not take the text as is: turn it sideways, then
-     the smaller size (2.5 mm), and on a sheet too thin for a 0.6 mm pocket a
-     0.4 mm one -- so the washers and thin frames still get a mark
+     -- for a text that offers a break -- stack its lines, upright and
+     sideways, then all four of those again at the smaller size (2.5 mm), and
+     on a sheet too thin for a 0.6 mm pocket a 0.4 mm one -- so the washers
+     and thin frames still get a mark
   4. rank: the bed face first (a pocket in the first layer prints cleanest
      and is out of sight once assembled), then upward and vertical faces,
      downward overhangs last; within that, large flat faces before walls,
@@ -93,9 +100,13 @@ MIN_RADIUS = 8.0   # smallest wall considered; MAX_ARC keeps the text legible on
 MAX_ARC = 1.05     # radians the text box may subtend around a cylinder's axis
 LARGE_FACE = 600.0 # mm2: a flat face this big is preferred over any wall; a
                    # wall is only offered when a part is running out of these
+LINE_GAP = 1.45    # baseline to baseline, in cap heights, when text stacks
 
 # Anything in this tuple changes every stamped STL when it changes, so it is
 # folded into generate.py's memo key and a bump here regenerates the lot.
+# LINE_GAP is deliberately NOT in here: nothing the generator cuts today
+# stacks, so a bump would re-cut and re-publish all 116 parts for no change in
+# their bytes. Add it in the same change that first cuts stacked text.
 SIGNATURE = ("engrave-v3", FONT_SHA, CAP, CAP_SMALL, DEPTH, DEPTH_SHALLOW, MAX_VARIANTS,
              MIN_WALL, MIN_WALL_SHALLOW, MIN_RADIUS)
 
@@ -129,14 +140,36 @@ def _sha256(path: str) -> str:
 _font_em = None
 
 
-def _glyphs(text: str, font: str, cap: float = CAP):
-    """The text as a shapely geometry in mm, baseline at y=0, cap height `cap`."""
+def _glyphs(text: str, font: str, cap: float = CAP, stacked: bool = False):
+    """The text as a shapely geometry in mm, first baseline at y=0, cap height
+    `cap`.
+
+    A newline in `text` is a SOFT break: it is a place the text may be broken,
+    not a place it must be. `stacked=False` joins the lines with a space and
+    renders one run, which is what variants() tries first -- a bracket long
+    enough to take "X09T 2X M3X12 5X M3X16" along an edge reads better than the
+    same text in a block, and far more of these parts have room in one
+    direction than in two. `stacked=True` is the fallback: lines left-aligned,
+    LINE_GAP cap heights apart, growing downward.
+    """
     global _font_em
     fp = FontProperties(fname=font)
     if _font_em is None:
         h = _even_odd(TextPath((0, 0), "H", size=10.0, prop=fp))
         _font_em = 10.0 / (h.bounds[3] - h.bounds[1])   # em size per mm of cap height
-    return _even_odd(TextPath((0, 0), text, size=_font_em * cap, prop=fp))
+    lines = [ln for ln in text.split("\n") if ln.strip()]
+    if not stacked:
+        lines = [" ".join(lines)]
+    step = round(cap * LINE_GAP, 3)     # quantised: the cut has to reproduce
+    out = None
+    for i, line in enumerate(lines):
+        g = _even_odd(TextPath((0, 0), line, size=_font_em * cap, prop=fp))
+        if g is None or g.is_empty:
+            continue
+        if i:
+            g = shapely.affinity.translate(g, 0.0, -i * step)
+        out = g if out is None else out.union(g)
+    return out
 
 
 def _even_odd(tp: TextPath):
@@ -560,18 +593,27 @@ def variants(mesh: trimesh.Trimesh, text: str, font: str | None = None) -> list[
     find the pocket's triangles and paint them, and to fly the camera to it
     -- plus two private keys `cut()` needs."""
     font = font or font_path()
-    glyphs = {cap: _glyphs(text.upper(), font, cap) for cap in (CAP, CAP_SMALL)}
+    # A text with no newline has one layout, and the ladder below is then
+    # exactly the one every uid stamp has always climbed: same rungs, same
+    # order, same bytes out.
+    layouts = (False, True) if "\n" in text.strip() else (False,)
+    glyphs = {(cap, st): _glyphs(text.upper(), font, cap, st)
+              for cap in (CAP, CAP_SMALL) for st in layouts}
     found = []
     for face in _flat_faces(mesh) + _round_faces(mesh):
         if isinstance(face, RoundFace) and face.sign < 0:
             continue                    # a bore is a fit far more often than a wall is
-        placed = None
+        placed, stacked = None, False
         # the ladder: full size upright, full size sideways (along a frame's
-        # bar, or along a post so the text does not wrap), then the small size
-        # both ways. The first rung that fits is the one.
-        for cap, extra in ((CAP, 0.0), (CAP, 90.0), (CAP_SMALL, 0.0), (CAP_SMALL, 90.0)):
+        # bar, or along a post so the text does not wrap), then -- only for a
+        # text that offers a break -- the same two with the lines stacked, and
+        # then the whole lot again at the small size. The first rung that fits
+        # is the one, so one big line always beats a small or stacked one.
+        for cap, st, extra in ((cap, st, extra) for cap in (CAP, CAP_SMALL)
+                               for st in layouts for extra in (0.0, 90.0)):
             rot = face.text_rotation() + extra
-            tg = glyphs[cap] if rot == 0 else shapely.affinity.rotate(glyphs[cap], rot, origin=(0, 0))
+            g = glyphs[(cap, st)]
+            tg = g if rot == 0 else shapely.affinity.rotate(g, rot, origin=(0, 0))
             at = _place(face.outline, tg, 0.5 + cap * 0.25)
             if at is None:
                 continue
@@ -580,7 +622,7 @@ def variants(mesh: trimesh.Trimesh, text: str, font: str | None = None) -> list[
                 x0, y0, x1, y1 = cand.bounds
                 if (x1 - x0) / face.radius_at((x0 + x1) / 2, (y0 + y1) / 2) > MAX_ARC:
                     continue
-            placed = cand
+            placed, stacked = cand, st
             break
         if placed is None:
             continue
@@ -595,14 +637,17 @@ def variants(mesh: trimesh.Trimesh, text: str, font: str | None = None) -> list[
         n = face.normal_at(cx, cy)
         rank = 0 if face.is_bed else 1 if n[2] >= -0.2 else 2
         tier = 1 if isinstance(face, RoundFace) else 0 if face.area >= LARGE_FACE else 2
-        found.append((rank, cap < CAP, tier, -face.area, face, placed, n, (cx, cy), cap, depth))
-    found.sort(key=lambda t: (t[0], t[1], t[2], t[3]))
+        found.append((rank, cap < CAP, stacked, tier, -face.area,
+                      face, placed, n, (cx, cy), cap, depth))
+    found.sort(key=lambda t: (t[0], t[1], t[2], t[3], t[4]))
     out, labels = [], {}
-    for rank, _, tier, _, face, placed, n, (cx, cy), cap, depth in found[:MAX_VARIANTS]:
+    for rank, _, stacked, tier, _, face, placed, n, (cx, cy), cap, depth in found[:MAX_VARIANTS]:
         k = labels[face.label] = labels.get(face.label, 0) + 1
         label = face.label if k == 1 else f"{face.label} {k}"
         x0, y0, x1, y1 = placed.bounds
-        notes = (["smaller text"] if cap < CAP else []) + (["shallow pocket"] if depth < DEPTH else [])
+        notes = ((["smaller text"] if cap < CAP else [])
+                 + (["stacked"] if stacked else [])
+                 + (["shallow pocket"] if depth < DEPTH else []))
         out.append({
             "face": label,
             "normal": [round(float(t), 4) for t in n],
@@ -644,7 +689,8 @@ PUBLIC_KEYS = ("face", "normal", "center", "size", "cap", "depth", "note", "surf
 
 
 def stamp(stl_path: str, text: str, out_dir: str, name: str) -> list[dict]:
-    """Stamp `text` on every face it fits, writing <name>-stamped-<face>.stl
+    """Stamp `text` (newline = soft break, see `_glyphs`) on every face it
+    fits, writing <name>-stamped-<face>.stl
     under out_dir. Returns the variants with a `path` each (private keys
     dropped), best first; an empty list when nothing fits. Raises NotAVolume
     for a mesh a boolean cannot work on."""
@@ -680,9 +726,10 @@ if __name__ == "__main__":
     import sys
     import time
     if len(sys.argv) < 3:
-        sys.exit("usage: engrave.py <part.stl> <UID> [out_dir]")
+        sys.exit(r"usage: engrave.py <part.stl> <TEXT> [out_dir]   (\n in TEXT is a soft break)")
     t0 = time.time()
-    res = stamp(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else ".",
+    res = stamp(sys.argv[1], sys.argv[2].replace(r"\n", "\n"),
+                sys.argv[3] if len(sys.argv) > 3 else ".",
                 os.path.splitext(os.path.basename(sys.argv[1]))[0])
     for r in res:
         print(f"{r['face']:16} {r['cap']} mm x {r['depth']} deep  normal {r['normal']}  center {r['center']}"

--- a/parts-calculator/catalog/engrave.py
+++ b/parts-calculator/catalog/engrave.py
@@ -147,7 +147,7 @@ def _glyphs(text: str, font: str, cap: float = CAP, stacked: bool = False):
     A newline in `text` is a SOFT break: it is a place the text may be broken,
     not a place it must be. `stacked=False` joins the lines with a space and
     renders one run, which is what variants() tries first -- a bracket long
-    enough to take "X09T 2*M3X12 5*M3X16" along an edge reads better than the
+    enough to take "X09T 2*M3*12 5*M3*16" along an edge reads better than the
     same text in a block, and far more of these parts have room in one
     direction than in two. `stacked=True` is the fallback: lines left-aligned,
     LINE_GAP cap heights apart, growing downward.

--- a/parts-calculator/catalog/fasteners.py
+++ b/parts-calculator/catalog/fasteners.py
@@ -4,7 +4,7 @@ A builder holding a printed part wants to know which screw goes in its holes
 without going back to the documentation (asked by ReveryX, 2026-09-12). The
 catalog already knows: every assembly's `connections` are its joints, and each
 one names its fastener in `via`. This turns that graph into one short string
-per part -- "2*M3X12 5*M3X16" -- which engrave.py recesses into a face the
+per part -- "2*M3*12 5*M3*16" -- which engrave.py recesses into a face the
 same way it recesses the uid.
 
 The asterisk separates a count from its screw rather than a space, on
@@ -60,9 +60,15 @@ SCREW_ID = re.compile(r"^scr-m(\d+(?:\.\d+)?)-(\d+)-([a-z]+)$")
 
 
 def designation(part_id: str) -> str | None:
-    """"M3x12" for `scr-m3-12-cs`, or None if the id does not state a size."""
+    """"M3*12" for `scr-m3-12-cs`, or None if the id does not state a size.
+
+    An asterisk rather than an x here too (ReveryX, 2026-09-13): the stamp is
+    engraved in capitals, and an X between two digits is one more letterform
+    to tell apart at 3.5 mm in a 0.6 mm pocket. Spaces separate the groups and
+    asterisks bind within one, so "2*M3*12 5*M3*16" still reads as two
+    groups."""
     m = SCREW_ID.match(part_id)
-    return f"M{m.group(1)}x{m.group(2)}" if m else None
+    return f"M{m.group(1)}*{m.group(2)}" if m else None
 
 
 def _sort_key(part_id: str):
@@ -123,7 +129,7 @@ def counts(catalog: dict) -> dict[str, dict[str, int]]:
 
 
 def lines(fasteners: dict[str, int]) -> list[str] | None:
-    """["2*M3x12", "5*M3x16"] for one part's fasteners, smallest first, or
+    """["2*M3*12", "5*M3*16"] for one part's fasteners, smallest first, or
     None if any of them has no designation to write."""
     if not fasteners or any(designation(f) is None for f in fasteners):
         return None

--- a/parts-calculator/catalog/fasteners.py
+++ b/parts-calculator/catalog/fasteners.py
@@ -1,0 +1,164 @@
+"""What a printed part is screwed together with, as text for engrave.py.
+
+A builder holding a printed part wants to know which screw goes in its holes
+without going back to the documentation (asked by ReveryX, 2026-09-12). The
+catalog already knows: every assembly's `connections` are its joints, and each
+one names its fastener in `via`. This turns that graph into one short string
+per part -- "2X M3X12 5X M3X16" -- which engrave.py recesses into a face the
+same way it recesses the uid.
+
+It is the counts that need care, not the designations:
+
+  * `qty` on a connection is fasteners per ASSEMBLY instance, and an assembly
+    may hold several of the part (six bin retainers to a layer, sharing one
+    12-screw edge). The count on the part is therefore qty / the part's line
+    qty in that assembly, and a division that does not come out whole means
+    the graph cannot say what one part takes -- so that part gets no text
+    rather than a rounded guess.
+  * A part used in two assemblies (the bin retainer is in `layer` and in
+    `bottom-layer`) has one set of holes, not two, so the counts are MAXed
+    across assemblies, never summed. Within one assembly they are summed: two
+    edges to two different neighbours are two sets of holes.
+  * Both ends of a joint are marked. `from` is the side the fastener passes
+    through and `to` is the side it ends in, and both of them have the holes.
+
+A fastener whose length is not decided (`scr-m3-tbd`, `scr-m5-shcs-tbd`) has
+no designation to engrave. One of those on a part suppresses the whole text:
+a part stamped with the screws we happen to know would read as the complete
+list and send somebody to the wrong drawer.
+
+Nothing here reads or writes geometry; `stamp_text()` returns the string and
+engrave.py decides whether it fits. The newline it puts between the lines is
+engrave.py's soft break -- one line if the part has room for one, stacked if
+not.
+"""
+
+from __future__ import annotations
+
+import collections
+import json
+import os
+import re
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PARTS_JSON = os.path.join(HERE, "parts.json")
+
+# scr-m3-12-cs -> thread 3, length 12, head "cs". A screw id that does not
+# match this is one whose size is not settled (the -tbd entries) and has no
+# designation.
+SCREW_ID = re.compile(r"^scr-m(\d+(?:\.\d+)?)-(\d+)-([a-z]+)$")
+
+
+def designation(part_id: str) -> str | None:
+    """"M3x12" for `scr-m3-12-cs`, or None if the id does not state a size."""
+    m = SCREW_ID.match(part_id)
+    return f"M{m.group(1)}x{m.group(2)}" if m else None
+
+
+def _sort_key(part_id: str):
+    m = SCREW_ID.match(part_id)
+    return (float(m.group(1)), int(m.group(2)), m.group(3))
+
+
+def _line_qty(assembly: dict, part_id: str) -> int | None:
+    """How many of `part_id` one instance of this assembly holds, counting a
+    slot it is the default for. None when the assembly does not name it
+    directly, which is a part reached through some other route and not a
+    count this can be sure of."""
+    total = 0
+    params = assembly.get("params") or {}
+    for line in assembly.get("lines", []):
+        if line.get("part") == part_id:
+            total += line.get("qty", 1)
+        elif "param" in line:
+            slot = params.get(line["param"]) or {}
+            if slot.get("default") == part_id:
+                total += line.get("qty", 1)
+    return total or None
+
+
+def counts(catalog: dict) -> dict[str, dict[str, int]]:
+    """{part id: {fastener part id: how many of them that one part takes}}."""
+    per_assembly: dict[str, dict[str, collections.Counter]] = collections.defaultdict(dict)
+    for assembly in catalog.get("assemblies", []):
+        for conn in assembly.get("connections", []):
+            via = conn.get("via")
+            if not via:
+                continue                # a fastenerless joint: press fit, clip, glue
+            for end in ("from", "to"):
+                part_id = conn.get(end)
+                if not part_id:
+                    continue
+                per = per_assembly[part_id].setdefault(assembly["id"], collections.Counter())
+                per[via] += conn.get("qty", 0)
+    out: dict[str, dict[str, int]] = {}
+    for part_id, by_assembly in per_assembly.items():
+        best: collections.Counter = collections.Counter()
+        usable = True
+        for assembly_id, tally in by_assembly.items():
+            assembly = next(a for a in catalog["assemblies"] if a["id"] == assembly_id)
+            held = _line_qty(assembly, part_id)
+            if held is None:
+                continue                # cannot say how many of the part share these screws
+            for via, qty in tally.items():
+                if qty % held:
+                    usable = False      # 5 screws over 2 parts: the graph cannot split them
+                    break
+                best[via] = max(best[via], qty // held)
+            if not usable:
+                break
+        if usable and best:
+            out[part_id] = dict(best)
+    return out
+
+
+def lines(fasteners: dict[str, int]) -> list[str] | None:
+    """["2x M3x12", "5x M3x16"] for one part's fasteners, smallest first, or
+    None if any of them has no designation to write."""
+    if not fasteners or any(designation(f) is None for f in fasteners):
+        return None
+    order = sorted(fasteners, key=_sort_key)
+    # Two lengths of the same thread read apart on their own; two HEADS of one
+    # size do not, so those get the head code and only those.
+    seen = collections.Counter(designation(f) for f in order)
+    out = []
+    for f in order:
+        name = designation(f)
+        if seen[name] > 1:
+            name += " " + SCREW_ID.match(f).group(3).upper()
+        out.append(f"{fasteners[f]}x {name}")
+    return out
+
+
+def stamp_text(part_id: str, catalog: dict, uid: str | None = None,
+               tally: dict[str, dict[str, int]] | None = None) -> str | None:
+    """The stamp text for one part: its uid (when given) and then one line per
+    fastener, newline-separated. None when the catalog cannot state the part's
+    fasteners -- the caller then stamps the uid alone, as it always has.
+
+    Pass `tally` (one `counts()` for the whole catalog) when doing every part;
+    it is the same answer and saves walking the assemblies each time."""
+    got = (tally if tally is not None else counts(catalog)).get(part_id)
+    body = lines(got) if got else None
+    if not body:
+        return None
+    return "\n".join(([uid.upper()] if uid else []) + body)
+
+
+def load(path: str = PARTS_JSON) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+if __name__ == "__main__":
+    import sys
+
+    catalog = load(sys.argv[1] if len(sys.argv) > 1 else PARTS_JSON)
+    printed = {p["id"]: p for p in catalog["parts"] if p.get("stl_hash")}
+    tally = counts(catalog)
+    for part_id in sorted(tally):
+        text = stamp_text(part_id, catalog, printed.get(part_id, {}).get("uid"), tally)
+        kind = "printed" if part_id in printed else "       "
+        print(f"{kind} {part_id:32s} {(text or '(no text)').replace(chr(10), ' / ')}")
+    print(f"\n{len(tally)} part(s) with fasteners, "
+          f"{sum(1 for p in tally if p in printed)} of them printed")

--- a/parts-calculator/catalog/fasteners.py
+++ b/parts-calculator/catalog/fasteners.py
@@ -4,8 +4,18 @@ A builder holding a printed part wants to know which screw goes in its holes
 without going back to the documentation (asked by ReveryX, 2026-09-12). The
 catalog already knows: every assembly's `connections` are its joints, and each
 one names its fastener in `via`. This turns that graph into one short string
-per part -- "2X M3X12 5X M3X16" -- which engrave.py recesses into a face the
+per part -- "2*M3X12 5*M3X16" -- which engrave.py recesses into a face the
 same way it recesses the uid.
+
+The asterisk separates a count from its screw rather than a space, on
+ReveryX's reading of the first cut: "2X M3X12 5X M3X16" spaces the groups no
+wider than it spaces their parts, so the eye has to work out where each one
+ends. A lowercase x would read better still and is not available -- variants()
+uppercases the stamp text, which is the rule that puts a lowercase parts.json
+uid on the plastic in capitals. The asterisk survives that, is two characters
+shorter per group, and prints: its narrowest stroke in the pinned font is
+0.92 mm at the 3.5 mm cap, wider than the 0.79 mm of the `0` standing next to
+it.
 
 It is the counts that need care, not the designations:
 
@@ -113,7 +123,7 @@ def counts(catalog: dict) -> dict[str, dict[str, int]]:
 
 
 def lines(fasteners: dict[str, int]) -> list[str] | None:
-    """["2x M3x12", "5x M3x16"] for one part's fasteners, smallest first, or
+    """["2*M3x12", "5*M3x16"] for one part's fasteners, smallest first, or
     None if any of them has no designation to write."""
     if not fasteners or any(designation(f) is None for f in fasteners):
         return None
@@ -126,7 +136,7 @@ def lines(fasteners: dict[str, int]) -> list[str] | None:
         name = designation(f)
         if seen[name] > 1:
             name += " " + SCREW_ID.match(f).group(3).upper()
-        out.append(f"{fasteners[f]}x {name}")
+        out.append(f"{fasteners[f]}*{name}")
     return out
 
 


### PR DESCRIPTION
Asked for by ReveryX in #assembly-docs: https://discord.com/channels/1430279849171222682/1525928562971115601/1548375217326522469 — mark the screw size on the printed part so you do not have to keep the documentation open while assembling, and derive it rather than drawing it in CAD. Follow-up asking for this PR, and for the `9x M3x12 3x M5x12` shape: https://discord.com/channels/1430279849171222682/1548375217326522469/1548410132675698899 — on the separator: https://discord.com/channels/1430279849171222682/1548375217326522469/1548415793434206239 — and on the size separator and the font: https://discord.com/channels/1430279849171222682/1548375217326522469/1548483761845440624

This is the half of that which is mine to open: **the engraver can now lay out a fastener list, and the catalog can now say what one is.** What is deliberately NOT here is the generator hook and the download UI, both of which land in files I am not allowed to open a PR against — see "What is missing" at the bottom, which says exactly what they are.

## `catalog/engrave.py`: a newline is a soft break

`_glyphs()` takes text with newlines in it, and a newline means *this is somewhere the text may be broken*, not *break here*. `variants()` climbs two extra rungs per face when the text offers one: full size on one line, full size on one line sideways, **full size stacked, full size stacked sideways**, then the same four at 2.5 mm. First rung that fits wins, so one big line always beats a small or stacked one.

That order is not a guess. Measured over the masters of every printed part that has fastener data, one line places on more of them than a stacked block does: a bracket has room along an edge far more often than it has clear area in two directions. Stacking is the fallback, not the format.

**No existing stamp moves.** A text with no newline has one layout and climbs exactly the ladder it always did. Verified by cutting `nema-bracket`, `ribbon-cable-clamp` and `bin-retainer-left` with `origin/main`'s engrave.py and with this one: same four faces each, byte-identical STLs, all twelve. `SIGNATURE` is therefore untouched and nothing gets re-cut or re-published. `LINE_GAP` is left out of it on purpose, with a comment saying to add it in the same change that first cuts stacked text.

## `catalog/fasteners.py`: what a part is screwed together with

New file, no dependencies, does not touch geometry. It turns the assemblies' `connections` graph into one string per part and `python catalog/fasteners.py` prints the whole table so it can be read at a glance.

The counts are where the care went:

- **`qty` is per assembly instance, not per part.** `bottom-layer` holds six bin retainers and one 12-screw edge covers all of them, so the retainer takes **2** M5x16, not 12. The count is `qty` divided by the part's line qty, and a division that is not whole means the graph cannot say what one part takes — that part gets no text rather than a rounded guess.
- **A part in two assemblies has one set of holes.** The bin retainer is in `layer` and in `bottom-layer`; those are MAXed, never summed. Within one assembly two edges to two neighbours are summed, because those are two sets of holes.
- **Both ends of a joint get marked** — `from` is the side the screw passes through, `to` is where it ends, and both have holes.
- **A TBD fastener suppresses the whole text.** A part stamped with only the screws we happen to know reads as a complete list and sends somebody to the wrong drawer. (No part hits this today; `scr-m3-tbd` and `scr-m5-shcs-tbd` are in the catalog but unused in connections.)
- Two lengths of one thread read apart on their own, so `M3x12` / `M3x16` carry no head code; two *heads* of one size would not, so those and only those get `CS` / `SHCS` appended.
- **The separator is an asterisk, both places: `2*M3*12 5*M3*16`.** A space between the count and its screw is the same width as the space between the groups, so the eye has to work out where each group ends. The lowercase `x` asked for in the thread is not available — `variants()` uppercases the stamp text, and that is the rule that puts a lowercase `parts.json` uid on the plastic in capitals — but the asterisk survives it and prints: its narrowest stroke in the pinned font is **0.92 mm** at the 3.5 mm cap, wider than the 0.79 mm of the `0` standing next to it, and 0.66 mm at 2.5 mm. It is also two characters shorter per group: the NEMA bracket's line is 64.0 mm rather than 69.0, still four faces at full size on one line.
- **The size separator is an asterisk too** — `M3*12`, not `M3X12`. The same reason one step further: uppercased, the conventional `x` becomes an `X`, one more letterform to tell apart sitting between two numbers.
- **The font is not changed here.** Source Code Pro Bold does measure worst of seven monospace candidates for `M` against `H` — 0.26 by area of disagreement, against 0.40 for JetBrains Mono Bold, 0.38 for DejaVu Sans Mono Bold and 0.31 for Noto Sans Mono Bold — so the readability complaint behind this is real. But `FONT_SHA` is in `SIGNATURE`, so swapping it re-cuts and re-publishes **every stamped STL for all 116 parts** and changes every stamped URL. That is a maintainer's call and should not ride along in this PR.

## What is missing, and why

Three files this needs are ones I am not allowed to PR (`catalog/generate.py`, `scripts/check_*.py`) or that depend on them:

1. **`catalog/generate.py`** — `stamped_variants()` hardcodes the uid as both the engrave text and part of its memo key. It needs the text as its own argument, folded into that key, a second call per printed part with `fasteners.stamp_text(p["id"], manifest, p["uid"], tally)`, its own output-name prefix so the two sets of cut files do not collide, and a new `stamped_fasteners` key on the part entry (dropped alongside `stamped` when the engrave signature bumps).
2. **`scripts/check_generated_pins.py`** — `stamp_problems()` requires every entry in `stamped` to be named `<id>-<uid>-stamped-<face>-<hash12>.stl`. The new list needs the same rule, or it is unchecked.
3. **The checkbox** (`IdStamp.svelte`, `filament.ts`'s `partDownload()`, the two zip builders, `+page.svelte`) — a second checkbox next to "Engrave version id" is four combinations of two booleans, so it needs the four URL sets to exist first. It is a small change once (1) ships and a dead control before that, which is why it is not in here.

## Checking this branch by hand

    cd parts-calculator
    python catalog/fasteners.py                        # the table, every part
    python catalog/engrave.py part.stl 'X09T\n2*M3*12\n5*M3*16' /tmp

The second prints the faces it found, the cap height, whether it stacked, and writes the STLs.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1525928562971115601/1548375217326522469
request: https://discord.com/channels/1430279849171222682/1548375217326522469/1548410132675698899
request: https://discord.com/channels/1430279849171222682/1548375217326522469/1548415793434206239
request: https://discord.com/channels/1430279849171222682/1548375217326522469/1548483761845440624
-->
