### PR TITLE
parts: record the cover's sharp-rooted fan bosses as a P0 broken change

### DIFF
--- a/parts-calculator/catalog/parts.json
+++ b/parts-calculator/catalog/parts.json
@@ -491,6 +491,21 @@
           "bulk-bucket-support"
         ]
       }
+    },
+    {
+      "id": "fillet-fan-boss-roots",
+      "name": "The cover's fan bosses have a sharp root and snap off",
+      "priority": "P0",
+      "condition": "broken",
+      "description": "The four bosses the 40 mm fan screws into on the Control Board Housing cover are plain ⌀6.00 mm cylinders standing 2.5 mm proud of the lid, bored ⌀2.50 mm, so the wall is 1.75 mm and the root where the boss meets the lid is a sharp 90° internal corner with no fillet. One builder broke four of them on a single cover, two of those on an M3 × 6 that should have gone in with room to spare against the 6.5 mm bore. Until the root is filleted, run the four screws by hand, stop as soon as the fan pulls down onto the cover, and back a screw out and clear the hole rather than forcing one that stops early. sorter-v2 issue #645.",
+      "targets": {
+        "parts": [
+          "ctrl-board-housing-cover"
+        ],
+        "assemblies": [
+          "ctrl-board-mount"
+        ]
+      }
     }
   ],
   "folders": [

--- a/parts-calculator/src/lib/data/catalog.generated.json
+++ b/parts-calculator/src/lib/data/catalog.generated.json
@@ -506,6 +506,21 @@
 					"bulk-bucket-support"
 				]
 			}
+		},
+		{
+			"id": "fillet-fan-boss-roots",
+			"name": "The cover's fan bosses have a sharp root and snap off",
+			"priority": "P0",
+			"condition": "broken",
+			"description": "The four bosses the 40 mm fan screws into on the Control Board Housing cover are plain \u23006.00 mm cylinders standing 2.5 mm proud of the lid, bored \u23002.50 mm, so the wall is 1.75 mm and the root where the boss meets the lid is a sharp 90\u00b0 internal corner with no fillet. One builder broke four of them on a single cover, two of those on an M3 \u00d7 6 that should have gone in with room to spare against the 6.5 mm bore. Until the root is filleted, run the four screws by hand, stop as soon as the fan pulls down onto the cover, and back a screw out and clear the hole rather than forcing one that stops early. sorter-v2 issue #645.",
+			"targets": {
+				"parts": [
+					"ctrl-board-housing-cover"
+				],
+				"assemblies": [
+					"ctrl-board-mount"
+				]
+			}
 		}
 	],
 	"folders": [


### PR DESCRIPTION
Adds one `changes` entry so the cover's fan bosses carry a warning everywhere the calculator draws them, and records the interim handling until the geometry is revised.

This is the board half of [#645](https://github.com/basicallysource/sorter-v2/issues/645), filed at **ReveryX**'s (@reveryx) [request](https://discord.com/channels/1430279849171222682/1548126898620731524/1548468985375363163). The issue has the measurements and the fix; this is what puts it in front of a builder.

### The entry

`fillet-fan-boss-roots`, **P0 / broken**, targeting the part `ctrl-board-housing-cover` and the assembly `ctrl-board-mount`.

The bosses are plain ⌀6.00 mm cylinders standing 2.5 mm proud of the lid, bored ⌀2.50, so the wall is 1.75 mm and the root is a sharp 90° internal corner with no fillet anywhere on the boss. Measured off the pinned STL (`stl_hash` 462b0290…, still v1). **Daddy-O's Bricks - Bill** (@daddyosbricksbill) broke four of them on one cover, [two of those on an M3 × 6](https://discord.com/channels/1430279849171222682/1548126898620731524/1548138479735808100) that should have gone in with room to spare against a 6.5 mm bore.

`broken` rather than a lower priority because it stops a build: there is no way to finish the housing once a boss is off, and it is coming off on screws that are not even long enough to bottom.

### Why this is an entry and not a fix

No catalog edit resolves it. The fastener spec on the page is correct and untouched, the assembly is correct, and the defect is in the geometry, which is a `cad` issue plus the entry that goes with it. The interim advice is already on the assembly page as a step 3 warning in #641.

### Checks

`generate.py --metadata-only` run and committed with the source; its pin, versioning and connection checks pass.

<!-- balloon-pr-context
request: https://discord.com/channels/1430279849171222682/1548126898620731524/1548468985375363163
preview: /parts
-->
